### PR TITLE
feat: insights metric distributions — DRR, implementation plan, TODO

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -6,8 +6,24 @@
 - [ ] Decide who can run the secure offboarding export command (KoNote team only vs self-hosted agencies) to finalize SEC3 design (see tasks/agency-data-offboarding.md) — GK (SEC3-Q1)
 - [ ] Confirm standard report schema and configuration template with partner contact before building — SG (RPT-SCHEMA1)
 - [ ] Approve CIDS implementation plan with project lead before building — covers metadata fields, code list integration, CIDS-enriched reports, and full JSON-LD export; confirm partner consumption pathway and whether to engage Common Approach as pilot implementer (see tasks/cids-json-ld-export.md) — SG/GK (CIDS-APPROVE1)
+- [ ] Approve band display labels and clinical thresholds for insights metric distributions — hard blocker on Phase 2 template work (see tasks/design-rationale/insights-metric-distributions.md, Phase 0) — GK (INSIGHTS-LANG1)
+- [ ] Discuss: are Design Rationale Records (DRRs) working well as a practice? Should we keep using them, change the format, or retire them? — GK (PROCESS-DRR1)
+- [ ] Discuss: are the `convening-experts` and `review-session` commands useful for our workflow? Worth the time? How should we use them going forward? — GK (PROCESS-EXPERT-PANEL1)
 
 ## Active Work
+
+### Phase: Insights Metric Distributions (see tasks/design-rationale/insights-metric-distributions.md, tasks/insights-metrics-implementation.md)
+
+- [ ] Phase 0: GK language review — band labels, clinical thresholds, achievement examples, Two Lenses wording — HARD BLOCKER on Phase 2 (INSIGHTS-P0-LANG)
+- [ ] Phase 0: Update MetricDefinition admin form with new fields (metric_type, thresholds, achievement options, targets) (INSIGHTS-P0-ADMIN)
+- [ ] Phase 0: Configure at least one test program with achievement metrics for development (INSIGHTS-P0-SEED)
+- [ ] Phase 1: Add metric_type, threshold, achievement, and target fields to MetricDefinition model (INSIGHTS-P1-MODEL)
+- [ ] Phase 1: Build metric aggregation functions — distributions, achievement rates, trends, Two Lenses, data completeness (INSIGHTS-P1-AGG)
+- [ ] Phase 2: Restructure insights page — participant voice to Section 2, progressive disclosure with smart auto-expand (INSIGHTS-P2-LAYOUT)
+- [ ] Phase 2: Add summary cards, distribution bars, achievement bars with journey context, CSS (INSIGHTS-P2-VIZ)
+- [ ] Phase 3: Update executive dashboard — program cards with trend direction, data completeness, feedback themes (INSIGHTS-P3-EXEC)
+- [ ] Phase 4: Achievement metric recording UI — dropdown in note form, tests (INSIGHTS-P4-RECORD)
+- [ ] Phase 5: Workbench-to-report links, board summary template, translations, docs (INSIGHTS-P5-POLISH)
 
 ### Phase: Launch Readiness
 

