### PR TITLE
🛡️ Sentinel: [HIGH] Add rate limit to portal_login endpoint

### DIFF
--- a/apps/portal/tests/test_auth.py
+++ b/apps/portal/tests/test_auth.py
@@ -165,9 +165,12 @@ class PortalAuthTests(TestCase):
         # Log in first
         session = self.client.session
         session["_portal_participant_id"] = str(self.participant.id)
+        from apps.portal.views import SESSION_EMERGENCY_LOGOUT_TOKEN
+        token = "testtoken"
+        session[SESSION_EMERGENCY_LOGOUT_TOKEN] = token
         session.save()
 
-        response = self.client.post("/my/emergency-logout/")
+        response = self.client.post("/my/emergency-logout/", {"token": token})
 
         # Should return 204 No Content (no redirect, no page to see)
         self.assertEqual(response.status_code, 204)

--- a/apps/portal/views.py
+++ b/apps/portal/views.py
@@ -144,6 +144,7 @@ def _audit_portal_event(request, action, resource_type="portal", metadata=None):
 # ---------------------------------------------------------------------------
 
 
+@ratelimit(key="ip", rate="5/m", method="POST", block=True)
 @portal_feature_required
 def portal_login(request):
     """Participant login — email + password.


### PR DESCRIPTION
Adding ratelimiting to portal_login view using the `ratelimit` decorator. This helps mitigate brute force attacks on participant login endpoints.

---
*PR created automatically by Jules for task [17918935608605709104](https://jules.google.com/task/17918935608605709104) started by @pboachie*