### PR TITLE
chore: link hosting docs to TODO deployment items

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -12,9 +12,9 @@
 
 ### Phase: Launch Readiness
 
-- [ ] Complete Agency Deployment Protocol with [funder partner] — Phase 0 Discovery Call first (see tasks/deployment-protocol.md) — (DEPLOY-PC1)
+- [ ] Complete Agency Deployment Protocol with [funder partner] — Phase 0 Discovery Call first, includes hosting preference (Azure vs OVHcloud) and data sovereignty requirements (see tasks/deployment-protocol.md, tasks/hosting-cost-comparison.md) — (DEPLOY-PC1)
 - [ ] Follow up with [funder contact] for additional must-haves on feature comparison — (DEPLOY-PC2)
-- [ ] Complete Agency Permissions Interview and signed Configuration Summary before first deployment — SG (ONBOARD-GATE)
+- [ ] Complete Agency Permissions Interview and signed Configuration Summary before first deployment — include hosting preference and data sovereignty questions — SG (ONBOARD-GATE)
 - [ ] Store signed Configuration Summary with each deployment so new admins can see what was decided and why — SG (DEPLOY-CONFIG-DOC1)
 - [ ] Test backup restore from a production-like database dump and capture runbook notes — PB (OPS4)
 - [ ] Document scheduled task setup for export monitoring in the runbook — PB (EXP2w)
@@ -52,7 +52,7 @@ Step-by-step commands for each task are in [tasks/recurring-tasks.md](tasks/recu
 - [ ] Add consent_to_aggregate_reporting field and audit tenant_schema column (see plan Tasks 5-6) — PB (MT-CONSENT1)
 - [ ] Validate existing features across tenant schemas — update test infrastructure, fix tenant-related test failures (see plan Tasks 7-8) — PB (MT-VALIDATE1)
 - [ ] Build deploy script to automate Phase 2 infrastructure provisioning — Azure resources, env vars, migrations, output a URL (plan: docs/plans/2026-02-20-deploy-script-design.md) (DEPLOY-SCRIPT1)
-- [ ] Define managed service model — who handles infrastructure, backups, updates, support tiers, funding model (see tasks/managed-service-model.md) (OPS-MANAGED1)
+- [ ] Define managed service model — who handles infrastructure, backups, updates, support tiers, funding model (see tasks/hosting-cost-comparison.md, tasks/design-rationale/ovhcloud-deployment.md) (OPS-MANAGED1)
 - [ ] Build cross-agency reporting API — standardised endpoint per instance for [funder partner] to consume published reports (plan: docs/plans/2026-02-20-cross-agency-reporting-api-design.md) (SCALE-API1)
 - [ ] Build umbrella admin dashboard — central view for [funder partner] to see instance health, published reports, and aggregate metrics across agencies (SCALE-DASH1)
 - [ ] Improve admin UI for self-service configuration — better guidance for terminology, metrics, templates (ADMIN-UX1)
@@ -122,7 +122,7 @@ Not yet clear we should build these, or the design isn't settled. May be too com
 - [ ] 90-day metric relevance check — prompt worker to confirm or change the chosen metric (METRIC-REVIEW1)
 - [ ] Alliance prompt rotation — cycle 3-4 phrasings to prevent habituation (ALLIANCE-ROTATE1)
 - [ ] Portal-based async alliance rating — post-session notification for participant self-rating (PORTAL-ALLIANCE1)
-- [ ] Consider self-hosted open-source LLM for AI operations (e.g. Qwen3.5-35B-A3B) — cost, privacy, and latency trade-offs vs cloud API — GK reviews (AI-SELFHOST1)
+- [ ] Self-hosted LLM for suggestion theme tagging — Qwen3.5-35B-A3B on OVHcloud Beauharnois, shared endpoint, nightly batch — see tasks/design-rationale/ai-feature-toggles.md for full analysis — GK reviews (AI-SELFHOST1)
 
 ## Recently Done
 


### PR DESCRIPTION
## Summary

- Updates DEPLOY-PC1 to include hosting preference (Azure vs OVHcloud) and data sovereignty in the discovery call
- Updates ONBOARD-GATE to include hosting preference and data sovereignty in the agency permissions interview
- Updates OPS-MANAGED1 to reference hosting-cost-comparison.md and ovhcloud-deployment.md
- Updates AI-SELFHOST1 with specific decision (Qwen3.5-35B-A3B on OVHcloud Beauharnois)

## Test plan

- [ ] Review TODO.md changes for accuracy and formatting

🤖 Generated with [Claude Code](https://claude.com/claude-code)