### PR TITLE
Permissions audit: sync docs, add validation tooling and tests

### DIFF
--- a/apps/auth_app/checks.py
+++ b/apps/auth_app/checks.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from django.conf import settings
 from django.core.checks import Error, Warning, register
 
-from apps.auth_app.permissions import ALL_PERMISSION_KEYS
+from apps.auth_app.permissions import ALL_PERMISSION_KEYS, validate_permissions
 
 
 # Patterns to detect hardcoded role decorators in Python files
@@ -201,3 +201,19 @@ def check_dead_permission_keys(app_configs, **kwargs):
         )
 
     return warnings
+
+
+@register()
+def check_permissions_matrix_complete(app_configs, **kwargs):
+    """E021: Error if the permissions matrix is incomplete (missing roles or keys)."""
+    is_valid, validation_errors = validate_permissions()
+    if is_valid:
+        return []
+    return [
+        Error(
+            f"Permissions matrix incomplete: {error}",
+            hint="Check apps/auth_app/permissions.py — every role must define every key.",
+            id="KoNote.E021",
+        )
+        for error in validation_errors
+    ]

--- a/apps/auth_app/management/commands/validate_permissions.py
+++ b/apps/auth_app/management/commands/validate_permissions.py
@@ -1,45 +1,344 @@
-"""Management command to validate the central permissions matrix."""
+"""Management command to validate the permissions matrix and audit user roles.
+
+Usage:
+    python manage.py validate_permissions              # Matrix completeness only
+    python manage.py validate_permissions --user casey  # Show one user's effective permissions
+    python manage.py validate_permissions --all-users   # Audit every active user
+    python manage.py validate_permissions --demo        # Validate demo users match expected roles
+"""
 from django.core.management.base import BaseCommand
 
-from apps.auth_app.permissions import validate_permissions, PERMISSIONS
+from apps.auth_app.permissions import (
+    ALLOW,
+    DENY,
+    GATED,
+    PER_FIELD,
+    PERMISSIONS,
+    PROGRAM,
+    permission_to_plain_english,
+    validate_permissions,
+)
+
+
+# Expected demo user role assignments — single source of truth for tests and
+# validation.  Format: username → list of (program_name, role).
+EXPECTED_DEMO_ROLES = {
+    "demo-frontdesk": [
+        ("Supported Employment", "receptionist"),
+        ("Housing Stability", "receptionist"),
+        ("Youth Drop-In", "receptionist"),
+        ("Newcomer Connections", "receptionist"),
+        ("Community Kitchen", "receptionist"),
+    ],
+    "demo-worker-1": [
+        ("Supported Employment", "program_manager"),
+        ("Housing Stability", "staff"),
+        ("Community Kitchen", "staff"),
+    ],
+    "demo-worker-2": [
+        ("Youth Drop-In", "staff"),
+        ("Newcomer Connections", "staff"),
+        ("Community Kitchen", "staff"),
+    ],
+    "demo-manager": [
+        ("Supported Employment", "program_manager"),
+        ("Housing Stability", "program_manager"),
+        ("Community Kitchen", "program_manager"),
+    ],
+    "demo-executive": [
+        ("Supported Employment", "executive"),
+        ("Housing Stability", "executive"),
+        ("Youth Drop-In", "executive"),
+        ("Newcomer Connections", "executive"),
+        ("Community Kitchen", "executive"),
+    ],
+}
+
+
+# Role display names for output
+ROLE_DISPLAY = {
+    "receptionist": "Front Desk",
+    "staff": "Direct Service",
+    "program_manager": "Program Manager",
+    "executive": "Executive",
+}
+
+# Permission level display
+LEVEL_DISPLAY = {
+    ALLOW: "YES",
+    PROGRAM: "SCOPED",
+    GATED: "GATED",
+    PER_FIELD: "PER FIELD",
+    DENY: "—",
+}
 
 
 class Command(BaseCommand):
-    help = "Validate that all roles have all permission keys defined"
+    help = "Validate permissions matrix and audit user role assignments."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--user",
+            type=str,
+            help="Show effective permissions for a specific username.",
+        )
+        parser.add_argument(
+            "--all-users",
+            action="store_true",
+            help="Audit all active users and their effective permissions.",
+        )
+        parser.add_argument(
+            "--demo",
+            action="store_true",
+            help="Validate demo user role assignments match expected configuration.",
+        )
 
     def handle(self, *args, **options):
