### PR TITLE
fix: program-specific demo suggestions (DEMO-FIX1)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -121,7 +121,7 @@ Step-by-step commands for each task are in [tasks/recurring-tasks.md](tasks/recu
 
 ### Phase: Demo Data Quality
 
-- [ ] Fix suggestion theme linking in seed_demo_data — make suggestions program-specific and remove blind fallback that links irrelevant notes to themes (see tasks/demo-data-suggestion-fix.md) — (DEMO-FIX1)
+_Nothing pending._
 
 ### Phase: Surveys Future Work
 
@@ -185,6 +185,7 @@ Step-by-step commands for each task are in [tasks/recurring-tasks.md](tasks/recu
 
 ## Recently Done
 
+- [x] Fix suggestion theme linking in seed_demo_data — program-specific suggestions, removed blind fallback — 2026-02-22 (DEMO-FIX1)
 - [x] Add quarterly date range presets to ad-hoc report form — optgroup dropdown with FY + quarters, i18n month names, 8 tests — 2026-02-22 (QA-R7-RPT-QUARTER1)
 - [x] QA Round 7 Tier 2 — verified 8 items already implemented, fixed IMPROVE-3 (executive nav) and BUG-7 (log communication) — 2026-02-22 (QA-R7-TIER2)
 - [x] Scenario YAML URL fixes — updated 7 files in konote-qa-scenarios repo from /admin/ to /manage/ paths (PR #14) — 2026-02-22 (QA-R7-YAML1)

--- a/apps/admin_settings/management/commands/seed_demo_data.py
+++ b/apps/admin_settings/management/commands/seed_demo_data.py
@@ -646,12 +646,44 @@ PARTICIPANT_REFLECTIONS = [
     "The hardest part is still showing up but once I'm here I always feel better about things",
 ]
 
-PARTICIPANT_SUGGESTIONS = [
-    "It would help to have more evening sessions for people who work during the day",
-    "Maybe we could do a group session where people share what's working for them",
+PROGRAM_SUGGESTIONS = {
+    "Supported Employment": [
+        "It would help to have more evening sessions for people who work during the day",
+        "Maybe we could do a group session where people share what's working for them",
+        "I think having a buddy or mentor from someone who's been through the program would really help",
+        "I wish there were weekend workshops for interview practice when I'm not at work",
+    ],
+    "Housing Stability": [
+        "The landlord hasn't responded to my maintenance request in two weeks and I don't know what to do",
+        "I didn't know about my tenant rights until my worker told me — more info on eviction rules would help",
+        "It would help if someone could explain the legal process for fighting a rent increase",
+        "I wish there was a faster way to get repair issues dealt with in my building",
+    ],
+    "Youth Drop-In": [
+        "It would be cool if we had more variety in our group activities, like cooking or art",
+        "I need a quiet space to do homework before the evening program starts",
+        "I wish we could stay later on Fridays — there's nothing to do at home",
+        "Can we try some different options for activities? The same ones every week get boring",
+    ],
+    "Newcomer Connections": [
+        "I think having a buddy system would help new people feel less alone at the start",
+        "It's hard to attend sessions when I have no one to watch my children",
+        "Being paired with someone who's been here longer would make it less scary at the start",
+        "I wish there was childcare available so parents can actually participate",
+    ],
+    "Community Kitchen": [
+        "It would be nice to take home extra portions for my family after cooking",
+        "I'd love more recipe variety that reflects different cultural backgrounds and dietary needs",
+        "Having written materials about food safety I can review at home would help",
+        "Could we have more options for people with dietary restrictions?",
+    ],
+}
+
+# Fallback for any program not in the dict above
+_DEFAULT_SUGGESTIONS = [
+    "It would help to have more flexibility in scheduling",
     "I think having a buddy system would help new people feel less alone at the start",
     "It would be nice to have some written materials I can take home and review later",
-    "I wish there was a way to check in between sessions when things get really hard",
 ]
 
 
@@ -1626,8 +1658,11 @@ class Command(BaseCommand):
 
             # Add participant suggestion to ~1/3 of full notes
             if not is_quick and note_idx % 3 == 1:
-                suggestion_idx = note_idx % len(PARTICIPANT_SUGGESTIONS)
-                note.participant_suggestion = PARTICIPANT_SUGGESTIONS[suggestion_idx]
+                suggestions = PROGRAM_SUGGESTIONS.get(
+                    program_name, _DEFAULT_SUGGESTIONS
+                )
+                suggestion_idx = note_idx % len(suggestions)
+                note.participant_suggestion = suggestions[suggestion_idx]
                 note.suggestion_priority = random.choice(
                     ["noted", "worth_exploring", "important"]
                 )
@@ -3338,19 +3373,10 @@ class Command(BaseCommand):
                         linked_notes.append(note)
                         link_count += 1
 
-                # If no keyword matches, link 1-2 arbitrary notes so theme isn't empty
-                if not linked_notes and notes_with_suggestions:
-                    for fallback_note in notes_with_suggestions[:2]:
-                        if not SuggestionLink.objects.filter(
-                            theme=theme, progress_note=fallback_note
-                        ).exists():
-                            SuggestionLink.objects.create(
-                                theme=theme,
-                                progress_note=fallback_note,
-                                auto_linked=False,
-                                linked_by=author,
-                            )
-                            link_count += 1
+                if not linked_notes:
+                    self.stdout.write(self.style.WARNING(
+                        f"    Theme '{theme.name}' ({program_name}) has no keyword matches — skipping."
+                    ))
 
                 # Recalculate priority from linked note priorities
                 recalculate_theme_priority(theme)


### PR DESCRIPTION
## Summary
- Replaced generic `PARTICIPANT_SUGGESTIONS` list with `PROGRAM_SUGGESTIONS` dict — each program now gets 3-4 suggestions containing keywords that match its themes
- Updated note creation to pull from program-specific pool instead of rotating through a single generic list
- Removed blind fallback that linked arbitrary notes to themes when keyword matching found zero matches — an empty theme is better than a wrong one (logs a warning instead)

## Verification
All 11 themes across 5 programs verified to have at least 1 keyword-matching suggestion. No database or model changes needed.

## Test plan
- [ ] Run `seed_demo_data --demo-mode` on a database with demo programs
- [ ] Check all 11 suggestion themes on the executive dashboard — each linked suggestion should be relevant to its theme
- [ ] Confirm no "Take-home portions for families" theme links to buddy system or check-in suggestions

🤖 Generated with [Claude Code](https://claude.com/claude-code)