### PR TITLE
chore: add pipeline resume checks to QA commands

### DIFF
--- a/.claude/commands/capture-page-states.md
+++ b/.claude/commands/capture-page-states.md
@@ -8,6 +8,10 @@ The test framework handles database setup, test data seeding, and live server st
 
 ---
 
+## Before running: check the pipeline log
+
+Read `qa/pipeline-log.txt`. This command is Pipeline B, Step B1. Only run it after Pipeline A is fully complete (Step 3 entry exists for the current round). If the last entry says "Step 2" with no "Step 3", tell the user to run `/process-qa-report` first.
+
 ## Steps
 
 ### Step 1: Verify test files exist

--- a/.claude/commands/process-qa-report.md
+++ b/.claude/commands/process-qa-report.md
@@ -1,0 +1,59 @@
+# Process QA Report: Expert Panel Review
+
+Reviews the latest satisfaction report and improvement tickets from the konote-qa-scenarios evaluation. Produces an action plan with prioritised fixes for TODO.md.
+
+**This is Pipeline A, Step 3** — run after `/run-scenarios` deposits handoff files in `qa/`.
+
+---
+
+## Before running: verify handoff files exist
+
+Read `qa/pipeline-log.txt`. The last entry should say "Step 2: Evaluation complete" with no subsequent "Step 3" entry. If Step 3 is already done for this round, STOP — the report has already been processed.
+
+Check that `qa/` contains:
+- Improvement tickets file for this round (e.g. `qa/2026-02-21-improvement-tickets.md`)
+- `qa/satisfaction-history.json`
+- `qa/pipeline-log.txt`
+
+If these are missing, STOP and tell the user:
+> The handoff files from `/run-scenarios` are not in `qa/`. Run `/run-scenarios` in the konote-qa-scenarios repo first.
+
+## Steps
+
+### Step 1: Read the latest improvement tickets
+
+Find the most recent `*-improvement-tickets.md` file in `qa/`. Read it fully — this contains all tickets from the evaluation round.
+
+### Step 2: Read the satisfaction history
+
+Read `qa/satisfaction-history.json` for trend data across rounds.
+
+### Step 3: Read the pipeline log
+
+Read `qa/pipeline-log.txt` for context on what was captured and evaluated.
+
+### Step 4: Convene expert panel review
+
+Analyse the tickets and produce an action plan:
+- Group tickets by severity (BLOCKER, BUG, IMPROVE, TEST)
+- Identify regressions (scores that dropped 0.5+ pts from previous round)
+- Prioritise into tiers: Tier 1 (fix now), Tier 2 (fix soon), Tier 3 (backlog)
+- Write the action plan to `tasks/qa-action-plan-YYYY-MM-DD.md`
+
+### Step 5: Update TODO.md
+
+Add Tier 1 tasks to Active Work, Tier 2 to Coming Up, Tier 3 to Parking Lot.
+
+### Step 6: Update the pipeline log
+
+Append a "Step 3" entry to `qa/pipeline-log.txt`:
+```
+YYYY-MM-DD HH:MM — Step 3: Action plan created, N tasks added to TODO (M tickets analysed, 4-expert panel). See tasks/qa-action-plan-YYYY-MM-DD.md.
+```
+
+### Next steps
+
+Tell the user:
+1. Pipeline A is complete for this round
+2. If Pipeline B (page audit) is needed, run `/capture-page-states` next
+3. Review the action plan at `tasks/qa-action-plan-YYYY-MM-DD.md`

--- a/.claude/commands/run-scenario-server.md
+++ b/.claude/commands/run-scenario-server.md
@@ -8,6 +8,14 @@ The test framework handles everything internally: database setup, migrations, te
 
 ---
 
+## Before running: check the pipeline log
+
+Read `qa/pipeline-log.txt`. If the last entry says "Step 2: Evaluation complete" with no subsequent "Step 3" entry, the evaluation is already done and waiting for `/process-qa-report`. Do NOT re-run scenarios — tell the user to run `/process-qa-report` first.
+
+If the last entry says "Step 1" with today's date, screenshots were already captured today. Do NOT re-capture — tell the user to go to konote-qa-scenarios and run `/run-scenarios`.
+
+Only proceed if the pipeline log shows the previous round is fully processed (Step 3 done) or the file doesn't exist.
+
 ## Steps
 
 ### Step 1: Run the scenario tests

--- a/tasks/recurring-tasks.md
+++ b/tasks/recurring-tasks.md
@@ -40,6 +40,17 @@ Run after major releases or substantial UI changes.
 
 Expected outcome: new dated reports in `qa-scenarios/reports/` and a prioritised fix list.
 
+### Before you start: check where the pipeline left off
+
+**This pipeline spans multiple sessions. Steps get dropped between sessions.** Before doing anything, read `qa/pipeline-log.txt` and find the last entry:
+
+- Last entry says **"Step 1"** → A2 is next (go to konote-qa-scenarios, run `/run-scenarios`)
+- Last entry says **"Step 2"** with no subsequent "Step 3" → A3 is next (run `/process-qa-report` in konote-app)
+- Last entry says **"Step 3"** → Pipeline A is done. Start Pipeline B (run `/capture-page-states`)
+- `qa/pipeline-log.txt` doesn't exist → start from A1
+
+Also check `qa/` for handoff files. If `qa/*-improvement-tickets.md` exists with today's date but no "Step 3" entry in the log, the evaluation is done and waiting to be processed.
+
 There are **two independent pipelines**. Do them in order. Each pipeline is a sequence of sessions — finish one step before starting the next.
 
 ### Pipeline A: Scenario Evaluation (always do this)


### PR DESCRIPTION
## Summary

- Every QA command file now reads `qa/pipeline-log.txt` before running to check where the pipeline left off
- Created `.claude/commands/process-qa-report.md` — the A3 step that had no command file, causing it to get dropped between sessions
- Added "Before you start" section to `tasks/recurring-tasks.md` with resume logic

## Problem

The QA pipeline spans 5 sessions. Steps keep getting dropped because new sessions don't know what was already done. Today: Round 7 evaluation was complete with handoff files waiting in `qa/`, but the session spent 20 minutes re-investigating before discovering this.

## What changed

| File | Change |
|------|--------|
| `tasks/recurring-tasks.md` | Added "check where the pipeline left off" section with decision tree |
| `.claude/commands/run-scenario-server.md` | Added resume check — won't re-capture if evaluation is pending |
| `.claude/commands/capture-page-states.md` | Added resume check — won't run Pipeline B until Pipeline A Step 3 is done |
| `.claude/commands/process-qa-report.md` | **NEW** — A3 step with handoff verification, expert panel instructions, pipeline log update |

## Test plan

- [ ] Verify each command file has a "Before running" section that reads `qa/pipeline-log.txt`
- [ ] Verify `process-qa-report.md` instructions match the pipeline log format used by previous rounds

🤖 Generated with [Claude Code](https://claude.com/claude-code)