### PR TITLE
fix: restore audit router priority, health check middleware, and SRE seeding

### DIFF
--- a/apps/admin_settings/management/commands/seed.py
+++ b/apps/admin_settings/management/commands/seed.py
@@ -19,6 +19,7 @@ class Command(BaseCommand):
         self._seed_feature_toggles()
         self._seed_instance_settings()
         self._seed_event_types()
+        self._seed_sre_categories()
         self._seed_note_templates()
         self._seed_intake_fields()
         if settings.DEMO_MODE:
@@ -64,6 +65,12 @@ class Command(BaseCommand):
         from django.core.management import call_command
 
         call_command("seed_event_types", stdout=self.stdout)
+
+    def _seed_sre_categories(self):
+        """Seed default Serious Reportable Event categories."""
+        from django.core.management import call_command
+
+        call_command("seed_sre_categories", stdout=self.stdout)
 
     def _seed_intake_fields(self):
         """Seed default custom fields for client intake forms."""

--- a/apps/tenants/management/commands/migrate_default.py
+++ b/apps/tenants/management/commands/migrate_default.py
@@ -1,0 +1,40 @@
+"""Management command to run migrations on the default database.
+
+Problem
+-------
+django_tenants replaces the standard `migrate` command with `migrate_schemas`,
+which routes tenant-app migrations (e.g. `clients`) only to *tenant* PostgreSQL
+schemas.  The *public* schema (used by management commands such as `seed`, and
+by the initial single-tenant installation) is skipped by TenantSyncRouter.
+
+This means that when a new migration is added to a tenant app (e.g.
+`clients.0034`), running `manage.py migrate` (= `migrate_schemas`) does NOT
+apply it to the public schema -- the table there is left behind.
+
+This command imports Django's original migrate Command directly (bypassing
+the django_tenants override) and defaults the database to "default".  Because
+it uses the real migrate, TenantSyncRouter is not involved, so all pending
+migrations are applied directly to whichever schema the connection is in
+(the public schema in production).
+
+Usage in entrypoint.sh
+----------------------
+    python manage.py migrate_default --noinput
+
+Run this BEFORE `manage.py migrate` (the django_tenants migrate_schemas) so
+the public schema is always up to date.
+"""
+
+from django.core.management.commands.migrate import Command as DjangoMigrateCommand
+
+
+class Command(DjangoMigrateCommand):
+    help = (
+        "Run Django migrations on the default database, bypassing django-tenants "
+        "schema routing so the public schema is kept in sync."
+    )
+
+    def add_arguments(self, parser):
+        super().add_arguments(parser)
+        # Default --database to "default" (explicit for clarity).
+        parser.set_defaults(database="default")

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,8 +7,17 @@ if [ -d ".git" ]; then
 fi
 
 echo "Running migrations..."
-python manage.py migrate --noinput
+# migrate_default uses Django's real migrate (bypassing django_tenants' migrate_schemas)
+# so the PUBLIC schema is kept in sync with all pending migrations, including
+# tenant-app migrations that migrate_schemas would skip for the public schema.
+python manage.py migrate_default --noinput
 echo "Migrations complete."
+
+echo "Running tenant schema migrations..."
+# migrate (overridden by django_tenants as migrate_schemas) now handles
+# per-tenant schema migrations for any existing agencies.
+python manage.py migrate --noinput
+echo "Tenant schema migrations complete."
 
 # Bootstrap single-tenant deployments: register the domain in the agency_domains
 # table so TenantMainMiddleware can route requests.  Safe to re-run (idempotent).

--- a/konote/middleware/health_check.py
+++ b/konote/middleware/health_check.py
@@ -1,0 +1,24 @@
+"""Health check middleware for KoNote.
+
+Handles GET /health/ before TenantMainMiddleware attempts domain lookup.
+TenantMainMiddleware requires a resolvable tenant domain — internal health
+checks from Railway / Docker or load-balancers arrive on an IP or an
+unregistered host, causing a 404/500 before the app is reachable.
+
+This middleware intercepts /health/ first and returns a minimal 200 response
+so the orchestrator knows the container is alive.
+"""
+
+from django.http import HttpResponse
+
+
+class HealthCheckMiddleware:
+    """Return 200 OK for GET /health/ without hitting tenant resolution."""
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        if request.method == "GET" and request.path == "/health/":
+            return HttpResponse("ok", content_type="text/plain", status=200)
+        return self.get_response(request)

