### PR TITLE
chore: address review-session findings (docs & comments)

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -1,3 +1,7 @@
+# Single-instance Caddyfile — uses the DOMAIN env var from docker-compose.yml.
+# For multi-instance setups (prod + dev on one VPS), replace this file with
+# hardcoded domain blocks and explicit container names. See Step 14 of
+# docs/deploy-ovhcloud.md for the multi-domain Caddyfile template.
 {$DOMAIN:localhost} {
     reverse_proxy web:8000
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,9 @@ services:
       - ALLOWED_HOSTS=${ALLOWED_HOSTS:-localhost}
       - CSRF_TRUSTED_ORIGINS=${CSRF_TRUSTED_ORIGINS:-}
       - DEMO_MODE=${DEMO_MODE:-}
+      # Email defaults: if not configured in .env, email logs to console (no
+      # real emails sent). To enable email, set EMAIL_BACKEND, EMAIL_HOST, and
+      # credentials in .env — see docs/deploy-ovhcloud.md Step 13.
       - DEFAULT_FROM_EMAIL=${DEFAULT_FROM_EMAIL:-KoNote <noreply@konote.app>}
       - EMAIL_BACKEND=${EMAIL_BACKEND:-django.core.mail.backends.console.EmailBackend}
       - EMAIL_HOST=${EMAIL_HOST:-}

--- a/docs/deploy-ovhcloud.md
+++ b/docs/deploy-ovhcloud.md
@@ -195,7 +195,7 @@ You need to generate four secret values. Run these commands on the VPS:
 ```bash
 # Install Python cryptography library (for key generation)
 sudo apt install -y python3 python3-pip
-pip3 install cryptography --break-system-packages
+pip3 install cryptography --break-system-packages  # this flag is required on Ubuntu 24.04+ — it's a Python safety check, not breaking anything
 
 # Generate Django secret key
 echo "SECRET_KEY:"
@@ -632,23 +632,25 @@ sudo nano /opt/konote/docker-compose.override.yml
 ```
 
 ```yaml
-# Production override -- connects Caddy and web to the shared proxy network
-# so Caddy can reach both prod and dev web containers by container name
+# Production override — connects Caddy and web to the shared proxy network
+# so Caddy can reach both prod and dev web containers by container name.
+# This file is automatically merged with docker-compose.yml when you run
+# "docker compose up". You don't need to reference it explicitly.
 services:
   web:
     networks:
       - frontend
       - backend
-      - konote-proxy
+      - konote-proxy    # adds the shared network so Caddy can route to this container
 
   caddy:
     networks:
       - frontend
-      - konote-proxy
+      - konote-proxy    # adds the shared network so Caddy can also reach the dev container
 
 networks:
   konote-proxy:
-    external: true
+    external: true      # "external" means this network already exists (created in Step 2)
 ```
 
 Apply the override:
@@ -765,19 +767,23 @@ sudo nano /opt/konote-dev/docker-compose.override.yml
 ```
 
 ```yaml
+# Dev instance override — gives each container a unique name, disables its own
+# Caddy (production Caddy handles both domains), and uses separate database
+# volumes so dev data is completely isolated from production.
 services:
   web:
-    container_name: konote-dev-web
-    ports: !reset []
+    container_name: konote-dev-web       # unique name so Caddy can address it directly
+    ports: !reset []                     # removes the host port mapping from the base file
+                                         # (Caddy reaches this container via Docker network instead)
     networks:
       - frontend
       - backend
-      - konote-proxy
+      - konote-proxy                     # shared network so production Caddy can reach this container
 
   db:
     container_name: konote-dev-db
     volumes:
-      - dev_pgdata:/var/lib/postgresql/data
+      - dev_pgdata:/var/lib/postgresql/data   # separate volume — dev data stays isolated from prod
 
   audit_db:
     container_name: konote-dev-audit-db
@@ -787,18 +793,18 @@ services:
 
   caddy:
     profiles:
-      - disabled
+      - disabled                         # disables this container — production Caddy handles both domains
 
   autoheal:
     container_name: konote-dev-autoheal
 
 volumes:
-  dev_pgdata:
+  dev_pgdata:                            # separate named volumes prevent data mixing
   dev_audit_pgdata:
 
 networks:
   konote-proxy:
-    external: true
+    external: true                       # connects to the shared network created in Step 2
 ```
 
 Key details:

--- a/scripts/backup-vps.sh
+++ b/scripts/backup-vps.sh
@@ -21,6 +21,11 @@ AUDIT_RETENTION_DAYS="${AUDIT_RETENTION_DAYS:-90}"
 TIMESTAMP=$(date +%Y-%m-%d_%H%M)
 
 # Load environment variables from .env
+# Safety note: source treats .env as a shell script, so values with shell
+# metacharacters (backticks, $(...), semicolons) would be executed. This is
+# safe because the deploy guide generates all passwords with Python's
+# secrets.token_urlsafe(), which produces only [A-Za-z0-9_-] characters.
+# If .env editing ever becomes user-facing, switch to a grep-based approach.
 if [ -f "$KONOTE_DIR/.env" ]; then
     set -a
     source "$KONOTE_DIR/.env"

--- a/scripts/backup-vps.sh
+++ b/scripts/backup-vps.sh
@@ -9,7 +9,11 @@
 #   - .env file with POSTGRES_USER, POSTGRES_DB, AUDIT_POSTGRES_USER, AUDIT_POSTGRES_DB
 #
 # Optional:
-#   - Set ALERT_WEBHOOK_URL in .env to receive failure alerts (e.g., UptimeRobot heartbeat URL)
+#   - Set ALERT_WEBHOOK_URL in .env to receive failure alerts
+#     Alerts are sent as plain-text HTTP POST (no JSON, no Content-Type header).
+#     Compatible with: UptimeRobot push monitors, Slack incoming webhooks,
+#     ntfy.sh, Uptime Kuma push monitors. For JSON-only endpoints, use a
+#     middleware like Zapier or n8n to transform the request.
 
 set -euo pipefail
 

--- a/scripts/disk-check.sh
+++ b/scripts/disk-check.sh
@@ -6,6 +6,9 @@
 #
 # Optional:
 #   - Set ALERT_WEBHOOK_URL in .env or environment to receive alerts
+#     Alerts are sent as plain-text HTTP POST (no JSON, no Content-Type header).
+#     Compatible with: UptimeRobot push monitors, Slack incoming webhooks,
+#     ntfy.sh, Uptime Kuma push monitors.
 #   - Set DISK_THRESHOLD (default: 80) to change the alert threshold percentage
 
 set -euo pipefail


### PR DESCRIPTION
## Summary
Addresses all 5 "Consider Later" items from the session code review:

- **#2** Add safety comment to backup script `.env` sourcing — explains why `source` is safe with generated passwords and when to revisit
- **#3** Add plain-language explanations to deploy guide — `--break-system-packages` flag explanation, inline comments on all Docker Compose override YAML blocks in Step 14
- **#4** Add comment to `docker-compose.yml` — clarifies email defaults safely log to console when not configured
- **#5** Document webhook format in both operational scripts — lists compatible services (UptimeRobot, Slack, ntfy.sh, Uptime Kuma), notes plain-text POST format
- **#6** Add comment to Caddyfile — explains env var approach is for single-instance, points to deploy guide Step 14 for multi-domain

## Test plan
- [ ] All changes are comments/docs only — no behaviour changes
- [ ] `docker compose config` still validates

🤖 Generated with [Claude Code](https://claude.com/claude-code)