### PR TITLE
Efix: change Railway healthcheck path to /health/ and fix SurveyLink d…

### DIFF
--- a/apps/admin_settings/management/commands/seed_demo_data.py
+++ b/apps/admin_settings/management/commands/seed_demo_data.py
@@ -4073,14 +4073,17 @@ class Command(BaseCommand):
 
         # --- Shareable Link for satisfaction survey ---
         if satisfaction:
-            SurveyLink.objects.get_or_create(
-                survey=satisfaction,
-                defaults={
-                    "is_active": True,
-                    "collect_name": True,
-                    "created_by": created_by,
-                },
-            )
+            existing_links = SurveyLink.objects.filter(survey=satisfaction)
+            if existing_links.count() > 1:
+                keep_pk = existing_links.first().pk
+                existing_links.exclude(pk=keep_pk).delete()
+            elif not existing_links.exists():
+                SurveyLink.objects.create(
+                    survey=satisfaction,
+                    is_active=True,
+                    collect_name=True,
+                    created_by=created_by,
+                )
 
         # --- Assignments and Responses ---
         portal_clients = [

--- a/railway.json
+++ b/railway.json
@@ -5,7 +5,7 @@
     "dockerfilePath": "Dockerfile"
   },
   "deploy": {
-    "healthcheckPath": "/auth/login/",
+    "healthcheckPath": "/health/",
     "healthcheckTimeout": 300,
     "restartPolicyType": "ON_FAILURE"
   },


### PR DESCRIPTION
…uplicates

- railway.json: change healthcheckPath from /auth/login/ to /health/ The Railway probe sends requests with an internal HOST header that doesn't match any registered tenant domain, causing TenantMainMiddleware to return
  404. The HealthCheckMiddleware already intercepts GET /health/ before tenant resolution — the healthcheck config just wasn't pointing at it.

- seed_demo_data.py: fix MultipleObjectsReturned on SurveyLink.get_or_create() Same duplicate pattern as the earlier SurveyTriggerRule fix: SurveyLink has no unique constraint on survey, so repeated re-seeds accumulate duplicates. Use filter+dedup+create instead of get_or_create.