### PR TITLE
🎨 Palette: Improve dynamic form accessibility

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -60,10 +60,10 @@ document.body.addEventListener("htmx:configRequest", function (event) {
 })();
 
 // --- Link form error messages to their inputs (aria-describedby) ---
-// Scans for <small class="error" id="..."> and links the preceding input/select/textarea
+// Scans for <small class="error"> and links the preceding input/select/textarea
 (function () {
     function linkErrorMessages() {
-        var errors = document.querySelectorAll("small.error[id]");
+        var errors = document.querySelectorAll("small.error");
         errors.forEach(function (errorEl) {
             // Walk backwards through siblings to find the form control
             var sibling = errorEl.previousElementSibling;
@@ -77,9 +77,15 @@ document.body.addEventListener("htmx:configRequest", function (event) {
                     input = sibling.querySelector("input, textarea, select");
                 }
                 if (input) {
+                    // Ensure error element has an ID for aria-describedby
+                    if (!errorEl.id) {
+                        errorEl.id = "error-" + Math.random().toString(36).substr(2, 9);
+                    }
                     var existing = input.getAttribute("aria-describedby");
                     if (existing) {
-                        input.setAttribute("aria-describedby", existing + " " + errorEl.id);
+                        if (existing.indexOf(errorEl.id) === -1) {
+                            input.setAttribute("aria-describedby", existing + " " + errorEl.id);
+                        }
                     } else {
                         input.setAttribute("aria-describedby", errorEl.id);
                     }
@@ -96,6 +102,9 @@ document.body.addEventListener("htmx:configRequest", function (event) {
     } else {
         linkErrorMessages();
     }
+
+    // Also run after HTMX swaps so dynamic form errors are linked
+    document.body.addEventListener("htmx:afterSwap", linkErrorMessages);
 })();
 
 // --- Auto-dismiss success messages after 8 seconds ---


### PR DESCRIPTION
🎨 Palette: Improve dynamic form accessibility

💡 What: Updated `linkErrorMessages()` in `app.js` to automatically link all `.error` messages (even those without an `id` attribute) to their adjacent form inputs via `aria-describedby` and `aria-invalid`. We also run this logic after HTMX swaps.
🎯 Why: Previously, only error messages with an explicitly defined `id` attribute in the template were being linked for screen readers. This meant many form validation errors across the app were visually present but programmatically disconnected from their inputs, failing WCAG 3.3.1. Furthermore, dynamically loaded errors (e.g. from HTMX submissions) were entirely ignored.
📸 Before/After: (Not a visual change; affects screen reader announcements).
♿ Accessibility: Vastly improves form validation feedback for screen reader users by automatically ensuring validation errors are programmatically associated with inputs, regardless of whether the developer remembered to add an `id` to the error message in the Django template.


---
*PR created automatically by Jules for task [6611104117109016061](https://jules.google.com/task/6611104117109016061) started by @pboachie*