### PR TITLE
🧹 Use relative import for portal signal registration

### DIFF
--- a/apps/portal/apps.py
+++ b/apps/portal/apps.py
@@ -8,4 +8,4 @@ class PortalConfig(AppConfig):
     verbose_name = "Participant Portal"
 
     def ready(self):
-        import apps.portal.signals  # noqa: F401 -- registers signal handlers
+        from . import signals  # noqa: F401 -- registers signal handlers


### PR DESCRIPTION
This pull request makes a minor improvement to the import style in the `PortalConfig` class, ensuring consistency with relative imports.

* Changed the import statement in the `ready` method of `PortalConfig` to use a relative import for `signals` instead of an absolute import.