### PR TITLE
fix: raise on decryption failure and enforce audit log immutability

### DIFF
--- a/apps/auth_app/models.py
+++ b/apps/auth_app/models.py
@@ -8,7 +8,7 @@ from django.db import models
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
-from konote.encryption import decrypt_field, encrypt_field
+from konote.encryption import decrypt_field, encrypt_field, DecryptionError
 
 
 class UserManager(BaseUserManager):
@@ -97,7 +97,10 @@ class User(AbstractBaseUser, PermissionsMixin):
     # Encrypted email property
     @property
     def email(self):
-        return decrypt_field(self._email_encrypted)
+        try:
+            return decrypt_field(self._email_encrypted)
+        except DecryptionError:
+            return "[DECRYPTION ERROR]"
 
     @email.setter
     def email(self, value):
@@ -106,7 +109,10 @@ class User(AbstractBaseUser, PermissionsMixin):
     # Encrypted MFA secret property
     @property
     def mfa_secret(self):
-        return decrypt_field(self._mfa_secret_encrypted)
+        try:
+            return decrypt_field(self._mfa_secret_encrypted)
+        except DecryptionError:
+            return "[DECRYPTION ERROR]"
 
     @mfa_secret.setter
     def mfa_secret(self, value):

--- a/apps/circles/models.py
+++ b/apps/circles/models.py
@@ -14,7 +14,7 @@ from django.conf import settings
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 
-from konote.encryption import decrypt_field, encrypt_field
+from konote.encryption import decrypt_field, encrypt_field, DecryptionError
 
 
 # ---------------------------------------------------------------------------
@@ -84,7 +84,10 @@ class Circle(models.Model):
 
     @property
     def name(self):
-        return decrypt_field(self._name_encrypted)
+        try:
+            return decrypt_field(self._name_encrypted)
+        except DecryptionError:
+            return "[DECRYPTION ERROR]"
 
     @name.setter
     def name(self, value):
@@ -150,7 +153,10 @@ class CircleMembership(models.Model):
 
     @property
     def member_name(self):
-        return decrypt_field(self._member_name_encrypted)
+        try:
+            return decrypt_field(self._member_name_encrypted)
+        except DecryptionError:
+            return "[DECRYPTION ERROR]"
 
     @member_name.setter
     def member_name(self, value):

--- a/apps/clients/models.py
+++ b/apps/clients/models.py
@@ -4,7 +4,7 @@ from django.db import models
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
-from konote.encryption import decrypt_field, encrypt_field
+from konote.encryption import decrypt_field, encrypt_field, DecryptionError
 
 
 class ClientFileQuerySet(models.QuerySet):
@@ -107,7 +107,10 @@ class ClientFile(models.Model):
     # Encrypted property accessors
     @property
     def first_name(self):
-        return decrypt_field(self._first_name_encrypted)
+        try:
+            return decrypt_field(self._first_name_encrypted)
+        except DecryptionError:
+            return "[DECRYPTION ERROR]"
 
     @first_name.setter
     def first_name(self, value):
@@ -115,7 +118,10 @@ class ClientFile(models.Model):
 
     @property
     def preferred_name(self):
-        return decrypt_field(self._preferred_name_encrypted)
+        try:
+            return decrypt_field(self._preferred_name_encrypted)
+        except DecryptionError:
+            return "[DECRYPTION ERROR]"
 
     @preferred_name.setter
     def preferred_name(self, value):
@@ -132,7 +138,10 @@ class ClientFile(models.Model):
 
     @property
     def middle_name(self):
-        return decrypt_field(self._middle_name_encrypted)
+        try:
+            return decrypt_field(self._middle_name_encrypted)
+        except DecryptionError:
+            return "[DECRYPTION ERROR]"
 
     @middle_name.setter
     def middle_name(self, value):
@@ -140,7 +149,10 @@ class ClientFile(models.Model):
 
     @property
     def last_name(self):
-        return decrypt_field(self._last_name_encrypted)
+        try:
+            return decrypt_field(self._last_name_encrypted)
+        except DecryptionError:
+            return "[DECRYPTION ERROR]"
 
     @last_name.setter
     def last_name(self, value):
@@ -148,8 +160,11 @@ class ClientFile(models.Model):
 
     @property
     def birth_date(self):
