### PR TITLE
fix: guard last-admin demotion and add permission check to client search

### DIFF
--- a/apps/clients/views.py
+++ b/apps/clients/views.py
@@ -1142,6 +1142,7 @@ def client_consent_save(request, client_id):
 
 
 @login_required
+@requires_permission("client.view_name")
 def client_search(request):
     """HTMX: return search results partial.
 


### PR DESCRIPTION
This pull request introduces important safeguards and permission checks to the admin and client management features. The main changes include preventing the removal of the last active admin user and enforcing permission requirements for client search functionality.

Admin user safety improvements:

* Added a guard in the `clean` method of `UserForm` to prevent the last active admin from removing their own admin status. If a user attempts to remove admin rights from the only remaining active admin, a validation error is raised. (`apps/auth_app/forms.py`)

Client management permissions:

* Added the `@requires_permission("client.view_name")` decorator to the `client_search` view, ensuring that only users with the appropriate permission can access client search results. (`apps/clients/views.py`)

FINDING 12: UserEditForm.clean() now raises ValidationError when the last active admin attempts to remove their own admin status, preventing a complete lockout of admin functionality.

FINDING 13: client_search HTMX endpoint now decorated with @requires_permission("client.view_name"), blocking executive-role and other users without client.view_name from invoking the endpoint.