### PR TITLE
fix: add EMAIL_HASH_KEY to build settings

### DIFF
--- a/konote/settings/build.py
+++ b/konote/settings/build.py
@@ -7,6 +7,7 @@ os.environ.setdefault("SECRET_KEY", "build-only-not-for-runtime")
 os.environ.setdefault("DATABASE_URL", "sqlite:///build-dummy.db")
 os.environ.setdefault("AUDIT_DATABASE_URL", "sqlite:///build-dummy-audit.db")
 os.environ.setdefault("FIELD_ENCRYPTION_KEY", "ly6OqAlMm32VVf08PoPJigrLCIxGd_tW1-kfWhXxXj8=")
+os.environ.setdefault("EMAIL_HASH_KEY", "build-only-not-for-runtime")
 
 from .base import *  # noqa: F401, F403
 


### PR DESCRIPTION
The EMAIL_HASH_KEY validation added in PR #258 raises ImproperlyConfigured during Docker build (collectstatic step) because build.py doesn't set it before importing base.py. Added a build-only placeholder value alongside the existing FIELD_ENCRYPTION_KEY default.