### PR TITLE
chore: update OVHcloud VPS pricing to March 2026 rates

### DIFF
--- a/tasks/hosting-cost-comparison.md
+++ b/tasks/hosting-cost-comparison.md
@@ -5,15 +5,15 @@
 <!-- COST_VERSION
 date: 2026-03-04
 role: Component pricing source (all scenarios)
-llm_vps: VPS-4, $40 CAD/mo (shared, all agencies)
-app_vps_single: VPS-2, $22 CAD/mo (per agency)
-app_vps_multi: VPS-3, $30 CAD/mo (shared)
+llm_vps: VPS-4, $31 CAD/mo (shared, all agencies)
+app_vps_single: VPS-2, $14 CAD/mo (per agency)
+app_vps_multi: VPS-3, $27 CAD/mo (shared)
 ai_api_per_agency: ~$7 CAD/mo (translation + metrics)
 key_vault: ~$2 CAD/mo
-ovh_single_1_agency: $74 CAD/mo
-ovh_multi_10_agencies: $15 CAD/mo/agency
-azure_single_1_agency: $141 CAD/mo
-azure_multi_10_agencies: $47 CAD/mo/agency
+ovh_single_1_agency: $57 CAD/mo
+ovh_multi_10_agencies: $13 CAD/mo/agency
+azure_single_1_agency: $132 CAD/mo
+azure_multi_10_agencies: $46 CAD/mo/agency
 ops_hours_1_agency: ~1 hr/mo human (LLM-assisted)
 ops_hours_5_agencies_network: ~2.5 hr/mo human (LLM-assisted)
 ops_hours_10_agencies_mt: ~4.5-5 hr/mo human (LLM-assisted)
@@ -82,13 +82,13 @@ This document compares two hosting approaches for KoNote, both using Azure Key V
 
 | Plan | vCores | RAM | Storage | Price (CAD/mo) |
 |------|--------|-----|---------|----------------|
-| VPS-1 | 4 | 8 GB | 75 GB NVMe | ~$11 |
-| VPS-2 | 4 | 16 GB | 100 GB NVMe | ~$22 |
-| VPS-3 | 8 | 24 GB | 200 GB NVMe | ~$30 |
-| VPS-4 | 8 | 32 GB | 200 GB NVMe | ~$44 |
+| VPS-1 | 4 | 8 GB | 75 GB NVMe | ~$9 |
+| VPS-2 | 6 | 12 GB | 100 GB NVMe | ~$14 |
+| VPS-3 | 8 | 24 GB | 200 GB NVMe | ~$27 |
+| VPS-4 | 12 | 48 GB | 300 GB NVMe | ~$31 |
 | VPS-6 | 24 | 96 GB | 400 GB NVMe | ~$105 |
 
