### PR TITLE
feat: re-add API-based auto-translation to translate_strings (I18N-API1)

### DIFF
--- a/apps/admin_settings/management/commands/translate_strings.py
+++ b/apps/admin_settings/management/commands/translate_strings.py
@@ -4,18 +4,28 @@ Extract translatable strings from templates and Python, add to .po, compile .mo.
 Replaces the need for gettext/makemessages on Windows. Uses regex extraction
 and polib for .po/.mo handling — pure Python, no system dependencies.
 
-Empty translations are filled in by Claude Code (editing the .po file directly),
-not by an external API.
+Empty translations can be filled in by:
+  - Claude Code (editing the .po file directly)
+  - An OpenAI-compatible translation API (--auto-translate flag)
 
 Usage:
-    python manage.py translate_strings            # Extract + add missing + compile
-    python manage.py translate_strings --dry-run  # Show what would change
+    python manage.py translate_strings                       # Extract + add missing + compile
+    python manage.py translate_strings --auto-translate      # Also auto-translate empty strings
+    python manage.py translate_strings --auto-translate --review  # Mark API translations as fuzzy
+    python manage.py translate_strings --dry-run             # Show what would change
 
 Exit codes:
     0 = success
     1 = error (duplicate msgids, file write failure, etc.)
+
+Environment variables (for --auto-translate):
+    TRANSLATE_API_KEY   — API key (required)
+    TRANSLATE_API_BASE  — API base URL (default: https://api.openai.com/v1)
+    TRANSLATE_MODEL     — Model name (default: gpt-4o-mini)
 """
 
+import json
+import logging
 import os
 import re
 import shutil
@@ -24,8 +34,33 @@ import tempfile
 from pathlib import Path
 
 import polib
+import requests
 from django.conf import settings
 from django.core.management.base import BaseCommand
+
+logger = logging.getLogger(__name__)
+
+# System prompt for the translation API — Canadian French nonprofit context.
+TRANSLATION_SYSTEM_PROMPT = """\
+You are a professional translator for a Canadian nonprofit case-management \
+application. Translate English strings to Canadian French.
+
+Rules:
+- Use formal "vous" (never "tu")
+- Use Canadian nonprofit terminology: organisme (not organisation), \
+bénéficiaire, intervenant, programme
+- Use Canadian French terms: courriel (not e-mail), téléverser (not uploader)
+- Use French typographic conventions: space before : ; ? !
+- Use « guillemets » for quotation marks (not "quotes")
+- Preserve ALL placeholders exactly as-is: %(name)s, %(count)d, {{ var }}, \
+{record_id}, etc.
+- Preserve ALL HTML tags exactly as-is: <strong>, <em>, <a href="...">, etc.
+- Do not translate text inside placeholders or HTML attributes
+
+You will receive a JSON object mapping numbers to English strings.
+Return a JSON object mapping the same numbers to French translations.
+Return ONLY the JSON object — no markdown fences, no explanation.\
+"""
 
 
 class Command(BaseCommand):
@@ -55,10 +90,34 @@ class Command(BaseCommand):
             default="fr",
             help="Target language code (default: fr).",
         )
+        parser.add_argument(
+            "--auto-translate",
+            action="store_true",
+            help=(
+                "Auto-translate empty strings via an OpenAI-compatible API. "
+                "Requires TRANSLATE_API_KEY environment variable."
+            ),
+        )
+        parser.add_argument(
+            "--review",
+            action="store_true",
+            help=(
+                "Mark API-translated strings as fuzzy for human review. "
+                "Only used with --auto-translate."
+            ),
+        )
+
+    # Batch size for API translation calls.
+    TRANSLATE_BATCH_SIZE = 25
 
     def handle(self, *args, **options):
         dry_run = options["dry_run"]
         lang = options["lang"]
+        auto_translate = options["auto_translate"]
+        review = options["review"]
+
+        # Determine total phases for display numbering.
+        total_phases = 4 if auto_translate else 3
 
         self.stdout.write("\nKoNote Translation Sync")
         self.stdout.write("=" * 40)
@@ -68,7 +127,7 @@ class Command(BaseCommand):
         # ----------------------------------------------------------
         # Phase 1: Extract strings
         # ----------------------------------------------------------
-        self.stdout.write("\n[1/3] Extracting strings...")
+        self.stdout.write(f"\n[1/{total_phases}] Extracting strings...")
 
         template_strings, template_file_count, blocktrans_count = (
             self._extract_templates(base_dir)
@@ -98,7 +157,7 @@ class Command(BaseCommand):
         # ----------------------------------------------------------
         # Phase 2: Compare with .po and add missing
         # ----------------------------------------------------------
-        self.stdout.write(f"\n[2/3] Comparing with django.po...")
+        self.stdout.write(f"\n[2/{total_phases}] Comparing with django.po...")
 
         po_path = self._find_po_file(lang, base_dir)
         if po_path is None:
@@ -194,6 +253,21 @@ class Command(BaseCommand):
                         f"    ... and {len(new_strings) - 20} more"
                     )
             total_empty = len(new_strings) + empty_count
+            if auto_translate and total_empty:
+                num_batches = (
+                    (total_empty + self.TRANSLATE_BATCH_SIZE - 1)
+                    // self.TRANSLATE_BATCH_SIZE
+                )
+                self.stdout.write(self.style.WARNING(
+                    f"\n  --auto-translate: {total_empty} strings "
+                    f"would be sent to the translation API "
+                    f"({num_batches} batch(es) of "
+                    f"{self.TRANSLATE_BATCH_SIZE})."
+                ))
+                if review:
+                    self.stdout.write(
+                        "  --review: translations would be marked fuzzy."
+                    )
             self._print_summary(total_empty, dry_run=True)
             return
 
@@ -208,9 +282,34 @@ class Command(BaseCommand):
             ))
 
         # ----------------------------------------------------------
-        # Phase 3: Compile .mo
+        # Phase 3 (optional): Auto-translate empty strings via API
         # ----------------------------------------------------------
-        self.stdout.write(f"\n[3/3] Compiling django.mo...")
+        if auto_translate:
+            self.stdout.write(
+                f"\n[3/{total_phases}] Auto-translating empty strings..."
+            )
+            translated = self._auto_translate_empty(po, review=review)
+            if translated:
+                self._save_po(po, po_path)
+                self.stdout.write(self.style.SUCCESS(
+                    f"      [OK] Translated {translated} strings via API"
+                ))
+                if review:
+                    self.stdout.write(
+                        "      [i] Translations marked as fuzzy for review"
+                    )
+            else:
+                self.stdout.write(
+                    "      No empty strings to translate."
+                )
+
+        # ----------------------------------------------------------
+        # Final phase: Compile .mo
+        # ----------------------------------------------------------
+        compile_phase = total_phases
+        self.stdout.write(
+            f"\n[{compile_phase}/{total_phases}] Compiling django.mo..."
+        )
 
         mo_path = po_path.with_suffix(".mo")
         fd, tmp_mo = tempfile.mkstemp(suffix=".mo", dir=str(mo_path.parent))
@@ -260,6 +359,158 @@ class Command(BaseCommand):
                 f"\n  ERROR writing .po file: {e}\n"
             ))
             sys.exit(1)
+
+    # ------------------------------------------------------------------
+    # Auto-translation helpers
+    # ------------------------------------------------------------------
+
+    def _auto_translate_empty(self, po, review=False):
+        """Translate all empty msgstr entries via an OpenAI-compatible API.
+
+        Sends strings in batches of TRANSLATE_BATCH_SIZE. Returns the total
+        number of strings successfully translated.
+        """
+        api_key = os.environ.get("TRANSLATE_API_KEY", "")
+        if not api_key:
+            self.stderr.write(self.style.ERROR(
+                "      ERROR: TRANSLATE_API_KEY environment variable not set."
+            ))
+            return 0
+
+        api_base = os.environ.get(
+            "TRANSLATE_API_BASE", "https://api.openai.com/v1"
+        ).rstrip("/")
+        model = os.environ.get("TRANSLATE_MODEL", "gpt-4o-mini")
+        url = f"{api_base}/chat/completions"
+
+        # Collect entries with empty translations.
+        empty_entries = [
+            entry for entry in po
+            if not entry.msgstr and not entry.msgstr_plural
+            and not entry.obsolete and entry.msgid
+        ]
+
+        if not empty_entries:
+            return 0
+
+        total_translated = 0
+
+        # Process in batches.
+        for batch_start in range(
+            0, len(empty_entries), self.TRANSLATE_BATCH_SIZE
+        ):
+            batch = empty_entries[
+                batch_start:batch_start + self.TRANSLATE_BATCH_SIZE
+            ]
+            batch_num = batch_start // self.TRANSLATE_BATCH_SIZE + 1
+            total_batches = (
+                (len(empty_entries) + self.TRANSLATE_BATCH_SIZE - 1)
+                // self.TRANSLATE_BATCH_SIZE
+            )
+
+            # Build the numbered mapping for the API.
+            source_map = {
+                str(i): entry.msgid for i, entry in enumerate(batch)
+            }
+
+            self.stdout.write(
+                f"      Batch {batch_num}/{total_batches} "
+                f"({len(batch)} strings)..."
+            )
+
+            try:
+                translations = self._call_translation_api(
+                    url, api_key, model, source_map
+                )
+            except Exception as exc:
+                logger.warning(
+                    "Translation API error on batch %d: %s", batch_num, exc
+                )
+                self.stderr.write(self.style.WARNING(
+                    f"      [!] Batch {batch_num} failed: {exc} — skipping"
+                ))
+                continue
+
+            # Apply translations to the .po entries.
+            batch_translated = 0
+            for i, entry in enumerate(batch):
+                key = str(i)
+                if key in translations and translations[key]:
+                    entry.msgstr = translations[key]
+                    if review:
+                        if "fuzzy" not in entry.flags:
+                            entry.flags.append("fuzzy")
+                    batch_translated += 1
+
+            total_translated += batch_translated
+
+        return total_translated
+
+    def _call_translation_api(self, url, api_key, model, source_map):
+        """Make a single API call and return the parsed translation mapping.
+
+        Args:
+            url: Full chat completions endpoint URL.
+            api_key: API bearer token.
+            model: Model name to use.
+            source_map: Dict mapping string indices to English source strings.
+
+        Returns:
+            Dict mapping string indices to French translations.
+
+        Raises:
+            requests.RequestException: On HTTP errors or timeouts.
+            ValueError: On JSON parse failures.
+        """
+        payload = {
+            "model": model,
+            "temperature": 0.3,
+            "messages": [
+                {"role": "system", "content": TRANSLATION_SYSTEM_PROMPT},
+                {"role": "user", "content": json.dumps(
+                    source_map, ensure_ascii=False
+                )},
+            ],
+        }
+
+        response = requests.post(
+            url,
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+            },
+            json=payload,
+            timeout=120,
+        )
+        response.raise_for_status()
+
+        data = response.json()
+        content = data["choices"][0]["message"]["content"].strip()
+
+        # Strip markdown code fences if the model wraps the response.
+        if content.startswith("```"):
+            # Remove opening fence (with optional language tag) and closing fence.
+            lines = content.split("\n")
+            if lines[0].startswith("```"):
+                lines = lines[1:]
+            if lines and lines[-1].strip() == "```":
+                lines = lines[:-1]
+            content = "\n".join(lines)
+
+        try:
+            translations = json.loads(content)
+        except json.JSONDecodeError as exc:
+            raise ValueError(
+                f"API returned invalid JSON: {exc}. "
+                f"Response: {content[:200]}"
+            ) from exc
+
+        if not isinstance(translations, dict):
+            raise ValueError(
+                f"API returned {type(translations).__name__}, expected dict."
+            )
+
+        return translations
 
     # ------------------------------------------------------------------
     # Extraction helpers

--- a/tests/test_translate_strings.py
+++ b/tests/test_translate_strings.py
@@ -1,0 +1,471 @@
+"""Tests for the translate_strings management command — auto-translate feature.
+
+Covers:
+  - API translations applied to empty .po entries
+  - --review flag marks translations as fuzzy
+  - Error handling for bad JSON responses
+  - Error handling for HTTP failures
+  - Missing API key handling
+  - Batch processing (multiple batches)
+  - Markdown fence stripping from API responses
+"""
+
+import io
+import json
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import polib
+from django.test import SimpleTestCase
+
+from apps.admin_settings.management.commands.translate_strings import (
+    Command,
+    TRANSLATION_SYSTEM_PROMPT,
+)
+
+
+class AutoTranslateEmptyTest(SimpleTestCase):
+    """Tests for Command._auto_translate_empty()."""
+
+    def _make_po(self, entries):
+        """Create a polib.POFile with the given (msgid, msgstr) pairs."""
+        po = polib.POFile()
+        po.metadata = {"Content-Type": "text/plain; charset=UTF-8"}
+        for msgid, msgstr in entries:
+            po.append(polib.POEntry(msgid=msgid, msgstr=msgstr))
+        return po
+
+    def _make_command(self):
+        """Create a Command instance with captured stdout/stderr."""
+        cmd = Command()
+        cmd.stdout = io.StringIO()
+        cmd.stderr = io.StringIO()
+        # style is auto-initialised by BaseCommand.__init__; no override needed.
+        return cmd
+
+    def _mock_api_response(self, translations_dict):
+        """Create a mock requests.Response returning the given translations."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "choices": [{
+                "message": {
+                    "content": json.dumps(
+                        translations_dict, ensure_ascii=False
+                    )
+                }
+            }]
+        }
+        return mock_response
+
+    # ------------------------------------------------------------------
+    # Happy path: translations are applied
+    # ------------------------------------------------------------------
+
+    @patch.dict(os.environ, {"TRANSLATE_API_KEY": "test-key-123"})
+    @patch("apps.admin_settings.management.commands.translate_strings.requests.post")
+    def test_translations_applied_to_empty_entries(self, mock_post):
+        """API translations are written into empty msgstr fields."""
+        po = self._make_po([
+            ("Hello", ""),
+            ("Goodbye", ""),
+            ("Already translated", "Deja traduit"),
+        ])
+
+        mock_post.return_value = self._mock_api_response({
+            "0": "Bonjour",
+            "1": "Au revoir",
+        })
+
+        cmd = self._make_command()
+        count = cmd._auto_translate_empty(po, review=False)
+
+        self.assertEqual(count, 2)
+        self.assertEqual(po.find("Hello").msgstr, "Bonjour")
+        self.assertEqual(po.find("Goodbye").msgstr, "Au revoir")
+        # Pre-existing translation untouched.
+        self.assertEqual(
+            po.find("Already translated").msgstr, "Deja traduit"
+        )
+
+    # ------------------------------------------------------------------
+    # --review flag marks entries as fuzzy
+    # ------------------------------------------------------------------
+
+    @patch.dict(os.environ, {"TRANSLATE_API_KEY": "test-key-123"})
+    @patch("apps.admin_settings.management.commands.translate_strings.requests.post")
+    def test_review_flag_marks_fuzzy(self, mock_post):
+        """With review=True, translated entries get the 'fuzzy' flag."""
+        po = self._make_po([
+            ("Save", ""),
+            ("Cancel", ""),
+        ])
+
+        mock_post.return_value = self._mock_api_response({
+            "0": "Enregistrer",
+            "1": "Annuler",
+        })
+
+        cmd = self._make_command()
+        count = cmd._auto_translate_empty(po, review=True)
+
+        self.assertEqual(count, 2)
+        self.assertIn("fuzzy", po.find("Save").flags)
+        self.assertIn("fuzzy", po.find("Cancel").flags)
+
+    @patch.dict(os.environ, {"TRANSLATE_API_KEY": "test-key-123"})
+    @patch("apps.admin_settings.management.commands.translate_strings.requests.post")
+    def test_no_fuzzy_without_review(self, mock_post):
+        """Without review=True, translated entries do NOT get 'fuzzy'."""
+        po = self._make_po([("Save", "")])
+
+        mock_post.return_value = self._mock_api_response({
+            "0": "Enregistrer",
+        })
+
+        cmd = self._make_command()
+        cmd._auto_translate_empty(po, review=False)
+
+        self.assertNotIn("fuzzy", po.find("Save").flags)
+
+    # ------------------------------------------------------------------
+    # Error handling: bad JSON
+    # ------------------------------------------------------------------
+
+    @patch.dict(os.environ, {"TRANSLATE_API_KEY": "test-key-123"})
+    @patch("apps.admin_settings.management.commands.translate_strings.requests.post")
+    def test_bad_json_skips_batch(self, mock_post):
+        """If the API returns invalid JSON, the batch is skipped."""
+        po = self._make_po([("Hello", "")])
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "choices": [{
+                "message": {"content": "This is not valid JSON!!!"}
+            }]
+        }
+        mock_post.return_value = mock_response
+
+        cmd = self._make_command()
+        count = cmd._auto_translate_empty(po, review=False)
+
+        self.assertEqual(count, 0)
+        self.assertEqual(po.find("Hello").msgstr, "")
+        # Warning was written to stderr.
+        self.assertIn("failed", cmd.stderr.getvalue().lower())
+
+    # ------------------------------------------------------------------
+    # Error handling: HTTP error
+    # ------------------------------------------------------------------
+
+    @patch.dict(os.environ, {"TRANSLATE_API_KEY": "test-key-123"})
+    @patch("apps.admin_settings.management.commands.translate_strings.requests.post")
+    def test_http_error_skips_batch(self, mock_post):
+        """If the API returns an HTTP error, the batch is skipped."""
+        import requests
+
+        po = self._make_po([("Hello", "")])
+
+        mock_response = MagicMock()
+        mock_response.status_code = 500
+        mock_response.raise_for_status.side_effect = (
+            requests.exceptions.HTTPError("500 Server Error")
+        )
+        mock_post.return_value = mock_response
+
+        cmd = self._make_command()
+        count = cmd._auto_translate_empty(po, review=False)
+
+        self.assertEqual(count, 0)
+        self.assertEqual(po.find("Hello").msgstr, "")
+
+    # ------------------------------------------------------------------
+    # Error handling: timeout
+    # ------------------------------------------------------------------
+
+    @patch.dict(os.environ, {"TRANSLATE_API_KEY": "test-key-123"})
+    @patch("apps.admin_settings.management.commands.translate_strings.requests.post")
+    def test_timeout_skips_batch(self, mock_post):
+        """If the API times out, the batch is skipped."""
+        import requests
+
+        po = self._make_po([("Hello", "")])
+
+        mock_post.side_effect = requests.exceptions.Timeout("Request timed out")
+
+        cmd = self._make_command()
+        count = cmd._auto_translate_empty(po, review=False)
+
+        self.assertEqual(count, 0)
+        self.assertEqual(po.find("Hello").msgstr, "")
+
+    # ------------------------------------------------------------------
+    # Missing API key
+    # ------------------------------------------------------------------
+
+    @patch.dict(os.environ, {}, clear=False)
+    def test_missing_api_key_returns_zero(self):
+        """If TRANSLATE_API_KEY is not set, return 0 and print error."""
+        # Ensure the key is not set.
+        env = os.environ.copy()
+        env.pop("TRANSLATE_API_KEY", None)
+
+        with patch.dict(os.environ, env, clear=True):
+            po = self._make_po([("Hello", "")])
+            cmd = self._make_command()
+            count = cmd._auto_translate_empty(po, review=False)
+
+            self.assertEqual(count, 0)
+            self.assertIn("TRANSLATE_API_KEY", cmd.stderr.getvalue())
+
+    # ------------------------------------------------------------------
+    # Batch processing
+    # ------------------------------------------------------------------
+
+    @patch.dict(os.environ, {"TRANSLATE_API_KEY": "test-key-123"})
+    @patch("apps.admin_settings.management.commands.translate_strings.requests.post")
+    def test_multiple_batches(self, mock_post):
+        """Strings are processed in batches of TRANSLATE_BATCH_SIZE."""
+        # Create 30 empty entries (should produce 2 batches with size 25).
+        entries = [(f"String {i}", "") for i in range(30)]
+        po = self._make_po(entries)
+
+        # Respond differently for each batch so we can verify both.
+        def side_effect(*args, **kwargs):
+            payload = kwargs.get("json", {})
+            user_msg = payload["messages"][1]["content"]
+            source = json.loads(user_msg)
+            translations = {k: f"FR-{v}" for k, v in source.items()}
+            return self._mock_api_response(translations)
+
+        mock_post.side_effect = side_effect
+
+        cmd = self._make_command()
+        # Use small batch size for testing.
+        original_batch_size = cmd.TRANSLATE_BATCH_SIZE
+        cmd.TRANSLATE_BATCH_SIZE = 25
+        try:
+            count = cmd._auto_translate_empty(po, review=False)
+        finally:
+            cmd.TRANSLATE_BATCH_SIZE = original_batch_size
+
+        self.assertEqual(count, 30)
+        self.assertEqual(mock_post.call_count, 2)
+        # Check a sample from each batch.
+        self.assertEqual(po.find("String 0").msgstr, "FR-String 0")
+        self.assertEqual(po.find("String 29").msgstr, "FR-String 29")
+
+    # ------------------------------------------------------------------
+    # No empty entries
+    # ------------------------------------------------------------------
+
+    @patch.dict(os.environ, {"TRANSLATE_API_KEY": "test-key-123"})
+    def test_no_empty_entries_returns_zero(self):
+        """If all entries are already translated, return 0 immediately."""
+        po = self._make_po([
+            ("Hello", "Bonjour"),
+            ("Goodbye", "Au revoir"),
+        ])
+
+        cmd = self._make_command()
+        count = cmd._auto_translate_empty(po, review=False)
+
+        self.assertEqual(count, 0)
+
+    # ------------------------------------------------------------------
+    # Markdown fence stripping
+    # ------------------------------------------------------------------
+
+    @patch.dict(os.environ, {"TRANSLATE_API_KEY": "test-key-123"})
+    @patch("apps.admin_settings.management.commands.translate_strings.requests.post")
+    def test_markdown_fences_stripped(self, mock_post):
+        """API responses wrapped in ```json fences are handled correctly."""
+        po = self._make_po([("Hello", "")])
+
+        fenced_content = '```json\n{"0": "Bonjour"}\n```'
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "choices": [{
+                "message": {"content": fenced_content}
+            }]
+        }
+        mock_post.return_value = mock_response
+
+        cmd = self._make_command()
+        count = cmd._auto_translate_empty(po, review=False)
+
+        self.assertEqual(count, 1)
+        self.assertEqual(po.find("Hello").msgstr, "Bonjour")
+
+    # ------------------------------------------------------------------
+    # API response that is not a dict
+    # ------------------------------------------------------------------
+
+    @patch.dict(os.environ, {"TRANSLATE_API_KEY": "test-key-123"})
+    @patch("apps.admin_settings.management.commands.translate_strings.requests.post")
+    def test_non_dict_response_skips_batch(self, mock_post):
+        """If the API returns a list instead of a dict, batch is skipped."""
+        po = self._make_po([("Hello", "")])
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "choices": [{
+                "message": {"content": '["Bonjour"]'}
+            }]
+        }
+        mock_post.return_value = mock_response
+
+        cmd = self._make_command()
+        count = cmd._auto_translate_empty(po, review=False)
+
+        self.assertEqual(count, 0)
+        self.assertEqual(po.find("Hello").msgstr, "")
+
+    # ------------------------------------------------------------------
+    # Partial batch: some keys missing in response
+    # ------------------------------------------------------------------
+
+    @patch.dict(os.environ, {"TRANSLATE_API_KEY": "test-key-123"})
+    @patch("apps.admin_settings.management.commands.translate_strings.requests.post")
+    def test_partial_response_applies_available(self, mock_post):
+        """If the API omits some keys, only available translations apply."""
+        po = self._make_po([
+            ("Hello", ""),
+            ("Goodbye", ""),
+            ("Thanks", ""),
+        ])
+
+        # Only translate keys 0 and 2; key 1 is missing.
+        mock_post.return_value = self._mock_api_response({
+            "0": "Bonjour",
+            "2": "Merci",
+        })
+
+        cmd = self._make_command()
+        count = cmd._auto_translate_empty(po, review=False)
+
+        self.assertEqual(count, 2)
+        self.assertEqual(po.find("Hello").msgstr, "Bonjour")
+        self.assertEqual(po.find("Goodbye").msgstr, "")
+        self.assertEqual(po.find("Thanks").msgstr, "Merci")
+
+
+class CallTranslationApiTest(SimpleTestCase):
+    """Tests for Command._call_translation_api()."""
+
+    def _make_command(self):
+        cmd = Command()
+        cmd.stdout = io.StringIO()
+        cmd.stderr = io.StringIO()
+        # style is auto-initialised by BaseCommand.__init__; no override needed.
+        return cmd
+
+    @patch("apps.admin_settings.management.commands.translate_strings.requests.post")
+    def test_sends_correct_payload(self, mock_post):
+        """Verify the API request payload structure."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "choices": [{
+                "message": {"content": '{"0": "Bonjour"}'}
+            }]
+        }
+        mock_post.return_value = mock_response
+
+        cmd = self._make_command()
+        source_map = {"0": "Hello"}
+        cmd._call_translation_api(
+            "https://api.example.com/v1/chat/completions",
+            "test-key",
+            "gpt-4o-mini",
+            source_map,
+        )
+
+        # Verify the call was made with correct structure.
+        call_kwargs = mock_post.call_args
+        self.assertEqual(
+            call_kwargs.kwargs["headers"]["Authorization"],
+            "Bearer test-key",
+        )
+        payload = call_kwargs.kwargs["json"]
+        self.assertEqual(payload["model"], "gpt-4o-mini")
+        self.assertEqual(payload["messages"][0]["role"], "system")
+        self.assertEqual(
+            payload["messages"][0]["content"], TRANSLATION_SYSTEM_PROMPT
+        )
+        self.assertEqual(payload["messages"][1]["role"], "user")
+        # User message is the JSON-encoded source map.
+        self.assertEqual(
+            json.loads(payload["messages"][1]["content"]),
+            {"0": "Hello"},
+        )
+
+    @patch("apps.admin_settings.management.commands.translate_strings.requests.post")
+    def test_env_var_defaults(self, mock_post):
+        """Verify default API base URL and model from env vars."""
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            "choices": [{
+                "message": {"content": '{"0": "Bonjour"}'}
+            }]
+        }
+        mock_post.return_value = mock_response
+
+        cmd = self._make_command()
+
+        # When env vars are not set, defaults should apply.
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("TRANSLATE_API_BASE", None)
+            os.environ.pop("TRANSLATE_MODEL", None)
+            os.environ["TRANSLATE_API_KEY"] = "key-123"
+
+            po = self._make_po_for_env_test(cmd)
+
+        # The URL used should be the default.
+        call_args = mock_post.call_args
+        self.assertTrue(
+            call_args.args[0].startswith("https://api.openai.com/v1")
+            or call_args.kwargs.get("url", "").startswith(
+                "https://api.openai.com/v1"
+            )
+        )
+
+    def _make_po_for_env_test(self, cmd):
+        """Helper to run _auto_translate_empty for env var tests."""
+        po = polib.POFile()
+        po.metadata = {"Content-Type": "text/plain; charset=UTF-8"}
+        po.append(polib.POEntry(msgid="Hello", msgstr=""))
+        cmd._auto_translate_empty(po, review=False)
+        return po
+
+
+class SystemPromptTest(SimpleTestCase):
+    """Verify the system prompt contains required context."""
+
+    def test_prompt_mentions_canadian_french(self):
+        self.assertIn("Canadian French", TRANSLATION_SYSTEM_PROMPT)
+
+    def test_prompt_requires_vous(self):
+        self.assertIn("vous", TRANSLATION_SYSTEM_PROMPT)
+
+    def test_prompt_mentions_placeholders(self):
+        self.assertIn("%(name)s", TRANSLATION_SYSTEM_PROMPT)
+        self.assertIn("{{ var }}", TRANSLATION_SYSTEM_PROMPT)
+
+    def test_prompt_mentions_html_tags(self):
+        self.assertIn("<strong>", TRANSLATION_SYSTEM_PROMPT)
+
+    def test_prompt_mentions_guillemets(self):
+        self.assertIn("guillemets", TRANSLATION_SYSTEM_PROMPT)
+
+    def test_prompt_mentions_courriel(self):
+        self.assertIn("courriel", TRANSLATION_SYSTEM_PROMPT)
+
+    def test_prompt_requests_json(self):
+        self.assertIn("JSON object", TRANSLATION_SYSTEM_PROMPT)


### PR DESCRIPTION
## Summary
- Adds `--auto-translate` flag to the `translate_strings` management command
- Calls any OpenAI-compatible API (DeepL via proxy, Open Router, Ollama, etc.) to auto-translate empty French strings
- `--review` flag marks API-translated entries as fuzzy for human review
- Batches 25 strings per API call with error handling (skip failed batches)
- System prompt enforces Canadian French nonprofit conventions
- 21 new tests (mock-based, no API key needed)

## Configuration
- `TRANSLATE_API_KEY` — API key (required)
- `TRANSLATE_API_BASE` — base URL (default: OpenAI)
- `TRANSLATE_MODEL` — model name (default: gpt-4o-mini)

## Test plan
- [ ] Run `pytest tests/test_translate_strings.py` — 21 tests
- [ ] Verify `python manage.py translate_strings --help` shows new options
- [ ] Verify command works normally without `--auto-translate` (no behaviour change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)