### PR TITLE
docs: add LLM operations runbook and update support cost model

### DIFF
--- a/docs/llm-operations-runbook.md
+++ b/docs/llm-operations-runbook.md
@@ -1,0 +1,363 @@
+# KoNote LLM Operations Runbook
+
+## Purpose
+
+This document is a prompt and reference for a capable LLM (Opus 4.6 or equivalent) managing KoNote production infrastructure. It defines exactly what the LLM does, what a human reviews, and when to escalate.
+
+**Operational model:** The LLM handles all routine technical work. A human reviews the LLM's output, approves changes, and handles anything requiring judgement or a personal relationship. This is not optional — it is the standard KoNote operational model.
+
+---
+
+## Who This Is For
+
+A capable coding LLM (Opus 4.6 or equivalent) with shell access that has:
+- SSH access to KoNote VPS(es) or access to run commands locally
+- Read access to the konote repo
+- Ability to run `docker compose` commands on the target host
+- Ability to send messages/emails for human review
+
+The human operator:
+- Reviews and approves the LLM's proposed changes
+- Handles agency relationship management (check-ins, training, onboarding)
+- Makes judgement calls on incidents the LLM can't resolve
+- Has final say on all production changes
+
+---
+
+## Standing Instructions for the LLM
+
+When managing a KoNote deployment, follow these rules:
+
+### Safety
+
+1. **Never delete production data.** No `DROP DATABASE`, no `rm -rf` on backup directories, no `docker volume rm` on production volumes.
+2. **Never modify `.env` without human approval.** Read it, propose changes, wait for confirmation.
+3. **Never restart production containers without stating what you're doing and why.** `docker compose restart web` is fine after an update — but say so first.
+4. **Never expose secrets in output.** If you read `.env`, redact `SECRET_KEY`, `FIELD_ENCRYPTION_KEY`, `EMAIL_HASH_KEY`, and all `*_PASSWORD` values.
+5. **If you're unsure, stop and ask.** Describe what you see, what you think should happen, and what you'd do. Let the human decide.
+
+### Communication
+
+6. **Lead with the action, not the reasoning.** "I'll pull the latest code and rebuild the web container" not "Let me explain the Docker build process..."
+7. **Flag anything unusual before acting.** Unexpected disk usage, unfamiliar processes, containers in unexpected states — report first, act second.
+8. **After every change, verify it worked.** Run a health check, check logs, confirm the service is responding.
+
+---
+
+## Routine Tasks
+
+### 1. Software Update (Monthly, ~15 min LLM + 5 min human review)
+
+**Trigger:** New release on the `main` branch, or scheduled monthly check.
+
+**LLM does:**
+```
+1. SSH to VPS (or run locally if same machine)
+2. cd /opt/konote  (or wherever the deployment lives)
+3. git fetch origin
+4. git log --oneline HEAD..origin/main  (show what's changed)
+5. Review the diff: git diff HEAD..origin/main
+6. Check for migration files: git diff HEAD..origin/main --name-only | grep migrations
+7. If migrations exist, note them and flag for human
+8. Prepare a summary:
+   - What changed (features, fixes, security patches)
+   - Whether migrations are needed
+   - Any .env changes required (check .env.example diff)
+   - Recommended action: "Pull and rebuild" or "Wait — breaking change needs discussion"
+9. Present summary to human for approval
+```
+
+**Human does:** Reviews the summary, approves or asks questions.
+
+**LLM does (after approval):**
+```
+1. git pull origin main
+2. docker compose up -d --build
+3. If migrations: docker compose exec web python manage.py migrate
+4. docker compose exec web python manage.py check --deploy
+5. Verify: curl -f http://localhost:8000/auth/login/ (or the public URL)
+6. Check logs: docker compose logs --tail=50 web
+7. Report: "Update applied successfully. Version [X]. Health check passed."
+```
+
+**Time:** ~15 min LLM work, ~5 min human review = ~20 min total.
+**Without LLM:** ~45–60 min (manual diff review, manual deploy, manual verification).
+
+### 2. Review Health Report (Daily, ~2 min LLM)
+
+**Trigger:** Daily health report email arrives (7 AM), or on-demand check.
+
+**LLM does:**
+```
+1. Read the health report email (or run the health check directly):
+   docker compose exec ops /usr/local/bin/ops-health-report.sh
+2. Check for anomalies:
+   - Database sizes: are they growing normally? Sudden jump = investigate
+   - Disk usage: below 80%? Good. Above 70%? Flag for human
+   - Backup: latest backup exists and is recent? Size reasonable?
+   - All containers: running and healthy?
+3. If everything normal: "Health report reviewed — all clear."
+4. If anomaly found: describe it, assess severity, recommend action
+```
+
+**Human does:** Reads the LLM's one-line summary. Acts only if flagged.
+
+**Time:** ~2 min LLM (no human time unless flagged).
+**Without LLM:** ~10–15 min (read email, mentally check each metric, decide if action needed).
+
+### 3. Investigate Alert (As needed, ~5–15 min LLM)
+
+**Trigger:** Webhook alert from ops sidecar (backup failure, disk threshold, backup verification failure) or UptimeRobot downtime alert.
+
+**LLM does:**
+```
+1. Identify the alert type from the webhook payload or email
+2. Run diagnostic commands based on alert type:
+
+   BACKUP FAILURE:
+   - docker compose logs --tail=100 ops | grep -i backup
+   - ls -la /opt/konote/backups/  (check recent files)
+   - docker compose exec ops pg_isready -h db -U $POSTGRES_USER
+   - docker compose exec ops pg_isready -h audit_db -U $AUDIT_POSTGRES_USER
+   - Likely causes: DB connection issue, disk full, permissions
+   - If DB unreachable: check container health, restart if needed
+   - If disk full: identify what's consuming space, recommend cleanup
+
+   DISK THRESHOLD:
+   - df -h
+   - du -sh /opt/konote/backups/ /var/lib/docker/
+   - docker system df
+   - Likely causes: old backups not pruned, Docker images accumulating, logs
+   - Recommend: prune Docker images, adjust retention, or upgrade VPS
+
+   DOWNTIME (UptimeRobot):
+   - docker compose ps  (are containers running?)
+   - docker compose logs --tail=100 web
+   - curl -f http://localhost:8000/auth/login/
+   - If container crashed: check why (OOM? error?), restart
+   - If VPS-level issue: UptimeRobot should have already triggered API reboot
+
+   BACKUP VERIFICATION FAILURE:
+   - docker compose logs --tail=100 ops | grep -i verify
+   - Check if the backup file exists and is non-empty
+   - Likely cause: corrupted backup or schema mismatch
+   - Run manual verification: attempt test restore
+
+3. Present findings and recommended action to human
+4. After human approval, execute the fix
+5. Verify the fix worked
+6. If the alert was a false positive, explain why and suggest tuning
+```
+
+**Time:** ~5–15 min LLM depending on complexity. Human approves fix (~2 min).
+**Without LLM:** ~30–60 min (SSH in, remember which logs to check, diagnose, fix, verify).
+
+### 4. Agency Support Request (As needed, ~5–10 min LLM)
+
+**Trigger:** Agency emails with a question or request.
+
+**LLM does:**
+```
+1. Read the request
+2. Categorise:
+   - QUESTION: Answer from docs/knowledge base. Draft a response.
+   - CONFIG CHANGE: Identify what needs changing, prepare the commands
+     (e.g., add a user, change a label, toggle a feature)
+   - BUG REPORT: Reproduce if possible, check logs, identify the issue
+   - FEATURE REQUEST: Note it, check if it's already planned
+3. Draft a response to the agency (plain language, not technical)
+4. If config change: prepare the exact commands to run
+5. Present draft response + commands to human for review
+```
+
+**Human does:** Reviews the draft, edits tone/content if needed, sends to agency. Approves config changes.
+
+**Time:** ~5–10 min LLM, ~5 min human review.
+**Without LLM:** ~15–30 min (read request, research answer, write response, make changes).
+
+### 5. Quarterly Security Review (~20 min LLM + 10 min human)
+
+**Trigger:** Calendar reminder, quarterly.
+
+**LLM does:**
+```
+1. Check for known vulnerabilities:
+   docker compose exec web pip-audit --json  (if pip-audit installed)
+   — or check Django security advisories manually
+2. Review access:
+   - List all user accounts: docker compose exec web python manage.py shell
+     -c "from django.contrib.auth.models import User; print([(u.username, u.is_active, u.last_login) for u in User.objects.all()])"
+   - Flag accounts that haven't logged in for 90+ days
+   - Flag accounts that are active but shouldn't be (check with human)
+3. Check encryption:
+   - Verify FIELD_ENCRYPTION_KEY is loaded (check Django settings, don't print the key)
+   - Verify encrypted fields are actually encrypted in the DB
+4. Check backups:
+   - List recent backups, verify sizes are consistent
+   - Confirm off-site backup is current (if configured)
+5. Check OS updates:
+   - apt list --upgradable (inside VPS, not container)
+   - Flag any security-critical updates
+6. Prepare a security review summary for human
+```
+
+**Human does:** Reviews the summary, approves any account deactivations, approves OS updates.
+
+**Time:** ~20 min LLM, ~10 min human. Amortised to ~10 min/mo.
+**Without LLM:** ~60–90 min (manual CVE check, manual account review, manual backup verification).
+
+### 6. Quarterly Backup Restore Test (~15 min LLM)
+
+**Trigger:** Calendar reminder, quarterly (in addition to the automated weekly verification).
+
+**LLM does:**
+```
+1. This is a deeper test than the automated weekly check.
+2. Create a temporary Docker Compose stack:
+   docker compose -f docker-compose.yml -f docker-compose.test.yml up -d db_test
+3. Restore the latest backup:
+   pg_restore -h localhost -p 5433 -U test -d konote_test /opt/konote/backups/latest.dump
+4. Run Django checks against the test database:
+   DATABASE_URL=postgres://test:test@localhost:5433/konote_test python manage.py check
+5. Verify row counts match production (approximate — exact match not required)
+6. Verify encrypted fields decrypt correctly with the current key
+7. Tear down test stack:
+   docker compose -f docker-compose.yml -f docker-compose.test.yml down db_test
+8. Report results to human
+```
+
+**Time:** ~15 min LLM. Amortised to ~5 min/mo.
+
+---
+
+## Estimated Hours: LLM-Assisted Operations
+
+With the LLM handling all technical work and a human reviewing/approving:
+
+| Task | Frequency | LLM time | Human time | Total |
+|------|-----------|----------|------------|-------|
+| Software update | Monthly | 15 min | 5 min | 20 min |
+| Review health reports | Daily (30×/mo) | 2 min × 30 = 60 min | 0 (unless flagged) | ~5 min |
+| Investigate alerts | ~2/mo | 10 min × 2 = 20 min | 2 min × 2 = 4 min | ~8 min |
+| Agency support (per agency) | ~2-3/mo | 8 min × 2.5 = 20 min | 5 min × 2.5 = 12.5 min | ~25 min |
+| Security review (amortised) | Quarterly | 20 min/quarter = 7 min/mo | 10 min/quarter = 3 min/mo | ~3 min |
+| Backup restore test (amortised) | Quarterly | 15 min/quarter = 5 min/mo | 0 | ~2 min |
+
+### Per-Agency Human Hours (the number that matters for pricing)
+
+| Scale | Human hours/mo | Notes |
+|-------|----------------|-------|
+| 1 agency | ~1.0 hr | Update review + health scan + 2-3 support requests |
+| 5 agencies (network ops shared) | ~2.5 hr | 0.5 hr ops + 5 × 25 min support |
+| 30 agencies (network ops shared) | ~13 hr | 0.75 hr ops + 30 × 25 min support |
+
+**Key insight:** The LLM eliminates the difference between "network ops" and "per-agency work" as a *technical* distinction. The LLM handles both. The human time is almost entirely **review and relationship** — approving updates, reviewing draft responses, facilitating check-ins. The split between "ops" and "support" in the pricing model reflects what the human does (infrastructure review vs. agency communication), not what the LLM does.
+
+---
+
+## Escalation: When the LLM Stops and Asks
+
+The LLM should stop and present findings to the human (not attempt to fix) when:
+
+1. **Data loss risk** — backup restore needed, database corruption suspected
+2. **Security incident** — unauthorized access, suspicious activity in audit logs
+3. **Infrastructure decision** — VPS upgrade needed, architecture change
+4. **Agency relationship** — complaint, training request, onboarding decision
+5. **Cost decision** — anything that changes monthly billing
+6. **Encryption key issues** — key rotation, key not loading, emergency key needed
+7. **Unknown state** — something the LLM doesn't recognize or can't diagnose
+
+---
+
+## Multi-Agency Operations
+
+When managing multiple agencies on separate VPSes:
+
+### Update Rollout
+```
+For each VPS in the fleet:
+  1. SSH to VPS
+  2. Run update procedure (Section 1 above)
+  3. Verify health
+  4. Move to next VPS
+
+Order: staging/test instance first, wait 24-48 hours, then production.
+At 5 agencies: ~30 min total LLM time (sequential)
+At 30 agencies: ~2 hours total LLM time (can parallelise with multiple SSH sessions)
+```
+
+### Consolidated Health Check
+```
+For each VPS:
+  1. Run health report
+  2. Collect results
+
+Present single consolidated summary:
+  "All 5 instances healthy. DB sizes normal. Backups current."
+  — or —
+  "4/5 healthy. agency-c.konote.ca: disk at 78% — recommend prune."
+```
+
+### Cross-Agency Alert Triage
+```
+When an alert fires:
+  1. Identify which VPS/agency it affects
+  2. Run diagnostics on that specific instance
+  3. Check if other instances have the same issue (pattern detection)
+  4. Report: "Backup failed on agency-b VPS. Other 4 instances unaffected. Cause: [X]."
+```
+
+---
+
+## Reference: Container Stack
+
+| Container | Purpose | Health check | Restart policy |
+|-----------|---------|-------------|----------------|
+| `web` | Django app (Gunicorn, port 8000) | `curl /auth/login/` every 30s | unless-stopped |
+| `db` | PostgreSQL 16 (main) | `pg_isready` every 5s | unless-stopped |
+| `audit_db` | PostgreSQL 16 (audit, INSERT-only) | `pg_isready` every 5s | unless-stopped |
+| `caddy` | Reverse proxy, auto-HTTPS | implicit (Caddy self-monitors) | unless-stopped |
+| `autoheal` | Restart unhealthy containers | implicit | always |
+| `ops` | Cron: backups, disk check, health report, verification, prune | `pgrep crond` | unless-stopped |
+
+## Reference: Key File Locations
+
+| File | Location on VPS |
+|------|----------------|
+| Application code | `/opt/konote/` |
+| Environment config | `/opt/konote/.env` |
+| Docker Compose | `/opt/konote/docker-compose.yml` |
+| Database backups | `/opt/konote/backups/` |
+| Ops scripts (inside container) | `/usr/local/bin/ops-*.sh` |
+| Caddy config | `/opt/konote/Caddyfile` |
+| SSL certificates | Caddy volume (auto-managed) |
+
+## Reference: Useful Commands
+
+```bash
+# Container status
+docker compose ps
+
+# Logs (last 50 lines of web container)
+docker compose logs --tail=50 web
+
+# Health check
+curl -f http://localhost:8000/auth/login/
+
+# Manual backup
+docker compose exec ops /usr/local/bin/ops-backup.sh
+
+# Manual health report
+docker compose exec ops /usr/local/bin/ops-health-report.sh
+
+# Django management
+docker compose exec web python manage.py check --deploy
+docker compose exec web python manage.py showmigrations
+
+# Database sizes
+docker compose exec db psql -U $POSTGRES_USER -d $POSTGRES_DB -c "SELECT pg_size_pretty(pg_database_size(current_database()));"
+
+# Disk usage
+df -h
+docker system df
+```