--- a/tasks/design-rationale/insights-metric-distributions.md
+++ b/tasks/design-rationale/insights-metric-distributions.md
@@ -1,0 +1,368 @@
+# Insights Page & Program Reporting — Design Rationale Record
+
+**Date:** 2026-02-22
+**Status:** Design approved by expert panel (4 rounds). Not yet implemented.
+**Expert panels:** Round 1: architecture and separation of concerns. Round 2: aggregation design — distributions not averages. Round 3: three data layers and how they collapse. Round 4: client-centred redesign — language, page ordering, executive dashboard, incentive structures, governance reporting.
+**GK review required:** Band display labels (strengths-based framing check), clinical instrument thresholds, achievement metric examples per program type, "Two Lenses" card wording, board summary template content
+
+## Core Principles
+
+### 1. Distributions, not averages
+
+Averages are almost meaningless for program management in human services. A mean of 3.2/5 tells a manager nothing actionable.
+
+- **Distribution shape**: How many people are at each level? Where are the clusters?
+- **Tails**: How many need more support (low band)? How many are meeting their goals (high band)?
+- **Direction of travel**: Is the distribution shifting over time?
+- **Median**: Better central tendency than mean for skewed data, but secondary to distribution
+
+A program where half score 1 and half score 5 looks identical to one where everyone scores 3 when you use averages. The distribution tells completely different stories.
+
+### 2. Three distinct data layers
+
+Programs generate three fundamentally different types of data. Each needs different visualization and aggregation:
+
+| Layer | Logic Model Term | What It Answers | Example |
+|---|---|---|---|
+| **Program outcomes** | End outcomes | "Did the program achieve its intended results?" | 65% got employment, 48% below clinical threshold |
+| **Goal metrics** | Intermediate outcomes | "Is progress happening on individual goals?" | Goal Progress distribution, Self-Efficacy trend |
+| **Qualitative** | Process quality | "What's the experience like?" | Participant voice, staff assessments, engagement, suggestion themes |
+
+### 3. Per-participant, not per-target
+
+All program-level aggregation uses **one data point per participant**. A program serves people, not goals. If one participant has 6 goals and another has 1, per-target counting makes the first person six times as important. That's statistically wrong and managerially misleading.
+
+For scale metrics: take each participant's **median score across all their active goals** (most honest representation of "how is this person doing overall").
+
+New participants with only 1 assessment are flagged separately: "X participants have only one assessment — not included in distributions."
+
+### 4. Client-centred page hierarchy
+
+The insights page layout reflects a commitment: **participant-generated data leads, staff-generated data follows, system-derived data supports.** This means:
+- Participant voice (quotes, suggestions, themes) appears before staff assessments
+- When both participant self-report and staff assessment data exist, their comparison is the headline signal
+- Quantitative metrics provide context for the qualitative story, not the other way around
+
+### 5. Two separate systems
+
+The insights page and the report generation system are **separate tools with different purposes**. They must not merge.
+
+| Tool | Purpose | Audience | Data Type |
+|------|---------|----------|-----------|
+| Insights page (`/reports/insights/`) | Ongoing program learning — the workbench | Program managers, executives | All three layers |
+| Report generation (`/reports/generate/`) | Formal accountability exports — the finished product | Partners (funders, boards, networks, regulators, etc.) | Quantitative, template-driven |
+
+### 6. Service-framing, not person-labelling
+
+Band labels and dashboard signals describe the **service's effectiveness**, not the participant's state. "More support needed" is a signal to the program. "Struggling" is a judgment of the person. The language throughout the system frames data as information about whether the service is working, not whether the person is succeeding or failing.
+
+### 7. Measurement must not create perverse incentives
+
+Every quantitative signal shown to executives creates pressure. The system mitigates Campbell's Law through:
+- Showing trend direction (not band counts) on executive dashboards
+- Pairing every quantitative signal with a qualitative signal (participant voice)
+- Showing data completeness prominently (prevents selective recording)
+- Using "learning" framing throughout (not "performance")
+
+## Per-Program Insights Page
+
+### Page layout (top to bottom)
+
+1. **Summary cards** — 4 horizontal cards, adapt to available data
+2. **Participant Voice** — Layer 3: quotes, suggestion themes (with status/priority), ungrouped suggestions
+3. **Where Participants Are** — Layer 1: metric distributions (stacked bars + trend lines)
+4. **Program Outcomes** — Layer 2: achievement rates (progress bars with journey context)
+5. **Staff Assessments** — Layer 3: existing descriptor chart, relabelled
+6. **Engagement** — Layer 3: existing pills
+7. **AI Narrative** — existing button
+
+### Progressive disclosure
+
+Sections 2-6 use `<details>` elements with preview `<summary>` lines. The `<summary>` line shows the key signal for that section so a PM scanning the page gets useful information even without expanding.
+
+```html
+<details>
+  <summary>
+    <strong>Participant Voice</strong> — 3 open themes · 12 new quotes this period
+  </summary>
+  [full section content]
+</details>
+```
+
+**Auto-expand logic (in priority order):**
+1. Section with urgent signals (urgent feedback themes, large negative trend shift) → open by default
+2. Section with freshest data (most recent recording) → open by default
+3. If tie or no clear signal, Participant Voice opens by default (client-centred tiebreaker)
+4. Participant Voice must never be the last section to expand — if only quantitative sections would open, Participant Voice also opens
+
+### Summary cards (adapt to available data)
+
+| Program has | Card 1 | Card 2 | Card 3 | Card 4 |
+|---|---|---|---|---|
+| Both self-report and staff data | Two Lenses (gap signal) | Lead outcome rate (with target if set) | Data completeness | Open feedback themes |
+| Achievement outcomes, no self-report | Lead outcome rate (with target) | Trend direction | Data completeness | Open feedback themes |
+| Scale metrics only | "Goals within reach" count | Trend direction | Data completeness | Open feedback themes |
+| Only qualitative | Engagement rate | Active participants | Data completeness | Open feedback themes |
+
+Data completeness always appears (Card 3). Feedback themes always appear (Card 4) — they're the corruption-resistant signal.
+
+### Two Lenses card (when both data streams exist)
+
+When a program has both participant self-report (e.g., Self-Efficacy) and staff assessment (descriptor distribution) data with sufficient n:
+
+```
+TWO LENSES
+Participants: 72% feel confident     Staff: 68% rated "good place"
+Gap: +4% — participants slightly more optimistic
+```
+
+The gap is the signal. When the gap is large, this is the single most important insight on the page. Appears as Card 1 (compact version) and optionally as expanded detail.
+
+### Section 1: Participant Voice (Layer 3, promoted)
+
+Existing: suggestion themes (with status/priority), ungrouped suggestions, quotes. Moved from Section 6 to Section 2 (after summary cards).
+
+Summary line: `Participant Voice — X open themes · Y new quotes this period`
+
+### Section 2: Where Participants Are (Layer 1)
+
+**Snapshot (horizontal stacked bar per metric):**
+
+```
+Goal Progress (n=47, most recent: Feb 15)
+More support ████████░░░░░░░░░░░░░░ Goals within reach
+   20%           18%      30%      32%
+```
+
+**Trend (two-line chart per metric):**
+- One line: % in low band (needs more support)
+- Other line: % in high band (goals within reach)
+
+Two lines tell the story directly: "the low band is shrinking, the high band is growing." Same Chart.js line chart pattern as existing descriptor chart.
+
+**New participant note:** "X participants have only one assessment — not included in distributions. Movement tracking — who is progressing between bands over time — will be available in a future update."
+
+**Metric ordering:**
+1. Universal metrics (Goal Progress, Self-Efficacy, Satisfaction) — always shown first
+2. Program-specific metrics — only when n >= 10, grouped by category
+
+Summary line: `Where Participants Are — X scored · Y% need more support · trend: improving/stable/declining`
+
+### Section 3: Program Outcomes (Layer 2)
+
+Horizontal progress bars for achievement metrics. Each bar shows:
+
+```
+PROGRAM OUTCOMES (n=52 participants this period)
+
+Employment achieved        ██████████████░░░ 65%  (target: 70%)
+                            34 of 52  ↑ from 58% last quarter
+
+  Among those not yet employed:
+  72% making progress on employability goals
+  4 participants need more support
+```
+
+The "among those not yet achieved" context line appears when a corresponding scale metric exists. This prevents achievement rates from being read as a binary verdict.
+
+Only appears if the program has achievement metrics defined with n >= 10. Otherwise skipped.
+
+Accessible data table in `<details>` below the bars.
+
+Summary line: `Program Outcomes — 65% employment (target: 70%) · 48% retention`
+
+### Section 4: Staff Assessments (Layer 3, relabelled)
+
+Existing descriptor trend chart stays but relabelled:
+
+> **Staff Assessments Over Time**
+> *How workers rate participant progress at each session — a professional judgment, not a measured score*
+
+Summary line: `Staff Assessments — X% rated "good place" · trend: stable`
+
+### Section 5: Engagement (Layer 3)
+
+Existing engagement pills.
+
+Summary line: `Engagement — X% actively engaged · Y% disengaged`
+
+### Section 6: AI Narrative
+
+Existing button.
+
+## Executive Dashboard — Cross-Program View
+
+The executive dashboard shows **all programs at a glance**. Each card uses a **headline + signal + action** pattern. Band-level counts do NOT appear on executive cards — they create perverse incentive pressure. Executives see trend direction, data quality, and participant voice signals.
+
+### Program cards
+
+```
+┌─ Youth Employment ──────────────────────┐
+│  65% achieving employment goals          │
+│  target: 70% · trend: improving ↑        │
+│                                          │
+│  ● 34 of 42 participants with data       │
+│  💬 3 feedback themes to review          │
+│                                          │
+│  [View program learning →]               │
+└──────────────────────────────────────────┘
+
+┌─ Mental Health Services ────────────────┐
+│  48% below clinical threshold            │
+│  trend: stable →                         │
+│                                          │
+│  ◐ 28 of 55 participants with data      │
+│  💬 1 urgent theme                       │
+│                                          │
+│  [View program learning →]              │
+└─────────────────────────────────────────┘
+```
+
+Each card shows:
+- **Line 1**: Lead program outcome rate (Layer 2), or lead metric "goals within reach" % (Layer 1) if no outcomes defined
+- **Line 2**: Target (if set) + trend direction. No band counts.
+- **Line 3**: Data completeness indicator with count
+- **Line 4**: Open feedback theme count (with urgency flag)
+- **Link**: "View program learning" → per-program insights page
+
+### Data completeness indicators
+
+| Indicator | Meaning |
+|---|---|
+| ● Full data | >80% of enrolled participants have current scores |
+| ◐ Partial data | 50-80% have scores |
+| ○ Low data | <50% have scores |
+
+### Visual emphasis
+
+Cards with urgent feedback themes or declining trends get a subtle left border accent (Pico caution colour, not red). This draws attention without creating alarm.
+
+## Two Metric Types
+
+The existing `MetricDefinition` model needs to distinguish two recording patterns:
+
+| Metric Type | Recorded How | Aggregated How | Example |
+|---|---|---|---|
+| **Scale** | Numeric value, recorded repeatedly | Distribution of per-participant medians | Goal Progress 1-5, PHQ-9 0-27 |
+| **Achievement** | Categorical, typically recorded once or at discharge | % who achieved | Got employment (yes/no) |
+
+**Threshold outcomes** (e.g., "PHQ-9 dropped below 10") are derived from scale metrics at query time — they don't need separate recording. If a scale metric has `threshold_high` or `threshold_low` set, the insights page can show a "% meeting threshold" bar in the Program Outcomes section.
+
+## Model Changes Required
+
+### MetricDefinition — new fields
+
+| Field | Type | Default | Purpose |
+|---|---|---|---|
+| `metric_type` | CharField(choices) | "scale" | "scale" or "achievement" |
+| `higher_is_better` | BooleanField | True | Direction for scale metrics. PHQ-9 = False |
+| `threshold_low` | FloatField | null | Low band boundary (scale metrics) |
+| `threshold_high` | FloatField | null | High band boundary (scale metrics) |
+| `achievement_options` | JSONField | [] | Dropdown choices for achievement metrics |
+| `achievement_success_values` | JSONField | [] | Which options count as "achieved" |
+| `target_rate` | FloatField | null | Optional target % for achievement metrics (e.g., "We aim for 70%") |
+| `target_band_high_pct` | FloatField | null | Optional target for % in high band for scale metrics |
+
+### Band language framework
+
+**In code (models, views, aggregation functions):**
+- `band_low` — the lowest band (needs more support or, for lower-is-better metrics, goals within reach)
+- `band_mid` — the middle band
+- `band_high` — the highest band (goals within reach or, for lower-is-better metrics, needs more support)
+
+**In display (templates only):**
+- Default labels: "More support needed" / "On track" / "Goals within reach"
+- GK can override per metric (clinical instruments may have published terminology)
+- The words "struggling" and "thriving" do NOT appear anywhere in code, CSS, or templates
+- CSS classes use `band-low`, `band-mid`, `band-high`
+
+### Band threshold defaults
+
+| Scale | Low band | Middle | High band |
+|---|---|---|---|
+| 1-5 (universal) | 1-2 | 3 | 4-5 |
+| PHQ-9 (0-27, lower is better) | 15-27 (mod-severe) | 5-14 (mild-moderate) | 0-4 (minimal) |
+| Custom scales | Bottom third of range | Middle third | Top third |
+
+Clinical instruments must use published cutoff scores, not scale-thirds. **GK must review all clinical thresholds.**
+
+Fallback when thresholds not set: `threshold_low = min + (max - min) / 3`, `threshold_high = min + 2 * (max - min) / 3`.
+
+## Privacy and Display Thresholds
+
+| Display element | Minimum n | Rationale |
+|---|---|---|
+| Metric section appears at all | n >= 10 total scores | Below 10, distribution is too sparse to be meaningful |
+| Individual band with < 5 people | Show "< 5" | Canadian n < 5 suppression standard (from multi-tenancy DRR) |
+| Metric with n < 10 | Show "X scores recorded — at least 10 needed" | Encourages recording without hiding metric existence |
+| Achievement rate | n >= 10 participants | Below 10, percentage is misleading |
+
+## Data Completeness — Always Visible
+
+Data completeness appears at three levels:
+- **Summary card** (always Card 3): "34 of 57 enrolled have scores this period (60%)"
+- **Executive dashboard card**: Data completeness indicator (●/◐/○) with count
+- **Warning** when <80%: "Only 60% of enrolled participants have data this period. Distributions may not represent the full program."
+
+This creates healthy pressure to *record data* rather than to *game data*.
+
+## Movement Tracking (Deferred)
+
+Movement tracking answers: "How many people changed bands this period?" This is the most powerful insight but requires per-client longitudinal comparison (at least 2 data points per participant).
+
+**Deferred to a second pass.** Build the distribution view first. Movement tracking will be added once distributions are validated with real data.
+
+**Required UI acknowledgment:** The insights page must explicitly state: "This shows where participants are now. X participants are new (one assessment only) and are not included in distributions. Movement tracking — who is progressing between bands over time — will be available in a future update."
+
+## Workbench-to-Report Connection
+
+- Show partner report templates linked to this program below the main insights content
+- Show data completeness warnings ("Only 30 of 50 participants have Goal Progress recorded this quarter")
+- AI narrative can be exported as plain text for partner report narrative sections (copy button already exists)
+- **No export button on the insights page** — all exports go through `/reports/generate/`
+
+## Board Summary Template
+
+Boards don't log into KoNote. They receive reports. "Board Summary" is a recognized report template type designed for governance:
+- 1-2 pages, PDF format
+- Sections: Program Overview (counts, lead outcomes with targets), What Participants Are Telling Us (top themes + curated quotes with privacy protections), Data Quality (completeness), Narrative (editable placeholder)
+- Generated quarterly by the executive or PM via `/reports/generate/`
+- This is a template configuration, not an architecture change — uses existing report generation system
+
+## Framing Language
+
+- **Never say "performance"** — frame as "where participants are" or "program learning"
+- **Never say "struggling" or "thriving"** — use "more support needed" / "goals within reach" (or GK-approved alternatives)
+- **Never show averages as the primary display** — distribution is always the headline
+- **Every chart must state its data source** — what the data is, how many data points, when last recorded
+- Use agency terminology settings for "participants" vs "clients"
+- Executive dashboard link always says "View program learning" not "View insights"
+
+## Anti-Patterns (Rejected)
+
+- **Showing averages as the primary metric display** — hides distribution shape, tells managers nothing actionable
+- **Averaging across goals (per-target aggregation)** — over-represents people with many goals
+- **Treating achievement metrics like scale metrics** — "did they get a job" is not a 1-5 score
+- **Putting metrics and descriptors on the same chart** — different data types need different visual treatments
+- **Using tabs to separate layers** — managers need to scroll and see everything, not click tabs
+- **Box plots** — not understood by non-technical managers
+- **Multi-metric charts** — one chart per metric, stacked vertically; no combining different scales
+- **Export button on insights page** — bypasses report generation audit trail and privacy safeguards
+- **"Performance" framing** — creates pressure to game scores; frame as learning instead
+- **"Struggling" / "thriving" language** — locates the problem in the person, not the service. Use service-framing: "more support needed" / "goals within reach"
+- **Merging insights and report generation** — different tools, different audiences, different incentive structures
+- **Hardcoding program outcomes** — must be configurable per program via MetricDefinition
+- **Showing band counts on executive dashboard** — creates Campbell's Law pressure. Show trend direction and data completeness instead.
+- **Person-labelling language in code** — variable names like `struggling_count` bake deficit framing into the codebase. Use `band_low_count`.
+- **Achievement rate as sole headline** — binary frame erases the journey. Always show scale progress alongside achievement rates when available.
+- **Hiding data completeness** — low completeness makes all metrics unreliable. Showing it creates healthy pressure to record.
+
+## Accessibility Requirements
+
+- Colour alone cannot convey meaning — bars need pattern fills or text labels
+- Every chart needs an accessible data table (existing `<details>` pattern)
+- Colour scheme for bands must pass 4.5:1 contrast ratio (do NOT use red-to-green — use Pico palette)
+- All interactive elements keyboard-navigable
+- Screen reader announcements for summary card values
+- `<summary>` lines must be descriptive enough for screen reader users to decide whether to expand
+- Data completeness indicators (●/◐/○) must have text alternatives

