### PR TITLE
fix: remove Pico button margin-bottom from .demo-btn

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -1529,6 +1529,7 @@ details.search-filters-panel[open] summary {
     text-decoration: none;
     transition: border-color var(--kn-transition), color var(--kn-transition), background var(--kn-transition);
     cursor: pointer;
+    margin-bottom: 0;
 }
 .demo-btn:hover {
     color: var(--kn-text);


### PR DESCRIPTION
Pico CSS applies 15px margin-bottom to all button elements. This was the actual cause of excess spacing between demo login buttons -- not form margins. Adding margin-bottom: 0 directly on .demo-btn.