### PR TITLE
chore: add shared Claude Code skills and commands

### DIFF
--- a/.claude/commands/review-session.md
+++ b/.claude/commands/review-session.md
@@ -1,0 +1,86 @@
+# /review-session
+
+Thorough end-of-session review of all code changes, followed by an expert panel discussion. Use this before merging, deploying, or wrapping up a session. For quick mid-session checks, use `/review-quick` instead.
+
+## Process
+
+### Step 1: Gather All Changes from This Session
+
+If this is a git repository, run:
+```bash
+git diff HEAD
+git status
+git log --oneline --since="today"
+```
+
+Tell the user what commit range you're reviewing so they can confirm it's the right scope.
+
+If not a git repository, review files discussed in this session instead.
+
+### Step 2: Review the Changes
+
+Review the diffs first. Only read full files when the diff doesn't provide enough context to assess an issue. Review for:
+
+**Correctness**
+- Logic errors, off-by-one bugs, race conditions
+- Missing error handling or edge cases
+- Broken assumptions about data types or state
+
+**Security**
+- Injection vulnerabilities (SQL, XSS, command injection)
+- Secrets or credentials accidentally included
+- Missing authentication/authorisation checks
+- OWASP Top 10 issues
+
+**Quality**
+- Dead code or unused imports introduced
+- Overly complex solutions where simpler ones exist
+- Copy-paste duplication that should be abstracted
+- Inconsistency with existing code patterns in the project
+
+**Testing**
+- If the project has tests, were they added or updated alongside the code changes?
+- Flag if code changed but tests didn't
+
+**Framework & Language Best Practices**
+- Check the project's CLAUDE.md and tech stack for framework-specific rules
+- Flag violations of whatever conventions the project already follows
+
+**Accessibility**
+- WCAG 2.2 AA compliance for any template/frontend changes
+- Missing alt text, aria labels, semantic HTML issues
+
+### Step 3: Write the Review Report
+
+Explain all issues in plain language that a non-developer can understand. Be concise — if a category has no issues, say so in one sentence. Don't pad sections with non-findings.
+
+**Lead with the action list** (this is what the user needs most):
+
+1. **Fix now** — critical issues that should be resolved before merging/deploying
+2. **Fix soon** — important issues to address in the next session
+3. **Consider later** — suggestions that can wait
+
+Then provide supporting detail in these sections:
+
+1. **Summary** — one paragraph overview of what was built/changed
+2. **Critical Issues** — things that MUST be fixed (bugs, security holes)
+3. **Warnings** — things that SHOULD be fixed (quality, maintainability)
+4. **Suggestions** — things that COULD be improved (nice-to-haves)
+5. **What Looks Good** — acknowledge solid work
+
+Be specific: reference file names and line numbers. Don't sugarcoat — this is a critical review. But also don't invent problems that aren't there.
+
+### Step 4: Convene Expert Panel
+
+After completing the review, use the **convening-experts** skill to discuss the report. Invoke it with the Skill tool, passing the review report as context.
+
+The panel should include perspectives relevant to the changes (e.g., security engineer, accessibility expert, UX designer — whatever fits the code that was changed).
+
+The experts should:
+- Prioritise and contextualise the findings for a non-developer audience
+- Debate the critical issues and whether the severity ratings are correct
+- Suggest concrete solutions for each issue
+
+### Step 5: Update Final Recommendations
+
+After the expert discussion, revise the prioritised action list from Step 3 if the panel changed any severity ratings or priorities. Present the final version clearly.

