### PR TITLE
Add French translations for new features and labels

### DIFF
--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -16787,3 +16787,48 @@ msgstr "Voir le répertoire de démonstration"
 
 msgid "Demo mode is not enabled."
 msgstr ""
+
+msgid "16/02/2026"
+msgstr ""
+
+msgid "2026-02-16 (ISO)"
+msgstr ""
+
+msgid "Access tier"
+msgstr ""
+
+msgid "Cannot remove admin status from the last active admin user."
+msgstr ""
+
+msgid "Date format"
+msgstr ""
+
+msgid "English label"
+msgstr ""
+
+msgid "Feb 16, 2026"
+msgstr ""
+
+msgid "French label (optional)"
+msgstr ""
+
+msgid "Invalid parameters for demo data generation."
+msgstr ""
+
+msgid "Product name"
+msgstr ""
+
+msgid "Support email"
+msgstr ""
+
+msgid "Tier 1 — Role-based only"
+msgstr ""
+
+msgid "Tier 2 — Role-based + field-level access"
+msgstr ""
+
+msgid "Tier 3 — Role-based + field-level + gated grants"
+msgstr ""
+
+msgid "Time span (days)"
+msgstr ""


### PR DESCRIPTION
This pull request adds new translation keys to the French localization file, preparing for upcoming features and UI improvements. The changes focus on supporting access tier labels, date formats, demo data generation, and admin user management.

New translation keys for access control and admin management:

* Added keys for access tiers (`Tier 1`, `Tier 2`, `Tier 3`) and related descriptions, supporting role-based and field-level access controls.
* Introduced a message for preventing removal of admin status from the last active admin user.

Date and label support:

* Added keys for multiple date formats (`16/02/2026`, `2026-02-16 (ISO)`, `Feb 16, 2026`) and their labels to enhance date handling and display.
* Included keys for English and French labels, product name, and support email to improve UI flexibility and localization.

Demo data generation:

* Added a message for invalid parameters in demo data generation to improve error handling.
* Introduced a key for specifying time span in days for demo data. ([locale/fr/LC_MESSAGES/django.poR16790-R16834](diffhunk://#diff-6445521761a1867bb075730cf951b8e2cc72bf15c73916ae4f2fcf0ff280f84bR16790-R16834)