### PR TITLE
chore: restructure P0 tasks + parallel sprint plan

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -11,29 +11,20 @@ _QA Round 8 Tier 1 complete — see Recently Done._
 
 ### Phase: P0 — Requirements Analysis (March 31)
 
-Items from `requirements-analysis.md` that must move from "Planned" to "Fully met" before deliverable deadline.
+Items from `requirements-analysis.md` that need work before the deliverable deadline. Grouped by type: product code, deployment automation, and cost optimization.
 
-**Funder reporting (RP2, RP3):**
-- [ ] Add partner report approval workflow — quality review, agency annotations, explicit publish step before sharing with partners (see tasks/funder-report-approval.md, plan: docs/plans/2026-02-20-funder-report-approval-design.md) (RPT-APPROVE1)
+**Product code to build:**
 
-**Cross-agency rollup (RP4):**
-- [ ] Write cross-agency reporting API design doc — which metrics aggregate, API spec, how funder views data across agencies (docs/plans/2026-02-20-cross-agency-reporting-api-design.md) — GK (DOC-RP4)
-- [ ] Build cross-agency data rollup for partners — waiting on requirements re: which metrics to aggregate — PB, GK reviews metric aggregation (SCALE-ROLLUP1)
-- [ ] Build cross-agency reporting API — standardised endpoint per instance for [funder partner] to consume published reports (plan: docs/plans/2026-02-20-cross-agency-reporting-api-design.md) (SCALE-API1)
-- [ ] Build umbrella admin dashboard — central view for [funder partner] to see instance health, published reports, and aggregate metrics across agencies (SCALE-DASH1)
-
-**Multi-tenancy and central management (MA3, MA4):**
-- [ ] Integrate django-tenants for schema-per-tenant multi-tenancy — PostgreSQL backend, shared/tenant app split, tenant model, domain model (see tasks/multi-tenancy-implementation-plan.md, Tasks 0-2) — PB (MT-CORE1)
-- [ ] Implement per-tenant encryption keys — key table in shared schema, encrypted by master key, update encryption.py (see plan Task 3) — PB (MT-ENCRYPT1)
-- [ ] Create consortium data model — Consortium, ConsortiumMembership, ProgramSharing, PublishedReport with program-level sharing granularity (see plan Task 4) — PB, GK reviews data model (MT-CONSORT1)
-- [ ] Add consent_to_aggregate_reporting field and audit tenant_schema column (see plan Tasks 5-6) — PB (MT-CONSENT1)
-- [ ] Validate existing features across tenant schemas — update test infrastructure, fix tenant-related test failures (see plan Tasks 7-8) — PB (MT-VALIDATE1)
-- [ ] Write deploy script design doc — how provisioning is automated, target: infrastructure in hours not weeks (docs/plans/2026-02-20-deploy-script-design.md) — PB (DOC-MA5)
-- [ ] Build deploy script to automate infrastructure provisioning — Azure/OVHcloud resources, env vars, migrations, output a URL (plan: docs/plans/2026-02-20-deploy-script-design.md) (DEPLOY-SCRIPT1)
-- [ ] Define managed service model — who handles infrastructure, backups, updates, support tiers, funding model (see tasks/hosting-cost-comparison.md, tasks/design-rationale/ovhcloud-deployment.md) (OPS-MANAGED1)
-
-**Outcome tracking (G4):**
+- [ ] Add partner report approval workflow — quality review, agency annotations, explicit publish step before sharing with partners (RP2/RP3) (see tasks/funder-report-approval.md, plan: docs/plans/2026-02-20-funder-report-approval-design.md) (RPT-APPROVE1)
 - [ ] Auto-update progress metrics when goal status changes — recalculate related metrics when a goal is marked achieved/abandoned (REQ-G4)
