### PR TITLE
⚡ Optimize N+1 Query in Circle Member Search

### DIFF
--- a/apps/circles/views.py
+++ b/apps/circles/views.py
@@ -68,20 +68,18 @@ def _get_accessible_clients_for_search(user):
 
     qs = get_client_queryset(user).filter(status="active")
     program_ids = get_user_program_ids(user)
-    enrolled_ids = set(
-        ClientProgramEnrolment.objects.filter(
-            program_id__in=program_ids, status="active"
-        ).values_list("client_file_id", flat=True)
-    )
+    enrolled_ids_qs = ClientProgramEnrolment.objects.filter(
+        program_id__in=program_ids, status="active"
+    ).values("client_file_id")
+
     # DV safety: exclude blocked clients
-    blocked_ids = set(
-        ClientAccessBlock.objects.filter(user=user, is_active=True)
-        .values_list("client_file_id", flat=True)
-    )
-    enrolled_ids -= blocked_ids
+    blocked_ids_qs = ClientAccessBlock.objects.filter(
+        user=user, is_active=True
+    ).values("client_file_id")
 
     results = []
-    for client in qs.filter(pk__in=enrolled_ids):
+    clients = qs.filter(pk__in=enrolled_ids_qs).exclude(pk__in=blocked_ids_qs)
+    for client in clients:
         name = f"{client.display_name} {client.last_name}".strip()
         results.append((client.pk, name or f"#{client.pk}"))
     results.sort(key=lambda x: x[1].lower())


### PR DESCRIPTION
💡 **What:** 
The optimization addresses the `_get_accessible_clients_for_search` helper function. Previously, the logic fetched the IDs of enrolled clients and blocked clients into Python `set` objects and then passed those sets back to the database as a large `pk__in=[...]` filter. 
The new implementation uses Django ORM subqueries directly, converting 3 separate queries into 1, and completely avoiding the memory overhead of serializing and deserializing lists of IDs.

🎯 **Why:** 
For larger datasets, evaluating `values_list(..., flat=True)` and sending back thousands of primary keys in an `IN` clause limits scalability, consumes excess application memory, and incurs the overhead of multiple network roundtrips to the DB.

📊 **Measured Improvement:** 
Baseline benchmarking scripts demonstrated a drop in the number of executed SQL queries required to search accessible clients, turning 3 roundtrips into 1 compound query. Memory complexity is vastly improved, as we no longer instantiate arrays of `ClientFile` IDs. Tests pass locally.

---
*PR created automatically by Jules for task [736891220688722691](https://jules.google.com/task/736891220688722691) started by @pboachie*