### PR TITLE
chore: fix QA workflow docs and recreate capture-page-states skill

### DIFF
--- a/.claude/commands/capture-page-states.md
+++ b/.claude/commands/capture-page-states.md
@@ -1,0 +1,57 @@
+# Capture Page States: Screenshot Generator for Page Audit
+
+Takes screenshots of every KoNote page for every authorised persona at multiple breakpoints. These screenshots feed into `/run-page-audit` in the konote-qa-scenarios repo.
+
+**This is TEST INFRASTRUCTURE**, not application code.
+
+The test framework handles database setup, test data seeding, and live server startup internally. No manual preflight or server startup needed.
+
+---
+
+## Steps
+
+### Step 1: Verify test files exist
+
+Check that these files exist:
+- `tests/utils/page_capture.py`
+- `tests/integration/test_page_capture.py`
+
+If either is missing, STOP and tell the user:
+> The page capture test infrastructure hasn't been built yet. See `tasks/page-capture-reference.md` for the design spec and `tasks/refactor-capture-page-states.md` for context. These test files need to be created as a separate task before this skill can run.
+
+### Step 2: Verify page inventory exists
+
+Check that `../konote-qa-scenarios/pages/page-inventory.yaml` exists.
+
+If missing, STOP and tell the user:
+> The page inventory file is missing. Clone the konote-qa-scenarios repo next to konote-app, or check that `pages/page-inventory.yaml` exists in it.
+
+### Step 3: Run the page capture tests
+
+Run from the konote-app directory:
+
+```
+pytest tests/integration/test_page_capture.py -v
+```
+
+**This takes 3-10 minutes** depending on page count and breakpoints. Use `timeout: 600000` (10 minutes) on the Bash call. Wait for it to finish. Do NOT poll or run other commands while it runs.
+
+Optional environment variable filters (set before running to narrow scope):
+- `PAGE_CAPTURE_PAGES` — comma-separated page IDs (e.g. `client-list,dashboard-staff`)
+- `PAGE_CAPTURE_PERSONAS` — comma-separated persona IDs (e.g. `R1,DS1`)
+- `PAGE_CAPTURE_BREAKPOINTS` — single breakpoint (e.g. `1366x768`)
+
+### Step 4: Report results
+
+After tests complete, report to the user:
+- Number of pages captured and total screenshots saved
+- Manifest location: `../konote-qa-scenarios/reports/screenshots/pages/.pages-manifest.json`
+- Any skipped pages or missing screenshots
+- Any failures or errors
+
+### Next steps
+
+Tell the user:
+1. Switch to the `konote-qa-scenarios` repo
+2. Run `/run-page-audit` to evaluate the captured screenshots
+3. See `tasks/page-capture-reference.md` for troubleshooting, screenshot naming, and advanced options

--- a/TODO.md
+++ b/TODO.md
@@ -47,7 +47,7 @@ Step-by-step commands for each task are in [tasks/recurring-tasks.md](tasks/recu
 
 - [ ] **UX walkthrough** — run after UI changes. In Claude Code: `pytest tests/ux_walkthrough/ -v`, then review `tasks/ux-review-latest.md` and add fixes to TODO (UX-WALK1)
 - [ ] **Code review** — run every 2–4 weeks or before a production deploy. Open Claude Code and paste the review prompt from [tasks/code-review-process.md](tasks/code-review-process.md) (REV1)
-- [ ] **Full QA suite** — run after major releases or substantial UI changes. In Claude Code: `/run-scenario-server`, then `/capture-page-states` in konote-app; `/run-scenarios`, then `/run-page-audit` in konote-qa-scenarios (QA-FULL1)
+- [ ] **Full QA suite** — run after major releases or substantial UI changes. Two pipelines (A then B), five sessions total — see [tasks/recurring-tasks.md](tasks/recurring-tasks.md) for full steps (QA-FULL1)
 - [ ] **French translation spot-check** — have a French speaker review key screens. Run `python manage.py check_translations` to verify .po file coverage (I18N-REV1)
 - [ ] **Redeploy to Railway** — after merging to main. Push to `main` and Railway auto-deploys (OPS-RAIL1)
 
@@ -113,9 +113,9 @@ Step-by-step commands for each task are in [tasks/recurring-tasks.md](tasks/recu
 ### Phase: Surveys QA Scenarios
 
 - [x] Add survey demo data to seed_demo_data — 3 surveys, trigger rule, shareable link, assignments, responses — 2026-02-21 (QA-SURV1)
-- [ ] Create CSV test fixture for survey import at tests/fixtures/sample-survey-import.csv (QA-SURV2)
+- [x] Create CSV test fixture for survey import at tests/fixtures/sample-survey-import.csv — 2026-02-21 (QA-SURV2)
 - [x] Write 8 scenario YAML files (SCN-110 through SCN-117) in konote-qa-scenarios repo — 2026-02-21 (QA-SURV3)
-- [ ] Add test methods for survey scenarios to tests/scenario_eval/test_scenario_eval.py (QA-SURV4)
+- [x] Add test methods for survey scenarios to tests/scenario_eval/test_scenario_eval.py — 2026-02-21 (QA-SURV4)
 - [ ] Update page-inventory.yaml in qa-scenarios repo with survey pages (QA-SURV5)
 
 ### Phase: Surveys Future Work


### PR DESCRIPTION
## Summary

- **TODO.md QA-FULL1 one-liner** — was listing stale command names that didn't match the actual 5-step process in `tasks/recurring-tasks.md`. Now says "see recurring-tasks.md" instead.
- **QA-SURV2 and QA-SURV4** — marked `[x]` in Active Work to match Recently Done (were completed 2026-02-21 but not updated in both places).
- **`/capture-page-states` skill** — recreated from scratch. Old version was 538 lines with embedded Python code. New version is 57 lines following the `run-scenario-server.md` pattern: imperative steps, prerequisite checks, no embedded code. Gracefully stops if test infrastructure files don't exist yet.

## Test plan

- [ ] Verify `tasks/recurring-tasks.md` QA-FULL1 section matches the TODO.md one-liner
- [ ] Verify `.claude/commands/capture-page-states.md` has no embedded Python, no hardcoded paths
- [ ] Verify skill structure matches `run-scenario-server.md` pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)