### PR TITLE
🧹 [Code Health] Remove unused `import json` in `apps/portal/views.py`

### DIFF
--- a/apps/portal/views.py
+++ b/apps/portal/views.py
@@ -7,7 +7,6 @@ auth system — participants are ParticipantUser, not User.
 Data isolation: every view scopes queries to request.participant_user.client_file.
 Sub-objects are always fetched with get_object_or_404(..., client_file=client_file).
 """
-import json
 import logging
 import secrets
 from functools import wraps


### PR DESCRIPTION
🎯 **What:** Removed unused `import json` statement from `apps/portal/views.py`.
💡 **Why:** `json` was imported but never used anywhere in the file. Removing it improves code clarity and maintainability.
✅ **Verification:** Ran test suite to verify tests (`python -m pytest tests/portal/`) pass with no issues, proving the module was not used. Verified code review was clean. 
✨ **Result:** A slightly cleaner and more readable module without unnecessary dependencies.

---
*PR created automatically by Jules for task [11629884669368381372](https://jules.google.com/task/11629884669368381372) started by @pboachie*