-        """Run validation and print results."""
-        is_valid, errors = validate_permissions()
+        """Run validation and optional user audits."""
+        errors = []
 
-        if is_valid:
-            self.stdout.write(self.style.SUCCESS("[OK] All 4 roles defined"))
-            self.stdout.write(self.style.SUCCESS("[OK] All permission keys present for each role"))
-            self.stdout.write(self.style.SUCCESS("[OK] No undefined permission levels"))
-            self.stdout.write(self.style.SUCCESS("[OK] Permissions matrix complete"))
+        # Always validate matrix completeness
+        matrix_errors = self._validate_matrix()
+        errors.extend(matrix_errors)
 
-            # Print summary
-            self.stdout.write("\n" + "=" * 60)
-            self.stdout.write("Permissions Matrix Summary")
-            self.stdout.write("=" * 60)
+        if options.get("demo"):
+            demo_errors = self._validate_demo_users()
+            errors.extend(demo_errors)
 
-            for role in ["receptionist", "staff", "program_manager", "executive"]:
-                role_perms = PERMISSIONS[role]
-                allow_count = sum(1 for v in role_perms.values() if v == "allow")
-                program_count = sum(1 for v in role_perms.values() if v == "program")
-                deny_count = sum(1 for v in role_perms.values() if v == "deny")
-                other_count = sum(1 for v in role_perms.values() if v not in ["allow", "program", "deny"])
+        if options.get("user"):
+            self._show_user_permissions(options["user"])
 
-                self.stdout.write(
-                    f"\n{role.upper()}: "
-                    f"{allow_count} ALLOW, "
-                    f"{program_count} PROGRAM, "
-                    f"{deny_count} DENY, "
-                    f"{other_count} OTHER"
-                )
+        if options.get("all_users"):
+            self._audit_all_users()
 
-            return 0
-        else:
-            self.stdout.write(self.style.ERROR("[FAIL] Permissions validation failed"))
+        if errors:
+            self.stdout.write("")
+            self.stdout.write(self.style.ERROR(f"[FAIL] {len(errors)} issue(s) found:"))
             for error in errors:
                 self.stdout.write(self.style.ERROR(f"  - {error}"))
             return 1