+- [ ] Write funder reporting dashboard design doc — waiting on funder reporting templates from Prosper Canada (expected March 2026), then: which metrics aggregate, how agencies publish data, how Prosper Canada views it — GK (DOC-RP4)
+- [ ] Build funder reporting dashboard — read-only view where Prosper Canada sees aggregate outcome data published by individual agencies. Not individual participant records. (SCALE-ROLLUP1)
+
+**Deployment automation (ops scripting, not product code):**
+
+- [ ] Write deploy script design doc — how provisioning is automated, target: new agency instance in hours not weeks (docs/plans/2026-02-20-deploy-script-design.md) — PB (DOC-MA5)
+- [ ] Build deploy script to automate agency instance provisioning — server setup, DNS, SSL, Docker, initial configuration, output a URL (plan: docs/plans/2026-02-20-deploy-script-design.md) (DEPLOY-SCRIPT1)
+- [ ] Define managed service model — who handles infrastructure, backups, updates, support tiers, funding model (see tasks/hosting-cost-comparison.md, tasks/design-rationale/ovhcloud-deployment.md) (OPS-MANAGED1)
 
 ### Phase: Launch Readiness
 
@@ -110,8 +101,15 @@ Step-by-step commands for each task are in [tasks/recurring-tasks.md](tasks/recu
 - [ ] Add second-tier "very unlikely" plausibility thresholds for financial metrics — tighter bounds beyond warn_max for edge case detection (DQ1-TIER2)
 - [ ] Pre-report data quality checks — validate data quality before partner report export (see tasks/data-validation-design.md) (DQ2)
 
-### Phase: Multi-Agency Scaling — remaining items after P0 (see tasks/design-rationale/multi-tenancy.md)
+### Phase: Server Sharing — cost optimization, not a launch prerequisite (see tasks/design-rationale/multi-tenancy.md)
 
+Multiple agencies can deploy today on independent instances ($35–100/month each). Server sharing allows agencies to share a server while keeping data walled off, reducing costs to $4–10/agency/month. Worth doing when the network grows beyond 3–5 agencies.
+
+- [ ] Integrate django-tenants for server sharing — multiple agencies on one server with walled-off database sections (see tasks/multi-tenancy-implementation-plan.md, Tasks 0-2) — PB (MT-CORE1)
+- [ ] Implement per-agency encryption keys — separate encryption key per agency, encrypted by master key (see plan Task 3) — PB (MT-ENCRYPT1)
+- [ ] Create cost-sharing group data model — which agencies share a server, program-level data sharing controls, published reports (see plan Task 4) — PB, GK reviews data model (MT-CONSORT1)
+- [ ] Add consent_to_aggregate_reporting field and audit agency column (see plan Tasks 5-6) — PB (MT-CONSENT1)
+- [ ] Validate existing features work across shared-server agencies — update test infrastructure, fix related test failures (see plan Tasks 7-8) — PB (MT-VALIDATE1)
 - [ ] Improve admin UI for self-service configuration — better guidance for terminology, metrics, templates (ADMIN-UX1)
 - [ ] Align report-template.json "bins" field naming with DemographicBreakdown model's "bins_json" when building Phase 2 template automation (TEMPLATE-ALIGN1)
 

--- a/tasks/parallel-sprint-plan.md
+++ b/tasks/parallel-sprint-plan.md
@@ -1,0 +1,180 @@
+# Parallel Sprint Plan — Bug Fixes, Accessibility, Features
+
+**Created:** 2026-03-02
+**Goal:** Address as many open TODO.md items as possible using parallel agents with worktrees to avoid file conflicts.
+
+## How This Works
+
+Each **track** runs in its own git worktree (isolated copy of the repo) on its own branch. Tracks within the same wave have no file conflicts and can run simultaneously. After a wave's PRs merge, the next wave starts.
+
+**Wave 1** runs 7 tracks in parallel (17 tasks).
+**Wave 2** runs 1 large track after Wave 1 merges (9 tasks).
+**Session 2** is a separate focused session for reports/funder features (3–4 tasks).
+**Session 3** is demo mode safeguards (5 tasks).
+
+**Total: 34 tasks.**
+
+---
+
+## Session 1, Wave 1 — Parallel Bug Fix Sprint
+
+All tracks run simultaneously. Each gets its own worktree branch off `develop`.
+
+### Track A: QA Scenarios Repo (3 tasks)
+**Branch:** `fix/qa-r8b-scenarios`
+**Repo:** `konote-qa-scenarios` (completely separate — zero conflict risk)
+**Files:** `scenarios/periodic/SCN-035-funder-reporting.yaml`, test runner code
+
+| ID | Task | Fix |
+|---|---|---|
+| QA-R8b-YAML1 | Fix SCN-035 YAML URL | Change `/reports/funder/` → `/reports/funder-report/` in scenario YAML |
+| QA-R8b-TEST1 | Fix test runner interactive step execution | Clicks, form fills, HTMX not working — investigate conftest.py and state_capture.py |
+| QA-R8b-TEST2 | Fix URL placeholder substitution | `{group_id}`, `{client_id}` appear literally — fix in conftest.py URL builder |
+
+### Track B: Plans App — REQ-G4 (1 task)
+**Branch:** `feat/g4-metric-auto-update`
+**Files:** `apps/plans/models.py`, `apps/plans/signals.py` (new), `apps/plans/views.py`, `tests/test_plans.py`
+
+| ID | Task | Fix |
+|---|---|---|
+| REQ-G4 | Auto-update progress metrics when goal status changes | Add post_save signal on PlanTarget status change → recalculate related MetricValue records. When a goal is marked achieved/abandoned, update linked progress metrics. Write tests. |
+
+**Context:** PlanTarget has status field. PlanTargetMetric links targets to MetricDefinitions. MetricValue stores recorded values. The signal should fire when target.status changes and create/update the corresponding MetricValue.
+
+### Track C: Client App Bundle (7 tasks)
+**Branch:** `fix/client-app-bundle`
+**Files:** `apps/clients/views.py`, `apps/clients/forms.py`, `apps/clients/helpers.py`, `apps/clients/matching.py`, `templates/clients/*.html`, `static/js/app.js` (tab navigation only)
+
+Run these sequentially within the track (they share `apps/clients/views.py`):
+
+| ID | Task | Fix |
+|---|---|---|
+| QA-R8-UX3 | Newly created client not searchable by other users | Check cache invalidation after client create. Encrypted search loads clients into Python — verify program-scoped queryset includes newly created records for all users with access. |
+| QA-R8-A11Y4 | Create form Tab order — Last Name before First Name | Fix field order in `ClientFileForm.Meta.fields` or `field_order`. Remove any `tabindex` overrides in `templates/clients/form.html`. |
+| QA-R8-UX5 | Missing validation error + success confirmation on create | Add `messages.success()` in `client_create` view. Ensure form errors render via `_form_errors.html` include. |
+| QA-R8-UX6 | Mobile edit navigates to wrong form | Check edit button href in `templates/clients/detail.html`. Verify it points to `{% url 'clients:client_edit' client.id %}` not the create URL. |
+| QA-R8-UX13 | Accent stripping — "Benoît" → "Benoit" | Fix `_strip_accents()` in views.py — it's used for search but should not affect display. Check that list template displays the original name, not the stripped version. |
+| QA-R8-A11Y5 | Excessive Tab presses to reach search results | Add skip link or reduce focusable elements in search filter controls. Check `templates/clients/search.html`. |
+| QA-R8-A11Y8 | Profile tabs arrow key — ArrowRight opens Actions dropdown | Add ARIA tab pattern JS to `static/js/app.js`: `role="tablist"`, `role="tab"`, ArrowLeft/Right to switch tabs. Check `templates/clients/detail.html` tab markup. |
+
+### Track D: Events App (1 task)
+**Branch:** `fix/calendar-feed-url`
+**Files:** `apps/events/views.py`, `apps/events/urls.py`, `apps/events/models.py`, `templates/events/calendar_feed_settings.html`
+
+| ID | Task | Fix |
+|---|---|---|
+| QA-R8-UX9 | Calendar feed URL generation failing silently | Add error handling and user feedback to `calendar_feed_settings()` view. Check token/UUID generation in model. |
+
+### Track E: Auth/Admin — User Management (1 task)
+**Branch:** `fix/pm-user-management`
+**Files:** `apps/auth_app/admin_urls.py`, `apps/auth_app/admin_views.py`, `templates/auth_app/user_list.html`
+
+| ID | Task | Fix |
+|---|---|---|
+| QA-R8-UX12 | PM user management path missing — `/manage/users/` not linked | Check if program managers have permission to see user list. If yes, add nav link. If no, decide whether PMs should have this access (may need to add to Flagged). |
+
+### Track F: Notes App (2 tasks)
+**Branch:** `fix/notes-app-bundle`
+**Files:** `apps/notes/views.py`, `apps/notes/urls.py`, `templates/notes/*.html`
+
+| ID | Task | Fix |
+|---|---|---|
+| QA-R8-UX4 | Quick note entry point unreachable — selector mismatch | Check `_quick_note_inline_buttons.html` and `templates/clients/detail.html` for broken selector or missing include. Fix the entry point link/button. |
+| AXE-HEADING1 | Missing h1 on notes-detail page | Add `<h1>` to `templates/notes/note_detail_page.html`. |
+
+### Track G: Verification Tasks (3 tasks)
+**Branch:** `fix/verification-checks`
+**Files:** Read-only investigation — may result in no code changes, or small fixes
+
+| ID | Task | Fix |
+|---|---|---|
+| QA-R8-LANG1 | Verify language middleware — check if FG-S-2 fix regressed | Test French language switching. If working, close. If broken, fix in `konote/middleware.py`. |
+| QA-R8-UX7 | Verify offline fallback — check if fix-log entry 9 regressed | Test offline/error states. If working, close. If broken, fix in `static/js/app.js` service worker or error handler. |
+| QA-R8-VERIFY1 | Verify data export routes against recent SEC3 work | Check if `/participants/<id>/export/` routes exist from the SEC3 export work. If they do, close. If gaps remain, document what's needed. |
+
+---
+
+## Session 1, Wave 2 — Accessibility Sweep
+
+Runs after Wave 1 PRs merge into develop. Single track because these tasks share `templates/base.html` and `static/css/`.
+
+### Track H: Base Template + CSS + Page Accessibility (9 tasks)
+**Branch:** `fix/accessibility-sweep`
+**Files:** `templates/base.html`, `templates/includes/`, `static/css/main.css`, `static/css/theme.css`, various page templates
+
+Run sequentially — many touch the same files:
+
+| ID | Task | Fix |
+|---|---|---|
+| AXE-ARIA1 | Fix ARIA role violations (59 pages, 512 nodes) | Likely a shared component pattern. Check `base.html` nav structure, menu items, interactive elements. Add missing `role` attributes. |
+| AXE-LANDMARK1 | Fix duplicate landmark regions (60 pages, 352 nodes) | Check `base.html` for multiple `<nav>`, `<main>`, `<footer>`. Add `aria-label` to distinguish multiple navs if needed. |
+| AXE-TEMPLATE1 | Fix 4 pages missing base template wrapper | Ensure export-confirmation, plan-section-edit, public-survey-link, public-unsubscribe extend `base.html`. |
+| AXE-CONTRAST1 | Fix colour contrast (11 pages, 257 nodes) | Audit CSS colour values against WCAG 4.5:1 ratio. Adjust in `main.css` and `theme.css`. Key pages: client-detail, dashboard-staff, plan-view, notes-list, events-list. |
+| AXE-TABLE1 | Fix empty table headers (4 admin pages) | Add text or `aria-label` to `<th>` elements in event-types, terminology, user-list, programs-list templates. |
+| QA-R8-A11Y6 | Fix checkbox touch target below 24px | Add `min-height: 44px; min-width: 44px` or padding to checkbox inputs in CSS. |
+| QA-R8-A11Y7 | Accessibility polish bundle | Language toggle confirmation, breadcrumb targets, field visibility, icon labels. Multiple small fixes across templates. |
+| QA-R8-I18N1 | Fix French navigation — create participant broken | Ensure nav links use `{% url %}` tags not hardcoded paths. Check French translations for "Create Participant" in `.po` file. |
+| QA-R8-UX10 | Fix form resubmission → help page | Investigate which form(s) redirect to help page on POST. Fix redirect target in the relevant view. |
+
+---
+
+## Session 2 — Reports & Funder Features (separate session)
+
+These tasks all touch `apps/reports/` and are interconnected. Run as a focused session.
+
+### Track: Reports App
+**Branch:** `feat/funder-report-approval`
+**Files:** `apps/reports/models.py`, `apps/reports/views.py`, `apps/reports/urls.py`, `apps/reports/forms.py`, `templates/reports/*.html`, `apps/clients/dashboard_views.py`
+
+| ID | Task | Fix |
+|---|---|---|
+| RPT-APPROVE1 | Partner report approval workflow (RP2/RP3) | New models (ReportApproval), views (quality review, preview, approve), templates. Read `tasks/funder-report-approval.md` and `docs/plans/2026-02-20-funder-report-approval-design.md` first. |
+| QA-R8-UX11 | Fix `/reports/funder/` returning 404 | Check `apps/reports/urls.py` — actual route is `/reports/funder-report/`. Either add redirect or fix references. |
+| QA-R8-UX8 | Add date presets + PDF export to executive dashboard | Date picker with presets in `apps/clients/dashboard_views.py`. PDF export endpoint in `apps/reports/`. Touches both apps. |
+| DOC-RP4 | Funder reporting dashboard design doc | Write after Prosper Canada provides funder reporting templates. |
+
+**Note on RP4:** The funder reporting templates from Prosper Canada will determine the scope. Once received, write `cross-agency-reporting-design.md`, then build SCALE-ROLLUP1. This may be a third session depending on timing.
+
+---
+
+## Session 3 — Demo Mode Safeguards (separate session)
+
+These tasks touch login templates, base template (banner), middleware, and report queries. Run after accessibility sweep merges to avoid base.html conflicts.
+
+### Track: Demo Mode
+**Branch:** `feat/demo-mode-safeguards`
+**Files:** `templates/auth/login.html`, `templates/base.html`, `konote/middleware.py`, `apps/admin_settings/`, report views
+
+| ID | Task | Fix |
+|---|---|---|
+| DEMO-ADMIN-RO1 | Restrict demo-admin to view-only for agency settings | Check permissions in admin settings views — demo users can view but not POST. |
+| DEMO-BANNER1 | Persistent training-mode banner | Amber banner on every page for demo sessions. Already partially exists in `base.html` lines 59-63 — may need enhancement. |
+| DEMO-LOGIN-UX1 | Visually separate demo buttons from real login | Restyle demo login section in `templates/auth/login.html` with distinct colour/section. |
+| DEMO-AUDIT1 | Audit demo logins | Log demo login events but exclude from PHIPA audit pipeline. |
+| DEMO-EXCLUDE1 | Verify reports exclude is_demo=True records | Audit every report query, aggregate count, CSV/PDF export for demo data leakage. |
+
+---
+
+## Conflict Matrix
+
+| Track | Key files | Conflicts with |
+|---|---|---|
+| A (QA scenarios) | qa-scenarios repo | Nothing (separate repo) |
+| B (Plans) | apps/plans/ | Nothing |
+| C (Clients) | apps/clients/, templates/clients/ | D if dashboard is in clients (resolved: UX8 → Session 2) |
+| D (Events) | apps/events/ | Nothing |
+| E (Auth) | apps/auth_app/ | Nothing |
+| F (Notes) | apps/notes/, templates/notes/ | Nothing |
+| G (Verification) | Read-only | Nothing |
+| H (Accessibility) | templates/base.html, static/css/ | Session 3 (demo banner in base.html) |
+| Session 2 (Reports) | apps/reports/, apps/clients/dashboard_views.py | Track C if run simultaneously (resolved: different waves) |
+| Session 3 (Demo) | templates/base.html, middleware | Track H (resolved: runs after H merges) |
+
+---
+
+## Checklist Before Starting
+
+- [ ] Pull latest develop: `git pull origin develop`
+- [ ] Verify no 🔨 IN PROGRESS items in TODO.md that another session is working on
+- [ ] Merge the `chore/todo-restructure-p0` PR first (TODO.md vocabulary updates)
+- [ ] Have the parallel sprint prompt ready (see below)

--- a/tasks/parallel-sprint-prompt.md
+++ b/tasks/parallel-sprint-prompt.md
@@ -1,0 +1,132 @@
+# Parallel Sprint Prompt — Session 1
+
+Paste this into a new Claude Code session in the KoNote repo.
+
+---
+
+## Prompt
+
+Read `tasks/parallel-sprint-plan.md` for the full plan. You are executing **Session 1: Wave 1** — a parallel bug fix sprint across 7 tracks, each in its own worktree.
+
+**Before starting:**
+1. `git pull origin develop`
+2. Read `TODO.md` — mark all tasks you're about to work on as 🔨 IN PROGRESS
+3. Commit the TODO.md update to develop (this is the one exception to "never commit to develop" — it's just marking work in progress)
+
+**Wave 1 — launch all 7 tracks as parallel agents, each in its own worktree:**
+
+### Track A: QA Scenarios (konote-qa-scenarios repo)
+Branch: `fix/qa-r8b-scenarios` in `/c/Users/gilli/GitHub/konote-qa-scenarios`
+- QA-R8b-YAML1: Fix SCN-035 YAML — change `/reports/funder/` → `/reports/funder-report/` in `scenarios/periodic/SCN-035-funder-reporting.yaml`
+- QA-R8b-TEST1: Fix test runner interactive step execution — clicks and form fills not working, duplicate screenshots. Investigate `tests/scenario_eval/conftest.py` and `state_capture.py`.
+- QA-R8b-TEST2: Fix URL placeholder substitution — `{group_id}`, `{client_id}` appear literally in URLs (affects SCN-075, SCN-076, SCN-084). Fix in conftest.py URL builder.
+Commit each fix separately. Push and create PR → main.
+
+### Track B: Plans App — REQ-G4
+Branch: `feat/g4-metric-auto-update` off develop
+Files: `apps/plans/`
+- REQ-G4: Add a Django post_save signal on PlanTarget. When a target's status changes (e.g., to achieved or abandoned), auto-update the linked MetricValue records. Read `apps/plans/models.py` first to understand PlanTarget → PlanTargetMetric → MetricValue relationships. Create `apps/plans/signals.py` if it doesn't exist. Register in `apps/plans/apps.py`. Add tests in `tests/test_plans.py`. Run `pytest tests/test_plans.py` to verify.
+Push and create PR → develop.
+
+### Track C: Client App Bundle
+Branch: `fix/client-app-bundle` off develop
+Files: `apps/clients/`, `templates/clients/`
+Do these sequentially, committing after each:
+1. **QA-R8-UX3**: Fix newly created client not searchable by other users. Check `apps/clients/views.py` client search — likely a cache or queryset scoping issue. The encrypted search loads clients into Python — verify the queryset includes newly created records for all users with program access.
+2. **QA-R8-A11Y4**: Fix create form Tab order — Last Name gets focus before First Name. Fix `field_order` in `ClientFileForm` or the field order in `templates/clients/form.html`. WCAG 1.3.2.
+3. **QA-R8-UX5**: Add validation error display + success confirmation on participant create. Add `messages.success()` to `client_create` view. Ensure form errors render.
+4. **QA-R8-UX6**: Fix mobile edit navigating to wrong form. Check edit button href in `templates/clients/detail.html` — should use `{% url 'clients:client_edit' %}`.
+5. **QA-R8-UX13**: Fix accent stripping — "Benoît" appears as "Benoit" in client list. The `_strip_accents()` function in views.py is for search, not display. Ensure the list template shows the original encrypted name, not the stripped version.
+6. **QA-R8-A11Y5**: Fix excessive Tab presses to reach search results. Add skip link or reduce focusable elements in filter controls. Check `templates/clients/search.html`.
+7. **QA-R8-A11Y8**: Fix profile tabs arrow key nav — ArrowRight opens Actions dropdown instead of next tab. Add ARIA tablist pattern: `role="tablist"` on container, `role="tab"` on each tab, ArrowLeft/Right JS in `static/js/app.js`.
+Run `pytest tests/test_clients.py` after all fixes. Push and create PR → develop.
+
+### Track D: Events App
+Branch: `fix/calendar-feed-url` off develop
+Files: `apps/events/`
+- QA-R8-UX9: Fix calendar feed URL generation failing silently. Check `calendar_feed_settings()` view in `apps/events/views.py`. Add error handling and user feedback. Check token/UUID generation in the model.
+Run related tests. Push and create PR → develop.
+
+### Track E: Auth/Admin
+Branch: `fix/pm-user-management` off develop
+Files: `apps/auth_app/`
+- QA-R8-UX12: PM user management path missing — `/manage/users/` not linked. Check `apps/auth_app/admin_urls.py` and `admin_views.py`. Check if program managers have `permission.admin_users`. If yes, add nav link. If the permission doesn't exist, create it. Check `templates/base.html` admin navigation section — but do NOT modify base.html structure, only add a link if the permission check passes.
+Push and create PR → develop.
+
+### Track F: Notes App
+Branch: `fix/notes-app-bundle` off develop
+Files: `apps/notes/`, `templates/notes/`
+1. **QA-R8-UX4**: Fix quick note entry point unreachable — selector mismatch on client profile. Check `templates/notes/_quick_note_inline_buttons.html` and how it's included in `templates/clients/detail.html`. Fix the broken selector or missing include.
+2. **AXE-HEADING1**: Fix missing h1 on notes-detail page. Add `<h1>` to `templates/notes/note_detail_page.html`.
+Push and create PR → develop.
+
+### Track G: Verification Tasks
+Branch: `fix/verification-checks` off develop
+Files: Various — read-only investigation, small fixes if needed
+1. **QA-R8-LANG1**: Test French language switching. Run the app or check `tests/test_language_switching.py`. If the fix from FG-S-2 still works, mark as verified. If broken, fix in `konote/middleware.py`.
+2. **QA-R8-UX7**: Test offline/error state handling. Check `static/js/app.js` for the `htmx:responseError` handler. If working, mark as verified.
+3. **QA-R8-VERIFY1**: Check if `/participants/<id>/export/` routes exist from the SEC3 export work (PR that added `export_agency_data`). If routes exist and work, mark as verified. Document any gaps.
+Push and create PR → develop (even if only verification notes, add to a VERIFICATION.md or update fix-log).
+
+---
+
+**After all 7 tracks complete:**
+1. Review each PR
+2. Merge all PRs into develop (use `--merge`, never squash)
+3. Pull develop: `git pull origin develop`
+4. Update TODO.md — mark completed tasks as `[x]` with date, move to Recently Done
+5. Proceed to Wave 2 (accessibility sweep) — this is Track H in the plan, a single sequential track
+
+**Wave 2 — Track H: Accessibility Sweep**
+Create branch `fix/accessibility-sweep` off develop. Run these sequentially:
+- AXE-ARIA1: Fix ARIA role violations in base template and shared components
+- AXE-LANDMARK1: Fix duplicate landmark regions in base template
+- AXE-TEMPLATE1: Fix 4 pages missing base template wrapper (export-confirmation, plan-section-edit, public-survey-link, public-unsubscribe)
+- AXE-CONTRAST1: Fix colour contrast failures in CSS (11 pages)
+- AXE-TABLE1: Fix empty table headers on 4 admin pages
+- QA-R8-A11Y6: Fix checkbox touch target size below WCAG 2.5.8 minimum
+- QA-R8-A11Y7: Accessibility polish bundle (language toggle, breadcrumbs, field visibility, icon labels)
+- QA-R8-I18N1: Fix French navigation — ensure nav links use `{% url %}` tags not hardcoded paths
+- QA-R8-UX10: Fix form resubmission navigating to help page — investigate which form, fix redirect
+
+Push and create PR → develop.
+
+---
+
+## Session 2 Prompt (Reports & Funder Features — run separately)
+
+Read `tasks/parallel-sprint-plan.md` Session 2 section. You are building the partner report approval workflow and fixing related report issues.
+
+Branch: `feat/funder-report-approval` off develop.
+
+**Before coding, read these design docs:**
+- `tasks/funder-report-approval.md`
+- `docs/plans/2026-02-20-funder-report-approval-design.md`
+
+Tasks (do sequentially — all in `apps/reports/`):
+1. **QA-R8-UX11**: Fix `/reports/funder/` returning 404. The actual URL is `/reports/funder-report/`. Either add a redirect from the old URL or update references.
+2. **RPT-APPROVE1**: Build partner report approval workflow — new ReportApproval model, quality review view, preview + annotation view, approve + publish view. Follow the design doc. This is RP2/RP3 from the requirements analysis.
+3. **QA-R8-UX8**: Add date presets (Last 30/90/365 days, This year, Custom) and PDF export button to executive dashboard. Dashboard views are in `apps/clients/dashboard_views.py`, PDF export goes in `apps/reports/`.
+
+Run `pytest tests/test_reports.py` after each task. Push and create PR → develop.
+
+If Prosper Canada has provided their funder reporting templates by now, also write `cross-agency-reporting-design.md` (DOC-RP4) to begin scoping the RP4 funder dashboard.
+
+---
+
+## Session 3 Prompt (Demo Mode Safeguards — run after Session 1 Wave 2 merges)
+
+Read `tasks/parallel-sprint-plan.md` Session 3 section. You are implementing demo mode safeguards from the expert panel review.
+
+Branch: `feat/demo-mode-safeguards` off develop.
+
+**Read first:** `tasks/design-rationale/ovhcloud-deployment.md` (Demo Mode Safeguards section).
+
+Tasks (do sequentially):
+1. **DEMO-ADMIN-RO1**: Restrict demo-admin to view-only for agency settings. Demo users with admin role can view but not modify terminology, feature toggles, or program config. Add permission check in admin settings views.
+2. **DEMO-BANNER1**: Enhance persistent training-mode banner. Check `templates/base.html` lines 59-63 for existing demo banner. Make it amber, persistent on every page: "Training Mode — changes here do not affect real participant records."
+3. **DEMO-LOGIN-UX1**: Visually separate demo buttons from real login form. In `templates/auth/login.html`, create a distinct "Training Accounts" section with different styling.
+4. **DEMO-AUDIT1**: Log demo login events (who, when, which demo user) for operational awareness. Exclude from PHIPA audit pipeline. Add to `apps/audit/`.
+5. **DEMO-EXCLUDE1**: Audit every report query, aggregate count, CSV/PDF export, and funder report for demo data leakage. Verify all filter on `is_demo=True`. Fix any that don't.
+
+Run full test suite when done. Push and create PR → develop.


### PR DESCRIPTION
## Summary

- Restructures P0 section in TODO.md to separate product code from ops work and cost optimization
- Moves server sharing (MT-*) items out of P0 into their own phase — they're a cost optimization, not a launch prerequisite
- Adds parallel sprint plan (`tasks/parallel-sprint-plan.md`) and session prompts (`tasks/parallel-sprint-prompt.md`) for 34 TODO items across 3 sessions

### TODO.md changes
- **P0 Product code:** RPT-APPROVE1 (RP2/RP3), REQ-G4, DOC-RP4, SCALE-ROLLUP1
- **P0 Deployment automation:** DOC-MA5, DEPLOY-SCRIPT1, OPS-MANAGED1
- **New phase "Server Sharing":** MT-CORE1 through MT-VALIDATE1 (cost optimization, not critical path)
- Updated vocabulary: "multi-tenancy" → "server sharing", "consortium" → "cost-sharing group"

### Sprint plan
- Session 1 Wave 1: 7 parallel tracks, 17 tasks (bug fixes in isolated apps)
- Session 1 Wave 2: 9 tasks (accessibility sweep — base template + CSS)
- Session 2: 3–4 tasks (reports & funder features — separate session)
- Session 3: 5 tasks (demo mode safeguards — separate session)

🤖 Generated with [Claude Code](https://claude.com/claude-code)