### PR TITLE
chore: fix misplaced tasks in TODO.md parking lots

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -100,14 +100,13 @@ Blocked on infrastructure (dedicated sprint):
 
 Scope is clear, just needs time. A session can pick these up without special approval.
 
-- [ ] Verify BLOCKER-1 and BLOCKER-2 with manual JAWS test — automated Playwright tests pass, manual assistive tech testing still needed. Do before launch. (T50)
-- [ ] Seed groups-attendance test data with 8+ members and 12+ sessions — fix in qa-scenarios repo. Defer until workflows stabilise. (QA-PA-TEST1)
-- [ ] Seed comm-my-messages populated state with actual messages — fix in qa-scenarios repo. Defer until workflows stabilise. (QA-PA-TEST2)
+_Nothing here right now._
 
 ## Parking Lot: Needs Review
 
 Not yet clear we should build these, or the design isn't settled. May be too complex, too risky, or not worth the effort. **Do not build without explicit user approval in the current conversation.**
 
+- [ ] Verify BLOCKER-1 and BLOCKER-2 with manual JAWS test — automated Playwright tests pass, manual assistive tech testing still needed. Do before launch. (T50)
 - [ ] PIPEDA data export from client profile — "Export Data" action for Section 8 access requests, needs design for data categories and output format — GK reviews privacy workflow (QA-R7-PRIVACY1)
 - [ ] Consent withdrawal workflow on client profile — wizard for PIPEDA consent withdrawal with data retention rules — GK reviews privacy/data retention (QA-R7-PRIVACY2)
 - [ ] Executive compliance report — aggregate dashboard showing privacy request counts, processing times (no PII) — GK reviews reporting methodology (QA-R7-EXEC-COMPLIANCE1)


### PR DESCRIPTION
## Summary
- Removed QA-PA-TEST1 and QA-PA-TEST2 duplicates from Parking Lot: Ready to Build (already in Documentation & Website Updates)
- Moved T50 (JAWS manual test) from Ready to Build to Needs Review

## Test plan
- [x] Verify no duplicates remain
- [x] Verify T50 appears in Parking Lot: Needs Review

🤖 Generated with [Claude Code](https://claude.com/claude-code)