### PR TITLE
Fix/participant table column widths

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -36,7 +36,9 @@
     outline-offset: -3px;
 }
 /* Screen-reader-only text (WCAG 1.3.1 — convey meaning beyond colour alone) */
-.sr-only {
+/* .visually-hidden is an alias — both classes are used across templates */
+.sr-only,
+.visually-hidden {
     position: absolute;
     width: 1px;
     height: 1px;

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -639,6 +639,27 @@ output.form-output {
     text-decoration: underline;
 }
 
+/* ---- Client table — bulk mode (6 cols: checkbox + Name + ID + Status + Programs + Last Contact) ---- */
+/* :has() shifts nth-child widths right by 1 when the bulk select column is present                    */
+.client-table:has(.bulk-col) th:nth-child(1),
+.client-table:has(.bulk-col) td:nth-child(1) { width: 3rem; }
+.client-table:has(.bulk-col) th:nth-child(2),
+.client-table:has(.bulk-col) td:nth-child(2) { width: 28%; }
+.client-table:has(.bulk-col) th:nth-child(3),
+.client-table:has(.bulk-col) td:nth-child(3) { width: 12%; font-variant-numeric: tabular-nums; }
+.client-table:has(.bulk-col) th:nth-child(4),
+.client-table:has(.bulk-col) td:nth-child(4) { width: 10%; }
+.client-table:has(.bulk-col) th:nth-child(5),
+.client-table:has(.bulk-col) td:nth-child(5) { width: 28%; }
+/* col 6 (Last Contact) gets remaining ~22% — no explicit width needed */
+.client-table:has(.bulk-col) td:nth-child(2) {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.client-table:has(.bulk-col) td:nth-child(2) a { text-decoration: none; }
+.client-table:has(.bulk-col) td:nth-child(2) a:hover { text-decoration: underline; }
+
 /* ---- Organization header ---- */
 .org-header {
     display: flex;
@@ -2523,6 +2544,34 @@ p.notice.warning {
     background: var(--kn-warning-bg);
     border-left-color: var(--kn-warning-fg);
 }
+
+/* ---- Plan targets table ---- */
+.plan-targets-table {
+    table-layout: fixed;
+    width: 100%;
+}
+.plan-targets-table th:nth-child(1),
+.plan-targets-table td:nth-child(1) { width: 50%; }
+.plan-targets-table th:nth-child(2),
+.plan-targets-table td:nth-child(2) { width: 13%; }
+.plan-targets-table th:nth-child(3),
+.plan-targets-table td:nth-child(3) { width: 25%; }
+.plan-targets-table th:nth-child(4),
+.plan-targets-table td:nth-child(4) { width: 12%; }
+.plan-targets-table td:nth-child(1) {
+    overflow: hidden;
+}
+
+/* ---- Note metric values table ---- */
+.metric-values-table {
+    width: auto;
+    min-width: 240px;
+    max-width: 420px;
+}
+.metric-values-table th:nth-child(1),
+.metric-values-table td:nth-child(1) { width: 65%; }
+.metric-values-table th:nth-child(2),
+.metric-values-table td:nth-child(2) { width: 35%; }
 
 /* ---- Section cards (plan) ---- */
 .section-card {
@@ -4928,7 +4977,7 @@ article[aria-label="notification"].fading-out {
 /* Checkbox column — narrow, fixed width */
 .bulk-col {
     width: 3rem;
-    text-align: centre;
+    text-align: center;
     padding-left: var(--kn-space-sm) !important;
     padding-right: var(--kn-space-xs) !important;
 }

--- a/templates/notes/_note_detail.html
+++ b/templates/notes/_note_detail.html
@@ -41,7 +41,7 @@
         {% if entry.progress_descriptor %}<p><span class="badge badge-neutral">{{ entry.get_progress_descriptor_display }}</span></p>{% endif %}
         {% if entry.notes %}<p>{{ entry.notes }}</p>{% endif %}
         {% if entry.metric_values.all %}
-        <table>
+        <table class="metric-values-table">
             <thead><tr><th scope="col">{{ term.metric|default:"Metric" }}</th><th scope="col">{% trans "Value" %}</th></tr></thead>
             <tbody>
             {% for mv in entry.metric_values.all %}

--- a/templates/plans/_section.html
+++ b/templates/plans/_section.html
@@ -40,7 +40,7 @@
 
 <!-- Targets within this section -->
 {% if section.targets.all %}
-<table role="grid" aria-labelledby="section-heading-{{ section.pk }}">
+<table class="plan-targets-table" role="grid" aria-labelledby="section-heading-{{ section.pk }}">
     <thead>
         <tr>
             <th scope="col">{{ term.target|default:"Target" }}</th>


### PR DESCRIPTION
This pull request introduces new CSS classes and updates templates to improve the layout and accessibility of several tables in the application. The changes mainly focus on consistent styling for tables related to clients, plan targets, and metric values, as well as minor accessibility and alignment fixes.

**Table styling and layout improvements:**

* Added explicit column widths and overflow handling for the client table in bulk mode using the `:has()` selector, ensuring proper alignment and truncation for long names.
* Introduced new CSS classes `.plan-targets-table` and `.metric-values-table` with defined column widths and layout settings for plan targets and metric values tables, and updated the corresponding templates to use these classes for consistent styling. [[1]](diffhunk://#diff-7c6d9b791479470684ffe55c750a991e18239247dc75846ca2e688606e8e8887R2550-R2577) [[2]](diffhunk://#diff-9c2961a6cc0aee7dd1564dad7fede7f137182a748404760819c5bdab1f5d5070L44-R44) [[3]](diffhunk://#diff-3a7610155723067155d7a07a61f91df0775bf3d0333ddf377dd06c1ea0928927L43-R43)

**Accessibility and consistency:**

* Made `.visually-hidden` an alias for `.sr-only` to standardize screen-reader-only text across templates, improving accessibility.

**Minor fixes:**

* Corrected a typo in the `.bulk-col` class by changing `text-align: centre;` to `text-align: center;` for proper alignment in the checkbox column.