--- a/.claude/skills/accessibility-review/SKILL.md
+++ b/.claude/skills/accessibility-review/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: accessibility-review
+description: Check web pages and code for WCAG 2.2 AA accessibility compliance. Use when the user mentions accessibility, WCAG, a11y, screen readers, colour contrast, keyboard navigation, alt text, or asks to check if something is accessible or usable by people with disabilities.
+---
+
+# Accessibility Review
+
+You are an accessibility specialist who ensures applications are inclusive and usable by everyone, regardless of abilities.
+
+## When This Skill Applies
+
+Use this skill when the user:
+- Asks to check accessibility compliance
+- Mentions WCAG, a11y, or accessibility
+- Wants to find accessibility barriers
+- Asks about screen reader compatibility
+- Mentions colour contrast, alt text, or keyboard navigation
+- Wants to make something more accessible
+
+## How to Perform an Accessibility Review
+
+### Step 1: Determine Scope
+
+Ask the user or determine from context:
+- **Entire project**: Analyse all HTML, CSS, JavaScript files
+- **Specific path**: Focus on files/folders they mention
+- **Current changes**: Use `git status` and `git diff` to find changed files
+- **Recent changes**: Use `git log` to find recently modified files
+
+### Step 2: Audit for WCAG Compliance
+
+Check for these issues:
+
+**Critical Issues (Blockers)**
+- Missing alt text on images
+- Inaccessible forms (missing labels)
+- Keyboard traps (can't navigate with keyboard)
+- Missing skip navigation links
+- No visible focus indicators
+
+**Major Issues**
+- Poor colour contrast (less than 4.5:1 for text)
+- Missing ARIA labels on interactive elements
+- Improper heading hierarchy (skipping levels)
+- Inaccessible modals and dialogs
+- Missing live regions for dynamic content
+
+**Minor Issues**
+- Redundant alt text ("image of...")
+- Missing lang attributes on HTML
+- Decorative images not hidden from screen readers
+- Inconsistent focus order
+
+### Step 3: Check Components
+
+**Forms**
+- All inputs have associated labels
+- Error messages are clear and accessible
+- Required fields are indicated
+- Validation feedback is announced to screen readers
+
+**Navigation**
+- Keyboard accessible (Tab, Enter, Escape)
+- Skip links present
+- Proper menu structure
+- Focus management works correctly
+
+**Media**
+- Images have alt text
+- Videos have captions
+- Audio has transcripts
+- Decorative images use `alt=""`
+
+**Interactive Elements**
+- Buttons are actual `<button>` elements
+- Links are actual `<a>` elements
+- Custom controls have ARIA roles
+- State changes are announced
+
+### Step 4: Create Report
+
+Save a markdown report to `/reports/accessibility-review-{timestamp}.md` with:
+
+```markdown
+# Accessibility Review Report
+Generated: {date}
+Scope: {what was reviewed}
+
+## Summary
+- WCAG compliance level: {A/AA/AAA/None}
+- Critical issues: {count}
+- Major issues: {count}
+- Minor issues: {count}
+
+## Critical Issues (Must Fix)
+{List each issue with file path and line number}
+
+## Major Issues (Should Fix)
+{List each issue with file path and line number}
+
+## Minor Issues (Consider Fixing)
+{List each issue with file path and line number}
+
+## Recommendations
+{Prioritised list of fixes}
+```
+
+## Accessibility Best Practices
+
+- Use semantic HTML first (`<nav>`, `<main>`, `<button>`)
+- Add ARIA only when HTML isn't sufficient
+- Ensure 4.5:1 colour contrast for normal text
+- Ensure 3:1 colour contrast for large text
+- Make all interactive elements keyboard accessible
+- Provide visible focus indicators
+- Don't rely on colour alone to convey meaning
+- Test with screen readers (NVDA on Windows)
+
+## Important
+
+**DO NOT make changes** - only analyse and report. Let the user decide what to fix, then help them implement fixes if they ask.

--- a/.claude/skills/codebase-overview/SKILL.md
+++ b/.claude/skills/codebase-overview/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: codebase-overview
+description: Generate a beginner-friendly overview of a codebase or project. Use when the user asks to understand a project, wants an overview, is new to a codebase, asks what a project does, or wants to know how code is organised.
+---
+
+# Codebase Overview
+
+You are a patient mentor who helps people understand codebases through clear, beginner-friendly explanations.
+
+## When This Skill Applies
+
+Use this skill when the user:
+- Asks for an overview of a project
+- Wants to understand how a codebase is organised
+- Is new to a project and needs orientation
+- Asks "what does this project do?"
+- Wants to know where to find things in the code
+
+## How to Create a Codebase Overview
+
+### Step 1: Assess the Audience
+
+If not clear from context, ask:
+- What's your experience level with this type of project?
+- Are you looking to contribute, or just understand?
+- Any specific areas you're most interested in?
+
+Adjust your language based on their level:
+- **Beginner**: Simple terms, more analogies, avoid jargon
+- **Experienced**: More technical detail, patterns, architecture
+
+### Step 2: Explore the Project
+
+Systematically investigate:
+- Read README.md and any documentation
+- Look at the folder structure
+- Identify the main technologies used
+- Find the entry points (where the app starts)
+- Understand the key components
+
+### Step 3: Create the Overview
+
+Structure your overview as follows:
+
+```markdown
+# Project Overview: {Project Name}
+
+## What This Project Does
+{One paragraph, plain language description}
+
+## Tech Stack
+{List main technologies - explain what each does if user is a beginner}
+
+## Project Structure
+
+```
+project-root/
+├── src/           # {what's in here}
+├── public/        # {what's in here}
+├── tests/         # {what's in here}
+└── config files   # {what these do}
+```
+
+## Key Files to Know
+
+### {filename}
+- **What it does**: {explanation}
+- **When you'd look here**: {when to open this file}
+
+## How Things Connect
+{Explain how the pieces work together - use simple diagrams if helpful}
+
+## Common Tasks
+
+### To add a new feature
+1. {step}
+2. {step}
+
+### To fix a bug
+1. {step}
+2. {step}
+
+## Where to Start
+{Concrete suggestions based on their goals}
+
+## Glossary
+{Define any project-specific terms}
+```
+
+### Step 4: Save the Report
+
+Save to `/reports/codebase-overview-{project-name}-{timestamp}.md`
+
+## Teaching Principles
+
+- **Start with the big picture** before diving into details
+- **Use analogies** to everyday concepts when helpful
+- **Avoid jargon** or explain technical terms when you use them
+- **Be specific** - use actual file names and paths from the project
+- **Suggest next steps** - what should they look at after reading this?
+
+## Important
+
+Keep explanations accessible. Remember the user may not have a programming background. Use plain language and explain concepts as you go.

--- a/.claude/skills/convening-experts/README.md
+++ b/.claude/skills/convening-experts/README.md
@@ -1,0 +1,3 @@
+# convening-experts
+
+Convenes expert panels for problem-solving. Use when user mentions panel, experts, multiple perspectives, MECE, DMAIC, RAPID, Six Sigma, root cause analysis, strategic decisions, or process improvement.

--- a/.claude/skills/convening-experts/SKILL.md
+++ b/.claude/skills/convening-experts/SKILL.md
@@ -1,0 +1,290 @@
+---
+name: convening-experts
+description: Convenes expert panels for problem-solving. Use when user mentions panel, experts, multiple perspectives, MECE, DMAIC, RAPID, Six Sigma, root cause analysis, strategic decisions, or process improvement.
+metadata:
+  version: 1.0.3
+---
+
+# Convening Experts
+
+Convene domain experts and methodological specialists to solve problems through multi-round collaborative discussion. Experts build on each other's insights, challenge assumptions, and synthesize recommendations.
+
+## Panel Format
+
+### Single-Round Consultation
+For simpler problems requiring multiple viewpoints:
+
+1. **Assemble panel** (3-5 experts based on problem domain)
+2. **Each expert provides independent perspective** (parallel, not sequential)
+3. **Synthesize recommendations** with attribution
+
+### Multi-Round Discussion
+For complex problems requiring collaborative reasoning:
+
+1. **Round 1**: Each expert analyzes problem independently
+2. **Round 2**: Experts respond to each other's insights, building on or challenging points
+3. **Round 3** (if needed): Converge on synthesis, resolve disagreements
+4. **Final synthesis**: Integrated recommendations with decision framework
+
+## Expert Roles
+
+**Available expertise spans:**
+- MSD domain experts (life sciences, engineering, manufacturing, quality, corporate functions)
+- Consulting framework specialists (strategic, process improvement, innovation, systems analysis, root cause)
+
+See [references/msd-domain-experts.md](references/msd-domain-experts.md) and [references/consulting-frameworks.md](references/consulting-frameworks.md) for complete role catalog.
+
+Claude loads relevant references based on problem domain.
+
+## Panel Convening Logic
+
+Claude selects 3-5 experts based on problem characteristics:
+
+**Problem type → Primary expert + Supporting experts**
+
+- **Technical troubleshooting** → Domain expert + Systems Thinker + Five Whys Facilitator
+- **Strategic decision** → McKinsey Consultant + relevant domain experts + SWOT Analyst
+- **Process improvement** → Six Sigma Black Belt + Lean Practitioner + domain Manufacturing Engineer
+- **Product innovation** → Design Thinking Facilitator + Jobs-to-Be-Done Specialist + relevant engineers
+- **Root cause analysis** → Domain expert + Five Whys Facilitator + Systems Thinker
+- **Market positioning** → Porter Framework Expert + Marketing Specialist + BCG Consultant
+- **Cross-functional problem** → Relevant domain experts + Bain Consultant (RAPID) + Systems Thinker
+
+## Response Format
+
+### Single-Round Format
+
+```
+## Expert Panel: [Topic]
+
+**Panel Members:**
+- [Expert 1 Role]
+- [Expert 2 Role]
+- [Expert 3 Role]
+
+---
+
+### [Expert 1 Role]
+[Independent analysis and recommendations]
+
+### [Expert 2 Role]
+[Independent analysis and recommendations]
+
+### [Expert 3 Role]
+[Independent analysis and recommendations]
+
+---
+
+## Synthesis
+[Integrated recommendations with decision framework]
+```
+
+### Multi-Round Format
+
+```
+## Expert Panel: [Topic]
+
+**Panel Members:**
+- [Expert 1 Role]
+- [Expert 2 Role]
+- [Expert 3 Role]
+
+---
+
+## Round 1: Initial Analysis
+
+### [Expert 1 Role]
+[Initial perspective]
+
+### [Expert 2 Role]
+[Initial perspective]
+
+### [Expert 3 Role]
+[Initial perspective]
+
+---
+
+## Round 2: Cross-Examination
+
+### [Expert 1 Role] responds to [Expert 2 Role]
+[Builds on or challenges specific points]
+
+### [Expert 2 Role] responds to [Expert 3 Role]
+[Integration or disagreement]
+
+### [Expert 3 Role] responds to [Expert 1 Role]
+[Synthesis attempt]
+
+---
+
+## Round 3: Convergence (if needed)
+
+[Experts resolve disagreements and converge]
+
+---
+
+## Final Synthesis
+[Integrated recommendations, highlighting consensus and productive disagreements]
+```
+
+## Expert Behavior Guidelines
+
+**Domain Experts:**
+- Apply MSD context (ECL platform, regulatory constraints, validated systems)
+- Use domain-appropriate terminology without over-explanation
+- Prioritize practical implementation over theoretical perfection
+- Flag domain-specific risks and constraints
+
+**Framework Experts:**
+- Apply frameworks systematically (show the structure)
+- Adapt frameworks to problem context (not rigid application)
+- Explain "why this framework" for this problem
+- Integrate domain context when applying generic frameworks
+
+**Cross-Panel Interaction:**
+- Reference other experts' points specifically ("Building on [Expert]'s observation about...")
+- Challenge constructively ("I see it differently because...")
+- Synthesize across disciplines ("This connects [Expert 1]'s technical constraint with [Expert 2]'s business priority...")
+- Flag tensions between perspectives explicitly
+
+**Disagreement Handling:**
+- Make disagreements productive (what assumptions differ?)
+- Present multiple valid approaches when consensus isn't required
+- Identify decision criteria to resolve disagreements
+- Escalate to user if expert consensus can't be reached
+
+## Decision Frameworks
+
+When panel must recommend action:
+
+**RAPID (Bain)**
+- **Recommend**: Panel's recommendation with rationale
+- **Agree**: Which stakeholders must agree
+- **Perform**: Who implements
+- **Input**: Who provides input
+- **Decide**: Who makes final decision
+
+**Weighted Decision Matrix**
+- Criteria (importance weighted)
+- Options scored on each criterion
+- Total score with sensitivity analysis
+
+**Risk-Benefit Analysis**
+- Upside potential (probability × impact)
+- Downside risk (probability × impact)
+- Mitigation strategies
+- Decision under uncertainty
+
+## MSD Integration
+
+Apply MSD-specific context automatically:
+
+**Technical constraints:**
+- ECL platform and assay chemistry
+- ISO 13485 compliance and validated systems
+- Regulatory requirements (FDA, CE marking)
+- Technology stack (Python, AWS, Java, TypeScript)
+
+**Business context:**
+- Life sciences market dynamics
+- Customer segments (pharma, biotech, CRO, academic)
+- Competitive landscape
+
+**Cultural factors:**
+- Scientific rigor and data-driven decisions
+- Cross-functional collaboration norms
+- Innovation balanced with risk management
+- Quality and regulatory consciousness
+
+## Examples
+
+### Example 1: Technical Troubleshooting
+
+```
+User: Our new assay is showing high background signal in serum samples
+
+Claude convenes:
+- Assay Scientist (primary)
+- Systems Thinker (feedback loops)
+- Five Whys Facilitator (root cause)
+
+Format: Multi-round (technical nuance requires collaboration)
+```
+
+### Example 2: Strategic Decision
+
+```
+User: Should we build internal ML infrastructure or use vendor solutions?
+
+Claude convenes:
+- Software Engineer (implementation)
+- McKinsey Consultant (strategic framing)
+- Finance Analyst (cost analysis)
+- DevOps Engineer (operational implications)
+
+Format: Single-round → RAPID framework synthesis
+```
+
+### Example 3: Process Improvement
+
+```
+User: Manufacturing yield dropped 8% after equipment upgrade
+
+Claude convenes:
+- Manufacturing Engineer (primary domain)
+- Six Sigma Black Belt (DMAIC)
+- Systems Thinker (unintended consequences)
+
+Format: Multi-round (root cause needs collaborative analysis)
+```
+
+## Constraints
+
+**Never:**
+- Use fictional names for experts (use role titles only: "Software Engineer", not "Dr. John Smith, Software Engineer")
+- Invent MSD-specific details beyond general domain knowledge
+- Apply frameworks rigidly without problem context
+- Create artificial consensus when legitimate disagreements exist
+- Include experts who add no value (quality over quantity)
+- Make experts repeat information (each should contribute uniquely)
+
+**Always:**
+- Select experts genuinely relevant to problem
+- Show framework structure when applying consulting methods
+- Make cross-expert references specific and substantive
+- Provide decision-ready synthesis (not "here are perspectives, you decide")
+- Acknowledge uncertainty explicitly when present
+
+## Activation Decision Tree
+
+```
+Is problem complex with multiple valid approaches?
+├─ Yes → Expert panel
+│   ├─ Spans multiple domains? → Multi-round discussion
+│   └─ Needs diverse perspectives? → Single-round consultation
+└─ No → Direct answer (don't force panel format)
+
+Requires systematic framework?
+├─ Yes → Include framework expert
+└─ No → Domain experts only
+
+MSD-specific context relevant?
+├─ Yes → Include domain experts, apply MSD constraints
+└─ No → Generic consulting approach
+```
+
+## Quality Indicators
+
+**Good panel:**
+- Each expert contributes unique insight
+- Cross-references are specific and substantive
+- Framework application shows structure and reasoning
+- Synthesis provides decision-ready recommendations
+- Disagreements are productive and resolved (or flagged)
+
+**Poor panel:**
+- Experts repeat same points
+- Generic advice not grounded in frameworks or domain
+- No synthesis or integration across perspectives
+- Consensus forced despite legitimate disagreements
+- Panel format used when direct answer would suffice

--- a/.claude/skills/convening-experts/_MAP.md
+++ b/.claude/skills/convening-experts/_MAP.md
@@ -1,0 +1,27 @@
+# convening-experts/
+*Files: 2 | Subdirectories: 2*
+
+## Subdirectories
+
+- [examples/](./examples/_MAP.md)
+- [references/](./references/_MAP.md)
+
+## Files
+
+### README.md
+- convening-experts `h1` :1
+
+### SKILL.md
+- Convening Experts `h1` :8
+- Panel Format `h2` :12
+- Expert Roles `h2` :29
+- Panel Convening Logic `h2` :39
+- Response Format `h2` :53
+- Expert Behavior Guidelines `h2` :130
+- Decision Frameworks `h2` :156
+- MSD Integration `h2` :178
+- Examples `h2` :199
+- Constraints `h2` :241
+- Activation Decision Tree `h2` :258
+- Quality Indicators `h2` :276
+

--- a/.claude/skills/convening-experts/examples/_MAP.md
+++ b/.claude/skills/convening-experts/examples/_MAP.md
@@ -1,0 +1,23 @@
+# examples/
+*Files: 3*
+
+## Files
+
+### process-improvement-example.md
+- Example: Manufacturing Yield Drop (Single-Round with DMAIC) `h1` :1
+- Expert Panel: Coating Process Analysis `h2` :5
+- Synthesis (DMAIC Phase: Improve & Control) `h2` :153
+
+### strategic-decision-example.md
+- Example: Build vs Buy Decision (Single-Round) `h1` :1
+- Expert Panel: ML Infrastructure Strategy `h2` :5
+- Synthesis (RAPID Framework) `h2` :111
+
+### technical-troubleshooting-example.md
+- Example: ECL Background Signal Issue (Multi-Round) `h1` :1
+- Expert Panel: ECL Assay Troubleshooting `h2` :5
+- Round 1: Initial Analysis `h2` :14
+- Round 2: Cross-Examination `h2` :108
+- Round 3: Convergence `h2` :179
+- Final Synthesis `h2` :230
+

--- a/.claude/skills/convening-experts/examples/process-improvement-example.md
+++ b/.claude/skills/convening-experts/examples/process-improvement-example.md
@@ -1,0 +1,211 @@
+# Example: Manufacturing Yield Drop (Single-Round with DMAIC)
+
+**User Query:** "Our plate coating yield dropped from 96% to 88% after we upgraded to the new coating robot. Same reagents, same protocols."
+
+## Expert Panel: Coating Process Analysis
+
+**Panel Members:**
+- Jennifer Kim, Manufacturing Engineer
+- Marcus Williams, Six Sigma Black Belt
+- Dr. Lisa Wang, Systems Thinker
+
+---
+
+### Jennifer Kim, Manufacturing Engineer
+
+**Process Context:**
+
+The coating robot upgrade changed three things simultaneously:
+1. **Dispense mechanism**: Peristaltic pump → precision syringe pump
+2. **Plate handling**: Manual loading → automated stacker
+3. **Environmental control**: Open bench → enclosed chamber (better humidity control)
+
+**Failure Mode Analysis:**
+
+Looking at the 8% yield loss (96% → 88%), that's **~8 plates per 100**. Current reject criteria:
+- CV% > 15% across wells (indicates coating uniformity issue)
+- Binding capacity < 80% of spec (insufficient coating density)
+
+**Data from last month** (100 plate run):
+- 5 plates failed CV% spec (wells at plate edges)
+- 3 plates failed binding capacity spec (consistent pattern: rows G-H)
+
+**Root Cause Hypotheses:**
+1. **Dispense precision**: Syringe pump may have air bubbles → inconsistent volumes (explains CV% failures)
+2. **Plate handling**: Automated stacker impacts → coating solution redistributes before incubation (explains edge effects)
+3. **Drying kinetics**: Enclosed chamber changes evaporation rate → coating dries unevenly (explains row patterns)
+
+**Engineering Assessment:** The irony is we upgraded for better precision but introduced new failure modes. Need to isolate which of the three changes is the culprit.
+
+---
+
+### Marcus Williams, Six Sigma Black Belt
+
+**DMAIC Framework Application:**
+
+**Define Phase (already done):**
+- Problem: Yield dropped from 96% to 88% post-equipment upgrade
+- CTQ (Critical to Quality): Coating CV% and binding capacity
+- Goal: Return to ≥95% yield within 4 weeks
+
+**Measure Phase - Current State:**
+
+Let's establish measurement system capability first:
+
+**Gage R&R Assessment Needed:**
+- Are CV% measurements reproducible across operators/instruments?
+- Is binding capacity assay sensitive enough to detect process variation?
+
+**Baseline Data Collection** (need 30+ plates):
+- Map failures by position on robot stacker (top/middle/bottom)
+- Map failures by position in incubator
+- Track environmental variables (temp, humidity, time-of-day)
+
+**Key Metric:** Defects Per Million Opportunities (DPMO)
+- Current: 88% yield = 120,000 DPMO (3.0 sigma level)
+- Target: 95% yield = 50,000 DPMO (3.3 sigma level)
+
+**Analyze Phase - Root Cause:**
+
+Jennifer identified three hypotheses. Let's **quantify each**:
+
+**Fishbone Diagram Categories:**
+```
+Defects (8% yield loss)
+├─ Man: Operator training on new equipment?
+├─ Machine: 
+│  ├─ Syringe pump air bubbles (Jennifer's hypothesis 1)
+│  ├─ Stacker impact forces (hypothesis 2)
+│  └─ Chamber airflow patterns (hypothesis 3)
+├─ Method: Protocol adapted for new equipment?
+├─ Material: Coating reagent lot change?
+├─ Measurement: CV% calculation method consistent?
+└─ Environment: Chamber humidity/temp stability?
+```
+
+**Statistical Analysis Plan:**
+1. **Multi-vari study**: Separate within-plate variation (wells) from plate-to-plate variation (equipment)
+2. **Hypothesis testing**: Run plates with old method (manual) in parallel for 1 week (5 plates/day × 5 days = 25 plates per method)
+   - Statistical power: Can detect 5% yield difference with 80% confidence
+3. **DOE (Design of Experiments)**: If parallel testing is inconclusive, run 2³ factorial:
+   - Factor A: Pump type (syringe vs peristaltic)
+   - Factor B: Loading (manual vs stacker)
+   - Factor C: Chamber (open vs enclosed)
+
+---
+
+### Dr. Lisa Wang, Systems Thinker
+
+**System-Level Patterns:**
+
+This is a **"Shifting the Burden" archetype**—we upgraded equipment to solve one problem (precision) but created new problems (complexity).
+
+**Interconnections Map:**
+```
+Precision Syringe Pump
+├─ (+) More accurate dispensing
+├─ (-) More sensitive to air bubbles
+├─ (-) Requires different priming procedure
+└─ (-) Operator learning curve
+
+Automated Stacker
+├─ (+) Higher throughput
+├─ (-) Mechanical impact on liquid
+├─ (-) Less flexibility in plate positioning
+└─ (-) New failure mode (stacker jams)
+
+Enclosed Chamber
+├─ (+) Better humidity control
+├─ (-) Restricted airflow observation
+├─ (-) Harder to troubleshoot in real-time
+└─ (-) Creates microenvironment gradients
+```
+
+**Emergent Behavior:** The three changes interact non-linearly:
+- Syringe pump precision helps IF air bubbles are purged (operator-dependent)
+- Stacker benefits require gentle plate handling (machine calibration-dependent)
+- Chamber control helps IF airflow is uniform (chamber design-dependent)
+
+**Feedback Loop Identification:**
+
+**Reinforcing (Bad):**
+```
+Equipment complexity → Operator uncertainty → Procedural variations → 
+Inconsistent results → More troubleshooting → Less production time → 
+Pressure to run faster → Skip steps → More failures
+```
+
+**Balancing (Good):**
+```
+Yield drops → Engineering investigation → Process optimization → 
+Better procedures → Yield improves → Production stabilizes
+```
+
+**Leverage Points:**
+1. **Highest**: Operator training on new equipment (affects all three changes)
+2. **Medium**: Syringe pump priming SOP (Jennifer's hypothesis 1)
+3. **Lower**: Chamber airflow modification (expensive, time-consuming)
+
+**Systems Recommendation:** Focus on **operators as the integration point**. New equipment requires new muscle memory. Don't assume protocol transfer is straightforward.
+
+---
+
+## Synthesis (DMAIC Phase: Improve & Control)
+
+**Integrated Root Cause Assessment:**
+
+All three experts converge on **operator adaptation** as the highest-leverage intervention:
+- Jennifer: "New equipment introduced new failure modes"
+- Marcus: "Man" category in Fishbone + need for training validation
+- Lisa: "Operator uncertainty" in reinforcing loop
+
+**Immediate Actions (Week 1-2):**
+
+1. **Validate Measurement System** (Marcus):
+   - Run Gage R&R on CV% and binding capacity assays
+   - Ensure defects are real, not measurement artifacts
+
+2. **Operator Competency Assessment** (Jennifer + Lisa):
+   - Observe 3 operators running coating protocol
+   - Document differences in technique (pump priming, plate loading, timing)
+   - Identify "best practices" from operator with highest yield
+
+3. **Parallel Testing** (Marcus):
+   - Run 25 plates with new equipment (strict SOP adherence)
+   - Compare to historical baseline (96% yield on old equipment)
+   - Confirm yield gap is reproducible
+
+**Optimization Actions (Week 3-4):**
+
+4. **Standardize Technique** (Jennifer):
+   - Create detailed work instructions with photos/videos
+   - Focus on:
+     - Syringe pump priming procedure (bubble elimination)
+     - Plate placement in stacker (minimize impact)
+     - Chamber loading sequence (environmental equilibration)
+   - Train all operators to best-practice standard
+
+5. **Equipment Calibration** (Marcus + Jennifer):
+   - If operator training doesn't close gap, run DOE to isolate equipment variables
+   - Adjust pump priming cycles, stacker speed, chamber airflow systematically
+
+**Control Phase (Ongoing):**
+
+6. **Statistical Process Control** (Marcus):
+   - Track yield weekly with control charts (UCL/LCL at ±2 sigma)
+   - Implement reaction plan for out-of-control signals
+   - Quarterly capability studies (Cpk monitoring)
+
+7. **System Resilience** (Lisa):
+   - Monitor for "work-arounds" (operators reverting to old habits)
+   - Build in redundancy: cross-train operators on troubleshooting
+   - Create feedback loop: operators report issues weekly, engineering responds monthly
+
+**Success Criteria:**
+- Week 4: Yield ≥93% (5% improvement)
+- Week 8: Yield ≥95% (return to baseline)
+- Week 12: Cpk ≥1.33 (process capability sustained)
+
+**Risk Mitigation:**
+- If yield doesn't improve after operator training (Week 2), escalate to equipment vendor for factory calibration
+- If DOE shows fundamental equipment limitation, document findings for future capital equipment decisions

--- a/.claude/skills/convening-experts/examples/strategic-decision-example.md
+++ b/.claude/skills/convening-experts/examples/strategic-decision-example.md
@@ -1,0 +1,139 @@
+# Example: Build vs Buy Decision (Single-Round)
+
+**User Query:** "Should we build internal ML infrastructure or use vendor solutions?"
+
+## Expert Panel: ML Infrastructure Strategy
+
+**Panel Members:**
+- Dr. Sarah Chen, Software Architect
+- James Morrison, McKinsey Consultant
+- David Kumar, Finance Analyst
+- Alexandra Torres, DevOps Engineer
+
+---
+
+### Dr. Sarah Chen, Software Architect
+
+The technical decision hinges on three factors: customization needs, team capability, and long-term flexibility.
+
+**Build Considerations:**
+- Full control over model architecture and feature engineering
+- Can optimize for MSD's specific assay data characteristics
+- Integration with existing Python data pipelines (pandas, scikit-learn already in use)
+- Team has Python/AWS expertise but limited ML ops experience
+
+**Buy Considerations:**
+- AWS SageMaker provides managed infrastructure we already use
+- Reduces time-to-production by 6-9 months
+- Built-in monitoring, versioning, A/B testing capabilities
+- Risk: vendor lock-in, less control over model explainability (critical for FDA submissions)
+
+**Hybrid Recommendation:** Start with SageMaker for rapid prototyping, build custom components only where regulatory explainability demands it.
+
+---
+
+### James Morrison, McKinsey Consultant
+
+Let's structure this with a classic make-vs-buy framework, examining strategic fit and capability gaps.
+
+**Issue Tree:**
+```
+ML Infrastructure Decision
+├─ Strategic Importance
+│  ├─ Core competency? (ECL assays = yes, ML infrastructure = no)
+│  ├─ Competitive advantage source? (Unlikely—models matter, infra doesn't)
+│  └─ Regulatory moat? (Possibly—explainability requirements)
+├─ Capability Assessment
+│  ├─ Current: Strong software eng, weak ML ops
+│  ├─ Gap: Model deployment, monitoring, drift detection
+│  └─ Build time: 12-18 months to production-grade
+└─ Economics
+   ├─ Build: High capex, low opex
+   └─ Buy: Low capex, high opex (scales with usage)
+```
+
+**MECE Analysis:** The only defensible "build" argument is regulatory explainability requirements. Everything else favors vendor solutions.
+
+**Recommendation:** Buy for infrastructure, build for domain-specific model components. This is a classic "partner on non-core capabilities" scenario.
+
+---
+
+### David Kumar, Finance Analyst
+
+**5-Year TCO Comparison:**
+
+**Build Option:**
+- Year 1: $800K (3 ML engineers, AWS infrastructure)
+- Years 2-5: $450K/year (maintenance, scaling)
+- Total: $2.6M
+- Risk: High upfront investment, 12-18 month delay to revenue
+
+**Buy Option (SageMaker):**
+- Year 1: $120K (training, inference, storage)
+- Years 2-5: $180K/year (scales with model usage)
+- Total: $840K
+- Risk: Vendor dependency, potential price increases
+
+**Break-Even Analysis:** Build becomes cost-competitive only if we deploy 50+ production models. Current roadmap shows 8-12 models over 3 years.
+
+**IRR Impact:** Delayed launch (build scenario) costs $1.2M in opportunity cost (6-month market delay × $200K monthly revenue).
+
+**Recommendation:** Buy for Phase 1 (3 years), revisit if model portfolio exceeds 30 models.
+
+---
+
+### Alexandra Torres, DevOps Engineer
+
+**Operational Reality Check:**
+
+**Current Infrastructure:**
+- AWS ECS for containers, Jenkins for CI/CD
+- No existing ML ops tooling (no MLflow, no model registry)
+- On-call team of 4, already at capacity for production incidents
+
+**Build Operational Cost:**
+- New on-call rotation for ML infrastructure (+1.5 FTE)
+- Model monitoring and drift detection systems (custom build = 6 months)
+- Integration with existing observability stack (DataDog)
+- Training required: team has limited Kubernetes/Kubeflow experience
+
+**Buy Operational Benefits:**
+- SageMaker integrates with existing AWS IAM, CloudWatch, ECS
+- Managed endpoints eliminate infra on-call burden
+- Built-in model registry, versioning, rollback
+
+**The DevOps Concern:** Building means we own incident response for ML infra during regulatory audits. That's high-stakes operational risk with limited team depth.
+
+**Recommendation:** Strong bias toward vendor solution to avoid operational overstretch.
+
+---
+
+## Synthesis (RAPID Framework)
+
+**Recommend:** Start with AWS SageMaker for ML infrastructure, build custom explainability layer for regulatory compliance.
+
+**Rationale:**
+1. **Strategic:** ML infrastructure is not core competency (Chen, Morrison)
+2. **Financial:** 3x cost advantage, faster time-to-revenue (Kumar)
+3. **Operational:** Reduces operational burden on constrained team (Torres)
+4. **Risk Mitigation:** Hybrid approach preserves regulatory control (Chen)
+
+**Agree:** Engineering leadership, Finance, Quality/Regulatory
+
+**Perform:**
+- Platform team: SageMaker setup and integration
+- ML team: Model development and explainability layer
+- DevOps: Monitoring and deployment automation
+
+**Input:**
+- Regulatory: Explainability requirements review
+- Customer Success: Model performance SLAs
+- Security: Vendor risk assessment
+
+**Decide:** VP Engineering (with CFO sign-off for budget)
+
+**Implementation Roadmap:**
+1. Month 1-2: SageMaker pilot with one non-critical model
+2. Month 3-4: Build custom explainability wrapper for regulatory-critical models
+3. Month 5-6: Production deployment with monitoring
+4. Quarter 2: Evaluate model portfolio growth for build vs continue-buy decision

--- a/.claude/skills/convening-experts/examples/technical-troubleshooting-example.md
+++ b/.claude/skills/convening-experts/examples/technical-troubleshooting-example.md
@@ -1,0 +1,246 @@
+# Example: ECL Background Signal Issue (Multi-Round)
+
+**User Query:** "Our new cytokine multiplex assay is showing 3-4x higher background in serum samples compared to buffer. Same plates work fine with buffer controls."
+
+## Expert Panel: ECL Assay Troubleshooting
+
+**Panel Members:**
+- Dr. Michael Rodriguez, Assay Scientist
+- Dr. Lisa Wang, Systems Thinker
+- Tom Anderson, Five Whys Facilitator
+
+---
+
+## Round 1: Initial Analysis
+
+### Dr. Michael Rodriguez, Assay Scientist
+
+**Immediate Biochemical Suspects:**
+
+Serum introduces matrix complexity that buffer doesn't have. Three primary hypotheses:
+
+1. **Non-specific antibody binding**: Serum proteins (albumin, IgG) binding to capture or detection antibodies
+   - Evidence needed: Does blocking buffer optimization help?
+   - Test: Try different blocking agents (BSA vs casein vs fish gelatin)
+
+2. **ECL signal interference**: Serum components quenching or amplifying background ECL
+   - Evidence needed: Dose-response with serum dilution
+   - Expected: Linear reduction in background with dilution suggests matrix interference
+
+3. **Antibody cross-reactivity**: Detection antibody reacting with abundant serum proteins
+   - Evidence needed: Run each cytokine individually vs multiplex
+   - Expected: If one cytokine drives background, it's cross-reactivity
+
+**Critical Missing Data:**
+- Serum dilution curve (1:2, 1:4, 1:10)?
+- Blocking buffer composition?
+- Background pattern across plate (uniform vs edge effects)?
+
+---
+
+### Dr. Lisa Wang, Systems Thinker
+
+**System-Level Pattern Recognition:**
+
+This reads like a classic **reinforcing feedback loop** in assay development:
+
+```
+High background → Lower signal-to-noise → Push detection sensitivity up 
+→ Amplifies background further → Higher background
+```
+
+**Interconnections to Map:**
+1. **Sample prep → Blocking → Detection**: Are we optimizing these in isolation or as a system?
+2. **Plate coating → Capture antibody density → Non-specific binding sites**: High capture density increases specific signal but also increases non-specific binding sites
+3. **Detection antibody concentration → Signal vs Background ratio**: There's usually an optimal concentration window
+
+**Emergence Observation:** Multiplex assays show non-linear behavior. Background in multiplex ≠ sum of single-plex backgrounds because antibodies can interact.
+
+**Leverage Points:**
+- **Highest leverage**: Sample dilution (reduces matrix effect exponentially)
+- **Medium leverage**: Blocking optimization (linear improvement)
+- **Lowest leverage**: Detection antibody concentration (narrow window)
+
+**System Hypothesis:** You're likely in a "Limits to Growth" archetype—pushing sensitivity hits fundamental matrix limitations. The system wants you to either:
+1. Dilute samples more (accept lower sensitivity)
+2. Reduce matrix interference (pre-treatment)
+
+---
+
+### Tom Anderson, Five Whys Facilitator
+
+**Root Cause Investigation:**
+
+**Problem Statement:** ECL background is 3-4x higher in serum than buffer.
+
+**Why #1:** Why is background higher in serum?
+→ Serum contains proteins/lipids that buffer doesn't have.
+
+**Why #2:** Why do these serum components cause background signal?
+→ They either bind non-specifically to the plate/antibodies OR interfere with ECL chemistry.
+
+**Why #3:** Why isn't blocking preventing this non-specific binding?
+→ Either blocking is insufficient OR the mechanism isn't binding-based.
+
+**Why #4:** If blocking is insufficient, why?
+→ Two possibilities:
+   a) Blocking agent doesn't cover the right epitopes (wrong blocker)
+   b) Blocking step is fine, but serum components displace blocker during incubation
+
+**Why #5:** What allows serum components to displace blocker?
+→ Incubation conditions (time, temperature, agitation) may favor displacement if serum proteins have higher affinity than blocker.
+
+**Diagnostic Tests:**
+1. Extend blocking time: 2hr → 4hr (tests if coverage is incomplete)
+2. Add blocking agent to sample diluent (prevents displacement)
+3. Reduce sample incubation time (less time for displacement)
+
+**Causal Chain:**
+```
+Serum proteins → Compete with blocker → Bind to plate/antibodies → 
+Non-specific detection antibody binding → ECL background
+```
+
+**Countermeasure Hypothesis:** Add blocking agent (BSA/casein) to serum diluent to maintain blocking equilibrium during sample incubation.
+
+---
+
+## Round 2: Cross-Examination
+
+### Dr. Rodriguez responds to Dr. Wang:
+
+Lisa's **reinforcing feedback loop** insight is critical—I've been focused on individual variables, not the system dynamics. 
+
+Building on her point: If we're in a "Limits to Growth" archetype, we need to **identify the limiting factor**:
+- Is it the assay's fundamental sensitivity limit?
+- Or is it matrix interference we can engineer around?
+
+**Connecting to my hypothesis**: Her leverage point analysis suggests I should prioritize:
+1. **Highest impact**: Increase sample dilution (1:2 → 1:4 or 1:10)
+2. **Second priority**: Optimize blocking
+3. **Avoid**: Increasing detection antibody concentration (low leverage, could worsen feedback loop)
+
+**Challenge to Tom's causal chain**: His "displacement" hypothesis is testable and elegant. If true, adding BSA to sample diluent is a simple fix. But **alternative hypothesis**: What if the issue is ECL substrate interaction with serum lipids, not antibody binding? That wouldn't show displacement dynamics.
+
+**Proposed test to differentiate**:
+- Run assay with streptavidin-HRP (no antibodies) on blocked plates with serum → If background persists, it's ECL chemistry interference, not antibody binding.
+
+---
+
+### Dr. Wang responds to Tom:
+
+Tom's **Five Whys** landed on "blocker displacement," which is mechanistically sound, but I want to **question the boundary conditions**:
+
+The "Limits to Growth" archetype suggests there's a **balancing feedback** that will kick in:
+```
+Increase sample dilution → Lower matrix interference → Better S/N → 
+BUT: Lower analyte concentration → Weaker signal → Worse S/N
+```
+
+So there's a **sweet spot**. Tom's countermeasure (add blocker to diluent) might shift that sweet spot, but won't eliminate the fundamental tension.
+
+**Integration with Michael's work**: His streptavidin-HRP control test will tell us if we're dealing with:
+- **Binding problem** (Tom's displacement) → Blocker in diluent fixes it
+- **Chemistry problem** (ECL interference) → Need different approach (substrate change, lipid removal pre-treatment)
+
+**System-level recommendation**: Don't optimize variables sequentially. Run a **factorial experiment**:
+- Sample dilution: 1:2, 1:4, 1:10
+- Blocker in diluent: Yes/No
+- Measure both signal and background
+
+This maps the system behavior space rather than chasing one causal chain.
+
+---
+
+### Tom responds to Dr. Rodriguez:
+
+Michael's **streptavidin-HRP control** is brilliant—it's a classic root cause isolation technique. Cut out antibody variables entirely.
+
+But I want to **push back on the experimental complexity**. Lisa's factorial experiment is thorough but requires 6+ plates. For troubleshooting, I prefer:
+
+**Sequential elimination with minimal experiments**:
+1. **Test 1**: Add BSA to sample diluent (tests my displacement hypothesis)
+   - If background drops → Root cause confirmed, move to optimization
+   - If no change → Move to test 2
+2. **Test 2**: Streptavidin-HRP control (tests Michael's ECL interference hypothesis)
+   - If background drops → Antibody-related, revisit blocking strategy
+   - If background persists → ECL chemistry issue
+
+**Why sequential vs factorial?** Each experiment gives **diagnostic information** that narrows the hypothesis space. If Test 1 solves it, we save 5 plates and 2 days.
+
+**However**, I agree with Lisa's point about the "sweet spot." Once we identify root cause, we **should** run the factorial to optimize rather than tune variables one at a time.
+
+**Synthesis proposal**:
+- Phase 1 (Diagnosis): Sequential tests (my approach)
+- Phase 2 (Optimization): Factorial design (Lisa's approach)
+
+---
+
+## Round 3: Convergence
+
+### Dr. Rodriguez (Assay Scientist):
+
+**Consensus emerging**: We've triangulated on a **diagnostic workflow** that combines our perspectives:
+
+1. **Immediate test** (Tom's sequential approach): Add BSA to serum diluent at same concentration as blocking buffer
+   - **Hypothesis**: Blocker displacement
+   - **Decision point**: If background reduces by 50%+, proceed to optimization
+   - **If not**: Run streptavidin-HRP control (my test) to rule out ECL interference
+
+2. **Optimization phase** (Lisa's system approach): Factorial design on sample dilution × blocker concentration once mechanism is confirmed
+
+**Addressing Lisa's feedback loop concern**: You're right that we can't eliminate the signal-vs-matrix tradeoff. But **reframing the goal**: We want S/N > 10 for lowest analyte concentration. That means:
+- 1:4 dilution with optimized blocking is likely optimal
+- Accept that we can't run serum at 1:2 dilution for this multiplex
+
+---
+
+### Dr. Wang (Systems Thinker):
+
+**Agreement with convergence**, but adding a **systems safeguard**:
+
+Tom and Michael's workflow is sound, but we need to **monitor for unintended consequences**:
+- Increasing blocker in diluent might increase viscosity → worse mixing → inconsistent results
+- Higher dilution reduces matrix effects but also reduces dynamic range → check if that impacts customer use cases
+
+**Recommendation**: Pilot with 3 customer serum samples (low, medium, high analyte) before committing to protocol change. This validates the system behavior across the input space.
+
+---
+
+### Tom (Five Whys Facilitator):
+
+**Full agreement**. Final workflow:
+
+**Phase 1: Root Cause Confirmation** (1-2 days)
+- Test blocker-in-diluent modification
+- If inconclusive, run streptavidin control
+
+**Phase 2: Optimization** (3-5 days)
+- Factorial experiment: dilution × blocker concentration
+- Measure signal, background, CV% across 3 customer serum pools
+
+**Phase 3: Validation** (1 week)
+- Run optimized protocol with customer samples
+- Monitor for Lisa's unintended consequences (viscosity, dynamic range)
+
+**Risk mitigation**: If we can't get S/N > 10 at practical dilutions, escalate to **R&D for assay redesign** (different antibody pairs, alternative blocking strategies, or pre-treatment methods).
+
+---
+
+## Final Synthesis
+
+**Root Cause Hypothesis:** Serum proteins displace blocking agent during sample incubation, leading to non-specific antibody binding and elevated ECL background (primary), with possible secondary contribution from ECL substrate interaction with serum lipids.
+
+**Three-Phase Resolution:**
+
+**Immediate (Phase 1):** Test blocker-in-diluent modification to confirm displacement mechanism. If inconclusive, isolate antibody vs ECL chemistry contribution via streptavidin-HRP control.
+
+**Optimization (Phase 2):** Run factorial experiment on sample dilution (1:2, 1:4, 1:10) and blocker concentration to map system behavior and identify optimal S/N conditions.
+
+**Validation (Phase 3):** Pilot optimized protocol with diverse customer serum samples, monitoring for unintended consequences (viscosity effects, dynamic range limitations).
+
+**Decision Framework:**
+- If optimized protocol achieves S/N > 10 → Implement new SOP
+- If S/N remains < 10 → Escalate to assay redesign (different antibody pairs or sample pre-treatment)
+
+**Key Insight (Systems Perspective):** This is a "Limits to Growth" scenario where increasing sensitivity amplifies background. The solution isn't higher sensitivity—it's shifting the system constraints through sample dilution and blocking equilibrium management.

--- a/.claude/skills/convening-experts/references/_MAP.md
+++ b/.claude/skills/convening-experts/references/_MAP.md
@@ -1,0 +1,20 @@
+# references/
+*Files: 2*
+
+## Files
+
+### consulting-frameworks.md
+- Consulting Framework Experts `h1` :1
+- Strategic Frameworks `h2` :3
+- Process Improvement `h2` :11
+- Innovation & Product `h2` :19
+- Systems & Analysis `h2` :27
+- Root Cause Analysis `h2` :35
+
+### msd-domain-experts.md
+- MSD Domain Experts `h1` :1
+- Life Sciences `h2` :3
+- Engineering `h2` :9
+- Manufacturing & Quality `h2` :21
+- Corporate Functions `h2` :27
+

--- a/.claude/skills/convening-experts/references/consulting-frameworks.md
+++ b/.claude/skills/convening-experts/references/consulting-frameworks.md
@@ -1,0 +1,39 @@
+# Consulting Framework Experts
+
+## Strategic Frameworks
+
+**McKinsey Consultant**: MECE principle, issue trees, hypothesis-driven problem solving, 7S framework (strategy, structure, systems, shared values, skills, style, staff)
+
+**BCG Consultant**: Growth-Share Matrix (cash cow/star/question mark/dog), competitive advantage analysis, segment profitability
+
+**Bain Consultant**: RAPID decision framework (Recommend, Agree, Perform, Input, Decide), value chain analysis, customer advocacy
+
+## Process Improvement
+
+**Six Sigma Black Belt**: DMAIC (Define, Measure, Analyze, Improve, Control), statistical process control, root cause analysis, measurement system analysis
+
+**Lean Practitioner**: Value stream mapping, waste elimination (muda/mura/muri), pull systems, continuous flow, kaizen
+
+**Design Thinking Facilitator**: Human-centered design (Empathize, Define, Ideate, Prototype, Test), rapid prototyping, user journey mapping
+
+## Innovation & Product
+
+**Lean Startup Coach**: Build-Measure-Learn loops, validated learning, minimum viable product, pivot vs persevere decisions
+
+**Jobs-to-Be-Done Specialist**: Customer jobs, desired outcomes, job mapping, competitive alternatives, circumstances analysis
+
+**First Principles Thinker**: Fundamental truths decomposition, reasoning from axioms, questioning assumptions, analogical thinking avoidance
+
+## Systems & Analysis
+
+**Systems Thinker**: Feedback loops (reinforcing/balancing), emergence, interconnections, leverage points, unintended consequences, archetypes (limits to growth, shifting the burden)
+
+**Porter Framework Expert**: Five Forces (supplier power, buyer power, competitive rivalry, threat of substitutes, threat of new entrants), value chain, differentiation vs cost leadership
+
+**SWOT Analyst**: Strengths, Weaknesses, Opportunities, Threats analysis, strategic positioning
+
+## Root Cause Analysis
+
+**Five Whys Facilitator**: Iterative questioning to reach root cause, causal chain analysis, countermeasure development
+
+**Fishbone Analyst**: Ishikawa diagram, categorical root causes (Man, Machine, Method, Material, Measurement, Environment)

--- a/.claude/skills/convening-experts/references/msd-domain-experts.md
+++ b/.claude/skills/convening-experts/references/msd-domain-experts.md
@@ -1,0 +1,37 @@
+# MSD Domain Experts
+
+## Life Sciences
+
+**Assay Scientist**: Biochemistry, ECL mechanisms, assay development, matrix effects, calibration
+
+**Research Scientist**: Experimental design, statistical analysis, hypothesis testing, literature synthesis
+
+## Engineering
+
+**Firmware Engineer**: Embedded systems, real-time constraints, hardware interfaces, bootloaders
+
+**Electrical Engineer**: Circuit design, signal integrity, EMI/EMC, component selection
+
+**Mechanical Engineer**: Fixture design, tolerance analysis, materials, DFM principles
+
+**Software Engineer** (Python/Java/TypeScript/SQL): Code architecture, performance, testing
+
+**DevOps Engineer**: CI/CD, containerization, infrastructure-as-code, AWS services
+
+## Manufacturing & Quality
+
+**Manufacturing Engineer**: Process design, yield optimization, production troubleshooting, ISO 13485
+
+**Quality Engineer**: CAPA, validation protocols, SPC, regulatory compliance
+
+## Corporate Functions
+
+**Patent Attorney**: IP strategy, patentability, prior art, claim drafting, FTO analysis
+
+**Technical Recruiter**: Skill assessment, market calibration, candidate sourcing
+
+**Finance Analyst**: Budget modeling, ROI analysis, cost optimization
+
+**HR Specialist**: Policy interpretation, recruiting strategy, performance frameworks
+
+**Marketing Specialist**: Positioning, messaging, competitive analysis, GTM strategy

--- a/.claude/skills/design-principles/SKILL.md
+++ b/.claude/skills/design-principles/SKILL.md
@@ -1,0 +1,198 @@
+---
+name: design-principles
+description: Use when making aesthetic decisions for web interfaces - choosing design direction, color palettes, typography, spacing systems, visual hierarchy, or UI polish. Use when user asks to make something look nicer, improve UX, choose a style, or needs guidance on crafted interface design. NOT for writing implementation code (use frontend-design for that).
+---
+
+# Design Principles
+
+Precise, crafted design for enterprise software, SaaS dashboards, admin interfaces, and web applications. Jony Ive-level precision with intentional personality.
+
+## When to Use This Skill
+
+Use design-principles when you need to:
+- Choose a design direction or personality for an interface
+- Select color foundations, typography, or spacing systems
+- Make aesthetic decisions about look and feel
+- Improve visual hierarchy or polish
+- Decide between design approaches (flat vs shadows, dense vs spacious)
+
+**Use frontend-design instead** when you need to write actual HTML/CSS/React code.
+
+## Design Direction (REQUIRED)
+
+**Before writing any code, commit to a design direction.** Don't default. Think about what this specific product needs to feel like.
+
+### Think About Context
+
+- **What does this product do?** A finance tool needs different energy than a creative tool.
+- **Who uses it?** Power users want density. Occasional users want guidance.
+- **What's the emotional job?** Trust? Efficiency? Delight? Focus?
+- **What would make this memorable?** Every product has a chance to feel distinctive.
+
+### Choose a Personality
+
+| Direction | Characteristics | Best For | Examples |
+|-----------|-----------------|----------|----------|
+| **Precision & Density** | Tight spacing, monochrome, information-forward | Power users who live in the tool | Linear, Raycast |
+| **Warmth & Approachability** | Generous spacing, soft shadows, friendly colors | Products that want to feel human | Notion, Coda |
+| **Sophistication & Trust** | Cool tones, layered depth, financial gravitas | Money or sensitive data | Stripe, Mercury |
+| **Boldness & Clarity** | High contrast, dramatic negative space, confident typography | Modern, decisive feel | Vercel |
+| **Utility & Function** | Muted palette, functional density, clear hierarchy | Work matters more than chrome | GitHub |
+| **Data & Analysis** | Chart-optimized, technical but accessible | Analytics, metrics, BI | Dashboards |
+
+Pick one. Or blend two. But commit.
+
+### Choose a Color Foundation
+
+| Foundation | Feel | Use When |
+|------------|------|----------|
+| **Warm** (creams, warm grays) | Approachable, comfortable, human | Collaborative, friendly products |
+| **Cool** (slate, blue-gray) | Professional, trustworthy, serious | Enterprise, finance, B2B |
+| **Pure neutrals** (true grays, black/white) | Minimal, bold, technical | Developer tools, modern SaaS |
+| **Tinted** (slight color cast) | Distinctive, memorable, branded | Products wanting unique identity |
+
+**Light or dark?** Dark feels technical, focused, premium. Light feels open, approachable, clean.
+
+**Accent color** — Pick ONE that means something. Blue for trust. Green for growth. Orange for energy. Violet for creativity.
+
+### Choose Typography
+
+| Type | Feel | Best For |
+|------|------|----------|
+| **System fonts** | Fast, native, invisible | Utility-focused products |
+| **Geometric sans** (Geist, Inter) | Modern, clean, technical | SaaS, developer tools |
+| **Humanist sans** (SF Pro, Satoshi) | Warmer, approachable | Consumer, collaborative |
+| **Monospace influence** | Technical, data-heavy | Developer tools, analytics |
+
+---
+
+## Core Craft Principles
+
+These apply regardless of design direction. This is the quality floor.
+
+### The 4px Grid
+
+| Spacing | Use |
+|---------|-----|
+| `4px` | Micro spacing (icon gaps) |
+| `8px` | Tight spacing (within components) |
+| `12px` | Standard spacing (between related elements) |
+| `16px` | Comfortable spacing (section padding) |
+| `24px` | Generous spacing (between sections) |
+| `32px` | Major separation |
+
+### Symmetrical Padding
+
+**TLBR must match.** If top padding is 16px, left/bottom/right must also be 16px.
+
+```css
+/* Good */
+padding: 16px;
+padding: 12px 16px; /* Only when horizontal needs more room */
+
+/* Bad */
+padding: 24px 16px 12px 16px;
+```
+
+### Border Radius Consistency
+
+Stick to the 4px grid. Pick a system and commit:
+- **Sharp:** 4px, 6px, 8px
+- **Soft:** 8px, 12px
+- **Minimal:** 2px, 4px, 6px
+
+### Depth & Elevation Strategy
+
+Choose ONE approach and commit:
+
+| Approach | When to Use | CSS |
+|----------|-------------|-----|
+| **Borders-only** | Utility tools, dense interfaces | `border: 0.5px solid rgba(0,0,0,0.08)` |
+| **Subtle single shadow** | Approachable, gentle lift | `0 1px 3px rgba(0,0,0,0.08)` |
+| **Layered shadows** | Premium, substantial feel | Multiple layers (see below) |
+| **Surface color shifts** | Hierarchy without shadows | Card `#fff` on background `#f8fafc` |
+
+```css
+/* Layered shadow approach */
+--shadow-layered:
+  0 0 0 0.5px rgba(0, 0, 0, 0.05),
+  0 1px 2px rgba(0, 0, 0, 0.04),
+  0 2px 4px rgba(0, 0, 0, 0.03),
+  0 4px 8px rgba(0, 0, 0, 0.02);
+```
+
+### Typography Hierarchy
+
+- **Headlines:** 600 weight, tight letter-spacing (-0.02em)
+- **Body:** 400-500 weight, standard tracking
+- **Labels:** 500 weight, slight positive tracking for uppercase
+- **Scale:** 11px, 12px, 13px, 14px (base), 16px, 18px, 24px, 32px
+
+### Monospace for Data
+
+Numbers, IDs, codes, timestamps belong in monospace. Use `tabular-nums` for columnar alignment.
+
+### Iconography
+
+Use **Phosphor Icons** (`@phosphor-icons/react`). Icons clarify, not decorate — if removing an icon loses no meaning, remove it.
+
+### Animation
+
+- 150ms for micro-interactions, 200-250ms for larger transitions
+- Easing: `cubic-bezier(0.25, 1, 0.5, 1)`
+- No spring/bouncy effects in enterprise UI
+
+### Contrast Hierarchy
+
+Build a four-level system: foreground (primary) → secondary → muted → faint.
+
+### Color for Meaning Only
+
+Gray builds structure. Color only appears when it communicates: status, action, error, success.
+
+---
+
+## Card Design
+
+**Card layouts vary, surface treatment stays consistent.**
+
+Design each card's internal structure for its specific content — but keep consistent: same border weight, shadow depth, corner radius, padding scale, typography.
+
+**Isolated controls:** Date pickers, filters, dropdowns should feel like crafted objects. Never use native `<select>` or `<input type="date">` for styled UI — build custom components.
+
+---
+
+## Dark Mode
+
+- **Borders over shadows** — Shadows less visible on dark. Use borders at 10-15% white opacity.
+- **Adjust semantic colors** — Desaturate status colors to avoid harshness.
+- **Same structure, different values** — The four-level hierarchy still applies, inverted.
+
+---
+
+## Anti-Patterns
+
+**Never:**
+- Dramatic drop shadows (`box-shadow: 0 25px 50px...`)
+- Large border radius (16px+) on small elements
+- Asymmetric padding without clear reason
+- Pure white cards on colored backgrounds
+- Thick borders (2px+) for decoration
+- Excessive spacing (margins > 48px between sections)
+- Spring/bouncy animations
+- Gradients for decoration
+- Multiple accent colors in one interface
+
+**Always ask:**
+- "Did I think about what this product needs, or did I default?"
+- "Does this direction fit the context and users?"
+- "Is my depth strategy consistent and intentional?"
+- "Are all elements on the grid?"
+
+---
+
+## The Standard
+
+Every interface should look designed by a team that obsesses over 1-pixel differences. Not stripped — *crafted*.
+
+The goal: intricate minimalism with appropriate personality. Same quality bar, context-driven execution.

--- a/.claude/skills/explain/SKILL.md
+++ b/.claude/skills/explain/SKILL.md
@@ -1,0 +1,139 @@
+---
+name: explain
+description: Provide clear, personalised explanations of code, concepts, or architecture. Use when the user asks to explain something, wants to understand how code works, asks why something is done a certain way, or says they don't understand something.
+---
+
+# Explain
+
+You are a patient mentor who provides clear, customised explanations tailored to the learner's level.
+
+## When This Skill Applies
+
+Use this skill when the user:
+- Asks "explain this" or "how does this work?"
+- Says they don't understand something
+- Asks "why is it done this way?"
+- Wants to learn about a concept in the code
+- Asks what a piece of code does
+- Needs help understanding an error
+
+## How to Explain Effectively
+
+### Step 1: Understand What They Need
+
+Before diving in, clarify:
+- What specifically do they want explained?
+- What's their familiarity with the topic?
+- What's their goal (just understand, or make changes)?
+
+If it's not clear, ask:
+- "What aspect would you like me to focus on?"
+- "Are you familiar with [related concept]?"
+- "What's your experience with [technology]?"
+
+### Step 2: Research First
+
+Before explaining:
+- Read the relevant code
+- Look for comments and documentation
+- Understand the context (what calls this? what does it call?)
+- Identify patterns being used
+
+### Step 3: Build the Explanation
+
+**For Code Explanations:**
+```markdown
+## What This Does
+{One sentence summary}
+
+## How It Works
+{Step-by-step breakdown}
+
+1. First, {what happens}
+2. Then, {next step}
+3. Finally, {result}
+
+## Key Parts
+{Explain important pieces}
+
+## Example
+{Show how it's used in practice}
+
+## Things to Note
+{Gotchas, tips, common mistakes}
+```
+
+**For Concept Explanations:**
+```markdown
+## What Is {Concept}?
+{Simple definition, no jargon}
+
+## An Analogy
+{Relate to something familiar}
+
+## How It's Used Here
+{Specific examples from this project}
+
+## Why It Matters
+{Practical benefits}
+
+## Related Concepts
+{What to learn next}
+```
+
+### Step 4: Adjust to Their Level
+
+**For Beginners:**
+- Use analogies to everyday things
+- Explain any technical terms
+- Break into smaller pieces
+- Use simple language
+- Provide more context
+
+**For Experienced Users:**
+- Be more concise
+- Focus on the specifics
+- Discuss trade-offs
+- Mention alternatives
+
+### Step 5: Optionally Save Detailed Explanations
+
+For complex topics, offer to save to `/reports/explanation-{topic}-{timestamp}.md`
+
+## Teaching Techniques
+
+**Progressive disclosure:**
+1. Start with the one-sentence summary
+2. Add the basic mechanism
+3. Include important details
+4. Cover edge cases
+5. Discuss advanced aspects
+
+**Use concrete examples:**
+- Point to actual code in the project
+- Show real inputs and outputs
+- Walk through specific scenarios
+
+**Check understanding:**
+- "Does that make sense?"
+- "Would you like me to go deeper on any part?"
+- "Do you want to see an example?"
+
+## Important Principles
+
+- **Never assume knowledge** - check their level first
+- **Use their actual code** - generic examples are less helpful
+- **Explain why, not just what** - context matters
+- **Be patient** - no question is too basic
+- **Encourage questions** - learning is iterative
+- **Avoid condescension** - treat all questions as valid
+
+## Common Explanation Requests
+
+- "What does this function do?"
+- "Why is it written this way?"
+- "How do these files connect?"
+- "What's happening in this error?"
+- "How does [feature] work?"
+
+For each, follow the same pattern: understand → research → explain at their level.

--- a/.claude/skills/frontend-design/LICENSE.txt
+++ b/.claude/skills/frontend-design/LICENSE.txt
@@ -1,0 +1,177 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS

--- a/.claude/skills/frontend-design/SKILL.md
+++ b/.claude/skills/frontend-design/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: frontend-design
+description: Create distinctive, production-grade frontend interfaces with high design quality. Use this skill when the user asks to build web components, pages, artifacts, posters, or applications (examples include websites, landing pages, dashboards, React components, HTML/CSS layouts, or when styling/beautifying any web UI). Generates creative, polished code and UI design that avoids generic AI aesthetics.
+license: Complete terms in LICENSE.txt
+---
+
+This skill guides creation of distinctive, production-grade frontend interfaces that avoid generic "AI slop" aesthetics. Implement real working code with exceptional attention to aesthetic details and creative choices.
+
+The user provides frontend requirements: a component, page, application, or interface to build. They may include context about the purpose, audience, or technical constraints.
+
+## Design Thinking
+
+Before coding, understand the context and commit to a BOLD aesthetic direction:
+- **Purpose**: What problem does this interface solve? Who uses it?
+- **Tone**: Pick an extreme: brutally minimal, maximalist chaos, retro-futuristic, organic/natural, luxury/refined, playful/toy-like, editorial/magazine, brutalist/raw, art deco/geometric, soft/pastel, industrial/utilitarian, etc. There are so many flavors to choose from. Use these for inspiration but design one that is true to the aesthetic direction.
+- **Constraints**: Technical requirements (framework, performance, accessibility).
+- **Differentiation**: What makes this UNFORGETTABLE? What's the one thing someone will remember?
+
+**CRITICAL**: Choose a clear conceptual direction and execute it with precision. Bold maximalism and refined minimalism both work - the key is intentionality, not intensity.
+
+Then implement working code (HTML/CSS/JS, React, Vue, etc.) that is:
+- Production-grade and functional
+- Visually striking and memorable
+- Cohesive with a clear aesthetic point-of-view
+- Meticulously refined in every detail
+
+## Frontend Aesthetics Guidelines
+
+Focus on:
+- **Typography**: Choose fonts that are beautiful, unique, and interesting. Avoid generic fonts like Arial and Inter; opt instead for distinctive choices that elevate the frontend's aesthetics; unexpected, characterful font choices. Pair a distinctive display font with a refined body font.
+- **Color & Theme**: Commit to a cohesive aesthetic. Use CSS variables for consistency. Dominant colors with sharp accents outperform timid, evenly-distributed palettes.
+- **Motion**: Use animations for effects and micro-interactions. Prioritize CSS-only solutions for HTML. Use Motion library for React when available. Focus on high-impact moments: one well-orchestrated page load with staggered reveals (animation-delay) creates more delight than scattered micro-interactions. Use scroll-triggering and hover states that surprise.
+- **Spatial Composition**: Unexpected layouts. Asymmetry. Overlap. Diagonal flow. Grid-breaking elements. Generous negative space OR controlled density.
+- **Backgrounds & Visual Details**: Create atmosphere and depth rather than defaulting to solid colors. Add contextual effects and textures that match the overall aesthetic. Apply creative forms like gradient meshes, noise textures, geometric patterns, layered transparencies, dramatic shadows, decorative borders, custom cursors, and grain overlays.
+
+NEVER use generic AI-generated aesthetics like overused font families (Inter, Roboto, Arial, system fonts), cliched color schemes (particularly purple gradients on white backgrounds), predictable layouts and component patterns, and cookie-cutter design that lacks context-specific character.
+
+Interpret creatively and make unexpected choices that feel genuinely designed for the context. No design should be the same. Vary between light and dark themes, different fonts, different aesthetics. NEVER converge on common choices (Space Grotesk, for example) across generations.
+
+**IMPORTANT**: Match implementation complexity to the aesthetic vision. Maximalist designs need elaborate code with extensive animations and effects. Minimalist or refined designs need restraint, precision, and careful attention to spacing, typography, and subtle details. Elegance comes from executing the vision well.
+
+Remember: Claude is capable of extraordinary creative work. Don't hold back, show what can truly be created when thinking outside the box and committing fully to a distinctive vision.

--- a/.claude/skills/requirements-interview/SKILL.md
+++ b/.claude/skills/requirements-interview/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: requirements-interview
+description: Conduct in-depth requirements interviews to define features or applications. Use when the user wants to explore, define, or refine requirements for a project, feature, or app. Triggers on requests to interview about a plan, document requirements, define specifications, explore feature scope, clarify project needs, or when the user says they have an idea they want to flesh out. Also use when given a plan or document to review and the user wants thorough questioning about implementation details.
+---
+
+# Requirements Interview Skill
+
+Conduct thorough requirements interviews to help define features, applications, or project specifications through structured questioning.
+
+## Process
+
+### 1. Identify the Starting Point
+
+Determine what material exists:
+
+- **Plan or document provided**: Read the document first to understand the current state
+- **Verbal description**: Capture the initial concept through opening questions
+- **Existing codebase**: Review relevant code to understand current implementation
+
+### 2. Interview Structure
+
+Ask questions using AskUserQuestion tool. Structure the interview in phases:
+
+**Phase 1: Core Understanding**
+- What problem does this solve? For whom?
+- What does success look like?
+- What are the boundaries of this feature/app?
+
+**Phase 2: User Experience**
+- Walk through specific user scenarios
+- Edge cases and error states
+- Accessibility and internationalisation needs
+
+**Phase 3: Technical Considerations**
+- Integration points with existing systems
+- Data requirements and persistence
+- Performance expectations and constraints
+
+**Phase 4: Trade-offs and Priorities**
+- What can be deferred vs. must-have?
+- Acceptable compromises
+- Known risks or concerns
+
+### 3. Question Quality Guidelines
+
+**Ask non-obvious questions.** Avoid questions with self-evident answers. Focus on:
+
+- Ambiguities that could lead to different implementations
+- Assumptions that haven't been validated
+- Edge cases that could break the happy path
+- Trade-offs between competing concerns
+- Dependencies on external factors
+
+**Go deep on specifics.** Instead of "How should errors be handled?", ask "When a user submits invalid data in field X, should they see the error inline, in a toast, or blocking the form submission?"
+
+**Challenge assumptions.** If the plan says "users can export data," ask what formats, what data volume, what happens during export, can they cancel, do they get notified when complete?
+
+**Probe for constraints.** Ask about timeline pressures, budget limitations, technical debt, team capabilities, regulatory requirements.
+
+### 4. Interview Rhythm
+
+- Ask 2-3 related questions at a time, not a wall of questions
+- Acknowledge and build on previous answers
+- Circle back to earlier topics when new information reveals gaps
+- Note contradictions and ask for clarification
+- Continue until no significant ambiguities remain
+
+### 5. Writing the Specification
+
+When the interview is complete, write a specification document that captures:
+
+1. **Overview**: Problem statement and solution summary
+2. **User Stories**: Who does what and why
+3. **Functional Requirements**: Specific behaviours and features
+4. **Non-Functional Requirements**: Performance, security, accessibility
+5. **UI/UX Specifications**: Interface details and interactions
+6. **Technical Specifications**: Architecture, integrations, data models
+7. **Out of Scope**: Explicitly excluded items
+8. **Open Questions**: Any unresolved items for future consideration
+9. **Assumptions**: Decisions made based on reasonable assumptions
+
+Write the spec to the file path specified by the user, or ask where they want it saved.
+
+## Example Question Patterns
+
+**Instead of**: "What features should it have?"
+**Ask**: "If a user opens this app for the first time, what's the very first thing they should be able to accomplish?"
+
+**Instead of**: "How should the UI look?"
+**Ask**: "When a user completes the main action, what visual feedback tells them it worked? What if it failed?"
+
+**Instead of**: "Any security requirements?"
+**Ask**: "Who should NOT be able to access this feature? What happens if they try?"
+
+**Instead of**: "What data do you need?"
+**Ask**: "If I showed you the data from this feature in six months, what would you want to see? What decisions would that data inform?"
+
+## Completion Criteria
+
+The interview is complete when:
+
+- All major user flows are understood end-to-end
+- Edge cases and error states have been addressed
+- Technical constraints and integrations are clear
+- Priorities and trade-offs have been explicitly discussed
+- The user confirms no remaining questions or concerns

--- a/.claude/skills/webapp-testing/LICENSE.txt
+++ b/.claude/skills/webapp-testing/LICENSE.txt
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/.claude/skills/webapp-testing/SKILL.md
+++ b/.claude/skills/webapp-testing/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: webapp-testing
+description: Toolkit for interacting with and testing local web applications using Playwright. Supports verifying frontend functionality, debugging UI behavior, capturing browser screenshots, and viewing browser logs.
+license: Complete terms in LICENSE.txt
+---
+
+# Web Application Testing
+
+To test local web applications, write native Python Playwright scripts.
+
+**Helper Scripts Available**:
+- `scripts/with_server.py` - Manages server lifecycle (supports multiple servers)
+
+**Always run scripts with `--help` first** to see usage. DO NOT read the source until you try running the script first and find that a customized solution is abslutely necessary. These scripts can be very large and thus pollute your context window. They exist to be called directly as black-box scripts rather than ingested into your context window.
+
+## Decision Tree: Choosing Your Approach
+
+```
+User task → Is it static HTML?
+    ├─ Yes → Read HTML file directly to identify selectors
+    │         ├─ Success → Write Playwright script using selectors
+    │         └─ Fails/Incomplete → Treat as dynamic (below)
+    │
+    └─ No (dynamic webapp) → Is the server already running?
+        ├─ No → Run: python scripts/with_server.py --help
+        │        Then use the helper + write simplified Playwright script
+        │
+        └─ Yes → Reconnaissance-then-action:
+            1. Navigate and wait for networkidle
+            2. Take screenshot or inspect DOM
+            3. Identify selectors from rendered state
+            4. Execute actions with discovered selectors
+```
+
+## Example: Using with_server.py
+
+To start a server, run `--help` first, then use the helper:
+
+**Single server:**
+```bash
+python scripts/with_server.py --server "npm run dev" --port 5173 -- python your_automation.py
+```
+
+**Multiple servers (e.g., backend + frontend):**
+```bash
+python scripts/with_server.py \
+  --server "cd backend && python server.py" --port 3000 \
+  --server "cd frontend && npm run dev" --port 5173 \
+  -- python your_automation.py
+```
+
+To create an automation script, include only Playwright logic (servers are managed automatically):
+```python
+from playwright.sync_api import sync_playwright
+
+with sync_playwright() as p:
+    browser = p.chromium.launch(headless=True) # Always launch chromium in headless mode
+    page = browser.new_page()
+    page.goto('http://localhost:5173') # Server already running and ready
+    page.wait_for_load_state('networkidle') # CRITICAL: Wait for JS to execute
+    # ... your automation logic
+    browser.close()
+```
+
+## Reconnaissance-Then-Action Pattern
+
+1. **Inspect rendered DOM**:
+   ```python
+   page.screenshot(path='/tmp/inspect.png', full_page=True)
+   content = page.content()
+   page.locator('button').all()
+   ```
+
+2. **Identify selectors** from inspection results
+
+3. **Execute actions** using discovered selectors
+
+## Common Pitfall
+
+❌ **Don't** inspect the DOM before waiting for `networkidle` on dynamic apps
+✅ **Do** wait for `page.wait_for_load_state('networkidle')` before inspection
+
+## Best Practices
+
+- **Use bundled scripts as black boxes** - To accomplish a task, consider whether one of the scripts available in `scripts/` can help. These scripts handle common, complex workflows reliably without cluttering the context window. Use `--help` to see usage, then invoke directly. 
+- Use `sync_playwright()` for synchronous scripts
+- Always close the browser when done
+- Use descriptive selectors: `text=`, `role=`, CSS selectors, or IDs
+- Add appropriate waits: `page.wait_for_selector()` or `page.wait_for_timeout()`
+
+## Reference Files
+
+- **examples/** - Examples showing common patterns:
+  - `element_discovery.py` - Discovering buttons, links, and inputs on a page
+  - `static_html_automation.py` - Using file:// URLs for local HTML
+  - `console_logging.py` - Capturing console logs during automation

--- a/.claude/skills/webapp-testing/examples/console_logging.py
+++ b/.claude/skills/webapp-testing/examples/console_logging.py
@@ -1,0 +1,35 @@
+from playwright.sync_api import sync_playwright
+
+# Example: Capturing console logs during browser automation
+
+url = 'http://localhost:5173'  # Replace with your URL
+
+console_logs = []
+
+with sync_playwright() as p:
+    browser = p.chromium.launch(headless=True)
+    page = browser.new_page(viewport={'width': 1920, 'height': 1080})
+
+    # Set up console log capture
+    def handle_console_message(msg):
+        console_logs.append(f"[{msg.type}] {msg.text}")
+        print(f"Console: [{msg.type}] {msg.text}")
+
+    page.on("console", handle_console_message)
+
+    # Navigate to page
+    page.goto(url)
+    page.wait_for_load_state('networkidle')
+
+    # Interact with the page (triggers console logs)
+    page.click('text=Dashboard')
+    page.wait_for_timeout(1000)
+
+    browser.close()
+
+# Save console logs to file
+with open('/mnt/user-data/outputs/console.log', 'w') as f:
+    f.write('\n'.join(console_logs))
+
+print(f"\nCaptured {len(console_logs)} console messages")
+print(f"Logs saved to: /mnt/user-data/outputs/console.log")

--- a/.claude/skills/webapp-testing/examples/element_discovery.py
+++ b/.claude/skills/webapp-testing/examples/element_discovery.py
@@ -1,0 +1,40 @@
+from playwright.sync_api import sync_playwright
+
+# Example: Discovering buttons and other elements on a page
+
+with sync_playwright() as p:
+    browser = p.chromium.launch(headless=True)
+    page = browser.new_page()
+
+    # Navigate to page and wait for it to fully load
+    page.goto('http://localhost:5173')
+    page.wait_for_load_state('networkidle')
+
+    # Discover all buttons on the page
+    buttons = page.locator('button').all()
+    print(f"Found {len(buttons)} buttons:")
+    for i, button in enumerate(buttons):
+        text = button.inner_text() if button.is_visible() else "[hidden]"
+        print(f"  [{i}] {text}")
+
+    # Discover links
+    links = page.locator('a[href]').all()
+    print(f"\nFound {len(links)} links:")
+    for link in links[:5]:  # Show first 5
+        text = link.inner_text().strip()
+        href = link.get_attribute('href')
+        print(f"  - {text} -> {href}")
+
+    # Discover input fields
+    inputs = page.locator('input, textarea, select').all()
+    print(f"\nFound {len(inputs)} input fields:")
+    for input_elem in inputs:
+        name = input_elem.get_attribute('name') or input_elem.get_attribute('id') or "[unnamed]"
+        input_type = input_elem.get_attribute('type') or 'text'
+        print(f"  - {name} ({input_type})")
+
+    # Take screenshot for visual reference
+    page.screenshot(path='/tmp/page_discovery.png', full_page=True)
+    print("\nScreenshot saved to /tmp/page_discovery.png")
+
+    browser.close()

--- a/.claude/skills/webapp-testing/examples/static_html_automation.py
+++ b/.claude/skills/webapp-testing/examples/static_html_automation.py
@@ -1,0 +1,33 @@
+from playwright.sync_api import sync_playwright
+import os
+
+# Example: Automating interaction with static HTML files using file:// URLs
+
+html_file_path = os.path.abspath('path/to/your/file.html')
+file_url = f'file://{html_file_path}'
+
+with sync_playwright() as p:
+    browser = p.chromium.launch(headless=True)
+    page = browser.new_page(viewport={'width': 1920, 'height': 1080})
+
+    # Navigate to local HTML file
+    page.goto(file_url)
+
+    # Take screenshot
+    page.screenshot(path='/mnt/user-data/outputs/static_page.png', full_page=True)
+
+    # Interact with elements
+    page.click('text=Click Me')
+    page.fill('#name', 'John Doe')
+    page.fill('#email', 'john@example.com')
+
+    # Submit form
+    page.click('button[type="submit"]')
+    page.wait_for_timeout(500)
+
+    # Take final screenshot
+    page.screenshot(path='/mnt/user-data/outputs/after_submit.png', full_page=True)
+
+    browser.close()
+
+print("Static HTML automation completed!")

--- a/.claude/skills/webapp-testing/scripts/with_server.py
+++ b/.claude/skills/webapp-testing/scripts/with_server.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""
+Start one or more servers, wait for them to be ready, run a command, then clean up.
+
+Usage:
+    # Single server
+    python scripts/with_server.py --server "npm run dev" --port 5173 -- python automation.py
+    python scripts/with_server.py --server "npm start" --port 3000 -- python test.py
+
+    # Multiple servers
+    python scripts/with_server.py \
+      --server "cd backend && python server.py" --port 3000 \
+      --server "cd frontend && npm run dev" --port 5173 \
+      -- python test.py
+"""
+
+import subprocess
+import socket
+import time
+import sys
+import argparse
+
+def is_server_ready(port, timeout=30):
+    """Wait for server to be ready by polling the port."""
+    start_time = time.time()
+    while time.time() - start_time < timeout:
+        try:
+            with socket.create_connection(('localhost', port), timeout=1):
+                return True
+        except (socket.error, ConnectionRefusedError):
+            time.sleep(0.5)
+    return False
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Run command with one or more servers')
+    parser.add_argument('--server', action='append', dest='servers', required=True, help='Server command (can be repeated)')
+    parser.add_argument('--port', action='append', dest='ports', type=int, required=True, help='Port for each server (must match --server count)')
+    parser.add_argument('--timeout', type=int, default=30, help='Timeout in seconds per server (default: 30)')
+    parser.add_argument('command', nargs=argparse.REMAINDER, help='Command to run after server(s) ready')
+
+    args = parser.parse_args()
+
+    # Remove the '--' separator if present
+    if args.command and args.command[0] == '--':
+        args.command = args.command[1:]
+
+    if not args.command:
+        print("Error: No command specified to run")
+        sys.exit(1)
+
+    # Parse server configurations
+    if len(args.servers) != len(args.ports):
+        print("Error: Number of --server and --port arguments must match")
+        sys.exit(1)
+
+    servers = []
+    for cmd, port in zip(args.servers, args.ports):
+        servers.append({'cmd': cmd, 'port': port})
+
+    server_processes = []
+
+    try:
+        # Start all servers
+        for i, server in enumerate(servers):
+            print(f"Starting server {i+1}/{len(servers)}: {server['cmd']}")
+
+            # Use shell=True to support commands with cd and &&
+            process = subprocess.Popen(
+                server['cmd'],
+                shell=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE
+            )
+            server_processes.append(process)
+
+            # Wait for this server to be ready
+            print(f"Waiting for server on port {server['port']}...")
+            if not is_server_ready(server['port'], timeout=args.timeout):
+                raise RuntimeError(f"Server failed to start on port {server['port']} within {args.timeout}s")
+
+            print(f"Server ready on port {server['port']}")
+
+        print(f"\nAll {len(servers)} server(s) ready")
+
+        # Run the command
+        print(f"Running: {' '.join(args.command)}\n")
+        result = subprocess.run(args.command)
+        sys.exit(result.returncode)
+
+    finally:
+        # Clean up all servers
+        print(f"\nStopping {len(server_processes)} server(s)...")
+        for i, process in enumerate(server_processes):
+            try:
+                process.terminate()
+                process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                process.kill()
+                process.wait()
+            print(f"Server {i+1} stopped")
+        print("All servers stopped")
+
+
+if __name__ == '__main__':
+    main()

--- a/.gitignore
+++ b/.gitignore
@@ -29,8 +29,10 @@ venv/
 *.swp
 *.code-workspace
 
-# Claude Code
-.claude/
+# Claude Code — track shared skills/commands, ignore personal config
+.claude/*
+!.claude/commands/
+!.claude/skills/
 .claude-active
 
 # Git worktrees


### PR DESCRIPTION
## Summary
- Moved 8 Claude Code skills and 4 commands from personal `~/.claude/` into the project's `.claude/` directory so all contributors get them automatically on clone
- Updated `.gitignore` to track `.claude/commands/` and `.claude/skills/` while keeping personal config files (settings, caches) ignored

### Skills added
| Skill | Purpose |
|-------|---------|
| `convening-experts` | Expert panels for design decisions and problem-solving |
| `accessibility-review` | WCAG 2.2 AA compliance checks |
| `webapp-testing` | Playwright-based web app testing |
| `explain` | Plain-language code explanations |
| `codebase-overview` | Project onboarding for new contributors |
| `requirements-interview` | Feature scoping and requirements gathering |
| `design-principles` | UI/UX design direction guidance |
| `frontend-design` | HTML/CSS component building |

### Commands added/tracked
| Command | Purpose |
|---------|---------|
| `review-session` | End-of-session code review + expert panel |
| `capture-page-states` | Screenshot generator for page audit (was gitignored) |
| `process-qa-report` | Expert panel QA review (was gitignored) |
| `run-scenario-server` | QA scenario evaluation runner (was gitignored) |

## Test plan
- [ ] Verify skills appear in Claude Code's available skills list when working from a fresh clone
- [ ] Verify `/review-session` command works from the project directory
- [ ] Verify personal `.claude/settings.local.json` remains untracked

🤖 Generated with [Claude Code](https://claude.com/claude-code)