-        val = decrypt_field(self._birth_date_encrypted)
-        return val if val else None
+        try:
+            val = decrypt_field(self._birth_date_encrypted)
+            return val if val else None
+        except DecryptionError:
+            return "[DECRYPTION ERROR]"
 
     @birth_date.setter
     def birth_date(self, value):
@@ -157,7 +172,10 @@ class ClientFile(models.Model):
 
     @property
     def phone(self):
-        return decrypt_field(self._phone_encrypted)
+        try:
+            return decrypt_field(self._phone_encrypted)
+        except DecryptionError:
+            return "[DECRYPTION ERROR]"
 
     @phone.setter
     def phone(self, value):
@@ -165,7 +183,10 @@ class ClientFile(models.Model):
 
     @property
     def email(self):
-        return decrypt_field(self._email_encrypted)
+        try:
+            return decrypt_field(self._email_encrypted)
+        except DecryptionError:
+            return "[DECRYPTION ERROR]"
 
     @email.setter
     def email(self, value):
@@ -544,7 +565,10 @@ class ClientDetailValue(models.Model):
     def get_value(self):
         """Return decrypted value if field is sensitive, plain value otherwise."""
         if self.field_def.is_sensitive:
-            return decrypt_field(self._value_encrypted)
+            try:
+                return decrypt_field(self._value_encrypted)
+            except DecryptionError:
+                return "[DECRYPTION ERROR]"
         return self.value
 
     def set_value(self, val):

--- a/apps/communications/models.py
+++ b/apps/communications/models.py
@@ -4,7 +4,7 @@ from django.db import models
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
-from konote.encryption import decrypt_field, encrypt_field
+from konote.encryption import decrypt_field, encrypt_field, DecryptionError
 
 
 class Communication(models.Model):
@@ -130,7 +130,10 @@ class Communication(models.Model):
     # Encrypted content accessor
     @property
     def content(self):
-        return decrypt_field(self._content_encrypted)
+        try:
+            return decrypt_field(self._content_encrypted)
+        except DecryptionError:
+            return "[DECRYPTION ERROR]"
 
     @content.setter
     def content(self, value):
@@ -247,7 +250,10 @@ class StaffMessage(models.Model):
 
     @property
     def content(self):
-        return decrypt_field(self._content_encrypted)
+        try:
+            return decrypt_field(self._content_encrypted)
+        except DecryptionError:
+            return "[DECRYPTION ERROR]"
 
     @content.setter
     def content(self, value):

--- a/apps/groups/models.py
+++ b/apps/groups/models.py
@@ -9,7 +9,7 @@ from django.conf import settings
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 
-from konote.encryption import decrypt_field, encrypt_field
+from konote.encryption import decrypt_field, encrypt_field, DecryptionError
 
 
 # ---------------------------------------------------------------------------
@@ -161,7 +161,10 @@ class GroupSession(models.Model):
 
     @property
     def notes(self):
-        return decrypt_field(self._notes_encrypted)
+        try:
+            return decrypt_field(self._notes_encrypted)
+        except DecryptionError:
+            return "[DECRYPTION ERROR]"
 
     @notes.setter
     def notes(self, value):
@@ -237,7 +240,10 @@ class GroupSessionHighlight(models.Model):
 
     @property
     def notes(self):
-        return decrypt_field(self._notes_encrypted)
+        try:
+            return decrypt_field(self._notes_encrypted)
+        except DecryptionError:
+            return "[DECRYPTION ERROR]"
 
     @notes.setter
     def notes(self, value):

--- a/apps/notes/models.py
+++ b/apps/notes/models.py
@@ -6,7 +6,7 @@ from django.db.models.signals import post_delete
 from django.dispatch import receiver
 from django.utils.translation import gettext_lazy as _
 
-from konote.encryption import decrypt_field, encrypt_field
+from konote.encryption import decrypt_field, encrypt_field, DecryptionError
 
 
 class ProgressNoteTemplate(models.Model):
@@ -181,7 +181,10 @@ class ProgressNote(models.Model):
     @property
     def notes_text(self):
         """Content for quick notes (decrypted)."""
-        return decrypt_field(self._notes_text_encrypted)
+        try:
+            return decrypt_field(self._notes_text_encrypted)
+        except DecryptionError:
+            return "[DECRYPTION ERROR]"
 
     @notes_text.setter
     def notes_text(self, value):
