### PR TITLE
Add logo usage task to TODO

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -92,6 +92,7 @@ Step-by-step commands for each task are in [tasks/recurring-tasks.md](tasks/recu
 - [ ] Seed groups-attendance test data with 8+ members and 12+ sessions — re-seed after workflow changes, fix in qa-scenarios repo (QA-PA-TEST1)
 - [ ] Seed comm-my-messages populated state with actual messages — re-seed after workflow changes, fix in qa-scenarios repo (QA-PA-TEST2)
 - [ ] Add new features and capabilities to the web site as they are built (WEBSITE-UPDATE1)
+- [ ] Use KoNote logos from `Logo/brand/` folder across app and website (see PR #100) — PB (LOGO1)
 
 ## Parking Lot: Ready to Build
 


### PR DESCRIPTION
## Summary
- Added TODO item (LOGO1) for using KoNote logos from `Logo/brand/` folder, assigned to PB
- References PR #100 which adds the logo assets

🤖 Generated with [Claude Code](https://claude.com/claude-code)