### PR TITLE
fix: add mandatory pull-main-first rule for worktree sessions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,9 +27,11 @@ A secure, web-based Participant Outcome Management system for nonprofits. Agenci
 
 ## Git Workflow
 
+**Pull main before doing anything.** At the very start of every session — before reading task files, before making decisions, before creating a branch — run `git pull origin main`. Worktrees and local copies go stale when other sessions merge PRs. If you skip this step, you will make decisions based on missing files and outdated plans.
+
 **Branch before working.** `main` has branch protection — never commit directly to it.
 
-1. **At the start of every task**, check the current branch with `git branch --show-current`
+1. **At the start of every task**, run `git pull origin main`, then check the current branch with `git branch --show-current`
 2. If on `main`, create a feature branch before making any changes: `git checkout -b fix/short-description` or `git checkout -b feat/short-description`
 3. Branch naming: `fix/` for bug fixes, `feat/` for new features, `chore/` for cleanup/config
 4. Commit frequently on the feature branch

--- a/tasks/phase-fhir-cids-prompt.md
+++ b/tasks/phase-fhir-cids-prompt.md
@@ -10,7 +10,9 @@ We're implementing the first step of the FHIR-informed data modelling plan combi
 
 ### Before you start
 
-1. Read these files in order:
+0. **Pull main first.** Run `git pull origin main` before anything else. Your worktree may be missing recently merged files (the implementation plan, DRR, and CLAUDE.md updates were merged in PR #120). If you skip this, you will be missing critical design documents.
+
+1. Read these files in order — **all four are required before writing any code**:
    - `tasks/fhir-informed-data-modelling.md` — the full implementation plan (focus on Phase F0)
    - `tasks/design-rationale/fhir-informed-modelling.md` — anti-patterns and trade-offs (DO NOT violate these)
    - `tasks/cids-json-ld-export.md` — Phase 1 fields (sections 1a through 1d)


### PR DESCRIPTION
## Summary

- Add "pull main before doing anything" as the first git rule in CLAUDE.md
- Add step 0 to the FHIR/CIDS implementation prompt

## Problem

Worktree sessions were making wrong decisions based on stale files. A session tried to implement the FHIR plan but couldn't find the DRR (merged minutes earlier) and concluded FHIR shouldn't be used because it only saw the old "not an EHR" doc.

## Test plan

- [ ] Verify new sessions in worktrees pull main before starting work

🤖 Generated with [Claude Code](https://claude.com/claude-code)