--- a/tasks/hosting-cost-comparison.md
+++ b/tasks/hosting-cost-comparison.md
@@ -14,8 +14,10 @@ ovh_single_1_agency: $74 CAD/mo
 ovh_multi_10_agencies: $15 CAD/mo/agency
 azure_single_1_agency: $141 CAD/mo
 azure_multi_10_agencies: $47 CAD/mo/agency
-ops_hours_1_agency: 4-5 hr/mo
-ops_hours_10_agencies_mt: 10-15 hr/mo
+ops_hours_1_agency: ~1 hr/mo human (LLM-assisted)
+ops_hours_5_agencies_network: ~2.5 hr/mo human (LLM-assisted)
+ops_hours_10_agencies_mt: ~4.5-5 hr/mo human (LLM-assisted)
+ops_model: LLM-assisted (see docs/llm-operations-runbook.md)
 downstream: p0-managed-service-plan.md, konote-prosper-canada/deliverables/costing-model.md
 -->
 
@@ -355,7 +357,7 @@ Total automation cost: ~$0 additional (uses free tiers of monitoring services).
 
 ## Technical Support Cost Estimates
 
-The 4-layer self-healing automation (see [OVHcloud deployment DRR](design-rationale/ovhcloud-deployment.md)) eliminates most routine operational work. This section estimates the remaining human support burden at each scale.
+The 4-layer self-healing automation (see [OVHcloud deployment DRR](design-rationale/ovhcloud-deployment.md)) eliminates most routine operational work. The remaining tasks are managed by a capable LLM (Opus 4.6 or equivalent) with human review and approval. See `docs/llm-operations-runbook.md` for the full operational prompt.
 
 ### What Self-Healing Handles Automatically (~$0)
 
