### PR TITLE
fix: migrate_default must bypass TenantSyncRouter (warn_min column missing)

### DIFF
--- a/apps/tenants/management/commands/migrate_default.py
+++ b/apps/tenants/management/commands/migrate_default.py
@@ -2,27 +2,32 @@
 
 Problem
 -------
-django_tenants replaces the standard `migrate` command with `migrate_schemas`,
-which routes tenant-app migrations (e.g. `clients`) only to *tenant* PostgreSQL
-schemas.  The *public* schema (used by management commands such as `seed`, and
-by the initial single-tenant installation) is skipped by TenantSyncRouter.
+django_tenants replaces `migrate` with `migrate_schemas`, which:
+  1. Applies SHARED_APPS migrations to the public schema.
+  2. Applies TENANT_APPS migrations to each non-public tenant schema.
 
-This means that when a new migration is added to a tenant app (e.g.
-`clients.0034`), running `manage.py migrate` (= `migrate_schemas`) does NOT
-apply it to the public schema -- the table there is left behind.
+In a single-agency deployment (schema_name='public'), step 2 has zero schemas
+to process — `.exclude(schema_name='public')` matches nothing.  Additionally,
+TenantSyncRouter.allow_migrate() returns False for TENANT_APPS when
+connection.schema_name equals PUBLIC_SCHEMA_NAME, so even a plain
+`manage.py migrate` cannot apply them there.
 
-This command imports Django's original migrate Command directly (bypassing
-the django_tenants override) and defaults the database to "default".  Because
-it uses the real migrate, TenantSyncRouter is not involved, so all pending
-migrations are applied directly to whichever schema the connection is in
-(the public schema in production).
+Result: any new TENANT_APP migration (plans, events, clients, etc.) is NEVER
+applied to the public schema after the initial flat-to-tenant upgrade.
+
+Fix
+---
+This command temporarily removes TenantSyncRouter from DATABASE_ROUTERS and
+runs Django's standard migrate, allowing ALL pending migrations (shared AND
+tenant-app) to be applied to the public schema.  AuditRouter stays in place
+so audit-app migrations are still directed only to the 'audit' database.
 
 Usage in entrypoint.sh
 ----------------------
     python manage.py migrate_default --noinput
 
-Run this BEFORE `manage.py migrate` (the django_tenants migrate_schemas) so
-the public schema is always up to date.
+Run this BEFORE `manage.py migrate` (migrate_schemas) so the public schema
+is up to date before per-tenant schemas are processed.
 """
 
 from django.core.management.commands.migrate import Command as DjangoMigrateCommand
@@ -30,11 +35,49 @@ from django.core.management.commands.migrate import Command as DjangoMigrateComm
 
 class Command(DjangoMigrateCommand):
     help = (
-        "Run Django migrations on the default database, bypassing django-tenants "
-        "schema routing so the public schema is kept in sync."
+        "Apply all pending migrations to the default database's public schema, "
+        "bypassing TenantSyncRouter so TENANT_APPS migrations run in "
+        "single-agency deployments where schema_name='public'."
     )
 
     def add_arguments(self, parser):
         super().add_arguments(parser)
-        # Default --database to "default" (explicit for clarity).
         parser.set_defaults(database="default")
+
+    def handle(self, *args, **options):
+        from django.conf import settings as django_settings
+        from django.db import router as dj_router
+
+        # TenantSyncRouter.allow_migrate() returns False for TENANT_APPS
+        # (plans, events, clients, etc.) whenever connection.schema_name equals
+        # PUBLIC_SCHEMA_NAME ('public').  This permanently prevents those
+        # migrations from being applied to the public schema.
+        # We temporarily remove TenantSyncRouter so all pending migrations can
+        # run.  After this command completes the original router list is
+        # restored.
+        original_routers = list(django_settings.DATABASE_ROUTERS)
+        filtered_routers = [
+            r for r in original_routers
+            if not (isinstance(r, str) and "TenantSyncRouter" in r)
+        ]
+        django_settings.DATABASE_ROUTERS = filtered_routers
+
+        # ConnectionRouter.routers is a @cached_property; clear it so Django
+        # re-instantiates routers from the updated DATABASE_ROUTERS list.
+        # Also reset _routers to None so the cached_property re-reads settings.
+        dj_router._routers = None
+        try:
+            del dj_router.__dict__["routers"]
+        except KeyError:
+            pass
+
+        try:
+            super().handle(*args, **options)
+        finally:
+            # Always restore the original router list.
+            django_settings.DATABASE_ROUTERS = original_routers
+            dj_router._routers = None
+            try:
+                del dj_router.__dict__["routers"]
+            except KeyError:
+                pass


### PR DESCRIPTION
## Root cause

`TenantSyncRouter.allow_migrate()` returns `False` for TENANT_APPS (`plans`, `events`, `clients`, etc.) whenever `connection.schema_name == PUBLIC_SCHEMA_NAME ('public')`.

Additionally, `migrate_schemas` explicitly excludes the public schema from its tenant phase:
```python
Agency.objects.exclude(schema_name=PUBLIC_SCHEMA_NAME)
```

In a single-agency deployment where the agency uses `schema_name='public'`, this means there are **zero** non-public tenant schemas to process. TENANT_APPS migrations are never applied through any current command.

**Result:** Tables created before multi-tenancy (via the old flat `manage.py migrate`) still exist but are missing columns from migrations added post-multi-tenancy. Specifically, `plans.0017` (adds `warn_min`, `warn_max`) was never applied, causing:
```
psycopg.errors.UndefinedColumn: column metric_definitions.warn_min does not exist
```

## Fix

Updated `migrate_default` to temporarily remove `TenantSyncRouter` from `DATABASE_ROUTERS` before running Django's standard migrate, then restore it afterwards. This lets all TENANT_APPS migrations run against the public schema. `AuditRouter` stays in place throughout so audit-app migrations are still correctly routed to the `audit` database only.

The bypass works by:
1. Filtering out `TenantSyncRouter` from `settings.DATABASE_ROUTERS`
2. Resetting `ConnectionRouter._routers = None` and clearing the `@cached_property` cache
3. Running `super().handle()` (Django's real migrate — all TENANT_APPS now allowed)
4. Restoring original routers in a `finally` block

## Why the original `migrate_default` didn't work

The first version of this command (from PR #248) just defaulted `--database=default` and called Django's standard migrate. But Django's migrate still checks `allow_migrate()` via the active routers — including `TenantSyncRouter` — before running any migration. With the public schema as the connection schema, `TenantSyncRouter` returned `False` for all TENANT_APPS, so the command reported "No migrations to apply" (it silently skipped them) while the actual columns remained missing.
