### PR TITLE
feat: add axe-core accessibility pass to /capture-page-states (T59)

### DIFF
--- a/.claude/commands/capture-page-states.md
+++ b/.claude/commands/capture-page-states.md
@@ -44,18 +44,22 @@ Optional environment variable filters (set before running to narrow scope):
 - `PAGE_CAPTURE_PAGES` — comma-separated page IDs (e.g. `client-list,dashboard-staff`)
 - `PAGE_CAPTURE_PERSONAS` — comma-separated persona IDs (e.g. `R1,DS1`)
 - `PAGE_CAPTURE_BREAKPOINTS` — single breakpoint (e.g. `1366x768`)
+- `PAGE_CAPTURE_SKIP_AXE` — set to `1` to skip axe-core accessibility scanning (faster for debugging)
 
 ### Step 4: Report results
 
 After tests complete, report to the user:
 - Number of pages captured and total screenshots saved
+- Axe-core accessibility findings: total scans, pages with violations, total violations
 - Manifest location: `../konote-qa-scenarios/reports/screenshots/pages/.pages-manifest.json`
+- Axe report location: `../konote-qa-scenarios/reports/screenshots/pages/axe-a11y-report.json`
 - Any skipped pages or missing screenshots
 - Any failures or errors
 
 ### Next steps
 
 Tell the user:
-1. Switch to the `konote-qa-scenarios` repo
-2. Run `/run-page-audit` to evaluate the captured screenshots
-3. See `tasks/page-capture-reference.md` for troubleshooting, screenshot naming, and advanced options
+1. Review `axe-a11y-report.json` for a quick accessibility summary grouped by violation type
+2. Switch to the `konote-qa-scenarios` repo
+3. Run `/run-page-audit` to evaluate the captured screenshots
+4. See `tasks/page-capture-reference.md` for troubleshooting, screenshot naming, and advanced options

--- a/TODO.md
+++ b/TODO.md
@@ -100,14 +100,9 @@ Blocked on infrastructure (dedicated sprint):
 
 Scope is clear, just needs time. A session can pick these up without special approval.
 
-- [ ] Add axe-core pass to `/capture-page-states` — automated WCAG checks for screen reader/speech recognition coverage (T59)
-- [ ] Verify BLOCKER-1 and BLOCKER-2 with manual JAWS test — automated Playwright tests pass, manual assistive tech testing still needed (T50)
-- [ ] Add stress testing for 50+ concurrent users (QA-T15)
-- [ ] Add legacy system import migration scenario test (QA-T16)
-- [ ] Implement multi-session testing for SCN-046 shared device scenario (QA-W55)
-- [ ] Seed groups-attendance test data with 8+ members and 12+ sessions — fix in qa-scenarios repo (QA-PA-TEST1)
-- [ ] Seed comm-my-messages populated state with actual messages — fix in qa-scenarios repo (QA-PA-TEST2)
-- [ ] Optimize encrypted client search performance beyond ~2000 records (PERF1)
+- [ ] Verify BLOCKER-1 and BLOCKER-2 with manual JAWS test — automated Playwright tests pass, manual assistive tech testing still needed. Do before launch. (T50)
+- [ ] Seed groups-attendance test data with 8+ members and 12+ sessions — fix in qa-scenarios repo. Defer until workflows stabilise. (QA-PA-TEST1)
+- [ ] Seed comm-my-messages populated state with actual messages — fix in qa-scenarios repo. Defer until workflows stabilise. (QA-PA-TEST2)
 
 ## Parking Lot: Needs Review
 
@@ -123,6 +118,10 @@ Not yet clear we should build these, or the design isn't settled. May be too com
 - [ ] Add in-app configuration dashboard showing all active settings with decision rationale and change history (DEPLOY-CONFIG-UI1)
 - [ ] Separate "Scheduled Assessment" workflow for standardized instruments (PHQ-9, etc.) — partner reporting (ASSESS1)
 - [ ] Split `ai_assist` toggle into `ai_assist_tools_only` (default enabled) and `ai_assist_participant_data` (default disabled) — see tasks/design-rationale/ai-feature-toggles.md — GK reviews (AI-TOGGLE1)
