### PR TITLE
Add deploy script design doc and VPS provisioning script (DOC-MA5 + DEPLOY-SCRIPT1)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -21,15 +21,14 @@ Items from `requirements-analysis.md` that need work before the deliverable dead
 
 **Deployment automation (ops scripting, not product code):**
 
-- [ ] Write deploy script design doc — how provisioning is automated, target: new agency instance in hours not weeks (docs/plans/2026-02-20-deploy-script-design.md) — PB (DOC-MA5)
-- [ ] Build deploy script to automate agency instance provisioning — server setup, DNS, SSL, Docker, initial configuration, output a URL (plan: docs/plans/2026-02-20-deploy-script-design.md) (DEPLOY-SCRIPT1)
+- [x] Write deploy script design doc — how provisioning is automated, target: new agency instance in hours not weeks (docs/plans/2026-02-20-deploy-script-design.md) — 2026-03-02 (DOC-MA5)
+- [x] Build deploy script to automate agency instance provisioning — server setup, DNS, SSL, Docker, initial configuration, output a URL (plan: docs/plans/2026-02-20-deploy-script-design.md) — 2026-03-02 (DEPLOY-SCRIPT1)
 - [ ] Define managed service model — who handles infrastructure, backups, updates, support tiers, funding model (see tasks/hosting-cost-comparison.md, tasks/design-rationale/ovhcloud-deployment.md) (OPS-MANAGED1)
 ### Phase: Launch Readiness
 
 - [ ] Run deployment protocol with [funder partner] — currently at Phase 0 (see tasks/deployment-protocol.md, tasks/hosting-cost-comparison.md) — SG (DEPLOY-PC1)
 - [ ] Discuss data handling acknowledgement during permissions interview — plaintext backup opt-in, designate contact person (see docs/data-handling-acknowledgement.md, deployment-protocol.md Phase 1) — SG (DEPLOY-DHA1)
 - [ ] Follow up with [funder contact] for additional must-haves on feature comparison — (DEPLOY-PC2)
-- [ ] Test backup restore from a production-like database dump and capture runbook notes — PB (OPS4)
 - [ ] Create AI-assisted admin toolkit decision documents (01-09) for agency setup — reformat deployment protocol into AI-consumable reference docs, test with [funder partner] dry run (see tasks/ai-assisted-admin-toolkit.md, docs/agency-setup-guide/). Document 10 (Data Responsibilities) is done — (DEPLOY-TOOLKIT1)
 - [ ] Review and merge data handling acknowledgement PR #130 — expanded to cover encryption key custody, SharePoint/Google Drive responsibilities, exports, plaintext backups, staff departures. Wired into deployment protocol Phases 0/4/5. Needs legal review before first agency use (see docs/data-handling-acknowledgement.md) — SG (SEC3-AGREE1)
 - [ ] Decide who can run the secure offboarding export command (KoNote team only vs self-hosted agencies) to finalize SEC3 design (see tasks/agency-data-offboarding.md) — SG (SEC3-Q1)
