### PR TITLE
chore: fix session review items

### DIFF
--- a/.claude/commands/process-qa-report.md
+++ b/.claude/commands/process-qa-report.md
@@ -34,7 +34,8 @@ Read `qa/pipeline-log.txt` for context on what was captured and evaluated.
 
 ### Step 4: Convene expert panel review
 
-Analyse the tickets and produce an action plan:
+Analyse the tickets and produce an action plan. Follow the format of the most recent `tasks/qa-action-plan-*.md` file for consistency across rounds.
+
 - Group tickets by severity (BLOCKER, BUG, IMPROVE, TEST)
 - Identify regressions (scores that dropped 0.5+ pts from previous round)
 - Prioritise into tiers: Tier 1 (fix now), Tier 2 (fix soon), Tier 3 (backlog)
@@ -42,7 +43,7 @@ Analyse the tickets and produce an action plan:
 
 ### Step 5: Update TODO.md
 
-Add Tier 1 tasks to Active Work, Tier 2 to Coming Up, Tier 3 to Parking Lot.
+Add Tier 1 tasks to Active Work, Tier 2 to Coming Up, Tier 3 to Parking Lot. Flag any items that match GK's consultation gates (see CLAUDE.md § "Consultation Gates") with "GK reviews [topic]" in the owner field.
 
 ### Step 6: Update the pipeline log
 

--- a/TODO.md
+++ b/TODO.md
@@ -116,7 +116,7 @@ Step-by-step commands for each task are in [tasks/recurring-tasks.md](tasks/recu
 - [x] Create CSV test fixture for survey import at tests/fixtures/sample-survey-import.csv — 2026-02-21 (QA-SURV2)
 - [x] Write 8 scenario YAML files (SCN-110 through SCN-117) in konote-qa-scenarios repo — 2026-02-21 (QA-SURV3)
 - [x] Add test methods for survey scenarios to tests/scenario_eval/test_scenario_eval.py — 2026-02-21 (QA-SURV4)
-- [ ] Update page-inventory.yaml in qa-scenarios repo with survey pages (QA-SURV5)
+- [x] Update page-inventory.yaml in qa-scenarios repo with survey pages — 2026-02-21 (QA-SURV5)
 
 ### Phase: Surveys Future Work
 


### PR DESCRIPTION
## Summary

- Mark QA-SURV5 as done in TODO.md (completed in qa-scenarios repo commit 740d2a8)
- Add "Follow the format of the most recent `tasks/qa-action-plan-*.md`" to `process-qa-report.md` Step 4 for consistent output across rounds
- Add GK consultation gate reminder to `process-qa-report.md` Step 5 so AI-generated action plans flag items needing subject matter expert review

From session review expert panel recommendations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)