### PR TITLE
Update TODO.md — remove expert panel flag, add cleanup task

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -3,7 +3,6 @@
 ## Flagged
 
 - [ ] Contact Common Approach to position KoNote as a pilot CIDS implementer — early engagement for co-marketing and advance notice of spec changes — GK (CIDS-CA-OUTREACH1)
-- [ ] Discuss: are the `convening-experts` and `review-session` commands useful for our workflow? Worth the time? How should we use them going forward? — GK (PROCESS-EXPERT-PANEL1)
 - [ ] To go live with demo survey: run `python manage.py seed_demo_survey` on konote-dev (PR #239 and #240 are now merged). The survey will be accessible at `/s/demo-program-feedback/` and the website demo page will embed it automatically — PB (DEMO-SURVEY1)
 
 ## Active Work
@@ -57,7 +56,7 @@ Step-by-step commands for each task are in [tasks/recurring-tasks.md](tasks/recu
 
 ### Phase: Server Sharing — cost optimization, not a launch prerequisite (completed in PR #220)
 
-Multiple agencies can deploy today on independent instances ($35–100/month each). Server sharing reduces per-agency costs to $4–10/month with walled database schemas per agency on one server.
+Multiple agencies can deploy today on independent OVHcloud VPS instances (~$22/month each). Server sharing reduces per-agency costs to $4–10/month with walled database schemas per agency on one server.
 
 Details: see [tasks/design-rationale/multi-tenancy.md](tasks/design-rationale/multi-tenancy.md) and Recently Done → Multi-Tenancy Infrastructure.
 
@@ -79,6 +78,7 @@ _All documentation tasks completed — see Recently Done._
 Scope is clear, just needs time. A session can pick these up without special approval.
 
 - [ ] Fill 863 empty French translations in django.po — run `translate_strings --auto-translate` then review output (I18N-FILL1)
+- [ ] Clean Railway/FullHost/Elestio references from ~24 historical task and plan files — these are in tasks/*.md, docs/archive/*, docs/plans/*, ENCRYPTION-PLAN.md, CHANGELOG.md. Not urgent (they're historical records, not active docs) but should be cleaned up for consistency (CHORE-HIST-CLEANUP1)
 
 ## Parking Lot: Needs Review
 


### PR DESCRIPTION
## Summary

- Removed PROCESS-EXPERT-PANEL1 flag (convening-experts/review-session discussion — resolved)
- Fixed server sharing cost description to reflect OVHcloud pricing (~$22/mo)
- Added CHORE-HIST-CLEANUP1 to Parking Lot for cleaning ~24 historical files still referencing Railway/FullHost/Elestio

🤖 Generated with [Claude Code](https://claude.com/claude-code)