@@ -372,62 +374,52 @@ The 4-layer self-healing automation (see [OVHcloud deployment DRR](design-ration
 | Dead man's switch (missed backups) | None | Healthchecks.io/UptimeRobot push monitor |
 | OS security patches | Manual apt upgrade | unattended-upgrades (automatic) |
 
-### Remaining Human Support Tasks
+### LLM-Assisted Support Model
 
-These are the tasks that still require a person. Estimated hours assume OVHcloud hosting with the full self-healing stack.
+KoNote operations use a capable LLM (Opus 4.6 or equivalent) for all routine technical work. The LLM reviews diffs, deploys updates, reads health reports, investigates alerts, and drafts agency responses. A human reviews, approves, and handles relationship management. See `docs/llm-operations-runbook.md` for the detailed operational prompt.
 
-| Task | Frequency | Est. hours | Notes |
-|------|-----------|------------|-------|
-| Review health report emails | Daily (2 min) | 1 hr/mo | Scan for anomalies, mostly no action needed |
-| Apply KoNote software updates | 1–2×/month | 1 hr/mo | `git pull` + `docker compose up -d --build` |
-| Investigate escalation alerts | ~1×/month | 0.5 hr/mo | Layer 4 alerts that self-healing couldn't resolve |
-| Respond to agency support requests | As needed | 1–2 hr/mo | Config changes, user account issues, questions |
-| Quarterly security review | 1×/quarter | 1 hr/quarter | Check CVEs, review access logs, rotate secrets |
-| Azure AD client secret renewal | 1×/year per agency | 0.5 hr/year | Calendar reminder set during deployment |
-| VPS capacity review | 1×/quarter | 0.5 hr/quarter | Check resource usage trends, plan upgrades |
-| **Total (1 agency)** | | **~4–5 hr/mo** | |
-| **Total (5 agencies, single-tenant)** | | **~8–12 hr/mo** | Some tasks scale per-agency, others are fixed |
-| **Total (10 agencies, multi-tenant)** | | **~10–15 hr/mo** | Multi-tenant reduces per-agency overhead |
+The hours below are **human hours only** — the time the operator spends reviewing, approving, and communicating. The LLM's time is infrastructure, not a billable cost.
+
+| Task | LLM does | Human does | Human time |
+|------|----------|------------|------------|
+| Software update (1–2×/mo) | Reviews diff, checks migrations, deploys, verifies health | Reviews summary, approves | 5–10 min/mo |
+| Review health reports (daily) | Reads report, flags anomalies, presents one-line summary | Scans summary, acts only if flagged | ~5 min/mo |
+| Investigate alerts (~2/mo) | Runs diagnostics, identifies cause, proposes fix | Approves fix | ~4 min/mo |
+| Agency support (2–3/mo per agency) | Drafts response, prepares config commands | Reviews draft, sends to agency | ~12 min/agency/mo |
+| Security review (quarterly) | Runs CVE check, reviews accounts, verifies backups | Reviews findings, approves changes | ~3 min/mo (amortised) |
+| Backup restore test (quarterly) | Runs full test restore, compares row counts, reports | Nothing unless failure | ~2 min/mo (amortised) |
+
+### Human Hours by Scale
+
+| Scale | Human hours/mo | Notes |
+|-------|----------------|-------|
+| 1 agency | ~0.8–1.0 hr | Update review + health scan + 2–3 support requests |
+| 5 agencies (ops shared) | ~2.5 hr | ~0.5 hr shared ops + 5 × 25 min agency support |
+| 10 agencies (ops shared) | ~4.5–5 hr | ~0.5–0.75 hr shared ops + 10 × 25 min agency support |
 
 ### Tech Support Cost by Scale (CAD/month)
 
-These costs supplement the infrastructure costs in the tables above. They represent the human operational burden.
+| Scale | Support model | Monthly cost | Per agency |
+|-------|--------------|-------------|------------|
+| 1–2 agencies | KoNote team (internal) | $0 (absorbed) | $0 |
+| 3–5 agencies | KoNote team (billed) | ~$250/mo | ~$50 |
+| 5–10 agencies (network) | KoNote team (network pricing) | ~$100 shared + $42/agency | ~$52–62 |
+| 10+ agencies (network) | KoNote team (network pricing) | ~$150 shared + $42/agency | ~$47–57 |
 
-| Scale | Support model | Fixed cost | Variable cost | Total support cost | Per agency |
-|-------|--------------|------------|---------------|-------------------|------------|
-| 1–2 agencies | KoNote team (internal) | $0 | Internal time (~5 hr/mo) | $0 (absorbed) | $0 |
-| 3–5 agencies | KoNote team + freelance sysadmin on-call | $75/mo retainer | ~$75–125/hr if called | ~$75–150/mo | ~$15–30 |
-| 5–10 agencies (single-tenant) | Freelance sysadmin retainer | $100–150/mo | ~$75–125/hr if called | ~$100–250/mo | ~$10–25 |
-| 5–10 agencies (multi-tenant) | Freelance sysadmin retainer | $100/mo | ~$75–125/hr if called | ~$100–200/mo | ~$10–20 |
-| 10+ agencies | Canadian MSP | $300–500/mo | Included in retainer | ~$300–500/mo | ~$30–50 |
-
-**Key insight:** At 1–5 agencies with full self-healing, a freelance sysadmin on retainer (~$75–150/mo) is sufficient. The MSP option ($300–500/mo) is only justified at 10+ agencies or if 24/7 SLA coverage is contractually required.
-
-**Freelance billing model:** The retainer covers availability (responding to Layer 4 escalation alerts within a few hours). The hourly rate ($75–125/hr) applies to actual incident work beyond the retainer — e.g., if a hardware failure requires 2 hours of SSH troubleshooting and backup restoration. In a typical month with full self-healing, the retainer is the only cost (0–1 incidents requiring human intervention).
+**Key insight:** With LLM-assisted operations, KoNote does not require a traditional sysadmin or MSP. A single operator with LLM assistance can manage 30+ agencies. The limiting factor is relationship management (check-ins, training sessions, onboarding), not technical operations.
 
 ### All-In Per-Agency Cost (Infrastructure + Support)
 
-Combines infrastructure costs from Scenario B (OVHcloud) with tech support estimates above.
+Combines infrastructure costs from Scenario B (OVHcloud) with LLM-assisted support estimates above.
 
 | Scale | Infrastructure/agency | Support/agency | **All-in/agency** |
 |-------|----------------------|----------------|-------------------|
 | 1 agency | $74 | $0 (internal) | **$74** |
-| 3 agencies (single-tenant) | ~$47 | ~$25 | **~$72** |
-| 5 agencies (single-tenant) | $40 | ~$20 | **~$60** |
-| 5 agencies (multi-tenant) | $22 | ~$20 | **~$42** |
-| 10 agencies (multi-tenant) | $15 | ~$15 | **~$30** |
+| 5 agencies (single-tenant, network) | $40 | ~$62 | **~$102** |
+| 5 agencies (multi-tenant) | $22 | ~$62 | **~$84** |
+| 10 agencies (multi-tenant, network) | $15 | ~$52 | **~$67** |
 
-### Further Automation Opportunities
-
-These automations could reduce the remaining 4–5 hr/month further. See the [automation roadmap](design-rationale/ovhcloud-deployment.md#automation-roadmap-reducing-tech-support-further) in the OVHcloud deployment DRR for implementation details.
-
-| Automation | Reduces | Est. savings | Complexity |
-|-----------|---------|-------------|------------|
-| GitOps auto-update (Watchtower or webhook) | Manual update deploys | 1 hr/mo | Medium |
-| Automated Django security advisory checks | Manual CVE review | 0.25 hr/quarter | Low |
-| Agency self-service admin portal | Config change requests | 0.5–1 hr/mo | High |
-| Automated capacity alerts with upgrade recommendations | Manual capacity review | 0.5 hr/quarter | Low |
-| Consolidated multi-agency health dashboard | Per-agency health report review | 0.5 hr/mo at 5+ agencies | Medium |
+> **Note on support cost comparison:** The previous version of this section estimated 4–5 hr/mo (1 agency) assuming a traditional sysadmin doing all tasks manually. With the LLM-assisted model, human time drops to ~1 hr/mo because the LLM handles the technical work and the human only reviews and approves. The total *work* is similar — it's the *human portion* that's dramatically lower.
 
 ---
 


### PR DESCRIPTION
## Summary

- **New file:** `docs/llm-operations-runbook.md` — operational prompt and reference for LLM-assisted KoNote infrastructure management (software updates, health reports, alert investigation, agency support, security reviews, backup testing)
- **Updated:** `tasks/hosting-cost-comparison.md` — replaced "Technical Support Cost Estimates" section with LLM-assisted model (human time drops from 4–5 hr/mo to ~1 hr/mo for 1 agency). Removes freelance sysadmin/MSP pricing tiers; replaces with KoNote team + LLM tiers.
- **Updated:** COST_VERSION header with new ops_hours values and ops_model reference

## Source

Drafted in `konote-prosper-canada/tasks/drafts/` and applied upstream per instructions in `hosting-cost-comparison-update.md`.

## Test plan

- [ ] Review runbook procedures against actual OVHcloud deployment stack
- [ ] Verify cost figures in hosting-cost-comparison.md are internally consistent
- [ ] Confirm `docs/llm-operations-runbook.md` link in hosting-cost-comparison.md resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)