### PR TITLE
fix: PM user management nav highlight and access test (QA-R8-UX12)

### DIFF
--- a/konote/context_processors.py
+++ b/konote/context_processors.py
@@ -25,7 +25,7 @@ def nav_active(request):
         section = "circles"
     elif path.startswith(("/manage/surveys/", "/surveys/")):
         section = "surveys"
-    elif path.startswith(("/admin/", "/erasure/", "/merge/")):
+    elif path.startswith(("/admin/", "/erasure/", "/merge/", "/manage/")):
         section = "admin"
     elif path.startswith("/communications/my-messages"):
         section = "messages"

--- a/tests/test_auth_views.py
+++ b/tests/test_auth_views.py
@@ -269,11 +269,21 @@ class AdminRoutePermissionTest(TestCase):
         self.staff = User.objects.create_user(
             username="staff", password="pass", display_name="Staff"
         )
+        self.pm = User.objects.create_user(
+            username="pm", password="pass", display_name="Program Manager"
+        )
         self.program = Program.objects.create(name="Test")
         UserProgramRole.objects.create(user=self.staff, program=self.program, role="staff")
+        UserProgramRole.objects.create(user=self.pm, program=self.program, role="program_manager")
 
     def tearDown(self):
         enc_module._fernet = None
+
+    def test_pm_can_access_user_list(self):
+        """Program Managers must be able to reach /manage/users/ (QA-R8-UX12)."""
+        self.http.login(username="pm", password="pass")
+        resp = self.http.get("/manage/users/")
+        self.assertEqual(resp.status_code, 200)
 
     def test_admin_can_access_user_list(self):
         self.http.login(username="admin", password="pass")


### PR DESCRIPTION
## Summary

- The `/manage/` path prefix was missing from `nav_active` context processor, so the **Manage** nav dropdown had no active/highlighted state when a Program Manager navigated to `/manage/users/` or other manage pages. PMs could not see which section they were in, making the nav link appear absent.
- Added `/manage/` to the `admin` section mapping in `konote/context_processors.py` — the Manage dropdown now correctly highlights on all `/manage/*` pages.
- Added `test_pm_can_access_user_list` to confirm PMs can reach `/manage/users/` (the view already had the correct permission — `user.manage: PROGRAM` in the matrix — but had no regression test).

## Root cause detail

The view (`user_list`) already accepted PMs via `@requires_permission("user.manage", allow_admin=True)`, and the permissions matrix already granted PMs `user.manage: PROGRAM`. The nav link itself was already present in `base.html` inside the PM "Manage" dropdown (`{% if can_manage_users %}<li><a href="{% url 'admin_users:user_list' %}">Team Members</a></li>{% endif %}`).

The missing piece was `nav_active`: `/manage/users/` fell through to `section = ""`, so the Manage dropdown had no `aria-current` or `.nav-active` styling when a PM was on that page — making the PM lose their place in the nav.

## Files changed

- `konote/context_processors.py` — add `/manage/` to the `"admin"` nav section mapping
- `tests/test_auth_views.py` — add PM access regression test for `/manage/users/`

## Test plan

- [x] `pytest tests/test_auth_views.py::AdminRoutePermissionTest` — all 8 tests pass including new `test_pm_can_access_user_list`
- [ ] Manual: log in as a PM user and confirm the Manage dropdown is highlighted when on `/manage/users/`
- [ ] Manual: confirm "Team Members" link appears in the Manage dropdown for PMs

🤖 Generated with [Claude Code](https://claude.com/claude-code)