### PR TITLE
feat: auto-update achievement status on goal status change (REQ-G4)

### DIFF
--- a/apps/plans/apps.py
+++ b/apps/plans/apps.py
@@ -6,3 +6,6 @@ class PlansConfig(AppConfig):
     name = "apps.plans"
     label = "plans"
     verbose_name = "Plans & Outcomes"
+
+    def ready(self):
+        import apps.plans.signals  # noqa: F401

--- a/apps/plans/signals.py
+++ b/apps/plans/signals.py
@@ -1,0 +1,95 @@
+"""Signals for the plans app.
+
+Handles auto-updating of achievement status and metric records when a
+PlanTarget's status changes (e.g. to completed or deactivated).
+"""
+import logging
+
+from django.db.models.signals import post_init, post_save
+from django.dispatch import receiver
+
+logger = logging.getLogger(__name__)
+
+
+@receiver(post_init, sender="plans.PlanTarget")
+def cache_plan_target_status(sender, instance, **kwargs):
+    """Cache the status value right after the instance is loaded from the DB.
+
+    This lets the post_save signal detect whether status actually changed.
+    """
+    instance.__original_status = instance.status
+
+
+@receiver(post_save, sender="plans.PlanTarget")
+def sync_achievement_on_status_change(sender, instance, created, **kwargs):
+    """When a PlanTarget's status changes, update linked metric records.
+
+    - completed  → mark achievement_status as "achieved" (worker_assessed)
+    - deactivated → mark achievement_status as "not_achieved" (worker_assessed)
+
+    Only fires when status genuinely changes — does not update on creation
+    or on saves that leave status unchanged.
+
+    MetricValues themselves are historical note records and are not modified.
+    The achievement_status field on PlanTarget is the aggregate "metric" that
+    reflects the final outcome of the goal.
+    """
+    from django.utils import timezone
+
+    if created:
+        # No prior status to compare against; nothing to propagate.
+        return
+
+    original = getattr(instance, "__original_status", None)
+    if original == instance.status:
+        # Status did not change — nothing to do.
+        return
+
+    new_status = instance.status
+
+    if new_status == "completed":
+        _set_achievement_status(instance, "achieved", timezone.now())
+    elif new_status == "deactivated":
+        _set_achievement_status(instance, "not_achieved", timezone.now())
+    # "default" (re-activation) — leave achievement_status alone; it will
+    # be recalculated the next time a ProgressNoteTarget is saved.
+
+    # Update the cached original so repeated saves in the same request
+    # don't re-fire unnecessarily.
+    instance.__original_status = instance.status
+
+
+def _set_achievement_status(plan_target, status, now):
+    """Write achievement_status directly to the database via QuerySet.update().
+
+    Uses QuerySet.update() instead of model.save() to avoid re-triggering the
+    post_save signal (which would cause infinite recursion).
+
+    Always marks source as 'worker_assessed' because this change is driven by
+    a deliberate worker action (changing the goal's lifecycle status), not by
+    computed metric trends.
+
+    Sets first_achieved_at when status is 'achieved' for the first time — in
+    line with the same rule in apps/plans/achievement.py.
+    """
+    from apps.plans.models import PlanTarget
+
+    update_kwargs = {
+        "achievement_status": status,
+        "achievement_status_source": "worker_assessed",
+        "achievement_status_updated_at": now,
+    }
+
+    if status == "achieved" and not plan_target.first_achieved_at:
+        update_kwargs["first_achieved_at"] = now
+
+    try:
+        PlanTarget.objects.filter(pk=plan_target.pk).update(**update_kwargs)
+        # Keep the in-memory instance consistent so callers don't see stale data.
+        for field, value in update_kwargs.items():
+            setattr(plan_target, field, value)
+    except Exception:
+        logger.exception(
+            "Failed to update achievement_status for PlanTarget %s",
+            plan_target.pk,
+        )

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -1,0 +1,254 @@
+"""Tests for the plans app — signals and achievement status behaviour (REQ-G4).
+
+Covers the post_save signal on PlanTarget that auto-updates achievement_status
+when a goal's lifecycle status changes.
+"""
+import pytest
+from cryptography.fernet import Fernet
+from django.test import TestCase, override_settings
+from django.utils import timezone
+
+import konote.encryption as enc_module
+from apps.clients.models import ClientFile, ClientProgramEnrolment
+from apps.plans.models import (
+    MetricDefinition,
+    PlanSection,
+    PlanTarget,
+    PlanTargetMetric,
+)
+from apps.programs.models import Program
+
+
+TEST_KEY = Fernet.generate_key().decode()
+
+
+@override_settings(FIELD_ENCRYPTION_KEY=TEST_KEY)
+class PlanTargetSignalTest(TestCase):
+    """Tests for the post_save signal on PlanTarget (REQ-G4).
+
+    The signal should:
+    - Set achievement_status = "achieved" when status → "completed"
+    - Set achievement_status = "not_achieved" when status → "deactivated"
+    - Do nothing when status does not change
+    - Not error when there are no linked PlanTargetMetric rows
+    """
+
+    databases = {"default", "audit"}
+
+    def setUp(self):
+        enc_module._fernet = None
+
+        self.program = Program.objects.create(name="Test Program")
+
+        self.client_file = ClientFile()
+        self.client_file.first_name = "Test"
+        self.client_file.last_name = "Client"
+        self.client_file.status = "active"
+        self.client_file.save()
+
+        ClientProgramEnrolment.objects.create(
+            client_file=self.client_file,
+            program=self.program,
+            status="active",
+        )
+
+        self.section = PlanSection.objects.create(
+            client_file=self.client_file,
+            name="Test Section",
+            program=self.program,
+        )
+
+    def tearDown(self):
+        enc_module._fernet = None
+
+    def _make_target(self, name="Test Goal"):
+        """Create a PlanTarget in the default (active) status."""
+        t = PlanTarget(
+            plan_section=self.section,
+            client_file=self.client_file,
+        )
+        t.name = name
+        t.save()
+        return t
+
+    # ------------------------------------------------------------------ #
+    # completed → achieved
+    # ------------------------------------------------------------------ #
+
+    def test_status_completed_sets_achievement_achieved(self):
+        """Changing status to 'completed' should set achievement_status to 'achieved'."""
+        target = self._make_target()
+        self.assertEqual(target.achievement_status, "")
+
+        target.status = "completed"
+        target.save()
+
+        target.refresh_from_db()
+        self.assertEqual(target.achievement_status, "achieved")
+        self.assertEqual(target.achievement_status_source, "worker_assessed")
+        self.assertIsNotNone(target.achievement_status_updated_at)
+
+    def test_status_completed_sets_first_achieved_at_when_unset(self):
+        """Completing a goal for the first time should record first_achieved_at."""
+        target = self._make_target()
+        self.assertIsNone(target.first_achieved_at)
+
+        target.status = "completed"
+        target.save()
+
+        target.refresh_from_db()
+        self.assertIsNotNone(target.first_achieved_at)
+
+    def test_status_completed_does_not_clear_existing_first_achieved_at(self):
+        """If first_achieved_at was already set, completing again must not change it."""
+        earlier = timezone.now() - timezone.timedelta(days=30)
+
+        target = self._make_target()
+        target.first_achieved_at = earlier
+        target.save(update_fields=["first_achieved_at"])
+
+        target.status = "completed"
+        target.save()
+
+        target.refresh_from_db()
+        # first_achieved_at should not be overwritten — still the earlier timestamp
+        self.assertEqual(
+            target.first_achieved_at.replace(microsecond=0),
+            earlier.replace(microsecond=0),
+        )
+
+    # ------------------------------------------------------------------ #
+    # deactivated → not_achieved
+    # ------------------------------------------------------------------ #
+
+    def test_status_deactivated_sets_achievement_not_achieved(self):
+        """Changing status to 'deactivated' should set achievement_status to 'not_achieved'."""
+        target = self._make_target()
+        self.assertEqual(target.achievement_status, "")
+
+        target.status = "deactivated"
+        target.save()
+
+        target.refresh_from_db()
+        self.assertEqual(target.achievement_status, "not_achieved")
+        self.assertEqual(target.achievement_status_source, "worker_assessed")
+        self.assertIsNotNone(target.achievement_status_updated_at)
+
+    def test_status_deactivated_does_not_set_first_achieved_at(self):
+        """Deactivating a goal should never set first_achieved_at."""
+        target = self._make_target()
+        target.status = "deactivated"
+        target.save()
+
+        target.refresh_from_db()
+        self.assertIsNone(target.first_achieved_at)
+
+    # ------------------------------------------------------------------ #
+    # No status change — signal must not fire
+    # ------------------------------------------------------------------ #
+
+    def test_save_without_status_change_does_not_update_achievement(self):
+        """Saving a PlanTarget without changing status must NOT alter achievement_status."""
+        target = self._make_target()
+        # Pre-populate a known achievement_status
+        PlanTarget.objects.filter(pk=target.pk).update(
+            achievement_status="improving",
+            achievement_status_source="auto_computed",
+        )
+
+        # Now save target (status stays "default") — simulate a name-only edit
+        target.refresh_from_db()
+        target.name = "Updated Goal Name"
+        target.save()
+
+        target.refresh_from_db()
+        # achievement_status must still be "improving" — signal should not have changed it
+        self.assertEqual(target.achievement_status, "improving")
+        self.assertEqual(target.achievement_status_source, "auto_computed")
+
+    def test_creation_does_not_set_achievement_status(self):
+        """Creating a new PlanTarget must not set achievement_status."""
+        target = self._make_target()
+        target.refresh_from_db()
+        self.assertEqual(target.achievement_status, "")
+
+    # ------------------------------------------------------------------ #
+    # Targets without linked PlanTargetMetric rows
+    # ------------------------------------------------------------------ #
+
+    def test_target_without_metrics_does_not_error_on_completed(self):
+        """Completing a target with no linked metrics must not raise any exception."""
+        target = self._make_target()
+        # No PlanTargetMetric rows — goal has no associated metric
+
+        try:
+            target.status = "completed"
+            target.save()
+        except Exception as exc:
+            self.fail(f"Signal raised an unexpected exception: {exc}")
+
+        target.refresh_from_db()
+        self.assertEqual(target.achievement_status, "achieved")
+
+    def test_target_without_metrics_does_not_error_on_deactivated(self):
+        """Deactivating a target with no linked metrics must not raise any exception."""
+        target = self._make_target()
+
+        try:
+            target.status = "deactivated"
+            target.save()
+        except Exception as exc:
+            self.fail(f"Signal raised an unexpected exception: {exc}")
+
+        target.refresh_from_db()
+        self.assertEqual(target.achievement_status, "not_achieved")
+
+    # ------------------------------------------------------------------ #
+    # Targets WITH linked PlanTargetMetric rows
+    # ------------------------------------------------------------------ #
+
+    def test_target_with_metrics_updates_correctly_on_completed(self):
+        """A target with linked metrics should still update achievement_status correctly."""
+        metric = MetricDefinition.objects.create(
+            name="Goal Progress",
+            definition="How close to the goal",
+            category="general",
+            metric_type="scale",
+            min_value=0,
+            max_value=10,
+        )
+        target = self._make_target()
+        PlanTargetMetric.objects.create(plan_target=target, metric_def=metric)
+
+        target.status = "completed"
+        target.save()
+
+        target.refresh_from_db()
+        self.assertEqual(target.achievement_status, "achieved")
+
+    # ------------------------------------------------------------------ #
+    # Multiple status transitions
+    # ------------------------------------------------------------------ #
+
+    def test_multiple_transitions(self):
+        """Status can move through multiple states; each transition updates correctly."""
+        target = self._make_target()
+
+        # Active → completed → default (re-opened) → deactivated
+        target.status = "completed"
+        target.save()
+        target.refresh_from_db()
+        self.assertEqual(target.achievement_status, "achieved")
+
+        # Re-open the goal — signal should not clear achievement_status
+        target.status = "default"
+        target.save()
+        target.refresh_from_db()
+        # Achievement status is left alone on re-activation (recalculated by note saves)
+        self.assertEqual(target.achievement_status, "achieved")
+
+        # Deactivate
+        target.status = "deactivated"
+        target.save()
+        target.refresh_from_db()
+        self.assertEqual(target.achievement_status, "not_achieved")


### PR DESCRIPTION
## Summary

- Adds `apps/plans/signals.py` with a `post_save` signal on `PlanTarget`
- When a worker changes a goal's lifecycle status, the signal automatically updates `achievement_status`:
  - `completed` → `achievement_status = "achieved"` (worker_assessed)
  - `deactivated` → `achievement_status = "not_achieved"` (worker_assessed)
- Uses `QuerySet.update()` (not `model.save()`) to avoid infinite signal recursion
- Caches the original status via `post_init` so the signal only fires on genuine status changes
- Registers the signal in `PlansConfig.ready()`

## Design notes

`MetricValue` records are historical measurements tied to progress notes and are not modified — they are immutable session records. The `achievement_status` field on `PlanTarget` is the aggregate outcome metric that reflects a goal's final state, which is exactly what this signal updates.

The `worker_assessed` source tag ensures the existing `update_achievement_status()` function in `achievement.py` will not overwrite this value with an auto-computed result on future note saves.

## Test plan

- [x] 11 unit tests in `tests/test_plans.py` — all passing
- [x] Covers: completed → achieved, deactivated → not_achieved, no-op on no change, creation is safe, targets without metrics don't error, targets with metrics work correctly, multiple transitions
- [x] No migrations needed (no model changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)