@@ -116,7 +115,7 @@ Multiple agencies can deploy today on independent instances ($35–100/month eac
 - [ ] Seed groups-attendance test data with 8+ members and 12+ sessions — re-seed after workflow changes, fix in qa-scenarios repo (QA-PA-TEST1)
 - [ ] Seed comm-my-messages populated state with actual messages — re-seed after workflow changes, fix in qa-scenarios repo (QA-PA-TEST2)
 - [ ] Add new features and capabilities to the web site as they are built (WEBSITE-UPDATE1)
-- [ ] Use KoNote logos from `Logo/brand/` folder across app and website (see PR #100) — PB (LOGO1)
+- [x] Use KoNote logos from `Logo/brand/` folder across app and website (see PR #100) — 2026-03-02 (LOGO1)
 
 ## Parking Lot: Ready to Build
 
@@ -151,6 +150,13 @@ Not yet clear we should build these, or the design isn't settled. May be too com
 - [ ] Decide executive audit log access for PIPEDA 4.1.4 board accountability — GK reviews data access policy (QA-R8-PERM2)
 
 ## Recently Done
+
+### PB Tasks Sprint — Deploy Script + Logo Integration
+
+- [x] Write deploy script design doc — automated provisioning plan for OVHcloud VPS — 2026-03-02 (DOC-MA5)
+- [x] Build deploy script — scripts/deploy-konote-vps.sh automates 9 of 15 manual steps — 2026-03-02 (DEPLOY-SCRIPT1)
+- [x] Add KoNote logo to navigation and social sharing meta tags — 2026-03-02 (LOGO1)
+- [x] Remove stale OPS4 — backup restore was already completed 2026-02-26 (see ARCHIVE.md) — 2026-03-02 (OPS4-CLEANUP)
 
 ### Wave 2 Sprint — Accessibility Sweep (PR #208)
 

--- a/docs/deploy-ovhcloud.md
+++ b/docs/deploy-ovhcloud.md
@@ -1,5 +1,39 @@
 # Deploying KoNote on OVHcloud VPS
 
+## Two Paths: Automated or Manual
+
+| Path | Time | Best for |
+|------|------|----------|
+| **Automated** (`scripts/deploy-konote-vps.sh`) | ~30 minutes | Production deployments, operators comfortable with SSH |
+| **Manual** (this guide) | 45–90 minutes | Learning, troubleshooting, or when the script can't run |
+
+### Automated Path (Recommended)
+
+The deploy script automates 9 of 15 steps below — from securing the OS through verifying the running instance. You need SSH access and a domain pointing to your VPS IP.
+
+```bash
+./scripts/deploy-konote-vps.sh \
+  --host 141.227.151.7 \
+  --domain konote.youragency.ca \
+  --admin-email admin@youragency.ca \
+  --org-name "Your Agency Name"
+```
+
+The script generates all credentials, SSHes into the VPS, hardens the OS, installs Docker, clones the repo, writes `.env`, starts the containers, creates the admin user, and sets up backup cron jobs. It prints credentials and a post-deploy checklist at the end.
+
+- **Safe to re-run** — skips already-completed steps
+- **Dry-run mode** — add `--dry-run` to preview without executing
+- **Full options** — run `./scripts/deploy-konote-vps.sh --help`
+- **Design doc** — see [deploy script design](plans/2026-02-20-deploy-script-design.md) for architecture decisions
+
+After the script finishes, skip to [Section 7: Point Your Domain to the VPS](#7-point-your-domain-to-the-vps) (if DNS isn't already configured) or [Section 12: Set Up Monitoring](#12-set-up-monitoring) to complete the remaining manual steps.
+
+### Manual Path
+
+Follow the full guide below step by step. This is useful for understanding what the script does, or for environments where the script can't run (e.g., non-Ubuntu servers, restricted SSH access).
+
+---
+
 This guide walks you through deploying KoNote on an OVHcloud VPS from scratch. It assumes:
 
 - You have an OVHcloud VPS with Ubuntu 24.04 or 25.04 (fresh install)
@@ -7,7 +41,7 @@ This guide walks you through deploying KoNote on an OVHcloud VPS from scratch. I
 - You are working from a Windows computer
 - You have Claude Code available to help if you get stuck
 
-**Time estimate:** 45-90 minutes for a first deployment.
+**Time estimate:** 45–90 minutes for a first deployment (manual path).
 
 ---
 
@@ -847,6 +881,26 @@ Open `https://konote-dev.yourdomain.ca` in your browser. You should see the logi
 
 When a new version is released:
 
+### Before You Update
+
+1. **Back up both databases** — in case the update introduces problems:
+
+```bash
+sudo /opt/konote/scripts/backup-vps.sh
+```
+
+2. **Note the current commit** — so you can roll back if needed:
+
+```bash
+cd /opt/konote
+sudo git log --oneline -1
+# Example output: a1b2c3d Fix dashboard layout
+```
+
+Save that commit hash (e.g., `a1b2c3d`). You'll need it if you want to undo the update.
+
+### Apply the Update
+
 ```bash
 cd /opt/konote
 
@@ -858,6 +912,31 @@ sudo docker compose up -d --build
 ```
 
 The entrypoint script handles database migrations automatically. Downtime is typically under 2 minutes.
+
+### Verify the Update
+
+1. Visit your KoNote URL — the login page should load
+2. Log in and check a few pages (dashboard, a client page, a report)
+3. Check container health: `sudo docker compose ps` — all should show "healthy"
+
+### If Something Goes Wrong (Rollback)
+
+If the update breaks your instance:
+
+```bash
+cd /opt/konote
+
+# Revert to the previous commit
+sudo git checkout a1b2c3d -- .
+# (Replace a1b2c3d with the hash you saved before updating)
+
+# Rebuild with the old code
+sudo docker compose up -d --build
+```
+
+If the broken update ran database migrations (new tables or columns), you may also need to restore from the backup you took. See [Troubleshooting: Restore from backup](#restore-from-backup) below.
+
+For detailed procedures, see the [Update and Rollback Guide](update-and-rollback.md).
 
 ### Update the dev instance too
 

--- a/docs/deploying-konote.md
+++ b/docs/deploying-konote.md
@@ -12,6 +12,7 @@ This guide covers everything you need to get KoNote running — from local devel
 | Deploy to Elestio | [Deploy to Elestio](#deploy-to-elestio) |
 | Deploy to FullHost | [Deploy to FullHost](#deploy-to-fullhost) |
 | Deploy to OVHcloud VPS | [Deploy to OVHcloud](deploy-ovhcloud.md) |
+| Update or roll back a deployment | [Update and Rollback Guide](update-and-rollback.md) |
 | Set up PDF reports | [PDF Report Setup](#pdf-report-setup) |
 | Go live with real data | [Before You Enter Real Data](#before-you-enter-real-data) |
 
@@ -250,6 +251,7 @@ KoNote automatically detects which platform it's running on and configures itsel
 |----------|-------------------|------------------------|
 | **Railway** | `RAILWAY_ENVIRONMENT` variable | Production settings, `.railway.app` domains allowed |
 | **Azure App Service** | `WEBSITE_SITE_NAME` variable | Production settings, `.azurewebsites.net` domains allowed |
+| **Azure Container Apps** | `CONTAINER_APP_NAME` variable | Production settings, `.azurecontainerapps.io` domains allowed |
 | **Elestio** | `ELESTIO_VM_NAME` variable | Production settings, `.elest.io` domains allowed |
 | **Docker/Self-hosted** | `DATABASE_URL` is set | Production settings, localhost allowed by default |
 
@@ -564,6 +566,105 @@ To let users log in with Microsoft credentials:
    - `AZURE_TENANT_ID=...`
    - `AZURE_REDIRECT_URI=https://your-domain/auth/callback/`
 
+### Railway CLI Operations
+
+The Railway CLI lets you run management commands on your production instance from your local machine. Install it from [docs.railway.app/guides/cli](https://docs.railway.app/guides/cli).
+
+**Link to your project (one-time setup):**
+
+```bash
+railway login
+railway link
+```
+
+**Run management commands:**
+
+```bash
+# Create an admin user (if you didn't use DEMO_MODE)
+railway run python manage.py createsuperuser
+
+# Run database migrations manually
+railway run python manage.py migrate
+railway run python manage.py migrate --database=audit
+
+# Check deployment health
+railway run python manage.py startup_check
+
+# Rotate the encryption key
+railway run python manage.py rotate_encryption_key --dry-run
+```
+
+**Manual database backup:**
+
+```bash
+# Back up the main database
+railway run pg_dump $DATABASE_URL > backup_main_$(date +%Y-%m-%d).sql
+
+# Back up the audit database
+railway run pg_dump $AUDIT_DATABASE_URL > backup_audit_$(date +%Y-%m-%d).sql
+```
+
+Store these backups securely — and always store your `FIELD_ENCRYPTION_KEY` separately from backups (you need both to restore encrypted data).
+
+### Data Residency Warning
+
+Railway's servers are in the United States. US-hosted data is subject to the [CLOUD Act](https://en.wikipedia.org/wiki/CLOUD_Act), which allows US authorities to request access to data stored by US companies — even if the data belongs to Canadian residents.
+
+**What this means for your organisation:**
+
+- **If you serve vulnerable populations** (health, mental health, domestic violence, children) — provincial health privacy laws (PHIPA in Ontario, HIA in Alberta) may require Canadian data residency. Railway may not meet this requirement.
+- **If your funder requires Canadian hosting** — some government contracts specify data must stay in Canada. Check your funding agreement.
+- **If neither applies** — Railway is fine for most small nonprofits. KoNote encrypts all PII fields (names, emails, birth dates, phone numbers) with a key you control. Even if data were accessed, the encrypted fields are unreadable without your `FIELD_ENCRYPTION_KEY`.
+
+**If you need Canadian data residency**, choose [OVHcloud VPS](deploy-ovhcloud.md) (Beauharnois, QC) or [Azure](https://portal.azure.com) (Canada Central region) instead.
+
+### Railway Troubleshooting
+
+**Deployment fails — "Build Error"**
+
+Check the **Logs** tab in the Railway dashboard. Common causes:
+
+- `ModuleNotFoundError: No module named '...'` — A Python package is missing from `requirements.txt`. This shouldn't happen with the main repository; report it as a bug.
+- `ERROR: could not translate host name '...'` — The database URL is incorrect. Copy `DATABASE_URL` directly from the PostgreSQL service (don't type it manually).
+
+**App starts but won't load — "502 Bad Gateway"**
+
+The app crashed shortly after starting:
+
+1. Click **Logs** in the Railway dashboard and scroll to startup messages
+2. Common causes: missing environment variables, database migrations failed, invalid `SECRET_KEY` or `FIELD_ENCRYPTION_KEY`
+3. Verify all required variables are set in the Variables tab
+
+**Login page loads but can't sign in**
+
+1. Check **Logs** for authentication errors
+2. Verify `AUTH_MODE` is set correctly (`local` for username/password, `azure` for SSO)
+3. If using Azure AD: verify `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, and `AZURE_REDIRECT_URI` are correct
+
+**"ALLOWED_HOSTS Invalid" or "DisallowedHost" error**
+
+Railway domains are auto-detected, but custom domains must be added manually:
+
+1. Go to **Variables** in the Railway dashboard
+2. Update `ALLOWED_HOSTS` to include your custom domain: `myapp.railway.app,outcomes.myorg.ca`
+3. Also update `CSRF_TRUSTED_ORIGINS`: `https://myapp.railway.app,https://outcomes.myorg.ca`
+4. Click **Redeploy**
+
+### Railway Scaling and Costs
+
+| Component | Monthly Cost (CAD) |
+|-----------|-------------------|
+| Railway Pro plan (removes limits) | ~$27 |
+| PostgreSQL — main database | ~$13–20 |
+| PostgreSQL — audit database | ~$13–20 |
+| **Total** | **~$45–55** |
+
+Railway's free tier provides ~$5 worth of compute per month — enough for testing but not production.
+
+To upgrade: click **Settings** in your Railway project → **Plan** → **Pro**.
+
+> **Note:** Railway cannot run multi-container stacks like ODK Central. If your agency needs [offline field collection](../docs/plans/2026-02-24-offline-field-collection-design.md), choose OVHcloud VPS instead.
+
 ---
 
 ## Deploy to Azure
@@ -728,6 +829,96 @@ Once logged in, you can invite additional staff through the web interface using 
 2. Add your domain
 3. Follow Azure's DNS validation instructions
 4. Azure automatically provisions an SSL certificate
+
+### Azure Operations
+
+Once your instance is running, here's how to manage it day-to-day.
+
+**Viewing logs:**
+
+In Azure Portal, go to your Container App → **Monitoring** → **Log stream** to see real-time output. For historical logs, use **Monitoring** → **Logs** with this query:
+
+```
+ContainerAppConsoleLogs_CL
+| where ContainerName_s == "konote-web"
+| order by TimeGenerated desc
+| take 100
+```
+
+**Running management commands:**
+
+Use a temporary Azure Container Instance (same pattern as migrations in Step 7):
+
+```bash
+az container create \
+  --resource-group KoNote-prod \
+  --name konote-cmd \
+  --image konoteregistry.azurecr.io/konote:latest \
+  --environment-variables DATABASE_URL="..." SECRET_KEY="..." FIELD_ENCRYPTION_KEY="..." \
+  --command-line "/bin/bash -c 'python manage.py <command>'"
+```
+
+Delete the container after it completes: `az container delete --resource-group KoNote-prod --name konote-cmd --yes`
+
+**Database backups:**
+
+Azure PostgreSQL Flexible Server includes automatic backups with configurable retention (7–35 days). To verify:
+
+1. Go to Azure Portal → your PostgreSQL server → **Settings** → **Backup**
+2. Confirm retention period (recommend 30 days for production)
+3. Point-in-time restore is available within the retention window
+
+**Scaling:**
+
+If the app feels slow under load, increase the Container App resources:
+
+```bash
+az containerapp update \
+  --name konote-web \
+  --resource-group KoNote-prod \
+  --cpu 0.5 \
+  --memory 1.0Gi
+```
+
+Start with 0.25 CPU / 0.5 GB (default). For 50+ concurrent users, try 0.5 CPU / 1 GB. Monitor using **Metrics** → **CPU Usage** and **Memory Usage** in the Container App blade.
+
+**Cost monitoring:**
+
+Set up a budget alert so you're notified before costs exceed your plan:
+
+1. Go to Azure Portal → **Cost Management** → **Budgets**
+2. Create a budget for your resource group
+3. Set alerts at 80% and 100% of your monthly target
+
+**Encryption key storage:**
+
+For production, consider storing your `FIELD_ENCRYPTION_KEY` in [Azure Key Vault](https://learn.microsoft.com/en-us/azure/key-vault/) rather than as a plain environment variable. This adds access control and audit logging around the most sensitive credential.
+
+### Azure Troubleshooting
+
+**Container App won't start:**
+
+1. Check **Log stream** for startup errors
+2. Verify all environment variables are set (especially `DATABASE_URL`, `FIELD_ENCRYPTION_KEY`)
+3. Test database connectivity: the PostgreSQL firewall must allow Azure services (`az postgres flexible-server firewall-rule create --rule-name AllowAzure --start-ip-address 0.0.0.0 --end-ip-address 0.0.0.0`)
+
+**"DisallowedHost" or "400 Bad Request":**
+
+Your domain isn't in `ALLOWED_HOSTS`. For Container Apps, set this environment variable explicitly — unlike App Service, Container Apps does not auto-detect domains.
+
+**"CSRF verification failed" on form submissions:**
+
+Set `CSRF_TRUSTED_ORIGINS` to include your full HTTPS domain:
+
+```
+CSRF_TRUSTED_ORIGINS=https://konote.youragency.ca,https://konote-web.happywave-abc123.canadacentral.azurecontainerapps.io
+```
+
+**"Permission denied" connecting to PostgreSQL:**
+
+1. Check that the PostgreSQL firewall allows your Container App's outbound IPs
+2. Verify the connection string uses the correct server name (`.postgres.database.azure.com`)
+3. For new servers, add `sslmode=require` to the connection string if not already present
 
 ---
 

--- a/docs/plans/2026-02-20-deploy-script-design.md
+++ b/docs/plans/2026-02-20-deploy-script-design.md
@@ -1,0 +1,225 @@
+# Deploy Script Design: Automated KoNote Agency Provisioning
+
+**Date:** 2026-02-20
+**Status:** Draft
+**Author:** Claude (DOC-MA5)
+**Reference:** [deploy-ovhcloud.md](../deploy-ovhcloud.md), [deploy-fullhost.ps1](../../deploy-fullhost.ps1)
+
+---
+
+## Goal
+
+Reduce new agency provisioning time from **45–90 minutes (manual)** to **under 30 minutes (scripted)** by automating the repeatable steps in `docs/deploy-ovhcloud.md`.
+
+A single operator runs one command from their local machine. The script SSHes into the target VPS and configures everything needed for a running KoNote instance with HTTPS.
+
+---
+
+## Target Platform
+
+| Property | Value |
+|----------|-------|
+| Provider | OVHcloud VPS |
+| Data centre | Beauharnois, QC (Canadian data residency) |
+| OS | Ubuntu 24.04 LTS or newer |
+| Prerequisites | Fresh VPS with SSH access, domain name pointed at VPS IP |
+
+---
+
+## Scope Boundary
+
+**In scope:** App-level provisioning on an **existing** VPS — everything from securing the OS through verifying the running instance.
+
+**Out of scope:**
+- VPS creation (done via OVHcloud console/API — no programmatic provisioning yet)
+- DNS record creation (varies by registrar — must be done manually before running the script)
+- SSH key setup on the operator's local machine (one-time per operator)
+- Email relay configuration (requires third-party account setup)
+- UptimeRobot monitoring (web UI)
+
+---
+
+## Approach
+
+A single Bash script (`scripts/deploy-konote-vps.sh`) that:
+
+1. Accepts configuration via command-line flags (VPS IP, domain, org name, etc.)
+2. Generates all credentials locally (never transmitted unencrypted)
+3. SSHes into the target VPS using ControlMaster for connection reuse
+4. Executes setup steps in order, with error handling at each step
+5. Prints a final summary with the URL and credentials
+
+This follows the same pattern as `deploy-fullhost.ps1` (Jelastic automation) but targets OVHcloud VPS via SSH instead of a PaaS API.
+
+---
+
+## Step Mapping
+
+The table below maps each step in `deploy-ovhcloud.md` to its automation status.
+
+| # | Manual Step | Automated? | Script Action |
+|---|-------------|------------|---------------|
+| 1 | Connect via SSH / set up SSH key | **No** — prerequisite | Operator must have SSH access before running the script |
+| 2 | Secure the VPS (ufw, unattended-upgrades) | **Yes** | `apt update && upgrade`, configure `ufw` (SSH + 80 + 443), install `unattended-upgrades` |
+| 3 | Install Docker | **Yes** | Run official Docker convenience script (`get.docker.com`), skip if Docker is already installed |
+| 4 | Clone KoNote | **Yes** | `git clone` to `/opt/konote`, skip if directory already contains a git repo |
+| 5 | Generate credentials | **Yes** | Generate locally using Python `secrets` + `cryptography.fernet` |
+| 6 | Create .env file | **Yes** | Write `.env` via SSH heredoc with generated credentials and user-provided domain/org values |
+| 7 | Point domain to VPS (DNS) | **No** — varies by registrar | Pre-check: script verifies DNS resolves to VPS IP before proceeding to deploy |
+| 8 | Deploy (docker compose up) | **Yes** | `docker compose up -d --build` |
+| 9 | Verify deployment | **Yes** | Wait for health check, curl HTTPS endpoint |
+| 10 | Create admin user | **Yes** | `docker compose exec web python manage.py createsuperuser --noinput` |
+| 11 | Set up backups (cron) | **Yes** | `chmod +x` backup/disk scripts, `mkdir backups`, install crontab entries |
+| 12 | Set up monitoring (UptimeRobot) | **No** — web UI | Printed as a post-deploy reminder |
+| 13 | Set up email relay | **No** — third-party account | Printed as a post-deploy reminder |
+| 14 | Run a second instance | **No** — optional/advanced | Out of scope for v1 |
+| 15 | Update process | **Yes** (partial) | Script includes `--update` flag documentation in help text; initial deploy sets up the git remote |
+
+**Summary:** 9 of 15 steps automated. The 6 manual steps are either one-time setup, third-party web UIs, or optional.
+
+---
+
+## Inputs
+
+| Flag | Required | Default | Description |
+|------|----------|---------|-------------|
+| `--host` | Yes | — | VPS IP address or hostname |
+| `--domain` | Yes | — | Domain name (e.g., `konote.agency.ca`) |
+| `--admin-email` | Yes | — | Email address for the admin user |
+| `--org-name` | Yes | — | Organization name (displayed in KoNote UI) |
+| `--admin-user` | No | `admin` | Username for the first admin account |
+| `--client-term` | No | `client` | What participants are called (terminology setting) |
+| `--ssh-key` | No | SSH agent default | Path to SSH private key |
+| `--ssh-user` | No | `ubuntu` | SSH username on the VPS |
+| `--branch` | No | `main` | Git branch to deploy |
+| `--dry-run` | No | off | Print commands without executing them |
+
+---
+
+## Outputs
+
+After a successful run, the operator receives:
+
+1. **Running instance** at `https://<domain>` with valid HTTPS (Let's Encrypt via Caddy)
+2. **Admin credentials** printed to terminal (username + generated password)
+3. **Encryption key** printed to terminal with a prominent warning to back it up
+4. **Automated backups** running via cron (nightly database dumps at 2 AM, hourly disk checks)
+5. **Post-deploy checklist** printed to terminal (DNS verification, UptimeRobot, email relay)
+
+---
+
+## Security Considerations
+
+| Concern | Mitigation |
+|---------|------------|
+| Credential transmission | All secrets (Django secret key, encryption key, DB passwords) are generated on the **local machine** using Python's `secrets` module and `cryptography.fernet`. They are transmitted to the VPS only via the SSH channel (encrypted in transit). |
+| Credential storage | The script does **not** store credentials in any file on the local machine. They exist only in memory during execution and are printed once at the end. Operator must save them to a password manager. |
+| .env file permissions | Set to `600` (owner read/write only) immediately after creation on the VPS. |
+| Encryption key loss | The final summary includes a `WARNING` block emphasising that loss of `FIELD_ENCRYPTION_KEY` means permanent loss of all encrypted participant data. |
+| SSH security | Uses `StrictHostKeyChecking=accept-new` (accepts the host key on first connection, rejects changes on subsequent connections — safer than `StrictHostKeyChecking=no`). |
+| Idempotency | Safe to re-run: checks for existing Docker installation, existing repo clone, existing `.env` file. Will not overwrite an existing `.env` (operator must pass `--force-env` to regenerate). |
+| Admin password | Generated using `secrets.token_urlsafe(16)` — 128 bits of entropy. Never echoed during intermediate steps, only in the final summary. |
+
+---
+
+## Decisions
+
+### 1. Generate credentials locally vs. on the VPS
+
+**Chosen:** Generate locally, send via SSH.
+
+**Alternatives considered:**
+- Generate on VPS: Requires Python + cryptography to be pre-installed on the VPS. Adds a dependency and a chicken-and-egg problem (we install Python packages in step 2, but need credentials in step 6).
+- Generate locally: The operator's machine already has Python (required to run the script's credential generation). Credentials travel over SSH (encrypted). Simpler and fewer moving parts.
+
+**Trade-off:** Credentials briefly exist in local process memory. Acceptable because the operator's machine is trusted (they have SSH access to the VPS anyway).
+
+### 2. SSH ControlMaster vs. individual connections
+
+**Chosen:** SSH ControlMaster (single TCP connection reused across all SSH commands).
+
+**Rationale:** The script makes 10+ SSH calls. Without ControlMaster, each call requires a new TCP handshake + key exchange (~1-2 seconds each). ControlMaster creates one persistent connection and multiplexes subsequent calls over it, saving 15-20 seconds total and reducing authentication noise in server logs.
+
+### 3. Docker install method
+
+**Chosen:** Official Docker convenience script (`https://get.docker.com`).
+
+**Alternatives considered:**
+- Manual apt repository setup: More steps, more things to break, same end result.
+- Snap: Docker snap has known issues with volume mounts and AppArmor on Ubuntu.
+
+**Trade-off:** The convenience script is maintained by Docker Inc. and handles Ubuntu version detection automatically. It's what the manual guide already recommends.
+
+### 4. Admin user creation
+
+**Chosen:** `createsuperuser --noinput` with environment variables (`DJANGO_SUPERUSER_USERNAME`, `DJANGO_SUPERUSER_PASSWORD`).
+
+**Rationale:** Django's built-in `--noinput` mode reads credentials from environment variables, avoiding interactive prompts over SSH. The password is generated locally and passed as an environment variable for the single command execution, then discarded.
+
+### 5. No Ansible / no Terraform (yet)
+
+**Chosen:** Plain Bash script.
+
+**Rationale:** The target audience is nonprofit consultants, not DevOps engineers. A single Bash script with clear output is easier to understand, debug, and modify than an Ansible playbook or Terraform configuration. The script is a stepping stone — if multi-tenant provisioning becomes common, wrapping it in Ansible or Terraform is a natural evolution (see Future Enhancements).
+
+### 6. Health check strategy
+
+**Chosen:** Poll `https://<domain>/auth/login/` every 10 seconds for up to 5 minutes after `docker compose up`.
+
+**Rationale:** The web container's health check in `docker-compose.yml` hits `http://localhost:8000/auth/login/` internally. Our external check via HTTPS validates the full stack: Caddy → web → database. The 5-minute timeout accounts for first-time Docker image builds (2-5 minutes) + migrations + Let's Encrypt certificate issuance.
+
+---
+
+## Error Handling
+
+The script uses `set -euo pipefail` and wraps each major step in a function with descriptive error messages:
+
+```
+Step 3/9: Installing Docker...
+  ✓ Docker 27.5.1 installed
+
+Step 4/9: Cloning KoNote...
+  ✗ FAILED: git clone failed (exit code 128)
+    Possible cause: repository is private and no GitHub token was provided
+    To retry: re-run the script (it will skip completed steps)
+```
+
+If a step fails, the script:
+1. Prints which step failed and the exit code
+2. Suggests a possible cause
+3. Exits with a non-zero status
+4. Does **not** attempt to roll back completed steps (they are idempotent)
+
+---
+
+## Future Enhancements
+
+| Enhancement | Description | Trigger |
+|-------------|-------------|---------|
+| OVHcloud API integration | Automate VPS creation via OVHcloud API, eliminating the manual console step | When provisioning volume exceeds 2-3 agencies per month |
+| Terraform wrapper | Wrap VPS creation + DNS + script execution in a Terraform module | When infrastructure-as-code is a requirement (e.g., for audits) |
+| Multi-tenant support | Deploy multiple agencies on a single VPS (separate Docker Compose stacks sharing Caddy) | After multi-tenancy DRR is resolved |
+| Backup verification | Add a post-backup restore test to a throwaway database | After first production backup incident |
+| Update command | `--update` flag to pull latest code and redeploy with zero-downtime | After initial deployments stabilise |
+| Monitoring integration | Auto-configure UptimeRobot via their API | When UptimeRobot API key management is sorted |
+
+---
+
+## File Location
+
+```
+scripts/deploy-konote-vps.sh    # The script itself
+docs/plans/2026-02-20-deploy-script-design.md   # This document
+```
+
+---
+
+## References
+
+- [docs/deploy-ovhcloud.md](../deploy-ovhcloud.md) — Manual deployment guide (the source of truth for what the script automates)
+- [deploy-fullhost.ps1](../../deploy-fullhost.ps1) — Jelastic automation script (analogous approach for a different platform)
+- [docker-compose.yml](../../docker-compose.yml) — Container orchestration (web, db, audit_db, caddy, autoheal)
+- [entrypoint.sh](../../entrypoint.sh) — Container startup (migrations, seeding, security checks, gunicorn)
+- [Caddyfile](../../Caddyfile) — HTTPS reverse proxy configuration
+- [scripts/backup-vps.sh](../../scripts/backup-vps.sh) — Nightly database backup script
+- [tasks/design-rationale/ovhcloud-deployment.md](../../tasks/design-rationale/ovhcloud-deployment.md) — OVHcloud deployment architecture DRR

--- a/docs/update-and-rollback.md
+++ b/docs/update-and-rollback.md
@@ -1,0 +1,247 @@
+# Updating and Rolling Back KoNote
+
+This guide covers how to safely update your KoNote instance to a new version, verify the update worked, and roll back if something goes wrong.
+
+**Applies to:** OVHcloud VPS (Docker Compose), any self-hosted Docker deployment
+
+For Railway or Azure, see the platform-specific sections in [Deploying KoNote](deploying-konote.md).
+
+---
+
+## Before You Update
+
+Every update should follow three steps: **back up → update → verify**. Don't skip the backup — it's your safety net.
+
+### 1. Back Up Both Databases
+
+```bash
+# Run the backup script (creates timestamped compressed dumps)
+sudo /opt/konote/scripts/backup-vps.sh
+
+# Verify the backups were created
+ls -lh /opt/konote/backups/
+```
+
+You should see two new `.sql.gz` files (one for the main database, one for the audit database).
+
+### 2. Record the Current Version
+
+```bash
+cd /opt/konote
+sudo git log --oneline -1
+```
+
+Write down or copy the commit hash (the short code at the start of the line, e.g., `a1b2c3d`). You'll need this if you have to roll back.
+
+### 3. Check Container Health
+
+```bash
+sudo docker compose ps
+```
+
+All containers should show "healthy" or "running" before you proceed. If something is already broken, fix it before updating.
+
+---
+
+## Applying the Update
+
+### Standard Update (Under 2 Minutes Downtime)
+
+```bash
+cd /opt/konote
+
+# Pull the latest code
+sudo git pull origin main
+
+# Rebuild containers and restart
+sudo docker compose up -d --build
+```
+
+The entrypoint script runs database migrations automatically during startup. Typical downtime is 1–2 minutes while the new container builds and starts.
+
+### What Happens During the Update
+
+1. `git pull` downloads new code (files change, but the running app is unaffected)
+2. `docker compose up -d --build` rebuilds the Docker image and replaces the running container
+3. The new container starts and runs `entrypoint.sh`, which:
+   - Applies any pending database migrations
+   - Runs seed data updates (new metrics, templates, etc.)
+   - Runs startup security checks
+   - Starts the web server
+
+### When to Update
+
+| Situation | Recommendation |
+|-----------|---------------|
+| **During business hours** | OK for minor updates (no database migrations). Check the release notes first. |
+| **After hours** | Recommended for updates with database migrations. Staff won't notice 2 minutes of downtime. |
+| **Emergency fix** | Update immediately regardless of time — security patches shouldn't wait. |
+
+---
+
+## Verifying the Update
+
+After `docker compose up -d --build` completes:
+
+### 1. Check Container Health
+
+```bash
+sudo docker compose ps
+```
+
+All containers should show "healthy" within 60 seconds. If the web container keeps restarting, check the logs.
+
+### 2. Check the Logs
+
+```bash
+sudo docker compose logs --tail 30 web
+```
+
+Look for:
+- `Starting gunicorn on port 8000` — app started successfully
+- `Applied X migration(s)` — database changes were applied
+- No `ERROR` or `CRITICAL` messages
+
+### 3. Test the Application
+
+1. Visit your KoNote URL — the login page should load
+2. Log in with your admin account
+3. Check a few pages: dashboard, a client profile, a report
+4. If you have a dev/demo instance, update that too and test there first
+
+### 4. Confirm the Version
+
+```bash
+cd /opt/konote
+sudo git log --oneline -1
+```
+
+The commit hash should match the latest release.
+
+---
+
+## Rolling Back
+
+If the update breaks your instance, you have two options depending on the severity.
+
+### Option A: Code-Only Rollback (No Database Changes)
+
+Use this when the update didn't include database migrations, or the migrations haven't run yet (container failed to start).
+
+```bash
+cd /opt/konote
+
+# Revert to the previous commit
+sudo git checkout <OLD_COMMIT_HASH> -- .
+# Replace <OLD_COMMIT_HASH> with the hash you recorded before updating
+
+# Rebuild with the old code
+sudo docker compose up -d --build
+```
+
+### Option B: Full Rollback (Code + Database)
+
+Use this when the update ran database migrations and those migrations caused problems (missing data, broken queries, etc.).
+
+```bash
+cd /opt/konote
+
+# Step 1: Stop the web container (keep databases running)
+sudo docker compose stop web
+
+# Step 2: Restore the main database from backup
+gunzip -c /opt/konote/backups/main_YYYY-MM-DD_0200.sql.gz | \
+  sudo docker compose exec -T db psql -U konote konote
+# Replace the filename with your actual backup file
+
+# Step 3: Restore the audit database from backup
+gunzip -c /opt/konote/backups/audit_YYYY-MM-DD_0200.sql.gz | \
+  sudo docker compose exec -T audit_db psql -U audit_writer konote_audit
+
+# Step 4: Revert the code
+sudo git checkout <OLD_COMMIT_HASH> -- .
+
+# Step 5: Rebuild and restart
+sudo docker compose up -d --build
+```
+
+> **Warning:** A full rollback restores the database to the point of the backup. Any data entered between the backup and the rollback will be lost. This is why we recommend updating after hours — less data at risk.
+
+### After Rolling Back
+
+1. Verify the app is working (follow the verification steps above)
+2. Report the issue — note what went wrong, which version caused it, and any error messages from `docker compose logs web`
+3. Wait for a fix before trying the update again
+
+---
+
+## Updating the Dev Instance
+
+If you're running a dev/demo instance alongside production (see [deploy-ovhcloud.md Section 14](deploy-ovhcloud.md#14-run-a-second-instance-devdemo)):
+
+**Update dev first, test, then update production:**
+
+```bash
+# Update dev
+cd /opt/konote-dev
+sudo git pull origin main
+sudo docker compose up -d --build
+
+# Test dev instance thoroughly
+# If everything looks good, update production:
+cd /opt/konote
+sudo git pull origin main
+sudo docker compose up -d --build
+```
+
+This gives you a safe testing environment before touching production data.
+
+---
+
+## Railway Updates
+
+Railway auto-deploys from GitHub when you merge to `main`. To roll back:
+
+1. Go to your Railway project → **Deployments**
+2. Find the last working deployment
+3. Click the three dots (⋯) → **Rollback**
+4. Railway redeploys the previous image
+
+If the failed deployment ran database migrations, you may need to restore from a backup. Use the Railway CLI:
+
+```bash
+# Download the backup from Railway
+railway run pg_dump $DATABASE_URL > rollback_main.sql
+
+# Contact Railway support for point-in-time recovery (Pro plan)
+```
+
+## Azure Updates
+
+Azure Container Apps auto-deploys when the CI/CD pipeline pushes a new image. To roll back:
+
+```bash
+# Redeploy the previous image (using a specific git commit SHA)
+az containerapp update \
+  --name konote-web \
+  --resource-group KoNote-prod \
+  --image konoteregistry.azurecr.io/konote:<previous-git-sha>
+```
+
+The CI/CD pipeline tags each image with its git commit SHA, so you can always point back to a known-good version.
+
+For database restore, use Azure Portal → PostgreSQL server → **Point-in-time restore** (available within your retention window).
+
+---
+
+## Quick Reference
+
+| Task | Command |
+|------|---------|
+| Back up before update | `sudo /opt/konote/scripts/backup-vps.sh` |
+| Record current version | `cd /opt/konote && sudo git log --oneline -1` |
+| Apply update | `cd /opt/konote && sudo git pull origin main && sudo docker compose up -d --build` |
+| Check container health | `sudo docker compose ps` |
+| Check logs | `sudo docker compose logs --tail 30 web` |
+| Roll back code only | `sudo git checkout <hash> -- . && sudo docker compose up -d --build` |
+| Roll back code + database | Stop web → restore backups → checkout old code → rebuild |

--- a/konote/settings/production.py
+++ b/konote/settings/production.py
@@ -4,6 +4,7 @@ Production settings — secure defaults for all deployment platforms.
 Supported platforms (auto-detected):
 - Railway: Sets RAILWAY_ENVIRONMENT, provides PORT
 - Azure App Service: Sets WEBSITE_SITE_NAME, provides PORT
+- Azure Container Apps: Sets CONTAINER_APP_NAME
 - Elestio: Sets ELESTIO_VM_NAME
 - Docker/self-hosted: Set DATABASE_URL and other required vars
 
@@ -105,6 +106,10 @@ if os.environ.get("WEBSITE_SITE_NAME"):
         ".azurewebsites.net",
     ])
 
+# Azure Container Apps
+if os.environ.get("CONTAINER_APP_NAME"):
+    ALLOWED_HOSTS.append(".azurecontainerapps.io")
+
 # Elestio
 if os.environ.get("ELESTIO_VM_NAME"):
     # Elestio provides CNAME or custom domain via env vars
@@ -151,6 +156,9 @@ if os.environ.get("RAILWAY_ENVIRONMENT"):
 if os.environ.get("WEBSITE_SITE_NAME"):
     site_name = os.environ.get("WEBSITE_SITE_NAME")
     _trusted_origins.append(f"https://{site_name}.azurewebsites.net")
+
+if os.environ.get("CONTAINER_APP_NAME"):
+    _trusted_origins.append("https://*.azurecontainerapps.io")
 
 if os.environ.get("ELESTIO_VM_NAME"):
     elestio_domain = os.environ.get("ELESTIO_DOMAIN", "")

--- a/scripts/deploy-konote-vps.sh
+++ b/scripts/deploy-konote-vps.sh
@@ -1,0 +1,567 @@
+#!/bin/bash
+# ==============================================================================
+# deploy-konote-vps.sh — Automated KoNote Agency Provisioning
+# ==============================================================================
+#
+# Deploys a new KoNote instance on an OVHcloud VPS (Ubuntu 24.04+).
+# Automates the manual steps from docs/deploy-ovhcloud.md.
+#
+# Usage:
+#   ./scripts/deploy-konote-vps.sh \
+#     --host 141.227.151.7 \
+#     --domain konote.agency.ca \
+#     --admin-email admin@agency.ca \
+#     --org-name "My Nonprofit"
+#
+# Prerequisites:
+#   - SSH access to the target VPS (key-based recommended)
+#   - Domain DNS A record pointing to the VPS IP
+#   - Python 3 with cryptography package (locally, for key generation)
+#
+# Design doc: docs/plans/2026-02-20-deploy-script-design.md
+# ==============================================================================
+
+set -euo pipefail
+
+# ==============================================================================
+# Colour output
+# ==============================================================================
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+NC='\033[0m' # No colour
+
+step_msg()  { echo -e "${YELLOW}▸ $1${NC}"; }
+ok_msg()    { echo -e "  ${GREEN}✓ $1${NC}"; }
+err_msg()   { echo -e "  ${RED}✗ $1${NC}"; }
+info_msg()  { echo -e "  ${CYAN}ℹ $1${NC}"; }
+warn_msg()  { echo -e "  ${YELLOW}⚠ $1${NC}"; }
+
+# ==============================================================================
+# Defaults
+# ==============================================================================
+HOST=""
+DOMAIN=""
+ADMIN_EMAIL=""
+ORG_NAME=""
+ADMIN_USER="admin"
+CLIENT_TERM="client"
+SSH_KEY=""
+SSH_USER="ubuntu"
+BRANCH="main"
+DRY_RUN=false
+FORCE_ENV=false
+DEPLOY_DIR="/opt/konote"
+REPO_URL="https://github.com/LogicalOutcomes/konote.git"
+
+# ==============================================================================
+# Usage
+# ==============================================================================
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") [OPTIONS]
+
+Deploy a new KoNote instance on an OVHcloud VPS.
+
+Required:
+  --host HOST             VPS IP address or hostname
+  --domain DOMAIN         Domain name (e.g., konote.agency.ca)
+  --admin-email EMAIL     Email for the admin user
+  --org-name NAME         Organization name
+
+Optional:
+  --admin-user USER       Admin username (default: admin)
+  --client-term TERM      What participants are called (default: client)
+  --ssh-key PATH          Path to SSH private key
+  --ssh-user USER         SSH username (default: ubuntu)
+  --branch BRANCH         Git branch to deploy (default: main)
+  --force-env             Overwrite existing .env file on VPS
+  --dry-run               Print commands without executing
+  --help                  Show this help message
+
+Examples:
+  # Basic deployment
+  $(basename "$0") --host 141.227.151.7 --domain konote.example.ca \\
+    --admin-email admin@example.ca --org-name "Example Nonprofit"
+
+  # With SSH key and custom branch
+  $(basename "$0") --host 141.227.151.7 --domain konote.example.ca \\
+    --admin-email admin@example.ca --org-name "Example Nonprofit" \\
+    --ssh-key ~/.ssh/ovh_konote --branch develop
+
+  # Dry run (preview commands)
+  $(basename "$0") --host 141.227.151.7 --domain konote.example.ca \\
+    --admin-email admin@example.ca --org-name "Example Nonprofit" --dry-run
+EOF
+    exit 0
+}
+
+# ==============================================================================
+# Parse arguments
+# ==============================================================================
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --host)        HOST="$2"; shift 2 ;;
+        --domain)      DOMAIN="$2"; shift 2 ;;
+        --admin-email) ADMIN_EMAIL="$2"; shift 2 ;;
+        --org-name)    ORG_NAME="$2"; shift 2 ;;
+        --admin-user)  ADMIN_USER="$2"; shift 2 ;;
+        --client-term) CLIENT_TERM="$2"; shift 2 ;;
+        --ssh-key)     SSH_KEY="$2"; shift 2 ;;
+        --ssh-user)    SSH_USER="$2"; shift 2 ;;
+        --branch)      BRANCH="$2"; shift 2 ;;
+        --force-env)   FORCE_ENV=true; shift ;;
+        --dry-run)     DRY_RUN=true; shift ;;
+        --help)        usage ;;
+        *)
+            err_msg "Unknown option: $1"
+            echo "Run '$(basename "$0") --help' for usage."
+            exit 1
+            ;;
+    esac
+done
+
+# ==============================================================================
+# Validate required arguments
+# ==============================================================================
+MISSING=()
+[[ -z "$HOST" ]]        && MISSING+=("--host")
+[[ -z "$DOMAIN" ]]      && MISSING+=("--domain")
+[[ -z "$ADMIN_EMAIL" ]] && MISSING+=("--admin-email")
+[[ -z "$ORG_NAME" ]]    && MISSING+=("--org-name")
+
+if [[ ${#MISSING[@]} -gt 0 ]]; then
+    err_msg "Missing required arguments: ${MISSING[*]}"
+    echo "Run '$(basename "$0") --help' for usage."
+    exit 1
+fi
+
+# ==============================================================================
+# SSH setup (ControlMaster for connection reuse)
+# ==============================================================================
+SSH_CONTROL_DIR=$(mktemp -d)
+SSH_CONTROL_PATH="${SSH_CONTROL_DIR}/konote-%r@%h:%p"
+
+SSH_OPTS=(
+    -o "StrictHostKeyChecking=accept-new"
+    -o "ControlMaster=auto"
+    -o "ControlPath=${SSH_CONTROL_PATH}"
+    -o "ControlPersist=300"
+    -o "ConnectTimeout=15"
+)
+
+if [[ -n "$SSH_KEY" ]]; then
+    SSH_OPTS+=(-i "$SSH_KEY")
+fi
+
+SSH_TARGET="${SSH_USER}@${HOST}"
+
+# Helper: run a command on the VPS via SSH
+run_remote() {
+    if [[ "$DRY_RUN" == true ]]; then
+        echo "  [DRY RUN] ssh ${SSH_TARGET}: $*"
+        return 0
+    fi
+    ssh "${SSH_OPTS[@]}" "${SSH_TARGET}" "$@"
+}
+
+# Helper: run a command on the VPS with sudo
+run_remote_sudo() {
+    run_remote "sudo bash -c '$*'"
+}
+
+# Cleanup: close SSH ControlMaster on exit
+cleanup() {
+    ssh "${SSH_OPTS[@]}" -O exit "${SSH_TARGET}" 2>/dev/null || true
+    rm -rf "${SSH_CONTROL_DIR}" 2>/dev/null || true
+}
+trap cleanup EXIT
+
+# ==============================================================================
+# Pre-flight checks
+# ==============================================================================
+echo ""
+echo -e "${BOLD}╔══════════════════════════════════════════════════╗${NC}"
+echo -e "${BOLD}║        KoNote VPS Deployment Script              ║${NC}"
+echo -e "${BOLD}╚══════════════════════════════════════════════════╝${NC}"
+echo ""
+echo -e "  Host:        ${CYAN}${HOST}${NC}"
+echo -e "  Domain:      ${CYAN}${DOMAIN}${NC}"
+echo -e "  Org:         ${CYAN}${ORG_NAME}${NC}"
+echo -e "  Admin:       ${CYAN}${ADMIN_USER} <${ADMIN_EMAIL}>${NC}"
+echo -e "  Branch:      ${CYAN}${BRANCH}${NC}"
+echo -e "  Client term: ${CYAN}${CLIENT_TERM}${NC}"
+if [[ "$DRY_RUN" == true ]]; then
+    echo -e "  Mode:        ${YELLOW}DRY RUN (no changes will be made)${NC}"
+fi
+echo ""
+
+# --- Check local Python + cryptography ---
+step_msg "Pre-flight: Checking local Python..."
+if ! command -v python3 &>/dev/null; then
+    err_msg "Python 3 is required locally for credential generation."
+    err_msg "Install Python 3 and the 'cryptography' package, then retry."
+    exit 1
+fi
+
+if ! python3 -c "from cryptography.fernet import Fernet" 2>/dev/null; then
+    err_msg "Python 'cryptography' package is required locally."
+    err_msg "Install it: pip install cryptography"
+    exit 1
+fi
+ok_msg "Python 3 + cryptography available"
+
+# --- Check SSH connectivity ---
+step_msg "Pre-flight: Testing SSH connection to ${HOST}..."
+if [[ "$DRY_RUN" == false ]]; then
+    if ! ssh "${SSH_OPTS[@]}" "${SSH_TARGET}" "echo ok" &>/dev/null; then
+        err_msg "Cannot connect to ${SSH_TARGET}"
+        err_msg "Check that:"
+        err_msg "  - The VPS IP is correct"
+        err_msg "  - Your SSH key is set up (see deploy-ovhcloud.md Step 1)"
+        err_msg "  - The VPS is running and accepting connections"
+        exit 1
+    fi
+    ok_msg "SSH connection successful"
+else
+    info_msg "[DRY RUN] Skipping SSH connection test"
+fi
+
+# ==============================================================================
+# Generate credentials (locally)
+# ==============================================================================
+step_msg "Generating credentials locally..."
+
+SECRET_KEY=$(python3 -c "import secrets; print(secrets.token_urlsafe(50))")
+FIELD_ENCRYPTION_KEY=$(python3 -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())")
+POSTGRES_PASSWORD=$(python3 -c "import secrets; print(secrets.token_urlsafe(32))")
+AUDIT_POSTGRES_PASSWORD=$(python3 -c "import secrets; print(secrets.token_urlsafe(32))")
+ADMIN_PASSWORD=$(python3 -c "import secrets; print(secrets.token_urlsafe(16))")
+
+ok_msg "All credentials generated (Django secret, encryption key, 2 DB passwords, admin password)"
+
+# ==============================================================================
+# Step 1/9: Secure the VPS
+# ==============================================================================
+STEP=1
+TOTAL=9
+step_msg "Step ${STEP}/${TOTAL}: Securing the VPS (updates, firewall, auto-updates)..."
+
+run_remote "sudo apt-get update -qq && sudo DEBIAN_FRONTEND=noninteractive apt-get upgrade -y -qq"
+ok_msg "System packages updated"
+
+# Configure firewall
+run_remote "sudo ufw allow OpenSSH && sudo ufw allow 80/tcp && sudo ufw allow 443/tcp && sudo ufw --force enable" 2>/dev/null
+ok_msg "Firewall configured (SSH + HTTP + HTTPS)"
+
+# Enable unattended security upgrades
+run_remote "sudo DEBIAN_FRONTEND=noninteractive apt-get install -y -qq unattended-upgrades"
+run_remote "echo 'Unattended-Upgrade::Automatic-Reboot \"false\";' | sudo tee /etc/apt/apt.conf.d/51konote-no-reboot >/dev/null"
+ok_msg "Unattended security upgrades enabled (auto-reboot disabled)"
+
+# ==============================================================================
+# Step 2/9: Install Docker
+# ==============================================================================
+STEP=2
+step_msg "Step ${STEP}/${TOTAL}: Installing Docker..."
+
+DOCKER_INSTALLED=$(run_remote "command -v docker >/dev/null 2>&1 && echo yes || echo no")
+
+if [[ "$DOCKER_INSTALLED" == "yes" ]]; then
+    DOCKER_VERSION=$(run_remote "docker --version 2>/dev/null | head -1")
+    ok_msg "Docker already installed: ${DOCKER_VERSION}"
+else
+    run_remote "curl -fsSL https://get.docker.com | sudo sh"
+    DOCKER_VERSION=$(run_remote "docker --version 2>/dev/null | head -1")
+    ok_msg "Docker installed: ${DOCKER_VERSION}"
+fi
+
+# Verify docker compose is available
+COMPOSE_VERSION=$(run_remote "sudo docker compose version 2>/dev/null | head -1" || true)
+if [[ -z "$COMPOSE_VERSION" ]]; then
+    err_msg "Docker Compose not found. Docker installation may be incomplete."
+    exit 1
+fi
+ok_msg "Docker Compose available: ${COMPOSE_VERSION}"
+
+# ==============================================================================
+# Step 3/9: Clone KoNote
+# ==============================================================================
+STEP=3
+step_msg "Step ${STEP}/${TOTAL}: Cloning KoNote to ${DEPLOY_DIR}..."
+
+REPO_EXISTS=$(run_remote "test -d ${DEPLOY_DIR}/.git && echo yes || echo no")
+
+if [[ "$REPO_EXISTS" == "yes" ]]; then
+    info_msg "Repository already exists at ${DEPLOY_DIR}"
+    run_remote "cd ${DEPLOY_DIR} && sudo git fetch origin && sudo git checkout ${BRANCH} && sudo git pull origin ${BRANCH}"
+    ok_msg "Updated to latest ${BRANCH}"
+else
+    run_remote "sudo mkdir -p ${DEPLOY_DIR}"
+    run_remote "sudo git clone --branch ${BRANCH} ${REPO_URL} ${DEPLOY_DIR}"
+    ok_msg "Cloned ${BRANCH} branch to ${DEPLOY_DIR}"
+fi
+
+# ==============================================================================
+# Step 4/9: Create .env file
+# ==============================================================================
+STEP=4
+step_msg "Step ${STEP}/${TOTAL}: Creating .env configuration file..."
+
+ENV_EXISTS=$(run_remote "test -f ${DEPLOY_DIR}/.env && echo yes || echo no")
+
+if [[ "$ENV_EXISTS" == "yes" && "$FORCE_ENV" == false ]]; then
+    warn_msg ".env file already exists at ${DEPLOY_DIR}/.env"
+    warn_msg "Use --force-env to overwrite (this will regenerate ALL credentials)"
+    info_msg "Skipping .env creation — using existing file"
+else
+    if [[ "$ENV_EXISTS" == "yes" ]]; then
+        # Back up existing .env before overwriting
+        run_remote "sudo cp ${DEPLOY_DIR}/.env ${DEPLOY_DIR}/.env.backup.\$(date +%Y%m%d_%H%M%S)"
+        info_msg "Backed up existing .env"
+    fi
+
+    # Write .env via heredoc over SSH (credentials travel through the SSH tunnel)
+    if [[ "$DRY_RUN" == true ]]; then
+        info_msg "[DRY RUN] Would write .env to ${DEPLOY_DIR}/.env"
+    else
+        ssh "${SSH_OPTS[@]}" "${SSH_TARGET}" "sudo tee ${DEPLOY_DIR}/.env > /dev/null" <<ENVFILE
+# ==============================================================================
+# KoNote Production Configuration
+# Generated by deploy-konote-vps.sh on $(date -u +"%Y-%m-%d %H:%M:%S UTC")
+# ==============================================================================
+
+# --- Security Keys ---
+SECRET_KEY=${SECRET_KEY}
+FIELD_ENCRYPTION_KEY=${FIELD_ENCRYPTION_KEY}
+
+# --- Main Database ---
+POSTGRES_USER=konote
+POSTGRES_PASSWORD=${POSTGRES_PASSWORD}
+POSTGRES_DB=konote
+
+# --- Audit Database ---
+AUDIT_POSTGRES_USER=audit_writer
+AUDIT_POSTGRES_PASSWORD=${AUDIT_POSTGRES_PASSWORD}
+AUDIT_POSTGRES_DB=konote_audit
+
+# --- Domain & Security ---
+DOMAIN=${DOMAIN}
+ALLOWED_HOSTS=${DOMAIN},localhost
+CSRF_TRUSTED_ORIGINS=https://${DOMAIN}
+AUTH_MODE=local
+KONOTE_MODE=production
+
+# --- Demo Mode ---
+# Creates demo users with quick-login buttons for staff training.
+# Demo users are separate from real participants (is_demo=True).
+DEMO_MODE=true
+
+# --- Email (configure manually later — see deploy-ovhcloud.md Step 13) ---
+# EMAIL_BACKEND=django.core.mail.backends.smtp.EmailBackend
+# EMAIL_HOST=smtp.resend.com
+# EMAIL_PORT=587
+# EMAIL_USE_TLS=True
+# EMAIL_HOST_USER=resend
+# EMAIL_HOST_PASSWORD=re_your_resend_api_key
+# DEFAULT_FROM_EMAIL=KoNote <noreply@${DOMAIN}>
+
+# --- AI Features (optional) ---
+# OPENROUTER_API_KEY=sk-or-...
+ENVFILE
+    fi
+
+    # Lock down .env permissions
+    run_remote "sudo chmod 600 ${DEPLOY_DIR}/.env"
+    run_remote "sudo chown root:root ${DEPLOY_DIR}/.env"
+    ok_msg ".env written and locked down (chmod 600, owned by root)"
+fi
+
+# ==============================================================================
+# Step 5/9: Deploy (docker compose up)
+# ==============================================================================
+STEP=5
+step_msg "Step ${STEP}/${TOTAL}: Building and starting containers..."
+
+run_remote "cd ${DEPLOY_DIR} && sudo docker compose up -d --build"
+ok_msg "Docker Compose started"
+
+# ==============================================================================
+# Step 6/9: Wait for health check
+# ==============================================================================
+STEP=6
+step_msg "Step ${STEP}/${TOTAL}: Waiting for KoNote to become healthy..."
+
+if [[ "$DRY_RUN" == true ]]; then
+    info_msg "[DRY RUN] Would wait for health check"
+else
+    MAX_WAIT=300  # 5 minutes
+    INTERVAL=10
+    ELAPSED=0
+
+    while [[ $ELAPSED -lt $MAX_WAIT ]]; do
+        HEALTH=$(run_remote "sudo docker compose -f ${DEPLOY_DIR}/docker-compose.yml ps --format json 2>/dev/null | grep -o '\"Health\":\"[^\"]*\"' | head -1" || true)
+
+        if echo "$HEALTH" | grep -q "healthy"; then
+            ok_msg "Web container is healthy (${ELAPSED}s)"
+            break
+        fi
+
+        if [[ $ELAPSED -gt 0 && $((ELAPSED % 30)) -eq 0 ]]; then
+            info_msg "Still waiting... (${ELAPSED}s / ${MAX_WAIT}s)"
+        fi
+
+        sleep "$INTERVAL"
+        ELAPSED=$((ELAPSED + INTERVAL))
+    done
+
+    if [[ $ELAPSED -ge $MAX_WAIT ]]; then
+        warn_msg "Health check timed out after ${MAX_WAIT}s"
+        warn_msg "The container may still be starting (first build can take 5+ minutes)"
+        info_msg "Check logs: ssh ${SSH_TARGET} 'cd ${DEPLOY_DIR} && sudo docker compose logs -f web'"
+        info_msg "Continuing with remaining steps..."
+    fi
+fi
+
+# ==============================================================================
+# Step 7/9: Create admin user
+# ==============================================================================
+STEP=7
+step_msg "Step ${STEP}/${TOTAL}: Creating admin user '${ADMIN_USER}'..."
+
+if [[ "$DRY_RUN" == true ]]; then
+    info_msg "[DRY RUN] Would create admin user"
+else
+    # Use Django's createsuperuser --noinput with env vars
+    # The password and username are passed as environment variables for this
+    # single command execution, not stored anywhere on the VPS.
+    ADMIN_CREATE_RESULT=$(run_remote "cd ${DEPLOY_DIR} && sudo docker compose exec -T \
+        -e DJANGO_SUPERUSER_USERNAME='${ADMIN_USER}' \
+        -e DJANGO_SUPERUSER_PASSWORD='${ADMIN_PASSWORD}' \
+        -e DJANGO_SUPERUSER_DISPLAY_NAME='System Admin' \
+        web python manage.py createsuperuser --noinput 2>&1" || true)
+
+    if echo "$ADMIN_CREATE_RESULT" | grep -qi "already taken\|already exists\|duplicate"; then
+        warn_msg "Admin user '${ADMIN_USER}' already exists — skipping"
+    elif echo "$ADMIN_CREATE_RESULT" | grep -qi "error\|traceback"; then
+        warn_msg "Admin creation had issues: ${ADMIN_CREATE_RESULT}"
+        info_msg "You can create the admin manually: ssh ${SSH_TARGET} 'cd ${DEPLOY_DIR} && sudo docker compose exec web python manage.py createsuperuser'"
+    else
+        ok_msg "Admin user '${ADMIN_USER}' created"
+    fi
+fi
+
+# ==============================================================================
+# Step 8/9: Set up automated backups
+# ==============================================================================
+STEP=8
+step_msg "Step ${STEP}/${TOTAL}: Setting up automated backups..."
+
+# Make scripts executable
+run_remote "sudo chmod +x ${DEPLOY_DIR}/scripts/backup-vps.sh ${DEPLOY_DIR}/scripts/disk-check.sh 2>/dev/null" || true
+
+# Create backup directory
+run_remote "sudo mkdir -p ${DEPLOY_DIR}/backups"
+
+# Install crontab entries (idempotent — checks before adding)
+CRON_BACKUP="0 2 * * * ${DEPLOY_DIR}/scripts/backup-vps.sh >> /var/log/konote-backup.log 2>&1"
+CRON_DISK="0 * * * * ${DEPLOY_DIR}/scripts/disk-check.sh >> /var/log/konote-disk.log 2>&1"
+CRON_PRUNE="0 4 * * 0 docker system prune -f >> /var/log/docker-prune.log 2>&1"
+
+if [[ "$DRY_RUN" == true ]]; then
+    info_msg "[DRY RUN] Would install cron entries"
+else
+    # Get existing crontab (may be empty)
+    EXISTING_CRON=$(run_remote "sudo crontab -l 2>/dev/null" || true)
+
+    NEW_CRON="$EXISTING_CRON"
+
+    # Add each entry only if not already present
+    if ! echo "$EXISTING_CRON" | grep -qF "backup-vps.sh"; then
+        NEW_CRON="${NEW_CRON}
+${CRON_BACKUP}"
+    fi
+
+    if ! echo "$EXISTING_CRON" | grep -qF "disk-check.sh"; then
+        NEW_CRON="${NEW_CRON}
+${CRON_DISK}"
+    fi
+
+    if ! echo "$EXISTING_CRON" | grep -qF "docker system prune"; then
+        NEW_CRON="${NEW_CRON}
+${CRON_PRUNE}"
+    fi
+
+    # Install updated crontab
+    echo "$NEW_CRON" | run_remote "sudo crontab -"
+    ok_msg "Cron jobs installed (nightly backup at 2 AM, hourly disk check, weekly Docker prune)"
+fi
+
+# ==============================================================================
+# Step 9/9: Verify deployment
+# ==============================================================================
+STEP=9
+step_msg "Step ${STEP}/${TOTAL}: Verifying deployment..."
+
+if [[ "$DRY_RUN" == true ]]; then
+    info_msg "[DRY RUN] Would verify HTTPS at https://${DOMAIN}/auth/login/"
+else
+    # Check HTTPS endpoint from the VPS itself (doesn't depend on DNS propagation
+    # to the operator's machine)
+    HTTP_STATUS=$(run_remote "curl -s -o /dev/null -w '%{http_code}' --max-time 15 https://${DOMAIN}/auth/login/ 2>/dev/null" || echo "000")
+
+    if [[ "$HTTP_STATUS" == "200" ]]; then
+        ok_msg "HTTPS is working — https://${DOMAIN}/auth/login/ returned 200"
+    elif [[ "$HTTP_STATUS" == "000" ]]; then
+        warn_msg "Could not reach https://${DOMAIN}/ from the VPS"
+        info_msg "This is normal if DNS hasn't fully propagated yet."
+        info_msg "Caddy will obtain the HTTPS certificate automatically once DNS resolves."
+        info_msg "Check Caddy logs: ssh ${SSH_TARGET} 'cd ${DEPLOY_DIR} && sudo docker compose logs caddy'"
+    else
+        warn_msg "https://${DOMAIN}/auth/login/ returned HTTP ${HTTP_STATUS}"
+        info_msg "The app may still be starting. Check: ssh ${SSH_TARGET} 'cd ${DEPLOY_DIR} && sudo docker compose logs web'"
+    fi
+fi
+
+# ==============================================================================
+# Final summary
+# ==============================================================================
+echo ""
+echo -e "${BOLD}╔══════════════════════════════════════════════════╗${NC}"
+echo -e "${BOLD}║              Deployment Complete                 ║${NC}"
+echo -e "${BOLD}╚══════════════════════════════════════════════════╝${NC}"
+echo ""
+echo -e "  ${GREEN}URL:${NC}           https://${DOMAIN}"
+echo -e "  ${GREEN}Admin user:${NC}    ${ADMIN_USER}"
+echo -e "  ${GREEN}Admin email:${NC}   ${ADMIN_EMAIL}"
+echo -e "  ${GREEN}Admin pass:${NC}    ${ADMIN_PASSWORD}"
+echo ""
+echo -e "${RED}${BOLD}  ┌──────────────────────────────────────────────────────────┐${NC}"
+echo -e "${RED}${BOLD}  │  WARNING: SAVE THESE CREDENTIALS NOW                     │${NC}"
+echo -e "${RED}${BOLD}  │                                                          │${NC}"
+echo -e "${RED}${BOLD}  │  Encryption Key:                                         │${NC}"
+echo -e "${RED}${BOLD}  │  ${FIELD_ENCRYPTION_KEY}  │${NC}"
+echo -e "${RED}${BOLD}  │                                                          │${NC}"
+echo -e "${RED}${BOLD}  │  If you lose this key, ALL encrypted participant data    │${NC}"
+echo -e "${RED}${BOLD}  │  (names, emails, birth dates) is PERMANENTLY lost.       │${NC}"
+echo -e "${RED}${BOLD}  │                                                          │${NC}"
+echo -e "${RED}${BOLD}  │  Save it in your password manager NOW.                   │${NC}"
+echo -e "${RED}${BOLD}  │  Print a backup copy and store it securely.              │${NC}"
+echo -e "${RED}${BOLD}  └──────────────────────────────────────────────────────────┘${NC}"
+echo ""
+echo -e "  ${YELLOW}Post-deploy checklist:${NC}"
+echo -e "    1. Save ALL credentials above in your password manager"
+echo -e "    2. Verify DNS: nslookup ${DOMAIN} (should return ${HOST})"
+echo -e "    3. Log in at https://${DOMAIN} and set org name + terminology"
+echo -e "    4. Set up UptimeRobot monitoring: https://uptimerobot.com/"
+echo -e "    5. Set up email relay (Resend/Brevo) — see deploy-ovhcloud.md Step 13"
+echo -e "    6. Test a backup: ssh ${SSH_TARGET} 'sudo ${DEPLOY_DIR}/scripts/backup-vps.sh'"
+echo ""
+echo -e "  ${CYAN}Useful commands:${NC}"
+echo -e "    View logs:     ssh ${SSH_TARGET} 'cd ${DEPLOY_DIR} && sudo docker compose logs -f web'"
+echo -e "    Restart:       ssh ${SSH_TARGET} 'cd ${DEPLOY_DIR} && sudo docker compose up -d'"
+echo -e "    Update:        ssh ${SSH_TARGET} 'cd ${DEPLOY_DIR} && sudo git pull && sudo docker compose up -d --build'"
+echo -e "    Manual backup: ssh ${SSH_TARGET} 'sudo ${DEPLOY_DIR}/scripts/backup-vps.sh'"
+echo ""

--- a/tasks/deployment-protocol.md
+++ b/tasks/deployment-protocol.md
@@ -227,7 +227,7 @@ After both sessions:
 
 **Duration:** 2–4 hours
 
-**Full technical guide:** [docs/archive/deploy-azure.md](../docs/archive/deploy-azure.md)
+**Full technical guide:** [Deploy to Azure](../docs/deploying-konote.md#deploy-to-azure) (in deploying-konote.md)
 
 ---
 
@@ -252,7 +252,7 @@ Before touching Azure, confirm all inputs are ready:
 
 ### Setup Steps
 
-Follow the [Azure deployment guide](../docs/archive/deploy-azure.md) for detailed instructions. Summary:
+Follow the [Azure deployment guide](../docs/deploying-konote.md#deploy-to-azure) for detailed instructions. Summary:
 
 **Infrastructure (Steps 1–3):**
 1. Create resource group in Canada Central
@@ -805,7 +805,7 @@ Walk through the "Before You Enter Real Data" checklist from [deploying-konote.m
 |----------|----------|---------|
 | Document Integration Design | [tasks/design-rationale/document-integration.md](design-rationale/document-integration.md) | Phase 0, 3, 4 |
 | Permissions Interview | [tasks/agency-permissions-interview.md](agency-permissions-interview.md) | Phase 1 |
-| Azure Deployment Guide | [docs/archive/deploy-azure.md](../docs/archive/deploy-azure.md) | Phase 2 |
+| Azure Deployment Guide | [docs/deploying-konote.md — Deploy to Azure](../docs/deploying-konote.md#deploy-to-azure) | Phase 2 |
 | Deploying KoNote (all platforms) | [docs/deploying-konote.md](../docs/deploying-konote.md) | Phase 2, 4 |
 | Administering KoNote | [docs/administering-konote.md](../docs/administering-konote.md) | Phase 3, 4 |
 | Data Offboarding | [tasks/agency-data-offboarding.md](agency-data-offboarding.md) | Post-deployment (if needed) |


### PR DESCRIPTION
## What

- **DOC-MA5**: Design document for automated KoNote agency provisioning on OVHcloud VPS
- **DEPLOY-SCRIPT1**: Bash script (\scripts/deploy-konote-vps.sh\) that automates 9 of 15 manual deployment steps

## Deploy Script Design Doc

Covers: goal (agency in <30 min), target platform (OVHcloud Beauharnois), scope boundary (app-level provisioning only), step mapping from deploy-ovhcloud.md, security considerations, and future enhancements.

## Deploy Script Features

- Takes VPS IP + domain + org name via flags
- SSHes in, hardens OS, installs Docker, clones repo, generates credentials, writes .env, runs Docker Compose
- Sets up nightly backup cron
- Idempotent (safe to re-run), dry-run support, colour output
- Prints summary with URL + credentials + post-deploy checklist

## TODO.md Updates

- Marked DOC-MA5, DEPLOY-SCRIPT1, LOGO1 as done
- Removed stale OPS4 entry (already archived 2026-02-26)