### PR TITLE
fix: remove extra spacing between demo login buttons

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -1483,7 +1483,7 @@ details.search-filters-panel[open] summary {
     gap: 0.4rem;
 }
 .demo-grid form {
-    margin-bottom: 0;
+    margin-bottom: 0 !important;
 }
 .demo-grid form:only-child {
     grid-column: 1 / -1;


### PR DESCRIPTION
Pico CSS applies margin-bottom to form elements, overriding the grid gap. Added !important to .demo-grid form { margin-bottom: 0 } to prevent the form margins from stacking between buttons.