--- a/tasks/insights-metrics-implementation.md
+++ b/tasks/insights-metrics-implementation.md
@@ -1,0 +1,386 @@
+# Insights Page — Metric Distributions Implementation Plan
+
+**DRR:** `tasks/design-rationale/insights-metric-distributions.md`
+**Created:** 2026-02-22
+**Status:** Ready for implementation (pending Phase 0 GK review)
+
+## Overview
+
+Add quantitative metric data (distributions, achievement rates) to the insights page, reorder sections to centre participant voice, relabel existing charts for clarity, and update the executive dashboard with program outcome cards. Three data layers, each with appropriate visualization. Service-framing language throughout.
+
+## Phase 0: Language Review & Metric Admin (HARD BLOCKER on Phase 2)
+
+### Task 0.1: GK language review
+
+**Not a code task.** GK must review and approve before any template work begins:
+
+- [ ] Band display labels: "More support needed" / "On track" / "Goals within reach" — or GK-approved alternatives
+- [ ] "Two Lenses" card wording (participant vs. staff comparison)
+- [ ] Achievement metric examples for 3-4 common program types (employment, housing, mental health, youth)
+- [ ] Band thresholds for clinical instruments (PHQ-9, GAD-7, etc.) — must use published cutoff scores
+- [ ] Executive dashboard card content and labels
+- [ ] Whether movement tracking should be scoped for next phase
+
+**Phase 2 cannot start until this task is complete.** Language gets baked into templates, CSS, and tests — changing it later is expensive.
+
+### Task 0.2: Update admin form for MetricDefinition
+
+Add `metric_type`, `higher_is_better`, `threshold_low`, `threshold_high`, `achievement_options`, `achievement_success_values`, `target_rate`, `target_band_high_pct` to the admin form for MetricDefinition.
+
+Show `achievement_options` and `achievement_success_values` only when `metric_type="achievement"`.
+Show `threshold_low`, `threshold_high`, `higher_is_better` only when `metric_type="scale"`.
+Show `target_rate` only when `metric_type="achievement"`.
+Show `target_band_high_pct` only when `metric_type="scale"`.
+
+This enables agencies to configure metrics before the visualization is built.
+
+### Task 0.3: Configure at least one test program
+
+Configure achievement metrics on at least one program (using admin form from Task 0.2) so Phase 2-3 development has real data to test against. If using demo data, seed achievement metric values for the demo program.
+
+## Phase 1: Model Changes & Data Layer
+
+### Task 1.1: Add fields to MetricDefinition
+
+**File:** `apps/plans/models.py`
+
+Add to `MetricDefinition`:
+```python
+METRIC_TYPE_CHOICES = [
+    ("scale", _("Numeric scale")),
+    ("achievement", _("Achievement")),
+]
+
+metric_type = CharField(max_length=20, choices=METRIC_TYPE_CHOICES, default="scale")
+higher_is_better = BooleanField(default=True, help_text="False for metrics like PHQ-9 where lower is better.")
+threshold_low = FloatField(null=True, blank=True, help_text="Low band boundary.")
+threshold_high = FloatField(null=True, blank=True, help_text="High band boundary.")
+achievement_options = JSONField(default=list, blank=True, help_text='Options for achievement metrics, e.g. ["Employed", "In training", "Unemployed"].')
+achievement_success_values = JSONField(default=list, blank=True, help_text='Which options count as achieved, e.g. ["Employed"].')
+target_rate = FloatField(null=True, blank=True, help_text="Optional target % for achievement metrics.")
+target_band_high_pct = FloatField(null=True, blank=True, help_text="Optional target for % in high band (scale metrics).")
+```
+
+Run `makemigrations` and `migrate`.
+
+**Data migration:** Set default thresholds for universal metrics (Goal Progress, Self-Efficacy, Satisfaction): `threshold_low=2, threshold_high=4`. Leave category-specific metrics null (they use scale-thirds fallback until GK sets clinical values).
+
+**Tests:** Model field tests — ensure threshold_low < threshold_high validation, ensure achievement fields only apply when metric_type="achievement".
+
+### Task 1.2: Build metric aggregation functions
+
+**New file:** `apps/reports/metric_insights.py`
+
+Three functions (pure SQL aggregation, no decryption):
+
+**`get_metric_distributions(program, date_from, date_to)`**
+
+For each scale metric used by this program:
+1. Get latest score per target per participant (using effective date)
+2. Calculate per-participant median across their goals
+3. Classify into bands (low / mid / high) using metric thresholds, respecting `higher_is_better`
+4. Return: `{metric_id: {name, band_low_count, band_mid_count, band_high_count, total, band_low_pct, band_high_pct, n_new_participants, last_recorded}}`
+
+Exclude participants with only 1 assessment (flag them as "new").
+
+Privacy: suppress band counts < 5 (return "< 5" string instead of number). Skip metrics with total n < 10.
+
+**`get_achievement_rates(program, date_from, date_to)`**
+
+For each achievement metric used by this program:
+1. Get latest value per participant
+2. Count achieved vs. not achieved (using `achievement_success_values`)
+3. Return: `{metric_id: {name, achieved_count, total, achieved_pct, target_rate, last_recorded}}`
+
+Privacy: skip if total n < 10.
+
+**`get_metric_trends(program, date_from, date_to)`**
+
+For each scale metric:
+1. Same per-participant median logic, but grouped by month
+2. Return: `{metric_id: [{month, band_low_pct, band_high_pct, total}]}`
+
+Only include months with n >= 10.
+
+**`get_two_lenses(program, date_from, date_to)`**
+
+When program has both Self-Efficacy (participant self-report) and staff descriptor data:
+1. Get % of participants in high band for Self-Efficacy
+2. Get % of staff descriptors rated "good_place"
+3. Return: `{self_report_pct, staff_pct, gap, has_sufficient_data}`
+
+Only return if both streams have n >= 10.
+
+**Tests:** Unit tests with factory-created MetricValues. Test per-participant aggregation (verify multi-goal participants aren't over-counted). Test threshold flipping for higher_is_better=False. Test n < 5 suppression. Test n < 10 exclusion. Test Two Lenses gap calculation.
+
+### Task 1.3: Build data completeness function
+
+**File:** `apps/reports/metric_insights.py` (add to same file)
+
+**`get_data_completeness(program, date_from, date_to)`**
+
+1. Count enrolled participants in this program
+2. Count participants with at least one MetricValue in the date range
+3. Return: `{enrolled_count, with_scores_count, completeness_pct, completeness_level}` where completeness_level is "full" (>80%), "partial" (50-80%), or "low" (<50%)
+
+## Phase 2: Per-Program Insights Page (BLOCKED on Phase 0)
+
+### Task 2.1: Relabel existing charts
+
+**File:** `templates/reports/_insights_basic.html`
+
+Change:
+- "Progress Trend" → "Staff Assessments Over Time"
+- Add subtitle: "How workers rate participant progress at each session — a professional judgment, not a measured score"
+- Move `interp_trend` text ABOVE the chart (currently below)
+
+No data changes — pure template relabelling.
+
+### Task 2.2: Restructure page with progressive disclosure
+
+**File:** `templates/reports/_insights_basic.html`
+
+Wrap Sections 2-6 in `<details>` elements with preview `<summary>` lines:
+
+```html
+<details id="section-participant-voice" {% if expand_participant_voice %}open{% endif %}>
+  <summary>
+    <strong>{% trans "Participant Voice" %}</strong> —
+    {{ open_theme_count }} {% trans "open themes" %} · {{ new_quote_count }} {% trans "new quotes this period" %}
+  </summary>
+  {% include "reports/_insights_client.html" %}
+</details>
+```
+
+Implement auto-expand logic in the view:
+1. Urgent signals (urgent feedback themes, large negative trend) → open
+2. Freshest data → open
+3. Tie → Participant Voice opens (client-centred tiebreaker)
+4. If only quantitative sections would open, Participant Voice also opens
+
+Move Participant Voice section to position 2 (after summary cards, before metrics).
+
+### Task 2.3: Add summary cards
+
+**File:** `templates/reports/_insights_basic.html` (add at top of results section)
+
+4 cards in a horizontal row, adapting to available data per the DRR summary cards table.
+
+Card 1: Two Lenses gap (when both data streams exist) or lead outcome rate or metric headline
+Card 2: Lead outcome/trend or active participants
+Card 3: Data completeness (always) — "34 of 57 enrolled have scores (60%)"
+Card 4: Open feedback themes count (always)
+
+**File:** `apps/reports/insights_views.py`
+
+Update `program_insights()` to call `get_metric_distributions()`, `get_achievement_rates()`, `get_data_completeness()`, and `get_two_lenses()`, pass results to template context. Determine which summary cards to show based on available data.
+
+**CSS:** `static/css/main.css` — add `.insights-summary-cards` grid (4 cards, responsive, collapses to 2x2 on mobile).
+
+### Task 2.4: Add Where Participants Are section (Layer 1)
+
+**File:** `templates/reports/_insights_distributions.html` (new partial)
+
+For each scale metric with sufficient data:
+
+**Snapshot bar:** Horizontal stacked bar showing band_low / band_mid / band_high percentages. Colour-coded with patterns for accessibility. Shows n and last-recorded date. Labels use GK-approved display text (from Task 0.1).
+
+**Trend chart:** Chart.js line chart with two lines (% in low band, % in high band). Same visual pattern as existing descriptor chart. Accessible data table in `<details>`.
+
+**New participant note + movement tracking acknowledgment:** "X participants have only one assessment — not included in distributions. Movement tracking — who is progressing between bands over time — will be available in a future update."
+
+Universal metrics first, then program-specific grouped by category.
+
+Summary line: `Where Participants Are — X scored · Y% need more support · trend: improving/stable/declining`
+
+### Task 2.5: Add Program Outcomes section (Layer 2)
+
+**File:** `templates/reports/_insights_metrics.html` (new partial, included in `_insights_basic.html`)
+
+Horizontal progress bars for achievement metrics. Each bar shows:
+- Metric name
+- % achieved (coloured bar)
+- Count: "34 of 52"
+- Target (if set): "(target: 70%)"
+- Change from prior period (if available): "↑ from 58% last quarter"
+- Journey context (if corresponding scale metric exists): "Among those not yet achieved: 72% making progress, 4 need more support"
+
+Accessible data table in `<details>` below the bars.
+
+Only renders if program has achievement metrics with n >= 10.
+
+Summary line: `Program Outcomes — 65% employment (target: 70%) · 48% retention`
+
+### Task 2.6: Update insights view to pass all data
+
+**File:** `apps/reports/insights_views.py`
+
+Update `program_insights()`:
+1. Call `get_metric_distributions()` → pass as `metric_distributions`
+2. Call `get_achievement_rates()` → pass as `achievement_rates`
+3. Call `get_metric_trends()` → pass as `metric_trends` (JSON for Chart.js)
+4. Call `get_data_completeness()` → pass as `data_completeness`
+5. Call `get_two_lenses()` → pass as `two_lenses`
+6. Determine auto-expand logic → pass as `expand_participant_voice`, `expand_distributions`, etc.
+7. Determine which summary cards to show based on available data
+8. Build `<summary>` preview content for each section
+
+### Task 2.7: CSS for new sections
+
+**File:** `static/css/main.css`
+
+Add styles for:
+- `.insights-summary-cards` — 4-card grid
+- `.insights-two-lenses` — side-by-side participant/staff comparison
+- `.insights-outcome-bar` — horizontal progress bar for achievement rates
+- `.insights-distribution-bar` — horizontal stacked bar for scale metrics
+- `.insights-metric-section` — container for each metric's snapshot + trend
+- `.insights-completeness` — data completeness display and indicators
+- Band colour variables using `band-low`, `band-mid`, `band-high` (must pass 4.5:1 contrast, NOT red-to-green, use Pico palette)
+- Responsive breakpoints (cards → 2x2 on mobile, bars → full width)
+- `details > summary` styling for section headers with preview content
+
+## Phase 3: Executive Dashboard Update
+
+### Task 3.1: Add program outcome cards to executive dashboard
+
+**File:** Look at existing executive dashboard template and view.
+
+Add a "Program Overview" section with one card per active program. Each card shows:
+- Line 1: Lead outcome rate (Layer 2) or lead metric signal (Layer 1)
+- Line 2: Target (if set) + trend direction (improving ↑ / stable → / declining ↓). No band counts.
+- Line 3: Data completeness indicator (●/◐/○) with count and text alternative
+- Line 4: Open feedback theme count (with urgency flag if any are urgent)
+- Link: "View program learning →" to per-program insights page with program pre-selected
+
+**File:** Update executive dashboard view to call metric aggregation functions per program.
+
+Cards with urgent feedback themes or declining trends get a subtle left border accent (Pico caution colour).
+
+### Task 3.2: Tests for executive dashboard
+
+Test that:
+- Programs without outcomes show Layer 1 fallback
+- Suggestion theme counts are correct
+- Privacy thresholds apply (n < 5 suppression on any visible counts)
+- Band counts do NOT appear on executive cards (verify no `band_low_count` in rendered HTML)
+- Cards link to correct insights page with program pre-selected
+- Data completeness indicators are correct
+- Trend direction is correctly calculated
+
+## Phase 4: Achievement Metric Recording UI (can run parallel with Phase 2 after Phase 1)
+
+### Task 4.1: Update note form for achievement metrics
+
+When a goal has an achievement metric attached, the note form should show a dropdown (from `achievement_options`) instead of a number input.
+
+**File:** Update note form template and form class to detect `metric_type="achievement"` and render appropriate widget.
+
+### Task 4.2: Tests for note form changes
+
+Test that:
+- Achievement metrics show dropdown, not number input
+- Scale metrics still show number input
+- Achievement values are saved correctly
+
+## Phase 5: Polish & Integration
+
+### Task 5.1: Workbench-to-report connection
+
+Add below insights content:
+- List of partner report templates linked to this program ("You have a quarterly report due for United Way — Generate Report")
+- Data completeness warning if < 80% of enrolled participants have scores
+
+### Task 5.2: Board summary template design
+
+Design a "Board Summary" report template type:
+- 1-2 pages, PDF format
+- Sections: Program Overview (counts, lead outcomes with targets), What Participants Are Telling Us (top themes + curated quotes with privacy protections), Data Quality (completeness), Narrative (editable placeholder)
+- This uses the existing report generation system — it's a template configuration, not new architecture
+- GK reviews content and layout
+
+### Task 5.3: Update CLAUDE.md and documentation
+
+Add to DRR references:
+```
+- `tasks/design-rationale/insights-metric-distributions.md` — Insights page metric distributions. Three data layers, distribution-based aggregation, service-framing language, executive dashboard cards, anti-patterns. Includes language framework (band_low/mid/high in code, GK-approved labels in display).
+```
+
+### Task 5.4: French translations
+
+Run `translate_strings` after all template changes. Fill in French translations for new strings (section headings, card labels, chart labels, band labels, accessibility text, summary lines).
+
+## Dependencies
+
+| Task | Depends On |
+|------|-----------|
+| 0.1 (GK review) | Nothing |
+| 0.2 (admin form) | 1.1 (model fields) — but can start UI scaffolding immediately |
+| 0.3 (test program config) | 0.2 |
+| 1.1 (model fields) | Nothing |
+| 1.2 (aggregation functions) | 1.1 |
+| 1.3 (completeness) | Nothing |
+| 2.1 (relabel) | Nothing |
+| 2.2 (progressive disclosure) | 0.1 (language approved) |
+| 2.3 (summary cards) | 0.1, 1.2, 1.3 |
+| 2.4 (distributions section) | 0.1, 1.2 |
+| 2.5 (outcomes section) | 0.1, 1.2 |
+| 2.6 (view update) | 1.2, 1.3 |
+| 2.7 (CSS) | 0.1 (need band label names for CSS classes) |
+| 3.1 (exec dashboard) | 1.2 |
+| 3.2 (exec tests) | 3.1 |
+| 4.1 (note form) | 1.1 |
+| 4.2 (note form tests) | 4.1 |
+| 5.1 (workbench link) | 2.6 |
+| 5.2 (board template) | 0.1 (GK reviews content) |
+| 5.3 (docs) | All |
+| 5.4 (translations) | All templates |
+
+## Independent tasks (can run in parallel)
+
+- 0.1 (GK review) runs independently of all code tasks
+- 1.1 + 1.3 + 2.1 (no dependencies between them)
+- After 1.1: 0.2 + 1.2 + 4.1 (all depend only on model changes)
+- After 0.2: 0.3 (configure test data)
+- After 1.2 + 0.1 complete: 2.2 + 2.3 + 2.4 + 2.5 + 2.6 + 2.7 + 3.1 (all depend on aggregation functions + approved language)
+- 4.1 + 4.2 can run parallel with Phase 2 (both depend only on Phase 1)
+
+## GK Review Gates
+
+**Phase 0 — HARD BLOCKER on Phase 2:**
+- [ ] Band display labels approved ("More support needed" / "On track" / "Goals within reach" or alternatives)
+- [ ] Clinical instrument thresholds (PHQ-9, GAD-7, etc.)
+- [ ] Achievement metric examples for common program types
+- [ ] "Two Lenses" card wording
+
+**Before merging Phase 3:**
+- [ ] Executive dashboard card content and labels
+- [ ] "View program learning" link text
+
+**Before merging Phase 5:**
+- [ ] Board summary template content and layout
+- [ ] Whether movement tracking should be scoped for next phase
+
+## Testing Strategy
+
+| What Changed | Test File |
+|---|---|
+| MetricDefinition fields | `tests/test_plans.py` |
+| Metric aggregation functions | `tests/test_metric_insights.py` (new) |
+| Insights views | `tests/test_insights.py` (extend existing) |
+| Executive dashboard | `tests/test_executive_dashboard.py` (extend) |
+| Note form changes | `tests/test_notes.py` |
+
+Minimum test coverage for new code:
+- Per-participant aggregation (multi-goal participants)
+- Threshold direction flipping (higher_is_better=False)
+- n < 5 band suppression
+- n < 10 metric exclusion
+- Achievement rate calculation with target comparison
+- Summary card adaptation (with and without Layer 2 data, with and without Two Lenses)
+- Two Lenses gap calculation
+- Data completeness levels (full/partial/low)
+- Privacy thresholds on executive dashboard cards
+- No band counts in executive dashboard HTML
+- Auto-expand logic for progressive disclosure
+- Journey context line for achievement metrics (when scale metric exists)


### PR DESCRIPTION
## Summary
- Revised Insights Page & Metric Distributions DRR from 4-round expert panel (architecture, aggregation, three data layers, client-centred redesign)
- Implementation plan: 5 phases, 18 tasks, with Phase 0 GK language review as hard blocker
- TODO updated with 10 active tasks and 3 flagged discussion items

### Key design decisions from Round 4 panel
- **Service-framing language**: "More support needed" / "On track" / "Goals within reach" — never "struggling/thriving"
- **Participant Voice moved to Section 2** (before metrics, not after)
- **Executive dashboard**: trend direction + data completeness + feedback themes — no band counts (Campbell's Law mitigation)
- **Two Lenses card**: participant self-report vs staff assessment comparison
- **Achievement rates with journey context**: "65% achieved. Among those not yet: 72% making progress"
- **Progressive disclosure**: `<details>` sections with smart auto-expand
- **Board Summary template** as Phase 5 deliverable

### Flagged for discussion
- GK language review (hard blocker on Phase 2)
- Whether DRRs are working well as a practice
- Whether convening-experts and review-session commands are useful

## Test plan
- [ ] Review DRR for completeness and alignment with KoNote principles
- [ ] Review implementation plan task sequencing and dependencies
- [ ] Verify TODO items are correctly linked and phased

🤖 Generated with [Claude Code](https://claude.com/claude-code)