+
+        if not options.get("user") and not options.get("all_users"):
+            self.stdout.write(self.style.SUCCESS("\n[OK] All validation checks passed."))
+        return 0
+
+    def _validate_matrix(self):
+        """Check that all 4 roles have all permission keys defined."""
+        is_valid, validation_errors = validate_permissions()
+        errors = []
+
+        if is_valid:
+            total_keys = len(next(iter(PERMISSIONS.values())))
+            self.stdout.write(
+                self.style.SUCCESS(
+                    f"[OK] Permissions matrix complete: "
+                    f"4 roles x {total_keys} permission keys"
+                )
+            )
+
+            # Print summary counts
+            for role in ["receptionist", "staff", "program_manager", "executive"]:
+                role_perms = PERMISSIONS[role]
+                counts = {}
+                for v in role_perms.values():
+                    counts[v] = counts.get(v, 0) + 1
+                parts = []
+                for level in [ALLOW, PROGRAM, GATED, PER_FIELD, DENY]:
+                    if counts.get(level, 0) > 0:
+                        parts.append(f"{counts[level]} {LEVEL_DISPLAY[level]}")
+                self.stdout.write(
+                    f"  {ROLE_DISPLAY.get(role, role):20s} {', '.join(parts)}"
+                )
+        else:
+            for e in validation_errors:
+                errors.append(e)
+
+        return errors
+
+    def _validate_demo_users(self):
+        """Check that demo users have exactly the expected role assignments."""
+        from apps.auth_app.models import User
+        from apps.programs.models import UserProgramRole
+
+        self.stdout.write("")
+        self.stdout.write("Demo User Role Validation")
+        self.stdout.write("=" * 60)
+
+        errors = []
+
+        for username, expected_roles in EXPECTED_DEMO_ROLES.items():
+            user = User.objects.filter(username=username, is_demo=True).first()
+            if not user:
+                errors.append(f"Demo user '{username}' not found")
+                self.stdout.write(self.style.ERROR(f"  {username}: NOT FOUND"))
+                continue
+
+            # Get actual roles
+            actual_roles = set(
+                UserProgramRole.objects.filter(user=user, status="active")
+                .values_list("program__name", "role")
+            )
+            expected_set = set(tuple(r) for r in expected_roles)
+
+            missing = expected_set - actual_roles
+            extra = actual_roles - expected_set
+
+            if not missing and not extra:
+                self.stdout.write(
+                    self.style.SUCCESS(
+                        f"  {username}: {len(actual_roles)} role(s) — all correct"
+                    )
+                )
+            else:
+                if missing:
+                    for prog, role in sorted(missing):
+                        errors.append(
+                            f"{username}: missing role {ROLE_DISPLAY.get(role, role)} "
+                            f"in {prog}"
+                        )
+                        self.stdout.write(
+                            self.style.ERROR(
+                                f"  {username}: MISSING {ROLE_DISPLAY.get(role, role)} "
+                                f"in {prog}"
+                            )
+                        )
+                if extra:
+                    for prog, role in sorted(extra):
+                        errors.append(
+                            f"{username}: unexpected role {ROLE_DISPLAY.get(role, role)} "
+                            f"in {prog}"
+                        )
+                        self.stdout.write(
+                            self.style.WARNING(
+                                f"  {username}: UNEXPECTED {ROLE_DISPLAY.get(role, role)} "
+                                f"in {prog}"
+                            )
+                        )
+
+        return errors
+
+    def _show_user_permissions(self, username):
+        """Print effective permissions for a specific user."""
+        from apps.auth_app.models import User
+        from apps.programs.models import UserProgramRole
+
+        self.stdout.write("")
+        user = User.objects.filter(username=username).first()
+        if not user:
+            self.stdout.write(self.style.ERROR(f"User '{username}' not found."))
+            return
+
+        self.stdout.write(f"Permissions for: {user.display_name} ({user.username})")
+        self.stdout.write("=" * 60)
+
+        if user.is_admin:
+            self.stdout.write(
+                self.style.WARNING("  [ADMIN] Has system configuration access")
+            )
+
+        roles = UserProgramRole.objects.filter(
+            user=user, status="active"
+        ).select_related("program").order_by("program__name")
+
+        if not roles.exists():
+            self.stdout.write("  No program roles assigned.")
+            if user.is_admin:
+                self.stdout.write(
+                    "  Admin-only: can manage settings but cannot access "
+                    "client data."
+                )
+            return
+
+        # Show role assignments
+        self.stdout.write("")
+        self.stdout.write("  Role Assignments:")
+        for role_obj in roles:
+            self.stdout.write(
+                f"    {role_obj.program.name:30s} "
+                f"{ROLE_DISPLAY.get(role_obj.role, role_obj.role)}"
+            )
+
+        # Show effective permissions per program
+        for role_obj in roles:
+            self.stdout.write("")
+            self.stdout.write(
+                f"  In {role_obj.program.name} "
+                f"({ROLE_DISPLAY.get(role_obj.role, role_obj.role)}):"
+            )
+            role_perms = PERMISSIONS.get(role_obj.role, {})
+
+            # Group by category
+            categories = {}
+            for key, level in sorted(role_perms.items()):
+                category = key.split(".")[0]
+                if category not in categories:
+                    categories[category] = []
+                categories[category].append((key, level))
+
+            for category, perms in sorted(categories.items()):
+                allowed = [
+                    (k, l) for k, l in perms if l != DENY
+                ]
+                if allowed:
+                    for key, level in allowed:
+                        label = LEVEL_DISPLAY.get(level, level)
+                        desc = permission_to_plain_english(key, level)
+                        self.stdout.write(f"    [{label:8s}] {desc}")
+
+        # Show what they CAN'T do (summary)
+        self.stdout.write("")
+        self.stdout.write("  Key restrictions (across all programs):")
+        # Use the user's highest role for a summary of denials
+        from apps.auth_app.constants import ROLE_RANK
+        all_roles = set(r.role for r in roles)
+        highest = max(all_roles, key=lambda r: ROLE_RANK.get(r, 0))
+        highest_perms = PERMISSIONS.get(highest, {})
+        denied = [
+            k for k, v in sorted(highest_perms.items()) if v == DENY
+        ]
+        if denied:
+            for key in denied[:10]:  # Show first 10 to avoid overwhelming
+                desc = permission_to_plain_english(key, DENY)
+                self.stdout.write(f"    {desc}")
+            if len(denied) > 10:
+                self.stdout.write(f"    ... and {len(denied) - 10} more denied.")
+
+    def _audit_all_users(self):
+        """Print a summary table of all active users and their roles."""
+        from apps.auth_app.models import User
+        from apps.programs.models import UserProgramRole
+
+        self.stdout.write("")
+        self.stdout.write("All Active Users")
+        self.stdout.write("=" * 60)
+
+        users = User.objects.filter(is_active=True).order_by("username")
+
+        for user in users:
+            roles = UserProgramRole.objects.filter(
+                user=user, status="active"
+            ).select_related("program").order_by("program__name")
+
+            flags = []
+            if user.is_admin:
+                flags.append("ADMIN")
+            if user.is_demo:
+                flags.append("DEMO")
+
+            flag_str = f" [{', '.join(flags)}]" if flags else ""
+
+            if roles.exists():
+                role_strs = [
+                    f"{ROLE_DISPLAY.get(r.role, r.role)} in {r.program.name}"
+                    for r in roles
+                ]
+                self.stdout.write(
+                    f"  {user.display_name} ({user.username}){flag_str}"
+                )
+                for rs in role_strs:
+                    self.stdout.write(f"    - {rs}")
+            else:
+                suffix = " (system config only)" if user.is_admin else " (no access)"
+                self.stdout.write(
+                    f"  {user.display_name} ({user.username}){flag_str}{suffix}"
+                )