--- a/konote/settings/base.py
+++ b/konote/settings/base.py
@@ -94,7 +94,11 @@ TENANT_MODEL = "tenants.Agency"
 TENANT_DOMAIN_MODEL = "tenants.AgencyDomain"
 
 MIDDLEWARE = [
-    # SecurityMiddleware MUST be first for security headers
+    # HealthCheckMiddleware MUST be first — it responds to GET /health/ before
+    # TenantMainMiddleware attempts domain lookup (which fails for internal IPs
+    # used by Railway / Docker health probes and load-balancers).
+    "konote.middleware.health_check.HealthCheckMiddleware",
+    # SecurityMiddleware MUST be second for security headers
     "django.middleware.security.SecurityMiddleware",
     # WhiteNoiseMiddleware serves static files directly, before tenant resolution
     "whitenoise.middleware.WhiteNoiseMiddleware",
@@ -180,8 +184,12 @@ if "postgresql" in DATABASES["default"].get("ENGINE", ""):
     DATABASES["default"]["ENGINE"] = "django_tenants.postgresql_backend"
 
 DATABASE_ROUTERS = [
-    "django_tenants.routers.TenantSyncRouter",
+    # AuditRouter MUST come first: it returns True/False definitively for the
+    # audit DB so TenantSyncRouter never sees audit-DB migration calls.
+    # TenantSyncRouter returns False for any db != 'default', which would
+    # incorrectly block audit migrations if it ran before AuditRouter.
     "konote.db_router.AuditRouter",
+    "django_tenants.routers.TenantSyncRouter",
 ]
 
 # Password hashing — Argon2 first


### PR DESCRIPTION
## What this fixes

Three production startup regressions from commit `32d58b73` (middleware reorder), which was branched from pre-`632220c9` code and overwrote fixes from that commit.

### 1. Critical — audit DB migrations never ran (tenant_schema column missing)

**Root cause:** `DATABASE_ROUTERS` had `TenantSyncRouter` before `AuditRouter`. `TenantSyncRouter.allow_migrate()` returns `False` for any `db != 'default'`, silently blocking *all* audit DB migrations. `audit.0007_auditlog_tenant_schema` was never applied, so the `tenant_schema` column does not exist in the audit DB. Every request that `AuditMiddleware` tries to log crashes with `column "tenant_schema" of relation "audit_log" does not exist`.

**Fix:** Move `AuditRouter` *before* `TenantSyncRouter` in `DATABASE_ROUTERS`. AuditRouter returns a definitive True/False for the audit DB so TenantSyncRouter never sees those calls.

### 2. Health check 500 loop (Railway / Docker)

**Root cause:** `TenantMainMiddleware` requires a resolvable tenant domain. Internal health probe IPs have no registered domain → 404/500 → orchestrator never marks the container healthy.

**Fix:** Add `HealthCheckMiddleware` as the very first middleware. It intercepts `GET /health/` and returns 200 before tenant resolution runs.

### 3. Public schema migrations not applied on multi-tenant deploy

**Root cause:** `python manage.py migrate` (overridden by django-tenants as `migrate_schemas`) skips the public schema for tenant-app migrations.

**Fix:** Add `migrate_default` command (Django's real migrate, defaulting `--database=default`) and run it *before* `migrate` in `entrypoint.sh`.

### 4. SRE categories not seeded on fresh deploy

The `seed` startup command did not call `seed_sre_categories`, so SRE categories were empty after every clean deployment.

**Fix:** Add `_seed_sre_categories()` call to `seed.handle()`.

## Files changed

| File | Change |
|------|--------|
| `konote/settings/base.py` | AuditRouter first in DATABASE_ROUTERS; add HealthCheckMiddleware to MIDDLEWARE |
| `konote/middleware/health_check.py` | New — returns 200 for GET /health/ |
| `apps/tenants/management/commands/migrate_default.py` | New — standard migrate defaulting to default DB |
| `entrypoint.sh` | Run `migrate_default` then `migrate` (two-step) |
| `apps/admin_settings/management/commands/seed.py` | Call `seed_sre_categories` during startup seed |

## Deploy note

After this merges and deploys, **`migrate_audit` will apply `audit.0007` for the first time** on any environment where it has not run. This is a safe additive migration (adds a `tenant_schema` varchar column with `default=''`).
