### PR TITLE
Link 'Powered by KoNote' footer to project website

### DIFF
--- a/templates/auth/login.html
+++ b/templates/auth/login.html
@@ -130,10 +130,10 @@
                 {% if site.support_email %}<span>{% trans "Support:" %} <a href="mailto:{{ site.support_email }}">{{ site.support_email }}</a></span>{% endif %}
             </div>
             <div class="site-footer-links">
-                <span class="powered-by">
+                <a href="https://logicaloutcomes.github.io/konote-website/" class="powered-by" target="_blank" rel="noopener">
                     <img src="{% static 'img/konote-icon.png' %}" alt="" width="20" height="20">
                     {% trans "Powered by" %} KoNote
-                </span>
+                </a>
                 <a href="{% url 'privacy' %}">{% trans "Privacy" %}</a>
                 <a href="{% url 'help' %}">{% trans "Help" %}</a>
             </div>


### PR DESCRIPTION
## Summary
- Made the "Powered by KoNote" text in the login footer a clickable link to the project website
- The `konote-website` repo was transferred from `gilliankerr` to `LogicalOutcomes` on GitHub
- GitHub Pages URL is now: https://logicaloutcomes.github.io/konote-website/

## Changes
- `templates/auth/login.html`: Changed `<span>` to `<a>` with `target="_blank" rel="noopener"` pointing to the website

## Test plan
- [ ] Visit the login page and verify "Powered by KoNote" is a clickable link
- [ ] Verify link opens the KoNote website in a new tab
- [ ] Verify https://logicaloutcomes.github.io/konote-website/ loads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)