### PR TITLE
Fix: clean up stale demo users during seed

### DIFF
--- a/apps/admin_settings/management/commands/seed.py
+++ b/apps/admin_settings/management/commands/seed.py
@@ -241,12 +241,12 @@ class Command(BaseCommand):
         # ClientDetailValue, ClientProgramEnrolment, ParticipantUser, etc.
         demo_clients.delete()
 
-        # Remove calendar feed tokens and roles for demo users
+        # Remove ALL demo users (and their calendar tokens / program roles).
+        # This ensures stale users from previous seed versions are cleaned up.
         demo_users = User.objects.filter(is_demo=True)
         CalendarFeedToken.objects.filter(user__in=demo_users).delete()
         UserProgramRole.objects.filter(user__in=demo_users).delete()
-        # Remove old demo-worker (replaced by demo-worker-1 and demo-worker-2)
-        User.objects.filter(username="demo-worker", is_demo=True).delete()
+        demo_users.delete()
 
         # Remove old program names that no longer exist
         for old_name in ("Demo Program", "Youth Services"):


### PR DESCRIPTION
## Summary
- The seed command's cleanup only removed one specific old username (`demo-worker`), so renamed demo users from previous seed versions (e.g. "Casey Counsellor", "Dana Receptionist") persisted in the database
- These stale users appeared as duplicate buttons on the login page alongside the current demo users
- Now deletes **all** `is_demo=True` users before recreating the current set, preventing stale accounts from surviving across re-seeds

## Test plan
- [ ] Run `python manage.py seed --reset-demo` on an instance that has stale demo users — verify only the 6 current demo users appear on the login page
- [ ] Confirm no non-demo users are affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)