### PR TITLE
chore: add hosting cost comparison — Azure vs OVHcloud

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,6 +192,7 @@ Current DRRs:
 - `tasks/design-rationale/insights-metric-distributions.md` — Insights page & program reporting. Distributions not averages, three data layers (outcomes/goals/qualitative), client-centred page hierarchy, Campbell's Law safeguards, band display labels.
 - `tasks/design-rationale/bilingual-requirements.md` — Bilingual (EN/FR) requirements. Why translation is non-negotiable (Official Languages Act, Ontario FLSA, funder requirements, WCAG 3.1.2). Anti-patterns (deferring translations, treating them as low-priority). Technical approach (Claude + API backup). Translation standards for Claude sessions.
 - `tasks/design-rationale/ai-feature-toggles.md` — AI feature toggle split. Two-tier design: `ai_assist_tools_only` (no participant data, default enabled) vs `ai_assist_participant_data` (de-identified participant content, default disabled). Anti-patterns (including translation in toggles, single three-level toggle). Future path: self-hosted open-source LLM for participant data.
+- `tasks/design-rationale/ovhcloud-deployment.md` — OVHcloud Beauharnois deployment architecture. Full stack (Docker Compose, Caddy, PostgreSQL x2), 4-layer self-healing automation, backup strategy, Azure Key Vault for encryption keys, LLM integration, multi-agency hosting. Anti-patterns (US cloud backups, missing autoheal, single-point key storage).
 
 ### How Claude Manages Tasks
 

--- a/TODO.md
+++ b/TODO.md
@@ -123,6 +123,7 @@ Not yet clear we should build these, or the design isn't settled. May be too com
 - [ ] 90-day metric relevance check — prompt worker to confirm or change the chosen metric (METRIC-REVIEW1)
 - [ ] Alliance prompt rotation — cycle 3-4 phrasings to prevent habituation (ALLIANCE-ROTATE1)
 - [ ] Portal-based async alliance rating — post-session notification for participant self-rating (PORTAL-ALLIANCE1)
+- [ ] Consider self-hosted open-source LLM for AI operations (e.g. Qwen3.5-35B-A3B) — cost, privacy, and latency trade-offs vs cloud API — GK reviews (AI-SELFHOST1)
 
 ## Recently Done
 