@@ -190,7 +193,10 @@ class ProgressNote(models.Model):
     @property
     def summary(self):
         """Summary of the session (decrypted)."""
-        return decrypt_field(self._summary_encrypted)
+        try:
+            return decrypt_field(self._summary_encrypted)
+        except DecryptionError:
+            return "[DECRYPTION ERROR]"
 
     @summary.setter
     def summary(self, value):
@@ -199,7 +205,10 @@ class ProgressNote(models.Model):
     @property
     def participant_reflection(self):
         """The participant's own words about what they're taking away (decrypted)."""
-        return decrypt_field(self._participant_reflection_encrypted)
+        try:
+            return decrypt_field(self._participant_reflection_encrypted)
+        except DecryptionError:
+            return "[DECRYPTION ERROR]"
 
     @participant_reflection.setter
     def participant_reflection(self, value):
@@ -208,7 +217,10 @@ class ProgressNote(models.Model):
     @property
     def participant_suggestion(self):
         """The participant's suggestion for program improvement (decrypted)."""
-        return decrypt_field(self._participant_suggestion_encrypted)
+        try:
+            return decrypt_field(self._participant_suggestion_encrypted)
+        except DecryptionError:
+            return "[DECRYPTION ERROR]"
 
     @participant_suggestion.setter
     def participant_suggestion(self, value):
@@ -338,7 +350,10 @@ class ProgressNoteTarget(models.Model):
     @property
     def notes(self):
         """Target-specific notes (decrypted)."""
-        return decrypt_field(self._notes_encrypted)
+        try:
+            return decrypt_field(self._notes_encrypted)
+        except DecryptionError:
+            return "[DECRYPTION ERROR]"
 
     @notes.setter
     def notes(self, value):
@@ -347,7 +362,10 @@ class ProgressNoteTarget(models.Model):
     @property
     def client_words(self):
         """What the client said about this goal today (decrypted)."""
-        return decrypt_field(self._client_words_encrypted)
+        try:
+            return decrypt_field(self._client_words_encrypted)
+        except DecryptionError:
+            return "[DECRYPTION ERROR]"
 
     @client_words.setter
     def client_words(self, value):

--- a/apps/plans/models.py
+++ b/apps/plans/models.py
@@ -4,7 +4,7 @@ from django.core.exceptions import ValidationError
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 
-from konote.encryption import decrypt_field, encrypt_field
+from konote.encryption import decrypt_field, encrypt_field, DecryptionError
 
 
 SELF_EFFICACY_METRIC_NAME = "Self-Efficacy"
@@ -232,7 +232,10 @@ class PlanTarget(models.Model):
 
     @property
     def name(self):
-        return decrypt_field(self._name_encrypted)
+        try:
+            return decrypt_field(self._name_encrypted)
+        except DecryptionError:
+            return "[DECRYPTION ERROR]"
 
     @name.setter
     def name(self, value):
@@ -240,7 +243,10 @@ class PlanTarget(models.Model):
 
     @property
     def description(self):
-        return decrypt_field(self._description_encrypted)
+        try:
+            return decrypt_field(self._description_encrypted)
+        except DecryptionError:
+            return "[DECRYPTION ERROR]"
 
     @description.setter
     def description(self, value):
@@ -248,7 +254,10 @@ class PlanTarget(models.Model):
 
     @property
     def status_reason(self):
-        return decrypt_field(self._status_reason_encrypted)
+        try:
+            return decrypt_field(self._status_reason_encrypted)
+        except DecryptionError:
+            return "[DECRYPTION ERROR]"
 
     @status_reason.setter
     def status_reason(self, value):
@@ -256,7 +265,10 @@ class PlanTarget(models.Model):
 
     @property
     def client_goal(self):
-        return decrypt_field(self._client_goal_encrypted)
+        try:
+            return decrypt_field(self._client_goal_encrypted)
+        except DecryptionError:
+            return "[DECRYPTION ERROR]"
 
     @client_goal.setter
     def client_goal(self, value):
@@ -287,7 +299,10 @@ class PlanTargetRevision(models.Model):
 
     @property
     def name(self):
-        return decrypt_field(self._name_encrypted)
+        try:
+            return decrypt_field(self._name_encrypted)
+        except DecryptionError:
+            return "[DECRYPTION ERROR]"
 
     @name.setter
     def name(self, value):
