### PR TITLE
fix: add session token to emergency logout and restrict iframe embedding to allowed origins

### DIFF
--- a/apps/portal/templates/portal/base_portal.html
+++ b/apps/portal/templates/portal/base_portal.html
@@ -17,6 +17,8 @@
 
     <!-- CSRF token for HTMX -->
     <meta name="csrf-token" content="{{ csrf_token }}">
+    <!-- Emergency logout token — session-bound, single-use; read by portal.js quickExit() -->
+    <meta name="emergency-logout-token" content="{{ emergency_logout_token }}">
 
     <!-- Pico CSS -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css">

--- a/konote/context_processors.py
+++ b/konote/context_processors.py
@@ -297,7 +297,12 @@ def portal_context(request):
         elif url_name == "settings":
             page = "settings"
 
-    return {"participant": participant, "portal_page": page}
+    emergency_logout_token = request.session.get("_portal_emergency_logout_token", "")
+    return {
+        "participant": participant,
+        "portal_page": page,
+        "emergency_logout_token": emergency_logout_token,
+    }
 
 
 def unread_messages(request):

--- a/konote/settings/base.py
+++ b/konote/settings/base.py
@@ -176,6 +176,22 @@ SECURE_BROWSER_XSS_FILTER = True
 SECURE_CONTENT_TYPE_NOSNIFF = True
 X_FRAME_OPTIONS = "DENY"
 
+# Iframe embedding for registration forms (?embed=1)
+# ─────────────────────────────────────────────────────────────────────
+# Comma-separated list of origins allowed to embed the public registration
+# form in an iframe, e.g. "https://example.org,https://agency.ca".
+# An empty list (the default) disables embedding even when ?embed=1 is passed.
+# In development this defaults to "*" so the embed preview works without
+# configuring real origins.  Set explicitly in production via EMBED_ALLOWED_ORIGINS.
+#
+# The list is used to build a CSP frame-ancestors directive on the response,
+# which is the authoritative browser-enforced restriction. X-Frame-Options is
+# also set to ALLOWALL on the response so older browsers respect it, but
+# frame-ancestors takes precedence in CSP-capable browsers.
+# ─────────────────────────────────────────────────────────────────────
+_embed_origins_raw = os.environ.get("EMBED_ALLOWED_ORIGINS", "")
+EMBED_ALLOWED_ORIGINS = [o.strip() for o in _embed_origins_raw.split(",") if o.strip()]
+
 # CSP — Content Security Policy
 # ─────────────────────────────────────────────────────────────────────
 # Controls which resources the browser is allowed to load.

--- a/konote/settings/development.py
+++ b/konote/settings/development.py
@@ -25,3 +25,7 @@ ALLOWED_HOSTS = ["*"]
 SESSION_COOKIE_SECURE = False
 LANGUAGE_COOKIE_SECURE = False
 SECURE_SSL_REDIRECT = False
+
+# Allow any origin to embed registration forms in dev so the embed preview
+# works without configuring real allowed origins.
+EMBED_ALLOWED_ORIGINS = ["*"]

--- a/static/js/portal.js
+++ b/static/js/portal.js
@@ -6,8 +6,15 @@
 function quickExit() {
     // Clear any localStorage drafts before leaving (privacy safety)
     try { localStorage.clear(); } catch (e) { /* ignore */ }
-    // Best-effort session destruction via sendBeacon
-    navigator.sendBeacon('/my/emergency-logout/');
+    // Read the session-bound emergency logout token from the meta tag.
+    // The token is validated server-side; without it the endpoint returns 403.
+    var tokenMeta = document.querySelector('meta[name="emergency-logout-token"]');
+    var token = tokenMeta ? tokenMeta.getAttribute('content') : '';
+    // Send token as form data so Django can read it via request.POST.get("token").
+    // sendBeacon with FormData sends a multipart/form-data POST, which Django parses.
+    var payload = new FormData();
+    payload.append('token', token);
+    navigator.sendBeacon('/my/emergency-logout/', payload);
     // Read configurable exit URL from button data attribute (set by admin)
     var btn = document.getElementById('quick-exit');
     var exitUrl = (btn && btn.dataset.exitUrl) || 'https://www.theweathernetwork.com';


### PR DESCRIPTION
## Summary

Fixes two LOW-severity security findings from the full codebase security audit.

**Finding 9 — CSRF-exempt emergency logout (portal safety concern)**
- Generated a `secrets.token_urlsafe(32)` token at all 4 portal login paths and stored it in the session
- `emergency_logout` view now validates the submitted token against the session token using `secrets.compare_digest`; returns 403 on mismatch; token is single-use (popped before session flush)
- Token exposed to templates via `konote/context_processors.py` as `emergency_logout_token`
- `<meta name="emergency-logout-token">` added to `portal/base_portal.html`
- `quickExit()` in `static/js/portal.js` reads the token from the meta tag and includes it in the `sendBeacon` `FormData` payload

**Finding 10 — Blanket iframe X-Frame-Options exempt on registration embed**
- Added `EMBED_ALLOWED_ORIGINS` setting (env var, default `[]` = no embedding; dev defaults to `["*"]`)
- When `?embed=1` is used: returns 403 if no origins configured; otherwise sets `Content-Security-Policy: frame-ancestors 'self' <origins>` header
- Tests updated: `@override_settings(EMBED_ALLOWED_ORIGINS=["https://example.org"])` on existing tests; new `test_embed_mode_denied_when_no_origins_configured` asserts 403

## Test plan
- [ ] Portal login → trigger quick exit → confirm session is destroyed (not 403)
- [ ] Attempt `navigator.sendBeacon('/my/emergency-logout/', new FormData())` without token → confirm 403
- [ ] Registration form with `EMBED_ALLOWED_ORIGINS=[]` and `?embed=1` → confirm 403
- [ ] Registration form with `EMBED_ALLOWED_ORIGINS=["https://example.org"]` and `?embed=1` → confirm `frame-ancestors` header present
- [ ] Run `pytest tests/test_registration.py tests/test_portal.py -x`

🤖 Generated with [Claude Code](https://claude.com/claude-code)