+- [ ] Add stress testing for 50+ concurrent users — defer until a client is onboarded (QA-T15)
+- [ ] Add legacy system import migration scenario test — defer until an import is needed (QA-T16)
+- [ ] Implement multi-session testing for SCN-046 shared device scenario — defer until workflows stabilise (QA-W55)
+- [ ] Optimize encrypted client search performance beyond ~2000 records — defer until a client approaches that scale (PERF1)
 - [ ] Metric cadence system — only prompt for metric values when due, configurable per metric (METRIC-CADENCE1)
 - [ ] 90-day metric relevance check — prompt worker to confirm or change the chosen metric (METRIC-REVIEW1)
 - [ ] Alliance prompt rotation — cycle 3-4 phrasings to prevent habituation (ALLIANCE-ROTATE1)
@@ -130,6 +129,7 @@ Not yet clear we should build these, or the design isn't settled. May be too com
 
 ## Recently Done
 
+- [x] Add axe-core pass to `/capture-page-states` — automated WCAG checks on every page+persona+state, standalone report, skip flag — 2026-02-25 (T59)
 - [x] Verified: surveys already implemented — full apps/surveys/ with models, views, forms, tests, migrations — 2026-02-24 (SURVEY1)
 - [x] Verified: first-run setup wizard already implemented — 8-step guided configuration in admin settings — 2026-02-24 (SETUP1-UI)
 - [x] Verified: deployment workflow enhancements already implemented — is_demo flag, seed command, demo/real separation — 2026-02-24 (DEPLOY1)

--- a/tasks/page-capture-reference.md
+++ b/tasks/page-capture-reference.md
@@ -62,6 +62,9 @@ The manifest is written to `../konote-qa-scenarios/reports/screenshots/pages/.pa
   "states_captured": ["default", "populated"],
   "breakpoints": ["1366x768", "1920x1080", "375x667"],
   "total_screenshots": 487,
+  "axe_total_scans": 124,
+  "axe_pages_with_violations": 5,
+  "axe_total_violations": 12,
   "skipped": [],
   "missing_screenshots": [],
   "pages": [
@@ -70,11 +73,52 @@ The manifest is written to `../konote-qa-scenarios/reports/screenshots/pages/.pa
       "url": "/clients/",
       "personas_captured": ["R1", "R2", "DS1"],
       "states_captured": ["default", "populated"],
