### PR TITLE
docs: Permission system documentation  DV-safe, GATED access, field controls, access tiers (DOC-PERM1/2/3)

### DIFF
--- a/docs/admin/access-tiers.md
+++ b/docs/admin/access-tiers.md
@@ -1,0 +1,225 @@
+# Access Tiers — KoNote's 3-Tier Permission Model
+
+> **What you'll need:** Administrator access to KoNote.
+> **Related:** [DV-Safe Mode & GATED Access](dv-safe-mode-and-gated-access.md) · [Per-Field Front Desk Access](per-field-front-desk-access.md) · [Users & Roles](users-and-roles.md)
+
+---
+
+## Overview
+
+Not all agencies have the same privacy needs. A small after-school program and a clinical counselling agency work with very different levels of data sensitivity.
+
+KoNote's **access tier** system lets your agency choose the right level of access control for your situation. Think of it as a dial — you can turn up the protections as your needs require, without changing how your team works day-to-day.
+
+There are three tiers:
+
+| Tier | Name | Best For |
+|---|---|---|
+| **Tier 1** | Open Access | Small teams, non-sensitive data |
+| **Tier 2** | Role-Based | Agencies with a dedicated front desk and distinct staff roles |
+| **Tier 3** | Clinical Safeguards | Clinical programs, DV agencies, and organisations handling sensitive data |
+
+Every tier includes the same baseline role permissions (Front Desk, Direct Service, Program Manager, Executive, Administrator). The tiers add features **on top of** that baseline.
+
+---
+
+## Comparison: What Each Tier Enables
+
+| Feature | Tier 1 | Tier 2 | Tier 3 |
+|---|---|---|---|
+| **Role-based permissions** (who can see what by role) | ✓ | ✓ | ✓ |
+| **Front desk limited by default** (can't see clinical notes, plans, or metrics) | ✓ | ✓ | ✓ |
+| **Executive role** (aggregate data only, no individual records) | ✓ | ✓ | ✓ |
+| **Client access blocks** (block specific staff from specific participants) | ✓ | ✓ | ✓ |
+| **Per-field front desk access** (choose which fields front desk can see/edit) | — | ✓ | ✓ |
+| **DV-Safe Mode** (hide sensitive fields for flagged participants) | — | ✓ | ✓ |
+| **Custom field DV-sensitivity** (mark fields as DV-sensitive) | — | ✓ | ✓ |
+| **Tighter email defaults** (email view-only for front desk) | — | — | ✓ |
+| **GATED clinical access** (managers must justify viewing clinical notes) | — | — | ✓ |
+| **Time-limited access grants** (access expires automatically) | — | — | ✓ |
+| **Configurable grant reasons and durations** | — | — | ✓ |
+
+---
+
+## Tier 1 — Open Access
+
+### What Each Role Can Do
+
+Tier 1 provides straightforward role-based access. Everyone on the team sees what they need for their role, and the system keeps clinical data away from people who don't need it.
+
+| Role | What They Can Do |
+|---|---|
+| **Front Desk** | See participant names, contact info, and safety information. Check people in and out. Create new participant files. Leave messages for case workers. Cannot see clinical notes, plans, metrics, or group rosters. |
+| **Direct Service** | Everything Front Desk can do, plus: view and write clinical notes, manage plans, see metrics, manage group rosters and sessions, record events, log communications, manage meetings. All scoped to their assigned program(s). |
+| **Program Manager** | Everything Direct Service can do, plus: view all data across their program(s), generate reports, manage program configuration, manage templates, review alerts, manage erasure requests, audit logs for own program(s). Cannot delete clinical notes. |
+| **Executive** | Aggregate data only — org-wide attendance reports, aggregate metrics, outcome insights, and funder reports. No individual participant records, names, or clinical data. |
+| **Administrator** | System configuration: manage users, programs, settings, terminology, and features. Does **not** automatically have access to participant data — that requires a separate program role. |
+
+### Front Desk Access at Tier 1
+
+At Tier 1, Front Desk uses safe defaults that cannot be changed:
+
+| Field | Default Access |
+|---|---|
+| First name, last name, display name, record ID, status | Always visible |
+| Phone number | View and edit |
+| Email address | View and edit |
+| Preferred name | View only |
+| Date of birth | Hidden |
+| Custom fields | Hidden (unless individually set to view/edit) |
+
+### Who Should Use Tier 1?
+
+- Small agencies where everyone on the team knows each other
+- Programs with non-sensitive data (recreation, education, after-school)
+- Agencies where there is no dedicated front desk — everyone wears multiple hats
+- Agencies just getting started with KoNote who want simplicity first
+
+---
+
+## Tier 2 — Role-Based
+
+### What's Added
+
+Tier 2 includes everything in Tier 1, plus:
+
+- **Per-field front desk access controls** — administrators can choose exactly which fields Front Desk staff can see and edit. See the [Per-Field Front Desk Access](per-field-front-desk-access.md) guide.
+- **DV-Safe Mode** — sensitive fields can be hidden from Front Desk for participants who have a DV safety flag. See the [DV-Safe Mode](dv-safe-mode-and-gated-access.md#dv-safe-mode) guide.
+- **Custom field DV-sensitivity** — each custom field can be marked as DV-sensitive, so it's automatically hidden for flagged participants.
+
+### How Roles Change at Tier 2
+
+The roles themselves don't change — the same five roles work the same way. What changes is that administrators can **fine-tune** what Front Desk sees:
+
+- Phone number: choose Hidden, View only, or View and edit
+- Email address: choose Hidden, View only, or View and edit
+- Preferred name: choose Hidden, View only, or View and edit
+- Date of birth: choose Hidden, View only, or View and edit
+- Each custom field: choose Hidden, View only, or View and edit
+
+### Confidential Programs
+
+At Tier 2, you can also designate programs as **confidential**. Confidential programs have additional restrictions on how data flows between programs — for example, clinical notes from a confidential program won't appear in cross-program views unless consent has been given.
+
+### Who Should Use Tier 2?
+
+- Agencies with a dedicated front desk / reception area
+- Organisations where front desk and clinical staff have clearly different roles
+- Agencies serving populations where some data is sensitive (e.g., health information, employment status)
+- Agencies that want DV safety protections
+
+---
+
+## Tier 3 — Clinical Safeguards
+
+### What's Added
+
+Tier 3 includes everything in Tier 2, plus:
+
+- **GATED clinical access** — Program Managers must document a reason before viewing individual clinical notes, plans, and related records. See the [GATED Clinical Access](dv-safe-mode-and-gated-access.md#gated-clinical-access) guide.
+- **Time-limited access grants** — when a manager requests clinical access, it's granted for a set number of days (default: 7, maximum: 30) and expires automatically.
+- **Configurable grant reasons** — administrators set the list of reasons managers choose from when requesting access (e.g., "Case supervision", "Safety concern follow-up").
+- **Tighter front desk defaults** — email is view-only by default instead of editable, because email addresses can reveal a participant's location.
+- **Admin grant review** — administrators can view all active and expired grants, providing accountability and oversight.
+
+### How Roles Change at Tier 3
+
+Program Managers experience the biggest change at Tier 3. Instead of having automatic access to all clinical data in their program(s), they must:
+
+1. Click on a clinical record (note, plan, etc.)
+2. Be redirected to a justification form
+3. Select a reason, write a brief explanation, and choose a duration
+4. Submit the form to receive time-limited access
+
+This happens the first time they try to view gated content. Once they have an active grant, they can access clinical data normally until the grant expires.
+
+**Direct Service** staff are **not** affected by GATED access — they continue to have full access to clinical data in their assigned program(s).
+
+**Front Desk** and **Executive** roles are also unaffected, since they don't have clinical data access in any tier.
+
+### The Gated Permissions
+
+At Tier 3, the following permissions require an access grant for Program Managers:
+
+| What's Gated | What This Means |
+|---|---|
+| View clinical data | Individual participant clinical information |
+| View progress notes | Reading notes written by Direct Service staff |
+| View participant plans | Goals, targets, and plan details |
+
+### Who Should Use Tier 3?
+
+- Clinical counselling agencies
+- Agencies serving people experiencing domestic violence (DV)
+- Organisations handling mental health, addiction, or trauma data
+- Agencies where funders or regulators require documented access justification
+- Organisations that want the strongest privacy protections KoNote offers
+
+---
+
+## How to Change Your Tier
+
+Changing your access tier is a settings change — it takes effect immediately and doesn't require a system restart.
+
+1. Go to **Admin → Settings**
+2. Find the **Access Tier** setting
+3. Select the tier you want:
+   - **Tier 1 — Open Access** (previously called "Role-based only" in setup)
+   - **Tier 2 — Role-Based** (previously called "Role-based + field-level access" in setup)
+   - **Tier 3 — Clinical Safeguards** (previously called "Role-based + field-level + gated grants" in setup)
+4. Click **Save**
+
+### What Happens When You Change Tiers
+
+**Moving up** (e.g., Tier 1 → Tier 2, or Tier 2 → Tier 3):
+
+- New features become available immediately
+- Existing data and access is preserved
+- You may want to configure the new features (field access, DV flags, grant reasons) right away
+
+**Moving down** (e.g., Tier 3 → Tier 2, or Tier 2 → Tier 1):
+
+- Higher-tier features are deactivated immediately
+- Existing access grants are preserved in the database (for audit purposes) but are no longer enforced
+- Field access configurations are preserved but may not apply if you drop below Tier 2
+- DV safety flags on participants are preserved but not enforced at Tier 1
+
+> **Good to know:** You can move between tiers freely. There's no lock-in. If you try Tier 3 and find it's more than your agency needs, you can move back to Tier 2 without losing any data.
+
+---
+
+## Recommendations: Which Tier for Which Agency?
+
+| Agency Type | Recommended Tier | Why |
+|---|---|---|
+| After-school or recreation programs | Tier 1 | Simple, low-sensitivity data |
+| Employment services | Tier 1 or Tier 2 | Tier 2 if you have a front desk and want to control what they see |
+| Community support programs | Tier 2 | Distinct front desk and staff roles, some sensitive data |
+| Settlement / newcomer services | Tier 2 | Some DV risk may warrant DV-safe mode |
+| Clinical counselling | Tier 3 | Clinical notes require access justification |
+| Addiction services | Tier 3 | Highly sensitive data with regulatory requirements |
+| Women's shelters / DV agencies | Tier 3 | Maximum protections for at-risk participants |
+| Multi-program agencies (mix of sensitive and non-sensitive) | Tier 2 or Tier 3 | Tier 3 if any program involves clinical or DV data |
+
+> **When in doubt, start with Tier 2.** It gives you fine-grained control without the overhead of access grants. You can always move to Tier 3 later if you need it.
+
+---
+
+## Frequently Asked Questions
+
+**Can I use different tiers for different programs?**
+No — the access tier is a system-wide setting that applies to all programs. If any of your programs handle sensitive clinical data, choose the tier that covers your most sensitive program.
+
+**Does changing tiers affect existing data?**
+No. Your participant records, notes, plans, and other data are unchanged. Only the access control features change.
+
+**Will my users notice when I change tiers?**
+- Moving from Tier 1 to Tier 2: Front Desk staff may notice fields appearing or disappearing, depending on how you configure field access
+- Moving to Tier 3: Program Managers will see the justification form the first time they try to view clinical notes
+- Moving down: users will notice fewer restrictions (e.g., no more justification forms)
+
+**Is there a Tier 4?**
+No. Three tiers cover the range of needs from low-sensitivity to clinical-grade protections. If you need something beyond Tier 3, contact KoNote support to discuss your requirements.
+
+**Who can change the tier?**
+Only administrators can change the access tier. The setting is in the admin settings area and requires admin privileges.

--- a/docs/admin/dv-safe-mode-and-gated-access.md
+++ b/docs/admin/dv-safe-mode-and-gated-access.md
@@ -1,0 +1,219 @@
+# DV-Safe Mode & GATED Clinical Access
+
+> **What you'll need:** Administrator access to KoNote.
+> **Related:** [Access Tiers](access-tiers.md) · [Per-Field Front Desk Access](per-field-front-desk-access.md) · [Users & Roles](users-and-roles.md)
+
+---
+
+## Overview
+
+Some agencies serve participants who are at risk of violence from a partner, family member, or other person. In these situations, even basic contact information — a phone number, an address, an emergency contact — can put someone in danger if the wrong person sees it.
+
+KoNote includes two safety features designed to protect participants in these situations:
+
+1. **DV-Safe Mode** — hides sensitive contact fields from Front Desk staff for specific participants who have been flagged as needing protection.
+2. **GATED Clinical Access** — requires Program Managers to document a reason before viewing clinical notes, with time-limited access that expires automatically. This is only active at Tier 3.
+
+Both features are designed to **fail closed**: if anything goes wrong or a setting can't be determined, KoNote hides the information rather than showing it. Safety comes first.
+
+---
+
+## DV-Safe Mode
+
+### What It Does
+
+When DV-Safe Mode is enabled on a participant's file, certain sensitive fields are automatically hidden from Front Desk staff. This protects participants whose contact information could be used to locate or harm them.
+
+The fields that are hidden include any custom field marked as **DV-sensitive** by an administrator (for example, address, emergency contact, employer). These fields are hidden on screen — Front Desk staff simply don't see them.
+
+Staff in other roles (Direct Service, Program Manager) continue to see all fields as usual.
+
+### Turning It On
+
+DV-Safe Mode works at the **participant level** — you set a DV safety flag on individual participant files, not as a system-wide switch.
+
+DV-Safe Mode is available at **Tier 2** and **Tier 3**. (At Tier 1, the system uses basic role-based access without DV-specific protections.)
+
+### Which Fields Are DV-Sensitive?
+
+As an administrator, you control which custom fields are treated as DV-sensitive. When creating or editing a custom field in KoNote, you'll see a checkbox labelled **"DV-sensitive"**. When this is checked:
+
+- The field behaves normally for Direct Service and Program Manager roles
+- If a participant has a DV safety flag, the field is **completely hidden** from Front Desk staff — even if the field would otherwise be visible to them
+
+Common fields to mark as DV-sensitive include:
+
+- Home address
+- Emergency contact name and phone
+- Employer or workplace
+- Alternate phone numbers
+- Any field that could reveal a participant's location
+
+> **Important:** DV-Safe Mode overrides normal field access settings. Even if you've configured a field to be visible to Front Desk, the DV safety flag will hide it for that participant.
+
+### Setting the DV Flag on a Participant
+
+Anyone with a Direct Service or Program Manager role can set the DV safety flag on a participant's file. Look for the **"DV-safe"** toggle on the participant's profile.
+
+When this flag is turned on:
+
+- All DV-sensitive custom fields are hidden from Front Desk staff for this participant
+- The flag is visible to Direct Service and Program Manager staff so they know protections are in place
+- An audit log entry is created
+
+### Removing the DV Flag (Two-Person Workflow)
+
+Removing a DV safety flag is deliberately harder than setting it. This uses a **two-person rule** to prevent accidental or coerced removal:
+
+1. **Step 1 — Request removal.** A staff member (Direct Service or Program Manager) submits a removal request. They must provide a written reason explaining why the DV safety flag should be removed (for example, "Participant has confirmed the safety concern is resolved and requested the flag be removed").
+
+2. **Step 2 — A different person reviews.** A Program Manager (who is **not** the person who submitted the request) reviews the request and either approves or rejects it. They can add a review note explaining their decision.
+
+3. **If approved:** The DV safety flag is removed from the participant's file, and all DV-sensitive fields become visible to Front Desk again.
+
+4. **If rejected:** The flag stays in place. The request is marked as rejected and a new request can be submitted later if circumstances change.
+
+> **Why two people?** In domestic violence situations, an abuser may pressure a staff member into removing safety protections. Requiring a second person to review and approve the change adds an important safeguard.
+
+### What Happens When Someone Is Denied Access
+
+When a Front Desk staff member views a participant who has a DV safety flag:
+
+- They see the participant's name, record ID, and status (these are always visible)
+- DV-sensitive fields simply don't appear on the page — there is no error message or alert drawing attention to the flag
+- The experience is designed to be discreet: the Front Desk user sees fewer fields, but the interface doesn't announce *why*
+
+### Fail-Closed Behaviour
+
+KoNote uses a **fail-closed** approach for DV safety. This means:
+
+- If the system can't determine whether a participant has a DV flag (for example, due to a database error), it hides the sensitive fields by default
+- If a staff member's access permissions can't be verified, they are denied access rather than granted it
+- This "safe by default" design ensures that a technical glitch never accidentally reveals protected information
+
+---
+
+## GATED Clinical Access
+
+### When It's Active (Tier 3 Only)
+
+GATED clinical access is only enforced when your agency is using **Tier 3: Clinical Safeguards**. At Tier 1 and Tier 2, Program Managers can view clinical notes without needing to document a reason.
+
+If you're not sure which tier your agency uses, check **Admin → Settings → Access Tier**. See the [Access Tiers](access-tiers.md) guide for details on what each tier provides.
+
+### What It Does
+
+At Tier 3, certain clinical data is protected behind a **justification gate**. When a Program Manager tries to view:
+
+- Progress notes
+- Participant plans
+- Other clinical records
+
+...they are redirected to a short form asking them to document **why** they need access. This creates an accountability record — the access is granted, but the reason is logged.
+
+This design reflects a principle called **"need-to-know" access**: managers should only view individual clinical records when they have a specific reason to do so, not routinely.
+
+### How a Staff Member Requests Access
+
+When a Program Manager clicks on a clinical record that is protected by a gate, KoNote automatically redirects them to the **Access Request** form. The form asks for:
+
+1. **Reason for access** — choose from a dropdown of pre-configured reasons (for example: "Case supervision", "Quality assurance review", "Safety concern follow-up")
+2. **Brief explanation** — a free-text field where they describe what they need to see and why
+3. **How long do you need access?** — choose a duration (1 day, 3 days, 7 days, 14 days, or 30 days)
+
+After submitting the form, the manager is immediately redirected to the page they originally wanted to see. There is no separate approval step — the gate creates an accountability record, not a waiting queue.
+
+### Grant Scope
+
+Access grants can cover:
+
+- **An entire program** — the manager can view all clinical records in that program for the duration of the grant
+- **A specific participant** — the manager can view that participant's clinical records only
+
+The scope is determined automatically based on what the manager was trying to access when the gate was triggered.
+
+### Grant Expiry and Renewal
+
+All access grants are **time-limited**. The default duration is 7 days, and the maximum is 30 days — but administrators can configure both of these values.
+
+When a grant expires:
+
+- The manager's access to the gated clinical data is automatically revoked
+- No action is required by anyone — it happens automatically
+- If the manager needs access again, they submit a new request with a fresh justification
+
+Managers can also **revoke their own grant early** from their access grants page if they no longer need it.
+
+### Configuring Reasons and Durations
+
+As an administrator, you can customise the GATED access system:
+
+**Managing reasons:**
+
+1. Go to **Admin → Access Grant Reasons**
+2. You'll see the list of reasons that appear in the dropdown when staff request access
+3. To add a new reason, type the label (and optionally a French translation) and click **Add**
+4. To deactivate a reason you no longer want available, click the toggle next to it — deactivated reasons won't appear in the dropdown, but existing grants that used them are preserved
+5. Five default reasons are created when KoNote is first set up
+
+**Configuring default and maximum durations:**
+
+Default and maximum grant durations are managed as instance settings:
+
+- **Default duration** (`access_grant_default_days`): How many days a grant lasts by default. The default is **7 days**.
+- **Maximum duration** (`access_grant_max_days`): The longest grant any user can request. The default is **30 days**.
+
+The duration options shown to staff (1, 3, 7, 14, or 30 days) are automatically filtered so that no option exceeds the maximum you've set.
+
+### How Admins Review Active Grants
+
+Administrators can see all access grants across all users and programs:
+
+1. Go to **Admin → Access Grants**
+2. You'll see a list of all grants — active and expired — with who requested them, the program, the reason, the justification text, when they were granted, and when they expire
+3. This page is only available at Tier 3
+
+Individual users can also see their own grants at **My Access Grants**, where they can review their active grants and revoke them early if needed.
+
+### Audit Trail
+
+Every access grant is recorded in the audit log with:
+
+- Who requested the access
+- What program (and optionally, which participant)
+- The selected reason and written justification
+- The duration and expiry date
+- When the grant was revoked (if applicable)
+
+This audit trail supports privacy compliance reviews, clinical supervision, and funder accountability.
+
+---
+
+## Frequently Asked Questions
+
+**Can I use DV-Safe Mode without Tier 3?**
+Yes. DV-Safe Mode is available at Tier 2 and above. You don't need to enable GATED clinical access to use DV protections.
+
+**Do Direct Service staff see DV-flagged participants differently?**
+Direct Service staff see all fields (including DV-sensitive ones) regardless of the DV flag. The flag only affects what Front Desk staff can see. Direct Service staff *can* see that the DV flag is set, so they know protections are in place.
+
+**What if Front Desk needs to reach a participant urgently?**
+If Front Desk staff need contact information that's hidden by a DV flag, they should ask a Direct Service or Program Manager to provide it. This ensures there's always a clinical judgement involved before sharing protected information.
+
+**What if I set Tier 3 and then switch back to Tier 2?**
+GATED access is immediately relaxed — Program Managers can view clinical notes without justification. Existing access grant records are preserved for audit purposes but are no longer enforced. You can switch back to Tier 3 at any time to re-enable the gates.
+
+**Can a manager bypass the gate in an emergency?**
+No — the gate cannot be bypassed. However, submitting the justification form takes less than a minute, and access is granted immediately after submission. There is no approval wait time.
+
+**Are access grants logged even at Tier 1 and Tier 2?**
+No. At Tier 1 and Tier 2, GATED permissions are automatically relaxed to "allow", so no grant is needed and none is logged. The audit trail for grants only exists at Tier 3.
+
+**Who can set the DV safety flag?**
+Any staff member with a Direct Service or Program Manager role can set the DV safety flag on a participant's file. Front Desk staff cannot set or see the flag.
+
+**What if the two reviewers disagree on removing a DV flag?**
+If the reviewing Program Manager rejects the removal request, the flag stays in place. A new request can be submitted later — perhaps with additional context or by a different staff member. The rejected request is preserved in the audit trail.
+
+**Does the system hide the fact that a participant has a DV flag from Front Desk?**
+Yes. Front Desk staff simply see fewer fields — they don't see a message saying "fields hidden due to DV flag" or anything similar. The design is intentionally discreet.

--- a/docs/admin/per-field-front-desk-access.md
+++ b/docs/admin/per-field-front-desk-access.md
@@ -1,0 +1,215 @@
+# Per-Field Front Desk Access Controls
+
+> **What you'll need:** Administrator access to KoNote. Your agency must be using **Tier 2** or **Tier 3**.
+> **Related:** [Access Tiers](access-tiers.md) · [DV-Safe Mode & GATED Access](dv-safe-mode-and-gated-access.md) · [Users & Roles](users-and-roles.md)
+
+---
+
+## Overview
+
+Not every agency wants Front Desk staff to see the same information. A drop-in centre might want reception to see phone numbers and email so they can follow up with participants. A clinical program might want to restrict everything except names.
+
+KoNote lets administrators control **exactly which fields** Front Desk staff can see and edit for each participant. This is called **per-field access control**.
+
+This feature is available at **Tier 2** and **Tier 3**. At Tier 1, safe defaults apply automatically and cannot be customised.
+
+---
+
+## How It Works
+
+Every field on a participant's profile can have one of three access levels for the Front Desk role:
+
+| Access Level | What It Means |
+|---|---|
+| **Hidden** | Front Desk staff cannot see this field at all. It doesn't appear on screen. |
+| **View only** | Front Desk staff can see the field's value but cannot change it. |
+| **View and edit** | Front Desk staff can both see and change the field's value. |
+
+There are two types of fields, and they are configured in different places:
+
+1. **Core fields** — built-in fields like phone, email, preferred name, and date of birth. These are configured on the **Field Access** admin page.
+2. **Custom fields** — fields your agency has added (like address, emergency contact, employer). Each custom field has its own Front Desk access setting, also configured on the **Field Access** admin page.
+
+---
+
+## Default Settings (Out of the Box)
+
+Before any administrator changes, KoNote uses safe defaults that balance usability with privacy:
+
+### Always-Visible Fields
+
+These fields are **always visible** to Front Desk staff and cannot be hidden. Front Desk needs them to identify and check in participants:
+
+- First name
+- Last name
+- Display name
+- Record ID
+- Status (active, discharged, etc.)
+
+### Configurable Core Fields — Defaults
+
+| Field | Tier 1–2 Default | Tier 3 Default |
+|---|---|---|
+| Phone number | View and edit | View and edit |
+| Email address | View and edit | View only |
+| Preferred name | View only | View only |
+| Date of birth | Hidden | Hidden |
+
+> **Why is email view-only at Tier 3?** Agencies using Tier 3 (Clinical Safeguards) typically serve higher-risk populations. Email addresses can reveal a participant's location or be used for unwanted contact, so the default is more restrictive.
+
+### Custom Fields
+
+All custom fields default to **Hidden** for Front Desk staff. Administrators must explicitly grant access to each custom field they want Front Desk to see.
+
+---
+
+## How to Configure (Step by Step)
+
+1. Go to **Admin → Field Access** (you'll find this in the admin settings area)
+2. You'll see two sections:
+
+### Core Fields
+
+The top section shows the four configurable core fields:
+
+- **Phone Number**
+- **Email Address**
+- **Preferred Name**
+- **Date of Birth**
+
+For each field, select the access level you want Front Desk staff to have:
+- **Hidden** — they won't see it
+- **View only** — they can see it but not change it
+- **View and edit** — they can see and change it
+
+### Custom Fields
+
+Below the core fields, you'll see all your agency's active custom fields, organised by their field groups (for example, "Contact Information", "Demographics").
+
+For each custom field, choose the same three options: Hidden, View only, or View and edit.
+
+3. Click **Save** when you're done
+4. Changes take effect immediately — no restart or logout needed
+
+### Resetting to Defaults
+
+If you've made changes and want to go back to the original safe defaults:
+
+1. On the **Field Access** page, click **Reset to Defaults**
+2. All core fields return to their tier-appropriate defaults (see the table above)
+3. All custom fields return to **Hidden**
+4. This action is logged in the audit trail
+
+---
+
+## Available Fields and What Each One Controls
+
+### Core Fields
+
+| Field | What It Contains | Notes |
+|---|---|---|
+| **Phone Number** | Participant's primary phone number | Commonly needed for scheduling and check-in |
+| **Email Address** | Participant's email address | May reveal location (email domain) in sensitive situations |
+| **Preferred Name** | The name the participant wants to be called | Useful for a welcoming front desk experience |
+| **Date of Birth** | Participant's date of birth | Clinical information — hidden by default |
+
+### Custom Fields
+
+Your agency's custom fields are fully configurable. Common examples include:
+
+| Example Field | Typical Access Level | Reason |
+|---|---|---|
+| Address | Hidden | Could reveal a participant's location |
+| Emergency contact | Hidden or View only | May be sensitive in DV situations |
+| Employer | Hidden | Could be used to locate someone |
+| Preferred pronouns | View only or View and edit | Supports respectful front desk interaction |
+| Allergies | View only | Safety information staff may need |
+
+The right configuration depends on your agency's services, population, and safety considerations.
+
+---
+
+## Interaction with DV-Safe Mode
+
+**DV-Safe Mode overrides field access settings.** Here's how the two features interact:
+
+1. You configure a custom field (say, "Home Address") as **View only** for Front Desk
+2. A participant has a DV safety flag set on their file
+3. The "Home Address" field is marked as **DV-sensitive**
+
+**Result:** Front Desk staff **cannot see** the Home Address for that participant, even though the field is normally set to "View only". The DV safety flag takes priority.
+
+In other words:
+
+| DV Flag On? | Field Is DV-Sensitive? | Normal Access Level | What Front Desk Sees |
+|---|---|---|---|
+| No | No | View only | The field value |
+| No | No | Hidden | Nothing |
+| No | Yes | View only | The field value |
+| **Yes** | **Yes** | View only | **Nothing** (DV flag overrides) |
+| **Yes** | **Yes** | View and edit | **Nothing** (DV flag overrides) |
+| Yes | No | View only | The field value (DV flag only hides DV-sensitive fields) |
+
+> **Key principle:** DV-Safe Mode is a safety net that sits *on top of* your field access configuration. It can hide fields that would otherwise be visible, but it never reveals fields that are already hidden.
+
+---
+
+## Examples: Common Configurations
+
+### Drop-In Centre
+
+A low-barrier drop-in centre where everyone on the team works together and there's no clinical data:
+
+| Field | Access Level |
+|---|---|
+| Phone | View and edit |
+| Email | View and edit |
+| Preferred Name | View and edit |
+| Date of Birth | Hidden |
+| Address (custom) | View only |
+| Emergency Contact (custom) | View only |
+
+**Tier recommendation:** Tier 1 or Tier 2
+
+### Community Counselling Agency
+
+A counselling agency with a dedicated reception desk and clinical programs:
+
+| Field | Access Level |
+|---|---|
+| Phone | View only |
+| Email | View only |
+| Preferred Name | View only |
+| Date of Birth | Hidden |
+| Address (custom) | Hidden |
+| Emergency Contact (custom) | Hidden |
+
+**Tier recommendation:** Tier 2
+
+### Women's Shelter or DV Agency
+
+An agency where participants may be at risk and contact information is highly sensitive:
+
+| Field | Access Level |
+|---|---|
+| Phone | Hidden |
+| Email | Hidden |
+| Preferred Name | View only |
+| Date of Birth | Hidden |
+| All contact fields (custom) | Hidden |
+
+Additionally, mark all contact-related custom fields as **DV-sensitive** and enable the DV safety flag for at-risk participants.
+
+**Tier recommendation:** Tier 3
+
+---
+
+## Audit Logging
+
+All changes to field access settings are recorded in the audit log. The log entry includes:
+
+- Who made the change
+- When it was made
+- Which fields were changed and what the old and new access levels were
+
+If you reset to defaults, that action is also logged separately.


### PR DESCRIPTION
## What this does

Three admin-facing documentation files explaining KoNote's permission and access control features. Written in plain language for non-technical agency administrators.

### Documents

1. **DV-Safe Mode and GATED Clinical Access** (`docs/admin/dv-safe-mode-and-gated-access.md`)
   - DV-Safe Mode: flag setting, hidden fields, two-person removal workflow, fail-closed behaviour
   - GATED Clinical Access (Tier 3): justification form, time-limited grants, configurable reasons/durations, admin review

2. **Per-Field Front Desk Access Controls** (`docs/admin/per-field-front-desk-access.md`)
   - Field-level access configuration for Front Desk role
   - Core + custom fields, defaults by tier, configuration steps
   - Interaction with DV-Safe Mode
   - Example configurations for different agency types

3. **Access Tiers  3-Tier RBAC Model** (`docs/admin/access-tiers.md`)
   - Tier 1 (Open Access) vs Tier 2 (Role-Based) vs Tier 3 (Clinical Safeguards)
   - Comparison table, what each tier enables
   - How to change tiers, agency-type recommendations

### Task reference
- TODO.md: DOC-PERM1, DOC-PERM2, DOC-PERM3
- Based on: apps/auth_app/decorators.py, apps/admin_settings/models.py, docs/permissions-matrix.md