@@ -295,7 +310,10 @@ class PlanTargetRevision(models.Model):
 
     @property
     def description(self):
-        return decrypt_field(self._description_encrypted)
+        try:
+            return decrypt_field(self._description_encrypted)
+        except DecryptionError:
+            return "[DECRYPTION ERROR]"
 
     @description.setter
     def description(self, value):
@@ -303,7 +321,10 @@ class PlanTargetRevision(models.Model):
 
     @property
     def status_reason(self):
-        return decrypt_field(self._status_reason_encrypted)
+        try:
+            return decrypt_field(self._status_reason_encrypted)
+        except DecryptionError:
+            return "[DECRYPTION ERROR]"
 
     @status_reason.setter
     def status_reason(self, value):
@@ -311,7 +332,10 @@ class PlanTargetRevision(models.Model):
 
     @property
     def client_goal(self):
-        return decrypt_field(self._client_goal_encrypted)
+        try:
+            return decrypt_field(self._client_goal_encrypted)
+        except DecryptionError:
+            return "[DECRYPTION ERROR]"
 
     @client_goal.setter
     def client_goal(self, value):

--- a/apps/portal/models.py
+++ b/apps/portal/models.py
@@ -18,7 +18,7 @@ from django.db import models
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
-from konote.encryption import decrypt_field, encrypt_field
+from konote.encryption import decrypt_field, encrypt_field, DecryptionError
 
 
 # ---------------------------------------------------------------------------
@@ -160,7 +160,10 @@ class ParticipantUser(AbstractBaseUser):
 
     @property
     def email(self):
-        return decrypt_field(self._email_encrypted)
+        try:
+            return decrypt_field(self._email_encrypted)
+        except DecryptionError:
+            return "[DECRYPTION ERROR]"
 
     @email.setter
     def email(self, value):
@@ -170,7 +173,10 @@ class ParticipantUser(AbstractBaseUser):
 
     @property
     def totp_secret(self):
-        return decrypt_field(self._totp_secret_encrypted)
+        try:
+            return decrypt_field(self._totp_secret_encrypted)
+        except DecryptionError:
+            return "[DECRYPTION ERROR]"
 
     @totp_secret.setter
     def totp_secret(self, value):
@@ -346,7 +352,10 @@ class ParticipantJournalEntry(models.Model):
 
     @property
     def content(self):
-        return decrypt_field(self._content_encrypted)
+        try:
+            return decrypt_field(self._content_encrypted)
+        except DecryptionError:
+            return "[DECRYPTION ERROR]"
 
     @content.setter
     def content(self, value):
@@ -405,7 +414,10 @@ class ParticipantMessage(models.Model):
 
     @property
     def content(self):
-        return decrypt_field(self._content_encrypted)
+        try:
+            return decrypt_field(self._content_encrypted)
+        except DecryptionError:
+            return "[DECRYPTION ERROR]"
 
     @content.setter
     def content(self, value):
@@ -450,7 +462,10 @@ class StaffPortalNote(models.Model):
 
     @property
     def content(self):
-        return decrypt_field(self._content_encrypted)
+        try:
+            return decrypt_field(self._content_encrypted)
+        except DecryptionError:
+            return "[DECRYPTION ERROR]"
 
     @content.setter
     def content(self, value):
@@ -535,7 +550,10 @@ class CorrectionRequest(models.Model):
 
     @property
     def description(self):
-        return decrypt_field(self._description_encrypted)
+        try:
+            return decrypt_field(self._description_encrypted)
+        except DecryptionError:
+            return "[DECRYPTION ERROR]"
 
     @description.setter
     def description(self, value):

--- a/apps/registration/models.py
+++ b/apps/registration/models.py
@@ -9,7 +9,7 @@ from django.db import models
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
-from konote.encryption import decrypt_field, encrypt_field
+from konote.encryption import decrypt_field, encrypt_field, DecryptionError
 
 
 def generate_unique_slug():
@@ -201,7 +201,10 @@ class RegistrationSubmission(models.Model):
     # Encrypted property accessors
     @property
     def first_name(self):