-      "screenshot_count": 18
+      "screenshot_count": 18,
+      "axe_results": [{"persona": "R1", "state": "default", "violation_count": 0, "violations": []}]
     }
   ]
 }
 ```
+
+## Axe-core Accessibility Scanning
+
+The capture pipeline runs axe-core 4.10.2 on every page+persona+state combination (once each, not per breakpoint). Results are saved in two places:
+
+### In the manifest (per-page)
+
+Each page entry in `.pages-manifest.json` includes an `axe_results` array:
+
+```json
+{
+  "page_id": "client-list",
+  "axe_results": [
+    {
+      "persona": "R1",
+      "state": "default",
+      "violation_count": 2,
+      "violations": [
+        {
+          "id": "color-contrast",
+          "impact": "serious",
+          "description": "Elements must have sufficient color contrast",
+          "help_url": "https://dequeuniversity.com/rules/axe/4.10/color-contrast",
+          "nodes_count": 3
+        }
+      ]
+    }
+  ]
+}
+```
+
+The manifest also includes top-level summary counts: `axe_total_scans`, `axe_pages_with_violations`, `axe_total_violations`.
+
+### Standalone report
+
+`axe-a11y-report.json` (same directory as the manifest) groups findings by rule type across all pages, sorted by severity. Useful for identifying systemic issues (e.g., colour contrast failing on 20 pages = one fix in the base template CSS).
+
+### Skipping axe
+
+Set `PAGE_CAPTURE_SKIP_AXE=1` to skip axe scanning for faster debugging runs.
 
 ## Environment Variable Filters
 
@@ -85,6 +129,7 @@ Set these before running to narrow the capture scope:
 | `PAGE_CAPTURE_PAGES` | `auth-login,client-list` | Only capture these pages |
 | `PAGE_CAPTURE_PERSONAS` | `R1,DS1` | Only use these personas |
 | `PAGE_CAPTURE_BREAKPOINTS` | `1366x768` | Only capture at this size |
+| `PAGE_CAPTURE_SKIP_AXE` | `1` | Skip axe-core accessibility scans |
 
 ## Persona Mapping
 

--- a/tests/integration/test_page_capture.py
+++ b/tests/integration/test_page_capture.py
@@ -428,11 +428,17 @@ class TestPageCapture(BrowserTestBase):
             axe_scans_count = manifest.get("axe_total_scans", 0)
             axe_violations = manifest.get("axe_total_violations", 0)
             axe_pages = manifest.get("axe_pages_with_violations", 0)
+            axe_errors = sum(1 for s in axe_scans if s.get("error"))
             print(f"\nAccessibility (axe-core)")
             print(f"------------------------")
             print(f"Axe scans: {axe_scans_count}")
             print(f"Pages with violations: {axe_pages}")
             print(f"Total violations: {axe_violations}")
+            if axe_errors and axe_errors == axe_scans_count:
+                print(f"WARNING: All {axe_errors} axe scans failed — "
+                      f"check CDN connectivity or network access")
+            elif axe_errors:
+                print(f"Axe scan errors: {axe_errors}")
             print(f"Axe report: {AXE_REPORT_PATH}")
         print(f"\nManifest: {MANIFEST_PATH}")
 

--- a/tests/integration/test_page_capture.py
+++ b/tests/integration/test_page_capture.py
@@ -25,6 +25,7 @@ import pytest
 
 from tests.ux_walkthrough.browser_base import BrowserTestBase, TEST_PASSWORD
 from tests.utils.page_capture import (
+    AXE_REPORT_PATH,
     MANIFEST_PATH,
     PAGE_INVENTORY_PATH,
     PERSONA_MAP,
@@ -35,6 +36,8 @@ from tests.utils.page_capture import (
     load_page_inventory,
     new_manifest,
     resolve_url_pattern,
+    run_axe_for_page,
+    write_axe_report,
     write_manifest,
 )
 
@@ -207,8 +210,10 @@ class TestPageCapture(BrowserTestBase):
         filter_pages = _env_list("PAGE_CAPTURE_PAGES")
         filter_personas = _env_list("PAGE_CAPTURE_PERSONAS")
         filter_breakpoints = _env_list("PAGE_CAPTURE_BREAKPOINTS")
+        skip_axe = os.environ.get("PAGE_CAPTURE_SKIP_AXE", "").strip() == "1"
 
         manifest = new_manifest()
+        axe_scans = []  # Accumulated for standalone axe report
         personas_seen = set()
         states_seen = set()
         current_persona = None  # track to avoid redundant logins
@@ -260,6 +265,7 @@ class TestPageCapture(BrowserTestBase):
                 "personas_captured": [],
                 "states_captured": [],
                 "screenshot_count": 0,
+                "axe_results": [],
             }
 
             for persona_id in persona_ids:
@@ -299,6 +305,63 @@ class TestPageCapture(BrowserTestBase):
                         continue
 
                 for state in capturable_states:
+                    # Navigate once per page+persona+state (not per breakpoint)
+                    full_url = self.live_url(resolved)
+                    try:
+                        self.page.goto(full_url, timeout=15000)
+                        self._wait_for_idle()
+                        page_loaded = True
+                    except Exception as exc:
+                        page_loaded = False
+                        for bp in breakpoints:
+                            if filter_breakpoints and bp not in filter_breakpoints:
+                                continue
+                            manifest["missing_screenshots"].append({
+                                "page_id": page_id,
+                                "persona": persona_id,
+                                "state": state,
+                                "breakpoint": bp,
+                                "reason": str(exc),
+                            })
+                        print(
+                            f"  FAIL  {page_id}/{persona_id}/{state}: {exc}",
+                            flush=True,
+                        )
+                        continue
+
+                    # Axe scan (once per page+persona+state, before viewport resizing)
+                    if not skip_axe and page_loaded:
+                        axe_result = run_axe_for_page(self.run_axe)
+                        axe_result["page_id"] = page_id
+                        axe_result["persona"] = persona_id
+                        axe_result["state"] = state
+                        axe_scans.append(axe_result)
+
+                        page_manifest["axe_results"].append({
+                            "persona": persona_id,
+                            "state": state,
+                            "violation_count": axe_result["violation_count"],
+                            "violations": axe_result["violations"],
+                        })
+
+                        manifest["axe_total_scans"] += 1
+                        if axe_result["violation_count"] > 0:
+                            manifest["axe_total_violations"] += (
+                                axe_result["violation_count"]
+                            )
+                            print(
+                                f"  AXE  {page_id}/{persona_id}/{state}: "
+                                f"{axe_result['violation_count']} violations",
+                                flush=True,
+                            )
+                        elif axe_result.get("error"):
+                            print(
+                                f"  AXE  {page_id}/{persona_id}/{state}: "
+                                f"ERROR {axe_result['error'][:60]}",
+                                flush=True,
+                            )
+
+                    # Screenshots at each breakpoint
                     for bp in breakpoints:
                         if filter_breakpoints and bp not in filter_breakpoints:
                             continue
@@ -307,9 +370,6 @@ class TestPageCapture(BrowserTestBase):
                         filepath = SCREENSHOT_DIR / filename
 
                         try:
-                            full_url = self.live_url(resolved)
-                            self.page.goto(full_url, timeout=15000)
-                            self._wait_for_idle()
                             capture_page_screenshot(self.page, filepath, bp)
 
                             manifest["total_screenshots"] += 1
@@ -337,10 +397,21 @@ class TestPageCapture(BrowserTestBase):
             manifest["pages"].append(page_manifest)
             manifest["pages_captured"] += 1
 
+        # Compute axe pages-with-violations count
+        if axe_scans:
+            pages_with_axe_issues = {
+                s["page_id"] for s in axe_scans if s["violation_count"] > 0
+            }
+            manifest["axe_pages_with_violations"] = len(pages_with_axe_issues)
+
         # Finalise manifest
         manifest["personas_tested"] = sorted(personas_seen)
         manifest["states_captured"] = sorted(states_seen)
         write_manifest(manifest)
+
+        # Write standalone axe report
+        if axe_scans:
+            write_axe_report(axe_scans, manifest["timestamp"])
 
         # Summary
         total = manifest["total_screenshots"]
@@ -353,6 +424,16 @@ class TestPageCapture(BrowserTestBase):
         print(f"Total screenshots: {total}")
         print(f"Skipped pages: {skipped}")
         print(f"Missing screenshots: {missing}")
+        if not skip_axe:
+            axe_scans_count = manifest.get("axe_total_scans", 0)
+            axe_violations = manifest.get("axe_total_violations", 0)
+            axe_pages = manifest.get("axe_pages_with_violations", 0)
+            print(f"\nAccessibility (axe-core)")
+            print(f"------------------------")
+            print(f"Axe scans: {axe_scans_count}")
+            print(f"Pages with violations: {axe_pages}")
+            print(f"Total violations: {axe_violations}")
+            print(f"Axe report: {AXE_REPORT_PATH}")
         print(f"\nManifest: {MANIFEST_PATH}")
 
         self.assertGreater(total, 0, "No screenshots were captured!")


### PR DESCRIPTION
## Summary

- Adds axe-core 4.10.2 accessibility scanning to the page capture pipeline — runs once per page+persona+state combination (not per breakpoint)
- Results recorded in the manifest (per-page `axe_results` array + top-level summary counts) and a standalone `axe-a11y-report.json` grouped by rule type
- Reuses existing `BrowserTestBase.run_axe()` — no new dependencies
- Moves `page.goto()` outside the breakpoints loop (was navigating 3x per page unnecessarily)
- `PAGE_CAPTURE_SKIP_AXE=1` env var to skip for faster debugging runs
- Defers QA-T15, QA-T16, QA-W55, PERF1 to Parking Lot (premature without a client)

## Test plan

- [ ] Run with narrow scope: `PAGE_CAPTURE_PAGES=client-list,dashboard-staff PAGE_CAPTURE_PERSONAS=R1 pytest tests/integration/test_page_capture.py -v -s`
- [ ] Verify manifest includes `axe_results` per page and top-level `axe_total_scans`
- [ ] Verify `axe-a11y-report.json` exists and groups violations by rule type
- [ ] Verify `PAGE_CAPTURE_SKIP_AXE=1` skips axe scanning
- [ ] Confirm screenshots are unchanged (same filenames, same directory)

🤖 Generated with [Claude Code](https://claude.com/claude-code)