### PR TITLE
Fix form resubmission redirect to help page (QA-R8-UX10)

### DIFF
--- a/templates/clients/form.html
+++ b/templates/clients/form.html
@@ -9,7 +9,7 @@
     <h1>{% if editing %}{% blocktrans with first=client.display_name last=client.last_name %}Edit {{ first }} {{ last }}{% endblocktrans %}{% else %}{% blocktrans with client=term.client|default:"Participant" %}New {{ client }}{% endblocktrans %}{% endif %}</h1>
 </hgroup>
 
-<form method="post" novalidate>
+<form method="post" action="{% if editing %}{% url 'clients:client_edit' client_id=client.pk %}{% else %}{% url 'clients:client_create' %}{% endif %}" novalidate>
     {% csrf_token %}
 
     {% include "includes/_form_errors.html" %}


### PR DESCRIPTION
## Summary
- Adds explicit `action` attribute to the create/edit participant form
- Prevents form POST from going to wrong URL after validation error re-render
- Fixes BUG-34 / QA-R8-UX10

## Test plan
- [ ] Create participant → submit with missing required fields → get validation errors → fix fields → resubmit → should create successfully and redirect to participant detail
- [ ] Edit participant → submit invalid data → fix → resubmit → should save and redirect correctly
- [ ] No redirect to /help/ under any circumstances during form submission

🤖 Generated with [Claude Code](https://claude.com/claude-code)