-        return decrypt_field(self._first_name_encrypted)
+        try:
+            return decrypt_field(self._first_name_encrypted)
+        except DecryptionError:
+            return "[DECRYPTION ERROR]"
 
     @first_name.setter
     def first_name(self, value):
@@ -209,7 +212,10 @@ class RegistrationSubmission(models.Model):
 
     @property
     def last_name(self):
-        return decrypt_field(self._last_name_encrypted)
+        try:
+            return decrypt_field(self._last_name_encrypted)
+        except DecryptionError:
+            return "[DECRYPTION ERROR]"
 
     @last_name.setter
     def last_name(self, value):
@@ -217,7 +223,10 @@ class RegistrationSubmission(models.Model):
 
     @property
     def email(self):
-        return decrypt_field(self._email_encrypted)
+        try:
+            return decrypt_field(self._email_encrypted)
+        except DecryptionError:
+            return "[DECRYPTION ERROR]"
 
     @email.setter
     def email(self, value):
@@ -230,7 +239,10 @@ class RegistrationSubmission(models.Model):
 
     @property
     def phone(self):
-        return decrypt_field(self._phone_encrypted)
+        try:
+            return decrypt_field(self._phone_encrypted)
+        except DecryptionError:
+            return "[DECRYPTION ERROR]"
 
     @phone.setter
     def phone(self, value):

--- a/apps/surveys/models.py
+++ b/apps/surveys/models.py
@@ -10,7 +10,7 @@ from django.db import models
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
-from konote.encryption import decrypt_field, encrypt_field
+from konote.encryption import decrypt_field, encrypt_field, DecryptionError
 
 
 class Survey(models.Model):
@@ -351,7 +351,10 @@ class SurveyAnswer(models.Model):
 
     @property
     def value(self):
-        return decrypt_field(self._value_encrypted)
+        try:
+            return decrypt_field(self._value_encrypted)
+        except DecryptionError:
+            return "[DECRYPTION ERROR]"
 
     @value.setter
     def value(self, val):
@@ -412,7 +415,10 @@ class PartialAnswer(models.Model):
 
     @property
     def value(self):
-        return decrypt_field(self.value_encrypted)
+        try:
+            return decrypt_field(self.value_encrypted)
+        except DecryptionError:
+            return "[DECRYPTION ERROR]"
 
     @value.setter
     def value(self, val):


### PR DESCRIPTION
## Summary

- **FINDING 3 (HIGH)** — Silent decryption failure is eliminated. `decrypt_field` now raises `DecryptionError` (new custom exception) instead of returning `""` on `InvalidToken`. Every model property accessor across the codebase now catches `DecryptionError` and returns `"[DECRYPTION ERROR]"` — a visible sentinel that staff cannot mistake for an empty field. A Django system check (`konote.E001`) validates the encryption key round-trip at startup, so a misconfigured or rotated key fails loudly at boot rather than silently at runtime.
- **FINDING 11 (LOW)** — `ImmutableAuditManager` and `ImmutableAuditQuerySet` added to `apps/audit/models.py`. Both override `update()` and `delete()` to raise `PermissionError`. `AuditLog.objects` is now this immutable manager. `.create()` and `.bulk_create()` are intentionally not overridden (append-only semantics preserved).

## Files changed

- `konote/encryption.py` — `DecryptionError` class, `decrypt_field` raises instead of returning `""`, startup system check registered with `django.core.checks`
- `apps/audit/models.py` — `ImmutableAuditQuerySet`, `ImmutableAuditManager`, `AuditLog.objects` assignment
- All 11 model files with encrypted property accessors — `DecryptionError` import and try/except wrapping on every getter

## Test plan

- [x] `pytest tests/test_encryption.py tests/test_audit_views.py -x -q` — 85 passed
- [x] `test_invalid_ciphertext_raises_decryption_error` replaces old `test_invalid_ciphertext_returns_empty_string`
- [x] `DecryptionErrorSentinelTest` — 4 tests verify model accessors return `"[DECRYPTION ERROR]"` when ciphertext is from a different key
- [x] `EncryptionSystemCheckTest` — 2 tests verify the startup check passes on valid key and produces `konote.E001` on invalid key
- [x] `ImmutableAuditManagerTests` — 6 tests: create and bulk_create succeed, update/delete raise `PermissionError` at queryset and manager level

🤖 Generated with [Claude Code](https://claude.com/claude-code)