### PR TITLE
Enhance consent field test for database column verification

### DIFF
--- a/tests/test_multi_tenancy.py
+++ b/tests/test_multi_tenancy.py
@@ -159,6 +159,15 @@ class TestConsentField(TestCase):
 
     def test_field_exists_and_defaults_false(self):
         from apps.clients.models import ServiceEpisode
+        
+        # Query the database to ensure the column exists
+        # (This catches missing migrations that _meta.get_field() would miss)
+        count = ServiceEpisode.objects.filter(
+            consent_to_aggregate_reporting=False
+        ).count()
+        assert count >= 0  # Could be 0 if no records exist, but query must succeed
+        
+        # Also verify the field metadata
         field = ServiceEpisode._meta.get_field("consent_to_aggregate_reporting")
         assert field is not None
         assert field.default is False


### PR DESCRIPTION
This pull request adds an extra check to the `test_field_exists_and_defaults_false` test to ensure that the `consent_to_aggregate_reporting` column actually exists in the database, not just in the model metadata. This helps catch missing migrations that might otherwise be missed.

Database integrity and migration validation:

* Added a query in `test_field_exists_and_defaults_false` to confirm the `consent_to_aggregate_reporting` column exists in the database, ensuring tests fail if migrations are missing.