-*Prices estimated from VPSBenchmarks and OVHcloud configurator. Post-April 2026 pricing (VPS-1 base = US$7.60). All plans include unlimited traffic. OVH parent is French-incorporated (OVH Groupe SA) — not subject to US CLOUD Act. Source: [OVHcloud Canada VPS](https://www.ovhcloud.com/en-ca/vps/), [VPSBenchmarks](https://www.vpsbenchmarks.com/compare/ovhcloud).*
+*Prices verified March 2026 from OVHcloud configurator. All plans include unlimited traffic. OVH parent is French-incorporated (OVH Groupe SA) — not subject to US CLOUD Act. VPS-6 price may need re-verification. Source: [OVHcloud Canada VPS](https://www.ovhcloud.com/en-ca/vps/).*
 
 ### AI API Costs (OpenRouter / Claude)
 
@@ -106,7 +106,7 @@ This document compares two hosting approaches for KoNote, both using Azure Key V
 |------|--------|
 | Model | Qwen3.5-35B-A3B (35B params, 3B active, MoE, Apache 2.0) |
 | Runtime | Ollama, CPU-only, nightly batch + on-demand insights |
-| Hosting | OVHcloud VPS-4 ($40 CAD/mo), Beauharnois, QC (shared endpoint) |
+| Hosting | OVHcloud VPS-4 (~$31 CAD/mo), Beauharnois, QC (shared endpoint) |
 | VPS specs | 12 vCPUs, 48 GB RAM, 300 GB NVMe |
 | Tokens per suggestion call | ~800 (prompt + suggestion + response) |
 | Volume (10 agencies) | ~1,000 suggestions/month = ~800K tokens/month |
@@ -141,8 +141,8 @@ KoNote application and databases on Azure Canada Central. Self-hosted LLM on OVH
 | Azure Key Vault | $2 | Negligible operation volume |
 | OpenRouter AI (translation) | $2 | ~100 calls/mo × gpt-4o-mini |
 | OpenRouter AI (metrics/targets) | $5 | ~200 calls/mo × Sonnet 4.5 |
-| OVHcloud VPS-4 (LLM, shared) | $40 | 1/N share of shared VPS-4 |
-| **Total per agency** | **~$141** | |
+| OVHcloud VPS-4 (LLM, shared) | $31 | 1/N share of shared VPS-4 |
+| **Total per agency** | **~$132** | |
 
 ### Multi-Agency Scaling — Single Tenant (one VM + DB per agency)
 
@@ -153,9 +153,9 @@ KoNote application and databases on Azure Canada Central. Self-hosted LLM on OVH
 | PostgreSQL storage | $3 | $15 | $30 |
 | Azure Key Vault (shared) | $2 | $2 | $2 |
 | OpenRouter AI (shared pool) | $7 | $35 | $70 |
-| OVHcloud LLM VPS-4 (shared) | $40 | $40 | $40 |
-| **Total** | **$141** | **$537** | **$1,032** |
-| **Per agency** | **$141** | **$107** | **$103** |
+| OVHcloud LLM VPS-4 (shared) | $31 | $31 | $31 |
+| **Total** | **$132** | **$528** | **$1,023** |
+| **Per agency** | **$132** | **$106** | **$102** |
 
 ### Multi-Agency Scaling — Multi-Tenant (shared infrastructure)
 
@@ -168,9 +168,9 @@ KoNote application and databases on Azure Canada Central. Self-hosted LLM on OVH
 | PostgreSQL storage (100 GB) | $16 | $16 | $16 |
 | Azure Key Vault (shared) | $2 | $2 | $2 |
 | OpenRouter AI (shared pool) | $7 | $35 | $70 |
-| OVHcloud LLM VPS-4 (shared) | $40 | $40 | $40 |
-| **Total** | **$403** | **$431** | **$466** |
-| **Per agency** | **$403** | **$86** | **$47** |
+| OVHcloud LLM VPS-4 (shared) | $31 | $31 | $31 |
+| **Total** | **$394** | **$422** | **$457** |
+| **Per agency** | **$394** | **$84** | **$46** |
 
 ---
 
@@ -182,25 +182,25 @@ KoNote application, databases, and LLM all on OVHcloud VPS(es) in Beauharnois. S
 
 | Component | 1 Agency | Notes |
 |-----------|----------|-------|
-| OVHcloud VPS-2 | $22 | Django + PostgreSQL x2 + Caddy |
+| OVHcloud VPS-2 | $14 | Django + PostgreSQL x2 + Caddy |
 | Azure Key Vault | $2 | Encryption key management |
 | OpenRouter AI (translation) | $2 | ~100 calls/mo × gpt-4o-mini |
 | OpenRouter AI (metrics/targets) | $5 | ~200 calls/mo × Sonnet 4.5 |
-| OVHcloud LLM VPS-4 (shared) | $40 | 1/N share of shared VPS-4 |
+| OVHcloud LLM VPS-4 (shared) | $31 | 1/N share of shared VPS-4 |
 | Automated backups (OVH option) | $3 | Optional add-on |
-| **Total per agency** | **~$74** | |
+| **Total per agency** | **~$57** | |
 
 ### Multi-Agency Scaling — Single Tenant (one VPS per agency)
 
 | Component | 1 Agency | 5 Agencies | 10 Agencies |
 |-----------|----------|------------|-------------|
-| OVHcloud VPS-2 per agency | $22 | $110 | $220 |
+| OVHcloud VPS-2 per agency | $14 | $70 | $140 |
 | Azure Key Vault (shared) | $2 | $2 | $2 |
 | OpenRouter AI (shared pool) | $7 | $35 | $70 |
-| OVHcloud LLM VPS-4 (shared) | $40 | $40 | $40 |
+| OVHcloud LLM VPS-4 (shared) | $31 | $31 | $31 |
 | Backup add-ons | $3 | $15 | $30 |
-| **Total** | **$74** | **$202** | **$362** |
-| **Per agency** | **$74** | **$40** | **$36** |
+| **Total** | **$57** | **$153** | **$273** |
+| **Per agency** | **$57** | **$31** | **$27** |
 
 ### Multi-Agency Scaling — Multi-Tenant (shared infrastructure)
 
@@ -208,15 +208,15 @@ KoNote application, databases, and LLM all on OVHcloud VPS(es) in Beauharnois. S
 
 | Component | 1 Agency | 5 Agencies | 10 Agencies |
 |-----------|----------|------------|-------------|
-| OVHcloud VPS-3 (shared app + DB) | $30 | $30 | $30 |
-| OVHcloud VPS-4 (LLM, shared) | $40 | $40 | $40 |
+| OVHcloud VPS-3 (shared app + DB) | $27 | $27 | $27 |
+| OVHcloud VPS-4 (LLM, shared) | $31 | $31 | $31 |
 | Azure Key Vault (shared) | $2 | $2 | $2 |
 | OpenRouter AI (shared pool) | $7 | $35 | $70 |
 | Backup add-ons | $3 | $3 | $3 |
-| **Total** | **$82** | **$110** | **$145** |
-| **Per agency** | **$82** | **$22** | **$15** |
+| **Total** | **$70** | **$98** | **$133** |
+| **Per agency** | **$70** | **$20** | **$13** |
 
-*At 10+ agencies, consider upgrading app VPS to VPS-4 ($44) for headroom.*
+*At 10+ agencies, consider upgrading app VPS to VPS-4 (~$31) for headroom.*
 
 ---
 
@@ -234,19 +234,19 @@ KoNote application, databases, and LLM all on OVHcloud VPS(es) in Beauharnois. S
 
 | Scale | Azure Single-Tenant | Azure Multi-Tenant | OVH Single-Tenant | OVH Multi-Tenant |
 |-------|--------------------|--------------------|--------------------|--------------------|
-| 1 agency | $141 | $403* | $74 | $82* |
-| 5 agencies | $107 | $86 | $40 | $22 |
-| 10 agencies | $103 | $47 | $36 | $15 |
+| 1 agency | $132 | $394* | $57 | $70* |
+| 5 agencies | $106 | $84 | $31 | $20 |
+| 10 agencies | $102 | $46 | $27 | $13 |
 
-*\*Multi-tenant with 1 agency is more expensive due to the larger shared VM — cost advantage kicks in at 3+ agencies. All scenarios include $40/mo shared LLM VPS (VPS-4).*
+*\*Multi-tenant with 1 agency is more expensive due to the larger shared VM — cost advantage kicks in at 3+ agencies. All scenarios include ~$31/mo shared LLM VPS (VPS-4).*
 
 ### Total Monthly Cost (CAD)
 
 | Scale | Azure Single-Tenant | Azure Multi-Tenant | OVH Single-Tenant | OVH Multi-Tenant |
 |-------|--------------------|--------------------|--------------------|--------------------|
-| 1 agency | $141 | $403 | $74 | $82 |
-| 5 agencies | $537 | $431 | $202 | $110 |
-| 10 agencies | $1,032 | $466 | $362 | $145 |
+| 1 agency | $132 | $394 | $57 | $70 |
+| 5 agencies | $528 | $422 | $153 | $98 |
+| 10 agencies | $1,023 | $457 | $273 | $133 |
 
 ---
 
@@ -277,10 +277,10 @@ These costs apply to both Azure and OVHcloud hosting scenarios.
 | Item | Value |
 |------|-------|
 | Model | Qwen3.5-35B-A3B on Ollama (primary); Qwen3.5-27B (backup/quality) |
-| Hosting | OVHcloud VPS-4 ($40 CAD/mo shared — 12 vCPUs, 48 GB RAM) |
+| Hosting | OVHcloud VPS-4 (~$31 CAD/mo shared — 12 vCPUs, 48 GB RAM) |
 | Volume (10 agencies) | ~1,000 suggestions/month |
 | CPU inference time | ~1–2 hours/month (nightly batch) |
-| Per-agency cost (10 agencies) | ~$4 CAD/mo |
+| Per-agency cost (10 agencies) | ~$3 CAD/mo |
 | API cost | $0 (self-hosted, Apache 2.0 licence) |
 
 ---
@@ -343,13 +343,13 @@ Total automation cost: ~$0 additional (uses free tiers of monitoring services).
 
 ## Recommendations
 
-1. **For 1–3 agencies (launch phase)**: OVHcloud single-tenant at ~$74/agency/month vs ~$141 on Azure. The $40 LLM VPS is a fixed cost that becomes negligible at scale.
+1. **For 1–3 agencies (launch phase)**: OVHcloud single-tenant at ~$57/agency/month vs ~$132 on Azure. The ~$31 LLM VPS is a fixed cost that becomes negligible at scale.
 
-2. **For 5–10 agencies (growth phase)**: Implement multi-tenancy first (MT-CORE1), then OVHcloud multi-tenant brings costs to $15–22/agency/month — still dramatically cheaper than Azure single-tenant.
+2. **For 5–10 agencies (growth phase)**: Implement multi-tenancy first (MT-CORE1), then OVHcloud multi-tenant brings costs to $13–20/agency/month — still dramatically cheaper than Azure single-tenant.
 
 3. **Azure makes sense if**: The agency or funder requires Azure specifically, or if the operational burden of self-managing PostgreSQL is unacceptable.
 
-4. **LLM hosting**: One shared OVHcloud VPS-4 ($40 CAD/month) serves all agencies — whether 1 or 100. Upgrade in-place if more capacity is needed (VPS-5 at ~$59, VPS-6 at ~$105). Complete data sovereignty on participant suggestions.
+4. **LLM hosting**: One shared OVHcloud VPS-4 (~$31 CAD/month) serves all agencies — whether 1 or 100. Upgrade in-place if more capacity is needed (VPS-6 at ~$105). Complete data sovereignty on participant suggestions.
 
 5. **Key Vault**: Use Azure Key Vault in both scenarios. The CLOUD Act exposure is limited to the encryption key only, and the operational simplicity of managed KMS outweighs the theoretical risk for KoNote's threat model.
 
@@ -414,10 +414,10 @@ Combines infrastructure costs from Scenario B (OVHcloud) with LLM-assisted suppo
 
 | Scale | Infrastructure/agency | Support/agency | **All-in/agency** |
 |-------|----------------------|----------------|-------------------|
-| 1 agency | $74 | $0 (internal) | **$74** |
-| 5 agencies (single-tenant, network) | $40 | ~$62 | **~$102** |
-| 5 agencies (multi-tenant) | $22 | ~$62 | **~$84** |
-| 10 agencies (multi-tenant, network) | $15 | ~$52 | **~$67** |
+| 1 agency | $57 | $0 (internal) | **$57** |
+| 5 agencies (single-tenant, network) | $31 | ~$62 | **~$93** |
+| 5 agencies (multi-tenant) | $20 | ~$62 | **~$82** |
+| 10 agencies (multi-tenant, network) | $13 | ~$52 | **~$65** |
 
 > **Note on support cost comparison:** The previous version of this section estimated 4–5 hr/mo (1 agency) assuming a traditional sysadmin doing all tasks manually. With the LLM-assisted model, human time drops to ~1 hr/mo because the LLM handles the technical work and the human only reviews and approves. The total *work* is similar — it's the *human portion* that's dramatically lower.
 


### PR DESCRIPTION
## Summary

- Updated OVHcloud VPS pricing table with current March 2026 specs and prices
- **VPS-2**: 4 vCores/16 GB → 6 vCores/12 GB, $22 → $14
- **VPS-4**: 8 vCores/32 GB/200 GB → 12 vCores/48 GB/300 GB, $44 → $31
- Resolved VPS-4 price mismatch ($40 in COST_VERSION header vs $44 in table → $31 everywhere)
- Cascaded new prices through all 8 scenario tables, both summary tables, recommendations, self-hosted LLM section, and all-in per-agency costs
- OVH single-tenant 1-agency drops from $74 → $57; multi-tenant 10-agency from $15 → $13

## Test plan

- [ ] Spot-check arithmetic in scenario tables (component lines should sum to totals)
- [ ] Verify VPS-6 price (~$105) — not updated, may also have changed
- [ ] Confirm downstream docs (`p0-managed-service-plan.md`, prosper-canada costing model) are updated separately

🤖 Generated with [Claude Code](https://claude.com/claude-code)