--- a/docs/permissions-matrix.md
+++ b/docs/permissions-matrix.md
@@ -30,7 +30,7 @@
 | See clinical data | — | Scoped | Gated | — | — |
 | Create new clients | Yes | Scoped | Scoped | — | — |
 | Edit client records | — | Scoped | Scoped | — | — |
-| Edit contact info (phone/email) | Per field | Scoped | — | — | — |
+| Edit contact info (phone/email) | Yes | Scoped | — | — | — |
 | Transfer between programs | — | Scoped | Scoped | — | — |
 | View consent records | — | Scoped | Yes | — | — |
 | Manage consent | — | Scoped | Scoped | — | — |
@@ -259,4 +259,5 @@ Circles represent families, households, or support networks. They are **cross-pr
 | Program Manager: view group session content | ALLOW | GATED | Phase 3 |
 | Program Manager: view individual metrics | ALLOW | GATED | Phase 3 |
 | Program Manager: view custom fields | ALLOW | GATED | Phase 3 |
+| Front Desk: edit contact info | ALLOW (whole page) | PER_FIELD (individual fields) | Phase 2 |
 | Direct Service: scoping | Program-wide | Assigned groups/clients only | Phase 2 |

--- a/tests/test_permissions_enforcement.py
+++ b/tests/test_permissions_enforcement.py
@@ -1,6 +1,6 @@
 """Parametrized permission enforcement test (Wave 6A).
 
-Tests all 48 permission keys x 4 roles = 192 cases. For each (role, key)
+Tests all 68 permission keys x 4 roles = 272 cases. For each (role, key)
 pair, makes an HTTP request to the URL protected by that key and asserts:
   - DENY -> 403 (or 302 redirect for executives on client-scoped URLs)
   - ALLOW / PROGRAM / GATED / PER_FIELD -> NOT 403
@@ -268,7 +268,7 @@ class PermissionEnforcementTest(TestCase):
     # ------------------------------------------------------------------
 
     def test_permission_matrix_enforcement(self):
-        """All 48 permission keys x 4 roles: DENY -> 403, others -> not 403."""
+        """All 68 permission keys x 4 roles: DENY -> 403, others -> not 403."""
         for role in ALL_ROLES:
             user = self.users[role]
             for perm_key, config in PERMISSION_URL_MAP.items():

--- a/tests/test_permissions_validation.py
+++ b/tests/test_permissions_validation.py
@@ -1,0 +1,265 @@
+"""Tests for permissions matrix completeness and demo user role validation.
+
+These tests ensure that:
+1. The permissions matrix is internally consistent (all roles have all keys).
+2. Every permission key in the code maps to a valid level.
+3. Demo users have exactly the expected role assignments.
+4. The validate_permissions management command works correctly.
+
+Run with:
+    pytest tests/test_permissions_validation.py
+"""
+from io import StringIO
+
+from cryptography.fernet import Fernet
+from django.core.management import call_command
+from django.test import TestCase, override_settings
+
+from apps.auth_app.permissions import (
+    ALLOW,
+    DENY,
+    GATED,
+    PERMISSIONS,
+    PER_FIELD,
+    PROGRAM,
+    validate_permissions,
+)
+import konote.encryption as enc_module
+
+TEST_KEY = Fernet.generate_key().decode()
+
+# Valid permission levels — anything else is a bug
+VALID_LEVELS = {ALLOW, DENY, PROGRAM, GATED, PER_FIELD}
+
+# The four roles that must exist
+EXPECTED_ROLES = {"receptionist", "staff", "program_manager", "executive"}
+
+
+class PermissionsMatrixCompletenessTest(TestCase):
+    """Validate the permissions matrix is internally consistent."""
+
+    def test_all_roles_present(self):
+        """All four roles must be defined in the PERMISSIONS dict."""
+        for role in EXPECTED_ROLES:
+            self.assertIn(role, PERMISSIONS, f"Role '{role}' missing from PERMISSIONS")
+
+    def test_all_roles_have_same_keys(self):
+        """Every role must define exactly the same set of permission keys."""
+        all_keys = set()
+        for role_perms in PERMISSIONS.values():
+            all_keys.update(role_perms.keys())
+
+        for role in EXPECTED_ROLES:
+            role_keys = set(PERMISSIONS[role].keys())
+            missing = all_keys - role_keys
+            extra = role_keys - all_keys
+            self.assertEqual(
+                missing, set(),
+                f"Role '{role}' is missing keys: {sorted(missing)}"
+            )
+            self.assertEqual(
+                extra, set(),
+                f"Role '{role}' has extra keys not in other roles: {sorted(extra)}"
+            )
+
+    def test_all_values_are_valid_levels(self):
+        """Every permission value must be one of the defined levels."""
+        for role, perms in PERMISSIONS.items():
+            for key, level in perms.items():
+                self.assertIn(
+                    level, VALID_LEVELS,
+                    f"Invalid level '{level}' for {role}.{key}"
+                )
+
+    def test_validate_permissions_function_passes(self):
+        """The validate_permissions() function should report success."""
+        is_valid, errors = validate_permissions()
+        self.assertTrue(is_valid, f"Validation failed: {errors}")
+
+    def test_no_unexpected_roles(self):
+        """No extra roles beyond the expected four."""
+        extra = set(PERMISSIONS.keys()) - EXPECTED_ROLES
+        self.assertEqual(
+            extra, set(),
+            f"Unexpected roles in PERMISSIONS: {extra}"
+        )
+
+
+class PermissionsDesignRulesTest(TestCase):
+    """Validate design rules that should hold across the matrix."""
+
+    def test_executive_has_no_client_data_access(self):
+        """Executives must DENY all individual client data permissions."""
+        client_keys = [
+            "client.view_name", "client.view_contact", "client.view_safety",
+            "client.view_medications", "client.view_clinical",
+            "client.edit", "client.create", "client.edit_contact",
+            "client.transfer",
+            "note.view", "note.create", "note.edit",
+            "plan.view", "plan.edit",
+            "event.view", "event.create",
+            "circle.view", "circle.create", "circle.edit",
+        ]
+        exec_perms = PERMISSIONS["executive"]
+        for key in client_keys:
+            self.assertEqual(
+                exec_perms.get(key), DENY,
+                f"Executive should DENY '{key}' but has '{exec_perms.get(key)}'"
+            )
+
+    def test_receptionist_denies_clinical(self):
+        """Front desk must DENY all clinical data access."""
+        clinical_keys = [
+            "client.view_medications", "client.view_clinical",
+            "note.view", "note.create", "note.edit",
+            "plan.view", "plan.edit",
+            "circle.view", "circle.create", "circle.edit",
+            "group.view_roster", "group.view_detail",
+        ]
+        fd_perms = PERMISSIONS["receptionist"]
+        for key in clinical_keys:
+            self.assertEqual(
+                fd_perms.get(key), DENY,
+                f"Receptionist should DENY '{key}' but has '{fd_perms.get(key)}'"
+            )
+
+    def test_receptionist_allows_safety_info(self):
+        """Front desk MUST see names, contact, and safety info (life-critical)."""
+        safety_keys = [
+            "client.view_name", "client.view_contact", "client.view_safety",
+        ]
+        fd_perms = PERMISSIONS["receptionist"]
+        for key in safety_keys:
+            self.assertEqual(
+                fd_perms.get(key), ALLOW,
+                f"Receptionist MUST ALLOW '{key}' (safety critical)"
+            )
+
+    def test_all_destructive_actions_denied(self):
+        """Delete permissions should be DENY for all roles."""
+        destructive_keys = ["note.delete", "client.delete", "plan.delete"]
+        for role in EXPECTED_ROLES:
+            for key in destructive_keys:
+                self.assertEqual(
+                    PERMISSIONS[role].get(key), DENY,
+                    f"{role} should DENY '{key}'"
+                )
+
+    def test_staff_cannot_manage_suggestion_themes(self):
+        """Staff can view suggestion themes but not create/edit/link them."""
+        self.assertNotEqual(
+            PERMISSIONS["staff"]["suggestion_theme.view"], DENY,
+            "Staff should be able to view suggestion themes"
+        )
+        self.assertEqual(
+            PERMISSIONS["staff"]["suggestion_theme.manage"], DENY,
+            "Staff should not manage suggestion themes"
+        )
+
+    def test_pm_clinical_data_is_gated(self):
+        """PM access to clinical data, notes, and plans must be GATED."""
+        gated_keys = [
+            "client.view_clinical", "note.view", "plan.view",
+        ]
+        pm_perms = PERMISSIONS["program_manager"]
+        for key in gated_keys:
+            self.assertEqual(
+                pm_perms.get(key), GATED,
+                f"PM '{key}' should be GATED (clinical safeguards) "
+                f"but is '{pm_perms.get(key)}'"
+            )
+
+    def test_alert_two_person_rule(self):
+        """Staff can recommend cancel but not cancel; PM can cancel but not recommend."""
+        staff = PERMISSIONS["staff"]
+        pm = PERMISSIONS["program_manager"]
+
+        self.assertEqual(staff["alert.cancel"], DENY)
+        self.assertNotEqual(staff["alert.recommend_cancel"], DENY)
+        self.assertNotEqual(pm["alert.cancel"], DENY)
+        self.assertEqual(pm["alert.recommend_cancel"], DENY)
+
+
+@override_settings(FIELD_ENCRYPTION_KEY=TEST_KEY)
+class DemoUserRoleValidationTest(TestCase):
+    """Validate demo user role assignments match the expected configuration.
+
+    This test seeds the demo database and then checks that the
+    EXPECTED_DEMO_ROLES dictionary in the validate_permissions command
+    matches what seed.py actually creates.
+    """
+
+    databases = {"default", "audit"}
+
+    @classmethod
+    def setUpClass(cls):
+        """Seed demo data once for all tests in this class."""
+        super().setUpClass()
+        enc_module._fernet = None
+
+    def setUp(self):
+        enc_module._fernet = None
+        from django.conf import settings
+        # Only run seed in DEMO_MODE
+        self._original_demo = getattr(settings, "DEMO_MODE", False)
+        settings.DEMO_MODE = True
+
+    def tearDown(self):
+        from django.conf import settings
+        settings.DEMO_MODE = self._original_demo
+        enc_module._fernet = None
+
+    def test_demo_seed_and_validate(self):
+        """Seed demo data and run --demo validation without errors."""
+        # Seed
+        out = StringIO()
+        call_command("seed", stdout=out, stderr=StringIO())
+
+        # Validate
+        out = StringIO()
+        result = call_command("validate_permissions", "--demo", stdout=out, stderr=StringIO())
+        output = out.getvalue()
+
+        # Should report all correct
+        self.assertNotIn("MISSING", output, f"Missing roles found:\n{output}")
+        self.assertNotIn("UNEXPECTED", output, f"Unexpected roles found:\n{output}")
+        self.assertNotIn("NOT FOUND", output, f"Users not found:\n{output}")
+
+
+class ValidatePermissionsCommandTest(TestCase):
+    """Test the management command runs without errors."""
+
+    def test_matrix_validation_passes(self):
+        """The command should succeed for matrix-only validation."""
+        out = StringIO()
+        result = call_command("validate_permissions", stdout=out)
+        self.assertEqual(result, 0)
+        self.assertIn("[OK]", out.getvalue())
+
+    @override_settings(FIELD_ENCRYPTION_KEY=TEST_KEY)
+    def test_user_flag_shows_permissions(self):
+        """--user should show permissions for an existing user."""
+        from apps.auth_app.models import User
+        from apps.programs.models import Program, UserProgramRole
+
+        enc_module._fernet = None
+        user = User.objects.create_user(
+            username="test-perm-user", password="test1234",
+            display_name="Test User",
+        )
+        prog = Program.objects.create(name="Test Program")
+        UserProgramRole.objects.create(user=user, program=prog, role="staff")
+
+        out = StringIO()
+        call_command("validate_permissions", "--user", "test-perm-user", stdout=out)
+        output = out.getvalue()
+
+        self.assertIn("Test User", output)
+        self.assertIn("Test Program", output)
+        self.assertIn("Direct Service", output)
+
+    def test_user_flag_handles_missing_user(self):
+        """--user should handle a non-existent username gracefully."""
+        out = StringIO()
+        call_command("validate_permissions", "--user", "nonexistent-user", stdout=out)
+        self.assertIn("not found", out.getvalue())


### PR DESCRIPTION
## Summary

- **Audit & fix docs/permissions-matrix.md** — corrected 8 discrepancies between documentation and code (7 from initial audit + 1 from expert panel review)
- **Upgrade `validate_permissions` management command** — added `--user`, `--all-users`, `--demo` modes with `EXPECTED_DEMO_ROLES` single source of truth
- **Add system check E021** — catches incomplete permissions matrix at Django startup
- **Add 16 new tests** — matrix completeness, design rule enforcement, demo role validation, command output
- **Fix enforcement test coverage** — added circle permission keys + feature toggle to parametrized tests, corrected stale key count comments (48 → 68)

### Documentation fixes applied
| Row | Was | Now | Why |
|-----|-----|-----|-----|
| PM clinical data | Yes | Gated | P6 implemented GATED clinical safeguards |
| PM progress notes | Yes | Gated | P6 implemented GATED note access |
| PM plans | Yes | Gated | P6 implemented GATED plan access |
| PM edit client records | — | Scoped | Code has PROGRAM, not DENY |
| Front Desk edit contact | Per field | Yes | Code has ALLOW; PER_FIELD is Phase 2 |
| Circles section | Missing | Added | circle.view/create/edit keys exist in matrix |
| Suggestion themes | Missing | Added | suggestion_theme.view/manage keys exist |
| Planned Changes | Listed P6 as future | Removed | P6 already implemented |

### Expert panel review
A 4-expert panel (Privacy/PHIPA specialist, Nonprofit ED, Django Security Architect, QA/Systems Thinker) verified all 68 permission keys × 4 roles. Found one remaining doc error (client.edit_contact "Per field" → "Yes") which is fixed in the final commit.

## Test plan
- [ ] `pytest tests/test_permissions_validation.py` — 16 tests pass
- [ ] `pytest tests/test_permissions_enforcement.py` — 272 subtests pass
- [ ] `python manage.py check` — E021 system check passes
- [ ] `python manage.py validate_permissions` — matrix validation passes
- [ ] `python manage.py validate_permissions --demo` (in DEMO_MODE) — demo roles match

🤖 Generated with [Claude Code](https://claude.com/claude-code)