--- a/TODO.md
+++ b/TODO.md
@@ -92,6 +92,7 @@ Step-by-step commands for each task are in [tasks/recurring-tasks.md](tasks/recu
 - [ ] Seed groups-attendance test data with 8+ members and 12+ sessions — re-seed after workflow changes, fix in qa-scenarios repo (QA-PA-TEST1)
 - [ ] Seed comm-my-messages populated state with actual messages — re-seed after workflow changes, fix in qa-scenarios repo (QA-PA-TEST2)
 - [ ] Add new features and capabilities to the web site as they are built (WEBSITE-UPDATE1)
+- [ ] Use KoNote logos from `Logo/brand/` folder across app and website (see PR #100) — PB (LOGO1)
 
 ## Parking Lot: Ready to Build
 

--- a/tasks/design-rationale/ovhcloud-deployment.md
+++ b/tasks/design-rationale/ovhcloud-deployment.md
@@ -425,6 +425,77 @@ For the first OVHcloud deployment (single agency):
 
 ---
 
+## Second-Level Support Options
+
+OVHcloud provides infrastructure-only support. Their [Statement of Support](https://us.ovhcloud.com/support/statement-of-support/) explicitly excludes OS administration, application troubleshooting, Docker, databases, and all software. Even at their Business tier ($300 USD/mo minimum, 30-minute P1 response), they will only confirm "your VPS is running" or replace failed hardware — they won't restart containers, check PostgreSQL, or investigate application issues.
+
+The 4-layer self-healing stack (see above) handles most incidents automatically. But when automated recovery fails, a human needs to SSH in and diagnose. These are the options for that second-level response:
+
+### Option 1: Canadian MSP (Managed Service Provider)
+
+OVHcloud maintains a [partner network](https://partner.ovhcloud.com/en/managed-services-provider/) of MSPs who provide managed operations on OVHcloud infrastructure.
+
+| Factor | Detail |
+|--------|--------|
+| Scope | OS patching, Docker management, PostgreSQL monitoring, incident response |
+| Availability | 24/7 or business hours depending on contract |
+| Cost | ~$200–500 CAD/mo for a small VPS fleet (varies by MSP) |
+| Data sovereignty | Must verify the MSP is Canadian-incorporated and stores logs in Canada |
+| Pros | Professional ops team, SLA-backed response, no KoNote team burden |
+| Cons | Cost, onboarding time, need to vet for data sovereignty |
+
+**When to use:** When KoNote is managing 5+ agency instances and the operational burden exceeds what the team can handle.
+
+### Option 2: Freelance Sysadmin on Retainer
+
+A Canadian-based Linux/Docker sysadmin with SSH access to the VPS(es), responding to escalation alerts from Layer 4.
+
+| Factor | Detail |
+|--------|--------|
+| Scope | Incident response, Docker troubleshooting, backup verification, OS updates |
+| Availability | Business hours + on-call for critical alerts |
+| Cost | ~$50–150 CAD/mo retainer + hourly for incidents (~$75–125/hr) |
+| Data sovereignty | Verify individual is Canadian-resident; SSH access from Canada |
+| Pros | Low fixed cost, personal relationship, can learn KoNote-specific runbook |
+| Cons | Single point of failure (one person), vacation coverage gaps |
+
+**When to use:** At launch through early growth (1–5 agencies). Low cost, good enough for the volume.
+
+### Option 3: KoNote Team Member with Runbook
+
+A designated KoNote team member (e.g., PB) trained on the deployment runbook, responding to escalation alerts.
+
+| Factor | Detail |
+|--------|--------|
+| Scope | Same as freelance sysadmin, but internal |
+| Availability | Business hours; after-hours = best-effort |
+| Cost | $0 additional (existing team) |
+| Pros | Deepest knowledge of the application, no onboarding, no data sovereignty concerns |
+| Cons | Adds operational burden to a small team, no after-hours SLA, bus-factor risk |
+
+**When to use:** From day one. This is the default — the question is when to add one of the options above alongside it.
+
+### OVHcloud Support Tiers (for reference — infrastructure only)
+
+| Tier | P1 Response | Hours | Cost | What It Gets You |
+|------|------------|-------|------|------------------|
+| Standard | 8 business hrs | Business hours | Included | Tickets, docs |
+| Premium | 2 business hrs | 24/7 incidents | ~$50–60 USD/mo | Priority handling |
+| Business | 30 minutes | 24/7 | 10% of bill, min $300 USD/mo | Dedicated contacts |
+| Enterprise | 15 minutes | 24/7 | Custom | Technical Account Manager |
+
+**Recommendation for KoNote:** Standard tier is sufficient. OVHcloud support only covers hardware/network — paying more won't help with application-level issues. Invest in a sysadmin retainer instead.
+
+### Recommended Progression
+
+| Stage | Second-Level Support | Estimated Cost |
+|-------|---------------------|----------------|
+| Launch (1–2 agencies) | KoNote team + runbook | $0 |
+| Early growth (3–5 agencies) | Add freelance sysadmin retainer | ~$100 CAD/mo |
+| Scale (5–10+ agencies) | Transition to Canadian MSP | ~$300–500 CAD/mo |
+
+---
+
 ## Anti-Patterns
 
 **Do not:**

--- a/tasks/design-rationale/ovhcloud-deployment.md
+++ b/tasks/design-rationale/ovhcloud-deployment.md
@@ -1,0 +1,437 @@
+# Design Rationale: OVHcloud Deployment Architecture
+
+*Last updated: 2026-02-26*
+
+## Context
+
+KoNote handles PHIPA-protected health data for Ontario nonprofits. The current Railway hosting (US-incorporated, US data centres) does not meet data sovereignty requirements for production agency deployments. This document records the architectural decisions for hosting KoNote on OVHcloud Beauharnois, QC — including the full deployment stack, automated self-healing, backup strategy, and encryption key management.
+
+**Related documents:**
+- [Hosting cost comparison](../hosting-cost-comparison.md) — Azure vs OVHcloud pricing at 1, 5, and 10 agency scales
+- [AI feature toggles DRR](ai-feature-toggles.md) — self-hosted LLM scope and rationale (PR #102)
+- [Multi-tenancy DRR](multi-tenancy.md) — schema-per-tenant architecture for multi-agency hosting
+
+## Decision: OVHcloud Beauharnois
+
+### Why OVHcloud
+
+| Factor | OVHcloud | Azure | Railway |
+|--------|----------|-------|---------|
+| Parent company | OVH Groupe SA (French) | Microsoft (US) | Railway (US) |
+| US CLOUD Act | **Not subject** | Subject | Subject |
+| Data centre | Beauharnois, QC | Toronto (Canada Central) | US only |
+| Canadian LE jurisdiction | Yes (Sept 2025 Ontario ruling) | Yes | N/A |
+| Cost (10 agencies, multi-tenant) | ~$116 CAD/mo total | ~$456 CAD/mo total | Not viable |
+
+**Key rationale:** The US CLOUD Act applies to US-incorporated companies regardless of where their data centres are located. OVHcloud's parent (OVH Groupe SA) is French-incorporated and not subject to US government data requests for Canadian operations. Canadian law enforcement jurisdiction over Canadian data at OVHcloud is expected and acceptable for KoNote's threat model.
+
+**Exception for populations with Canadian LE concerns:** Agencies serving undocumented newcomers or populations with specific concerns about Canadian law enforcement should evaluate whether the Sept 2025 Ontario court ruling (RCMP compelling OVH Canada to produce data) affects their risk profile.
+
+### What Azure Key Vault Adds
+
+Even in the OVHcloud scenario, Azure Key Vault is used for encryption key management (see [Encryption Key Management](#encryption-key-management) below). This introduces a limited Azure dependency:
+
+- Only the `FIELD_ENCRYPTION_KEY` is stored in Azure — not participant data
+- The key alone is useless without access to the encrypted database on OVHcloud
+- If zero Azure dependency is required, alternatives exist (see below)
+
+---
+
+## Deployment Stack
+
+### Architecture Overview
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  OVHcloud VPS (Beauharnois, QC)                         │
+│                                                         │
+│  ┌──────────┐  ┌──────────┐  ┌──────────┐  ┌────────┐  │
+│  │  Caddy   │──│  Django   │──│ Postgres │  │ Postgres│  │
+│  │ (ports   │  │ Gunicorn  │  │  (main)  │  │ (audit) │  │
+│  │  80/443) │  │ (port     │  │          │  │         │  │
+│  │          │  │  8000)    │  │          │  │         │  │
+│  └──────────┘  └──────────┘  └──────────┘  └────────┘  │
+│                                                         │
+│  ┌──────────┐  ┌──────────────────────────────────────┐ │
+│  │ Autoheal │  │ Cron: backups, log rotation, monitor │ │
+│  └──────────┘  └──────────────────────────────────────┘ │
+└─────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────┐
+│  OVHcloud VPS (Beauharnois, QC) — shared LLM endpoint   │
+│                                                         │
+│  ┌──────────────────────────────────────────────────┐   │
+│  │ Ollama (Qwen3.5-35B-A3B) — nightly batch only    │   │
+│  └──────────────────────────────────────────────────┘   │
+└─────────────────────────────────────────────────────────┘
+
+External:
+  ├── Azure Key Vault (encryption key storage)
+  ├── OpenRouter API (translation + metrics/targets AI)
+  ├── UptimeRobot (external uptime monitoring)
+  └── Let's Encrypt (TLS via Caddy auto-HTTPS)
+```
+
+### Container Stack
+
+The existing `docker-compose.yml` runs unmodified on OVHcloud. Four application containers plus two operational containers:
+
+| Container | Image | Purpose | Existing? |
+|-----------|-------|---------|-----------|
+| `web` | KoNote Dockerfile | Django + Gunicorn (2 workers, port 8000) | Yes |
+| `db` | postgres:16-alpine | Main application database | Yes |
+| `audit_db` | postgres:16-alpine | Tamper-resistant audit log (INSERT-only after lockdown) | Yes |
+| `caddy` | caddy:2-alpine | Reverse proxy, auto-HTTPS via Let's Encrypt | Yes |
+| `autoheal` | willfarrell/autoheal | Restarts unhealthy containers automatically | **New** |
+| `ollama` | ollama/ollama | Self-hosted LLM for suggestion theme tagging | **New** (separate VPS or same VPS) |
+
+### Extended docker-compose.yml (OVHcloud additions)
+
+The production `docker-compose.yml` needs two additions for OVHcloud deployment:
+
+**1. Autoheal container** — monitors Docker HEALTHCHECK status and restarts failed containers:
+
+```yaml
+  autoheal:
+    image: willfarrell/autoheal
+    restart: always
+    environment:
+      - AUTOHEAL_CONTAINER_LABEL=all
+      - AUTOHEAL_INTERVAL=30
+      - AUTOHEAL_START_PERIOD=60
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+```
+
+**2. HEALTHCHECK on the web container** — the web container currently relies on Railway's external health check (`/auth/login/`). For OVHcloud, add an internal Docker HEALTHCHECK:
+
+```yaml
+  web:
+    # ... existing config ...
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8000/auth/login/"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+      start_period: 60s
+```
+
+The `db` and `audit_db` containers already have `pg_isready` health checks.
+
+### VPS Sizing
+
+| Workload | Recommended VPS | Specs | Cost (CAD/mo) |
+|----------|----------------|-------|---------------|
+| 1 agency (app + DB) | VPS-2 | 4 vCores, 16 GB RAM, 100 GB NVMe | ~$22 |
+| 5 agencies (multi-tenant) | VPS-3 | 8 vCores, 24 GB RAM, 200 GB NVMe | ~$30 |
+| 10 agencies (multi-tenant) | VPS-3 or VPS-4 | 8 vCores, 24–32 GB RAM, 200 GB NVMe | ~$30–44 |
+| LLM (shared, all agencies) | VPS-1 | 4 vCores, 8 GB RAM, 75 GB NVMe | ~$11 |
+
+---
+
+## Self-Healing Architecture
+
+OVHcloud provides unmanaged VPS — no automatic container restarts, no managed health checks, no PaaS recovery. The self-healing stack compensates with four layers of automation.
+
+### Layer 1: Docker Container Recovery (~$0)
+
+**What it does:** Restarts individual containers that fail their health check.
+
+**How it works:**
+- Docker's built-in `restart: unless-stopped` policy handles process crashes
+- `willfarrell/autoheal` sidecar container monitors HEALTHCHECK status every 30 seconds
+- If a container reports unhealthy 3 times consecutively, autoheal restarts it
+- This handles: Django OOM, PostgreSQL crash, Caddy config error, transient failures
+
+**Covers:** ~80% of incidents (application-level failures)
+
+### Layer 2: VPS-Level Recovery (~$0)
+
+**What it does:** Reboots the entire VPS when containers can't self-recover.
+
+**How it works:**
+- [UptimeRobot](https://uptimerobot.com/) (free tier: 50 monitors, 5-minute interval) monitors the public HTTPS endpoint
+- On 3 consecutive failures (15 minutes of downtime), UptimeRobot fires a webhook
+- Webhook calls the [OVHcloud API](https://api.ovh.com/console/#/vps) `POST /vps/{serviceName}/reboot`
+- VPS reboots → Docker starts → `restart: unless-stopped` brings up all containers → `entrypoint.sh` runs migrations and startup checks
+
+**Implementation:** A small webhook relay (e.g., [Pipedream](https://pipedream.com/) free tier or a Cloudflare Worker) translates the UptimeRobot webhook into an authenticated OVHcloud API call.
+
+**Covers:** ~15% of incidents (kernel panics, Docker daemon failures, disk full, network issues)
+
+### Layer 3: Preventive Automation (~$0)
+
+**What it does:** Prevents failures before they happen.
+
+**Cron jobs on the VPS (added to the host, not inside containers):**
+
+```cron
+# Nightly PostgreSQL backup (both databases)
+0 2 * * * /opt/konote/scripts/backup.sh >> /var/log/konote-backup.log 2>&1
+
+# Nightly log rotation (prevent disk fill)
+0 3 * * * /usr/sbin/logrotate /etc/logrotate.d/konote
+
+# Disk usage check (alert if >80%)
+0 * * * * /opt/konote/scripts/disk-check.sh
+
+# Docker system prune (remove dangling images/containers weekly)
+0 4 * * 0 docker system prune -f >> /var/log/docker-prune.log 2>&1
+
+# Nightly LLM batch (suggestion theme tagging)
+0 1 * * * /opt/konote/scripts/run-suggestion-batch.sh >> /var/log/konote-llm.log 2>&1
+```
+
+**backup.sh outline:**
+```bash
+#!/bin/bash
+TIMESTAMP=$(date +%Y-%m-%d_%H%M)
+BACKUP_DIR=/opt/konote/backups
+
+# Dump main database
+docker compose exec -T db pg_dump -U $POSTGRES_USER $POSTGRES_DB \
+  > $BACKUP_DIR/main_$TIMESTAMP.sql
+
+# Dump audit database
+docker compose exec -T audit_db pg_dump -U $AUDIT_POSTGRES_USER $AUDIT_POSTGRES_DB \
+  > $BACKUP_DIR/audit_$TIMESTAMP.sql
+
+# Compress
+gzip $BACKUP_DIR/main_$TIMESTAMP.sql $BACKUP_DIR/audit_$TIMESTAMP.sql
+
+# Retain 30 days of daily backups
+find $BACKUP_DIR -name "*.sql.gz" -mtime +30 -delete
+
+# Upload to off-site storage (e.g., OVHcloud Object Storage or separate VPS)
+# rclone copy $BACKUP_DIR remote:konote-backups/ --max-age 1d
+```
+
+**disk-check.sh outline:**
+```bash
+#!/bin/bash
+USAGE=$(df / | tail -1 | awk '{print $5}' | tr -d '%')
+if [ "$USAGE" -gt 80 ]; then
+  curl -s -X POST "https://hooks.example.com/alert" \
+    -d "KoNote VPS disk usage at ${USAGE}%"
+fi
+```
+
+**Covers:** ~4% of incidents (preventable failures: disk full, stale images, missed backups)
+
+### Layer 4: Human Escalation (~$0)
+
+**What it does:** Alerts the KoNote team when automated recovery fails.
+
+**Channels:**
+- **UptimeRobot email alerts** — sent when downtime is detected and again on recovery
+- **Backup failure alerts** — backup.sh sends email/Slack on non-zero exit
+- **Disk space alerts** — disk-check.sh sends alert above threshold
+- **LLM batch failure alerts** — run-suggestion-batch.sh sends alert on failure
+
+**Escalation path:**
+1. Automated recovery handles the issue (Layers 1–3) → no human action needed
+2. If still down after 15 minutes → UptimeRobot reboots VPS (Layer 2)
+3. If still down after 30 minutes → email alert to KoNote team (Layer 4)
+4. Human investigates via SSH
+
+**What humans handle:** Hardware failure (OVHcloud support ticket), data corruption (restore from backup), security incident (incident response plan), capacity upgrade (resize VPS).
+
+### Recovery Time Estimates
+
+| Failure Type | Example | Recovery Method | Estimated Downtime |
+|-------------|---------|-----------------|-------------------|
+| Container crash | Django OOM | Autoheal restart | 30–90 seconds |
+| Stuck container | Gunicorn deadlock | Autoheal restart | 30–90 seconds |
+| Docker daemon failure | Daemon crash | UptimeRobot → VPS reboot | 15–20 minutes |
+| VPS kernel panic | Kernel bug | UptimeRobot → VPS reboot | 15–20 minutes |
+| Disk full | Logs not rotated | Preventive cron (shouldn't happen) | 0 (prevented) |
+| Hardware failure | Disk failure | Human + OVHcloud support | 1–4 hours |
+| Data corruption | DB corruption | Human + backup restore | 1–4 hours |
+
+---
+
+## Backup Strategy
+
+### What Gets Backed Up
+
+| Data | Method | Frequency | Retention |
+|------|--------|-----------|-----------|
+| Main PostgreSQL (app data) | `pg_dump` via cron | Nightly (2 AM ET) | 30 days |
+| Audit PostgreSQL (audit log) | `pg_dump` via cron | Nightly (2 AM ET) | 90 days (compliance) |
+| Docker volumes (pgdata) | Implicit in pg_dump | — | — |
+| `.env` file | Manual backup | On change | Stored in password manager |
+| `FIELD_ENCRYPTION_KEY` | Azure Key Vault | Always available | Key Vault versioning |
+
+### Off-Site Backup Storage
+
+On-VPS backups protect against application failures but not hardware failures. Off-site copies are essential.
+
+**Options (in order of preference for data sovereignty):**
+1. **Second OVHcloud VPS** — separate VPS in same or different OVHcloud region. `rsync` or `rclone` nightly. ~$11 CAD/mo.
+2. **OVHcloud Object Storage** — S3-compatible, Beauharnois region. `rclone` nightly. Pay-per-GB (~$0.01/GB/mo).
+3. **Encrypted local copy** — download to KoNote team workstation via automated script. $0.
+
+**Anti-pattern: Do not use Azure Blob Storage or AWS S3 for backups.** This would reintroduce US CLOUD Act exposure on the full database dump, defeating the purpose of OVHcloud hosting.
+
+### Backup Verification
+
+- **Monthly test restore:** Restore the latest backup to a separate Docker Compose instance (`docker-compose.test.yml`) and verify data integrity
+- **Backup monitoring:** If `backup.sh` exits non-zero, send alert via email or webhook
+- **Size check:** Compare backup file size to previous day — alert on >50% change (could indicate corruption or data loss)
+
+---
+
+## Encryption Key Management
+
+### Architecture
+
+```
+┌──────────────────────┐         ┌──────────────────────┐
+│  OVHcloud VPS        │         │  Azure Key Vault      │
+│                      │         │  (Canada Central)     │
+│  Django app reads    │◄────────│  FIELD_ENCRYPTION_KEY  │
+│  key at startup      │  HTTPS  │  stored as Secret     │
+│  via Azure SDK       │         │                      │
+│                      │         │  Access: Azure AD     │
+│  Key cached in       │         │  service principal    │
+│  process memory      │         │  (read-only)          │
+└──────────────────────┘         └──────────────────────┘
+```
+
+### How It Works
+
+1. **At container startup**, Django reads `FIELD_ENCRYPTION_KEY` from Azure Key Vault using the Azure Identity SDK
+2. The key is cached in process memory for the lifetime of the Gunicorn workers
+3. All Fernet encrypt/decrypt operations use the in-memory key — no per-operation Key Vault calls
+4. Key Vault operations: ~2 per day (startup + any worker recycle) = negligible cost (~$1–5 CAD/mo)
+
+### Access Control
+
+- **Azure AD service principal** with `Key Vault Secrets User` role (read-only)
+- Service principal credentials (`AZURE_CLIENT_ID`, `AZURE_CLIENT_SECRET`, `AZURE_TENANT_ID`) stored in `.env` on the VPS
+- Key Vault access policy: deny all except the service principal
+- Key Vault audit logging enabled (who accessed what, when)
+
+### Key Custody
+
+- **Primary:** Azure Key Vault (always available, versioned, audited)
+- **Emergency backup:** Printed key stored in sealed envelope, held by two designated officers (executive director + board member). Neither person alone can access the key.
+- **Key rotation:** Supported by Fernet (decrypt with old key, re-encrypt with new key). Schedule: annually or on personnel change.
+
+### Alternative to Azure Key Vault
+
+If zero Azure dependency is required:
+
+| Alternative | Pros | Cons |
+|-------------|------|------|
+| HashiCorp Vault (self-hosted on OVHcloud) | No Azure dependency, full sovereignty | Operational overhead, another service to maintain |
+| Manual key custody (`.env` file + sealed envelope) | Simple, no external dependency | No audit trail, no programmatic rotation |
+| OVHcloud KMS (if available in BHS) | Same provider, no cross-provider dependency | Limited availability, less mature than Azure KV |
+
+**Current recommendation:** Azure Key Vault. The CLOUD Act exposure is limited to the encryption key only, and the operational benefits (audit logging, versioning, access policies) outweigh the theoretical risk.
+
+---
+
+## LLM Integration (Suggestion Theme Tagging)
+
+### Deployment Options
+
+| Option | When to Use | Cost (CAD/mo) |
+|--------|-------------|---------------|
+| Ollama on separate VPS-1 | Default — isolates LLM from app | ~$11 (shared) |
+| Ollama on same VPS | 1–3 agencies, cost-sensitive | $0 additional |
+
+### Batch Processing
+
+- **Schedule:** Nightly cron (1 AM ET), before backups (2 AM ET)
+- **Scope:** Unprocessed `participant_suggestion` entries from all agencies
+- **Volume:** ~1,000 suggestions/month across 10 agencies = ~1–2 hours CPU inference
+- **Output:** Theme tags stored in app database (aggregate only, never individual-level)
+- **Failure handling:** Log error, send alert, retry next night. Suggestions accumulate safely — no data loss.
+
+### Multi-Agency Isolation
+
+- Shared Ollama endpoint serves all agencies
+- Each agency's suggestions are processed in separate batches — no cross-agency data mixing
+- Suggestions are sent to the LLM one at a time — the model never sees data from multiple agencies in the same context window
+- Agency ID is not sent to the LLM — only the suggestion text and theme list
+
+---
+
+## Multi-Agency Hosting
+
+### Single-Tenant (Current Architecture)
+
+Each agency gets its own VPS with its own Docker Compose stack. Simple but expensive at scale.
+
+```
+Agency A: VPS-2 ($22) → Docker Compose (web + db + audit_db + caddy)
+Agency B: VPS-2 ($22) → Docker Compose (web + db + audit_db + caddy)
+Agency C: VPS-2 ($22) → Docker Compose (web + db + audit_db + caddy)
+Shared:   VPS-1 ($11) → Ollama (suggestion theme tagging)
+```
+
+### Multi-Tenant (Future — requires MT-CORE1)
+
+All agencies share one VPS with schema-per-tenant isolation via django-tenants. One Docker Compose stack serves all agencies.
+
+```
+Shared:   VPS-3 ($30) → Docker Compose (web + db + audit_db + caddy)
+                         └── Schema per tenant (agency_a, agency_b, agency_c)
+Shared:   VPS-1 ($11) → Ollama (suggestion theme tagging)
+```
+
+**Prerequisites:**
+- MT-CORE1: Integrate django-tenants for schema-per-tenant
+- MT-ENCRYPT1: Per-tenant encryption keys (each agency's FIELD_ENCRYPTION_KEY in Key Vault)
+- Caddy wildcard or multi-domain config for tenant routing
+
+---
+
+## Initial Deployment Checklist
+
+For the first OVHcloud deployment (single agency):
+
+1. **Provision VPS-2** on OVHcloud Canada (Beauharnois)
+2. **Install Docker + Docker Compose** on the VPS
+3. **Generate credentials:** `SECRET_KEY`, database passwords (via `python -c "from django.core.management.utils import get_random_secret_key; print(get_random_secret_key())"`)
+4. **Create Azure Key Vault** in Canada Central, store `FIELD_ENCRYPTION_KEY`
+5. **Create Azure AD service principal** with read-only Key Vault access
+6. **Configure `.env`** with all environment variables (see `.env.example`)
+7. **Set `DOMAIN`** in `.env` for Caddy auto-HTTPS
+8. **Configure DNS** — point agency domain to VPS IP
+9. **Deploy:** `docker compose up -d`
+10. **Verify:** Health check passes, login works, demo data loads (if DEMO_MODE)
+11. **Add autoheal container** to docker-compose.yml
+12. **Set up cron jobs:** backup, log rotation, disk check
+13. **Configure UptimeRobot** — monitor HTTPS endpoint, webhook to OVHcloud API
+14. **Test backup/restore** — dump, restore to test instance, verify data
+15. **Document:** VPS IP, domain, Key Vault name, service principal, backup location
+
+---
+
+## Risks and Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| OVHcloud Beauharnois outage | Low | High (downtime) | UptimeRobot alerts, backup restore to new VPS |
+| VPS hardware failure | Low | High (data loss if no off-site backup) | Nightly off-site backups, test monthly restore |
+| OVHcloud discontinues BHS region | Very low | Medium | Architecture is provider-agnostic — migrate Docker Compose to any VPS |
+| Azure Key Vault outage | Very low | Medium (can't restart) | Emergency key in sealed envelope, restart with env var fallback |
+| Disk full | Medium | High (DB crash) | Preventive cron, disk alerts, log rotation |
+| Unpatched vulnerability | Medium | High | Automated `apt upgrade` via `unattended-upgrades`, Docker image updates |
+| LLM batch failure | Low | Low (suggestions queue) | Retry next night, alert on failure, no data loss |
+| OVHcloud price increase | Medium | Low | VPS-1 increasing to US$7.60 (Apr 2026). Budget with 20% headroom. |
+
+---
+
+## Anti-Patterns
+
+**Do not:**
+- Store database backups on Azure Blob Storage or AWS S3 (reintroduces CLOUD Act exposure)
+- Run PostgreSQL without Docker volumes (data loss on container recreation)
+- Skip the autoheal container (silent failures with no recovery)
+- Store `FIELD_ENCRYPTION_KEY` only in `.env` (single point of failure — use Key Vault)
+- Run Ollama on the same VPS as a high-traffic multi-tenant deployment (resource contention)
+- Send agency identifiers to the LLM endpoint (unnecessary data exposure)
+- Use OVHcloud's built-in VPS backup feature as the only backup (no granular restore, no off-site copy)

--- a/tasks/hosting-cost-comparison.md
+++ b/tasks/hosting-cost-comparison.md
@@ -4,6 +4,8 @@
 
 This document compares two hosting approaches for KoNote, both using Azure Key Vault for encryption key management. All prices are estimates in CAD unless noted. Verify current prices with provider pricing calculators before committing.
 
+**Related:** [OVHcloud deployment architecture](design-rationale/ovhcloud-deployment.md) — full deployment stack, self-healing automation, backup strategy, and encryption key management.
+
 ---
 
 ## Assumptions

--- a/tasks/hosting-cost-comparison.md
+++ b/tasks/hosting-cost-comparison.md
@@ -1,0 +1,335 @@
+# Hosting Cost Comparison: Azure vs OVHcloud
+
+*Last updated: 2026-02-26*
+
+This document compares two hosting approaches for KoNote, both using Azure Key Vault for encryption key management. All prices are estimates in CAD unless noted. Verify current prices with provider pricing calculators before committing.
+
+---
+
+## Assumptions
+
+| Parameter | Value |
+|-----------|-------|
+| Participants per agency | ~200 |
+| Visits per participant per month | ~2 |
+| Notes per month per agency | ~400 |
+| Notes with suggestions (~25%) | ~100 |
+| Translation requests per month | ~50–100 (admin-initiated) |
+| Metrics/targets AI calls per month | ~100–200 |
+| Multi-tenancy status | Single-tenant now; schema-per-tenant planned (see TODO MT-CORE1) |
+| Exchange rate used | 1 USD = 1.43 CAD (approximate) |
+
+---
+
+## Component Pricing Reference
+
+### Azure Virtual Machines — Canada Central (Linux, pay-as-you-go)
+
+| VM Size | vCPUs | RAM | Price (USD/hr) | Price (CAD/mo) |
+|---------|-------|-----|----------------|----------------|
+| B2s | 2 | 4 GB | ~$0.053 | ~$55 |
+| B2ms | 2 | 8 GB | ~$0.083 | ~$87 |
+| B4ms | 4 | 16 GB | ~$0.185 | ~$194 |
+| D2as v5 | 2 | 8 GB | ~$0.096 | ~$100 |
+
+*Source: [Azure Pricing Calculator](https://azure.microsoft.com/en-ca/pricing/calculator/), [CloudOptimo](https://costcalc.cloudoptimo.com/azure-pricing-calculator/vm/Standard-B4ms). Canada Central is typically 10–15% above cheapest US regions.*
+
+### Azure Database for PostgreSQL — Flexible Server (pay-as-you-go)
+
+| SKU | vCores | RAM | Price (USD/mo) | Price (CAD/mo) |
+|-----|--------|-----|----------------|----------------|
+| B1ms (Burstable) | 1 | 2 GB | ~$12 | ~$17 |
+| B2s (Burstable) | 2 | 4 GB | ~$25 | ~$36 |
+| B2ms (Burstable) | 2 | 8 GB | ~$50 | ~$72 |
+| D2s v5 (General Purpose) | 2 | 8 GB | ~$100 | ~$143 |
+| Storage | — | — | $0.115 USD/GiB/mo | $0.16 CAD/GiB/mo |
+
+*KoNote requires 2 databases (main + audit). Burstable tier is appropriate for small agencies. Source: [Azure PostgreSQL pricing](https://azure.microsoft.com/en-ca/pricing/details/postgresql/flexible-server/), [Neon cost comparison](https://dev.to/bobur/cost-comparison-neon-vs-azure-database-for-postgresql-flexible-server-2lpp).*
+
+### Azure Key Vault (Standard tier)
+
+| Item | Price |
+|------|-------|
+| Secret operations | $0.03 USD per 10,000 operations |
+| Key operations | $0.03 USD per 10,000 operations |
+| Setup fee | None |
+| Typical monthly cost | **~$1–5 CAD** |
+
+*KoNote uses Key Vault for `FIELD_ENCRYPTION_KEY` storage. Low operation volume = negligible cost. Source: [Azure Key Vault pricing](https://azure.microsoft.com/en-us/pricing/details/key-vault/), [Infisical pricing guide](https://infisical.com/blog/azure-key-vault-pricing).*
+
+### OVHcloud VPS — Beauharnois, QC (VPS 2026 range)
+
+| Plan | vCores | RAM | Storage | Price (CAD/mo) |
+|------|--------|-----|---------|----------------|
+| VPS-1 | 4 | 8 GB | 75 GB NVMe | ~$11 |
+| VPS-2 | 4 | 16 GB | 100 GB NVMe | ~$22 |
+| VPS-3 | 8 | 24 GB | 200 GB NVMe | ~$30 |
+| VPS-4 | 8 | 32 GB | 200 GB NVMe | ~$44 |
+| VPS-6 | 24 | 96 GB | 400 GB NVMe | ~$105 |
+
+*Prices estimated from VPSBenchmarks and OVHcloud configurator. Post-April 2026 pricing (VPS-1 base = US$7.60). All plans include unlimited traffic. OVH parent is French-incorporated (OVH Groupe SA) — not subject to US CLOUD Act. Source: [OVHcloud Canada VPS](https://www.ovhcloud.com/en-ca/vps/), [VPSBenchmarks](https://www.vpsbenchmarks.com/compare/ovhcloud).*
+
+### AI API Costs (OpenRouter / Claude)
+
+| Model | Input (per 1M tokens) | Output (per 1M tokens) | Use Case |
+|-------|----------------------|------------------------|----------|
+| Claude Haiku 4.5 | $1.00 USD | $5.00 USD | Translation |
+| Claude Sonnet 4.5 | $3.00 USD | $15.00 USD | Metrics/targets generation |
+| gpt-4o-mini (current) | $0.15 USD | $0.60 USD | Translation (current default) |
+
+*Source: [Anthropic pricing](https://platform.claude.com/docs/en/about-claude/pricing), [OpenRouter pricing](https://openrouter.ai/pricing).*
+
+### Self-Hosted LLM (Suggestion Theme Tagging)
+
+| Item | Detail |
+|------|--------|
+| Model | Qwen3.5-35B-A3B (35B params, 3B active, MoE, Apache 2.0) |
+| Runtime | Ollama, CPU-only, nightly batch |
+| Hosting | OVHcloud Beauharnois VPS (shared endpoint) |
+| Tokens per suggestion call | ~800 (prompt + suggestion + response) |
+| Volume (10 agencies) | ~1,000 suggestions/month = ~800K tokens/month |
+| Inference time (CPU) | ~1–2 hours/month |
+
+*See [tasks/design-rationale/ai-feature-toggles.md](tasks/design-rationale/ai-feature-toggles.md) for full analysis.*
+
+### Railway (Current Hosting — for comparison)
+
+| Component | Price (USD/mo) | Price (CAD/mo) |
+|-----------|----------------|----------------|
+| Pro plan base | $5 | ~$7 |
+| Django app (usage) | ~$15–25 | ~$21–36 |
+| 2x PostgreSQL (usage) | ~$10–20 | ~$14–29 |
+| **Total** | **~$30–50** | **~$42–72** |
+
+*Railway hosts in US regions only. US-incorporated. Not appropriate for PHIPA data sovereignty requirements. Source: [Railway pricing](https://railway.app/pricing).*
+
+---
+
+## Scenario A: Azure Hosting (Canada Central)
+
+KoNote application and databases on Azure Canada Central. Self-hosted LLM on OVHcloud (data sovereignty for participant suggestions). Azure Key Vault for encryption keys.
+
+### Per-Agency Costs — Single Tenant
+
+| Component | 1 Agency | Notes |
+|-----------|----------|-------|
+| Azure VM (B2s) | $55 | Django + Gunicorn + Caddy |
+| Azure PostgreSQL x2 (B1ms) | $34 | Main + audit databases |
+| PostgreSQL storage (20 GB) | $3 | 10 GB each, grows slowly |
+| Azure Key Vault | $2 | Negligible operation volume |
+| OpenRouter AI (translation) | $2 | ~100 calls/mo × gpt-4o-mini |
+| OpenRouter AI (metrics/targets) | $5 | ~200 calls/mo × Sonnet 4.5 |
+| OVHcloud VPS share (LLM) | $11 | 1/N share of shared VPS-1 |
+| **Total per agency** | **~$112** | |
+
+### Multi-Agency Scaling — Single Tenant (one VM + DB per agency)
+
+| Component | 1 Agency | 5 Agencies | 10 Agencies |
+|-----------|----------|------------|-------------|
+| Azure VMs (B2s each) | $55 | $275 | $550 |
+| Azure PostgreSQL x2 per agency (B1ms) | $34 | $170 | $340 |
+| PostgreSQL storage | $3 | $15 | $30 |
+| Azure Key Vault (shared) | $2 | $2 | $2 |
+| OpenRouter AI (shared pool) | $7 | $35 | $70 |
+| OVHcloud LLM VPS (shared) | $11 | $11 | $30 |
+| **Total** | **$112** | **$508** | **$1,022** |
+| **Per agency** | **$112** | **$102** | **$102** |
+
+### Multi-Agency Scaling — Multi-Tenant (shared infrastructure)
+
+*Requires django-tenants implementation (see TODO MT-CORE1). One VM + DB serves multiple agencies via schema-per-tenant.*
+
+| Component | 1 Agency | 5 Agencies | 10 Agencies |
+|-----------|----------|------------|-------------|
+| Azure VM (B4ms shared) | $194 | $194 | $194 |
+| Azure PostgreSQL x2 (B2ms shared) | $144 | $144 | $144 |
+| PostgreSQL storage (100 GB) | $16 | $16 | $16 |
+| Azure Key Vault (shared) | $2 | $2 | $2 |
+| OpenRouter AI (shared pool) | $7 | $35 | $70 |
+| OVHcloud LLM VPS (shared) | $11 | $11 | $30 |
+| **Total** | **$374** | **$402** | **$456** |
+| **Per agency** | **$374** | **$80** | **$46** |
+
+---
+
+## Scenario B: OVHcloud Hosting (Beauharnois, QC)
+
+KoNote application, databases, and LLM all on OVHcloud VPS(es) in Beauharnois. Self-managed PostgreSQL via Docker. Azure Key Vault for encryption keys (only Azure dependency).
+
+### Per-Agency Costs — Single Tenant
+
+| Component | 1 Agency | Notes |
+|-----------|----------|-------|
+| OVHcloud VPS-2 | $22 | Django + PostgreSQL x2 + Caddy |
+| Azure Key Vault | $2 | Encryption key management |
+| OpenRouter AI (translation) | $2 | ~100 calls/mo × gpt-4o-mini |
+| OpenRouter AI (metrics/targets) | $5 | ~200 calls/mo × Sonnet 4.5 |
+| OVHcloud LLM VPS share | $11 | 1/N share of shared VPS-1 |
+| Automated backups (OVH option) | $3 | Optional add-on |
+| **Total per agency** | **~$45** | |
+
+### Multi-Agency Scaling — Single Tenant (one VPS per agency)
+
+| Component | 1 Agency | 5 Agencies | 10 Agencies |
+|-----------|----------|------------|-------------|
+| OVHcloud VPS-2 per agency | $22 | $110 | $220 |
+| Azure Key Vault (shared) | $2 | $2 | $2 |
+| OpenRouter AI (shared pool) | $7 | $35 | $70 |
+| OVHcloud LLM VPS (shared) | $11 | $11 | $30 |
+| Backup add-ons | $3 | $15 | $30 |
+| **Total** | **$45** | **$173** | **$352** |
+| **Per agency** | **$45** | **$35** | **$35** |
+
+### Multi-Agency Scaling — Multi-Tenant (shared infrastructure)
+
+*Requires django-tenants implementation (see TODO MT-CORE1). One larger VPS serves multiple agencies. LLM runs on the same or separate VPS.*
+
+| Component | 1 Agency | 5 Agencies | 10 Agencies |
+|-----------|----------|------------|-------------|
+| OVHcloud VPS-3 (shared app + DB) | $30 | $30 | $30 |
+| OVHcloud VPS-1 (LLM, shared) | $11 | $11 | $11 |
+| Azure Key Vault (shared) | $2 | $2 | $2 |
+| OpenRouter AI (shared pool) | $7 | $35 | $70 |
+| Backup add-ons | $3 | $3 | $3 |
+| **Total** | **$53** | **$81** | **$116** |
+| **Per agency** | **$53** | **$16** | **$12** |
+
+*At 10+ agencies, consider upgrading to VPS-4 ($44) for headroom. LLM VPS can stay on VPS-1 — the batch load is minimal.*
+
+---
+
+## Summary Comparison
+
+### Per-Agency Monthly Cost (CAD)
+
+| Scale | Azure Single-Tenant | Azure Multi-Tenant | OVH Single-Tenant | OVH Multi-Tenant |
+|-------|--------------------|--------------------|--------------------|--------------------|
+| 1 agency | $112 | $374* | $45 | $53* |
+| 5 agencies | $102 | $80 | $35 | $16 |
+| 10 agencies | $102 | $46 | $35 | $12 |
+
+*\*Multi-tenant with 1 agency is more expensive due to the larger shared VM — cost advantage kicks in at 3+ agencies.*
+
+### Total Monthly Cost (CAD)
+
+| Scale | Azure Single-Tenant | Azure Multi-Tenant | OVH Single-Tenant | OVH Multi-Tenant |
+|-------|--------------------|--------------------|--------------------|--------------------|
+| 1 agency | $112 | $374 | $45 | $53 |
+| 5 agencies | $508 | $402 | $173 | $81 |
+| 10 agencies | $1,022 | $456 | $352 | $116 |
+
+---
+
+## AI Costs Breakdown (included in totals above)
+
+These costs apply to both Azure and OVHcloud hosting scenarios.
+
+### Translation (French)
+
+| Model | Cost per call | Calls/mo (10 agencies) | Monthly (CAD) |
+|-------|--------------|------------------------|---------------|
+| gpt-4o-mini (current) | ~$0.001 | ~1,000 | ~$1.50 |
+| Claude Haiku 4.5 | ~$0.005 | ~1,000 | ~$7 |
+
+*Translation uses `TRANSLATE_API_BASE` env var. Currently defaults to gpt-4o-mini. Minimal cost either way.*
+
+### Metrics/Targets Generation
+
+| Model | Cost per call | Calls/mo (10 agencies) | Monthly (CAD) |
+|-------|--------------|------------------------|---------------|
+| Claude Sonnet 4.5 (via OpenRouter) | ~$0.03 | ~2,000 | ~$86 |
+| Claude Haiku 4.5 | ~$0.005 | ~2,000 | ~$14 |
+
+*Currently hardcoded to OpenRouter. Quality-sensitive — Sonnet recommended. At high volume, consider Haiku for routine calls and Sonnet for complex ones.*
+
+### Suggestion Theme Tagging (Self-Hosted LLM)
+
+| Item | Value |
+|------|-------|
+| Model | Qwen3.5-35B-A3B on Ollama |
+| Hosting | OVHcloud VPS-1 ($11 CAD/mo shared) |
+| Volume (10 agencies) | ~1,000 suggestions/month |
+| CPU inference time | ~1–2 hours/month (nightly batch) |
+| Per-agency cost (10 agencies) | ~$1.10 CAD/mo |
+| API cost | $0 (self-hosted, Apache 2.0 licence) |
+
+---
+
+## Data Sovereignty Comparison
+
+| Factor | Azure (Canada Central) | OVHcloud (Beauharnois, QC) |
+|--------|----------------------|--------------------------|
+| Parent company | Microsoft (US-incorporated) | OVH Groupe SA (French-incorporated) |
+| US CLOUD Act exposure | **Yes** — US govt can compel disclosure | **No** — French parent not subject |
+| Canadian law enforcement | Yes (normal, expected) | Yes (Sept 2025 Ontario court ruling) |
+| Data residency | Canada Central (Toronto) | Beauharnois, QC |
+| PHIPA compliance | Yes (Azure compliance docs) | Yes (self-managed compliance) |
+| SOC 2 / ISO 27001 | Yes (Azure certifications) | Yes (OVHcloud certifications) |
+| Managed services | Full PaaS (DB, Key Vault, monitoring) | VPS only — self-manage DB, backups |
+
+### Azure Key Vault Dependency (Both Scenarios)
+
+Both scenarios use Azure Key Vault for encryption key management. This introduces a limited Azure dependency:
+
+- **Data at risk**: Only the encryption key itself, not participant data
+- **CLOUD Act exposure**: Theoretical — US govt could compel Microsoft to reveal the encryption key, which would allow decryption of KoNote data stored elsewhere
+- **Mitigation**: Key Vault access is authenticated and audited. The encryption key alone is useless without access to the encrypted database.
+- **Alternative**: If zero Azure dependency is required, consider HashiCorp Vault (self-hosted on OVHcloud) or manual key custody with two-person split
+
+---
+
+## Operational Considerations
+
+### Azure Hosting
+
+| Pro | Con |
+|-----|-----|
+| Managed PostgreSQL (automated backups, patching, HA) | Higher cost (~2–3x OVHcloud) |
+| Azure Monitor, alerts, diagnostics built in | US CLOUD Act exposure on all components |
+| SLA-backed uptime (99.9%+) | Vendor lock-in risk |
+| Easy scaling (resize VM, add replicas) | Overkill for small nonprofit workloads |
+
+### OVHcloud Hosting
+
+| Pro | Con |
+|-----|-----|
+| 60–70% lower cost than Azure | Self-managed PostgreSQL (backups, patching, monitoring) |
+| No US CLOUD Act exposure on application data | No managed database service in BHS for PostgreSQL |
+| Can run app + DB + LLM on one VPS | Single point of failure without HA setup |
+| French data sovereignty (GDPR-aligned parent) | Less tooling than Azure (monitoring, alerting) |
+
+### Self-Healing Automation (OVHcloud)
+
+To address the self-managed operations gap, a 4-layer automated recovery stack is recommended:
+
+1. **Docker HEALTHCHECK + autoheal** — auto-restart failed containers (~$0)
+2. **UptimeRobot → OVHcloud API webhook** — reboot VPS on extended downtime (~$0)
+3. **Preventive cron jobs** — nightly backups, log rotation, disk monitoring (~$0)
+4. **Email alerts** — escalation to KoNote team on unrecoverable failures (~$0)
+
+Total automation cost: ~$0 additional (uses free tiers of monitoring services).
+
+---
+
+## Recommendations
+
+1. **For 1–3 agencies (launch phase)**: OVHcloud single-tenant is the clear winner at ~$45/agency/month vs ~$112 on Azure. Self-managed PostgreSQL is acceptable at this scale.
+
+2. **For 5–10 agencies (growth phase)**: Implement multi-tenancy first (MT-CORE1), then OVHcloud multi-tenant brings costs to $12–16/agency/month — an order of magnitude cheaper than Azure single-tenant.
+
+3. **Azure makes sense if**: The agency or funder requires Azure specifically, or if the operational burden of self-managing PostgreSQL is unacceptable.
+
+4. **LLM hosting**: Keep on OVHcloud regardless of app hosting choice. The self-hosted Ollama VPS is $11 CAD/month shared across all agencies — negligible cost for complete data sovereignty on participant suggestions.
+
+5. **Key Vault**: Use Azure Key Vault in both scenarios. The CLOUD Act exposure is limited to the encryption key only, and the operational simplicity of managed KMS outweighs the theoretical risk for KoNote's threat model.
+
+---
+
+## Price Verification
+
+These estimates should be verified before budget commitments:
+
+- **Azure**: [Azure Pricing Calculator](https://azure.microsoft.com/en-ca/pricing/calculator/) — set region to Canada Central, currency to CAD
+- **OVHcloud**: [OVHcloud Canada VPS](https://www.ovhcloud.com/en-ca/vps/) — prices displayed in CAD
+- **OpenRouter**: [OpenRouter Pricing](https://openrouter.ai/pricing) — per-model token rates
+- **Azure Key Vault**: [Key Vault Pricing](https://azure.microsoft.com/en-us/pricing/details/key-vault/)


### PR DESCRIPTION
## Summary

- Adds `tasks/hosting-cost-comparison.md` comparing Azure Canada Central vs OVHcloud Beauharnois hosting scenarios
- Covers 1, 5, and 10 agency scales in both single-tenant and multi-tenant configurations
- Includes AI costs (OpenRouter for translation/metrics, self-hosted Qwen3.5-35B-A3B for suggestion theme tagging)
- Both scenarios use Azure Key Vault for encryption key management
- Data sovereignty analysis (CLOUD Act, PHIPA compliance, jurisdictional considerations)

## Key Findings

| Scale | Azure Single-Tenant | OVH Multi-Tenant |
|-------|--------------------|--------------------|
| 1 agency | ~$112 CAD/mo | ~$53 CAD/mo |
| 5 agencies | ~$102/agency | ~$16/agency |
| 10 agencies | ~$102/agency | ~$12/agency |

## Test plan

- [ ] Review pricing estimates against Azure Pricing Calculator and OVHcloud Canada configurator
- [ ] Verify data sovereignty analysis accuracy
- [ ] Confirm multi-tenancy cost projections align with MT-CORE1 implementation plan

🤖 Generated with [Claude Code](https://claude.com/claude-code)