### PR TITLE
chore: reorder Offline Field Collection, remove WEB-EVIDENCE1

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -10,13 +10,6 @@
 
 ## Active Work
 
-### Phase: Offline Field Collection (remaining items — code merged via PR #34)
-
-- [ ] Deploy ODK Central on Canadian VM (Docker Compose) — ops task (FIELD-ODK-DEPLOY1)
-- [ ] Circle Observation XLSForm — depends on circles in ODK (FIELD-ODK-FORM-CIR1)
-- [ ] Push Circle/CircleMember Entity lists — depends on above (FIELD-ODK-CIRCLES1)
-- [ ] Agency-facing documentation — ODK Collect setup, device loss protocol (FIELD-ODK-DOC1)
-
 ### Phase: Launch Readiness
 
 - [ ] Complete Agency Deployment Protocol with [funder partner] — Phase 0 Discovery Call first (see tasks/deployment-protocol.md) — (DEPLOY-PC1)
@@ -76,6 +69,13 @@ Step-by-step commands for each task are in [tasks/recurring-tasks.md](tasks/recu
 - [ ] Compute CIDS impact dimensions (scale, depth, duration) from existing KoNote data — no new data entry (Phase 4) — (CIDS-IMPACT1)
 - [ ] Add CIDS conformance badge and detailed validation reporting (Phase 5) — (CIDS-VALIDATE1)
 
+### Phase: Offline Field Collection (if requested by client)
+
+- [ ] Deploy ODK Central on Canadian VM (Docker Compose) — ops task (FIELD-ODK-DEPLOY1)
+- [ ] Circle Observation XLSForm — depends on circles in ODK (FIELD-ODK-FORM-CIR1)
+- [ ] Push Circle/CircleMember Entity lists — depends on above (FIELD-ODK-CIRCLES1)
+- [ ] Agency-facing documentation — ODK Collect setup, device loss protocol (FIELD-ODK-DOC1)
+
 ### Phase: Other Upcoming
 
 Blocked on infrastructure (dedicated sprint):
@@ -92,7 +92,6 @@ Blocked on infrastructure (dedicated sprint):
 
 - [ ] Create deployment documentation for surveys and portal features (DOC-DEPLOY1)
 - [ ] Update technical documentation in GitHub for surveys and portal architecture (DOC-TECH1)
-- [ ] Add Evidence section to website — adapt docs/evidence-outcome-measurement.md into a public-facing page explaining the research behind KoNote's outcome measurement approach (see tasks/web-evidence-prompt.md) (WEB-EVIDENCE1)
 - [ ] Seed groups-attendance test data with 8+ members and 12+ sessions — re-seed after workflow changes, fix in qa-scenarios repo (QA-PA-TEST1)
 - [ ] Seed comm-my-messages populated state with actual messages — re-seed after workflow changes, fix in qa-scenarios repo (QA-PA-TEST2)
 - [ ] Add new features and capabilities to the web site as they are built (WEBSITE-UPDATE1)


### PR DESCRIPTION
## Summary
- Renamed "Phase: Offline Field Collection (remaining items — code merged via PR #34)" to "Phase: Offline Field Collection (if requested by client)" and moved it from Active Work to Coming Up
- Removed WEB-EVIDENCE1 task which has been repeatedly removed but keeps reappearing

## Test plan
- [x] Verify TODO.md formatting is correct
- [x] Confirm Offline Field Collection section appears under Coming Up
- [x] Confirm WEB-EVIDENCE1 line is fully removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)