### PR TITLE
fix: address 11 review findings from metric/alliance PR

### DIFF
--- a/apps/notes/models.py
+++ b/apps/notes/models.py
@@ -112,6 +112,10 @@ class ProgressNoteTemplateMetric(models.Model):
         ordering = ["sort_order"]
 
 
+# Alliance prompt rotation sets — 3 phrasings cycled per-client to prevent
+# habituation.  Currently hardcoded; if the content team needs to add or edit
+# prompts without a code deploy, consider moving to a DB-backed model or a
+# JSON config file loaded at startup.
 ALLIANCE_PROMPT_SETS = [
     {
         "prompt": "How well are we working together?",

--- a/apps/notes/views.py
+++ b/apps/notes/views.py
@@ -216,23 +216,37 @@ def _build_target_forms(client, post_data=None, auto_calc=None):
         ptm_qs = PlanTargetMetric.objects.filter(plan_target=target).select_related("metric_def").order_by("sort_order")
         metric_forms = []
         skipped_metrics = []
+
+        # Prefetch cadence data: last recorded time per metric_def for this client
+        cadenced_defs = [
+            ptm.metric_def_id for ptm in ptm_qs
+            if ptm.metric_def.cadence_sessions and ptm.metric_def.cadence_sessions > 1
+        ]
+        last_recorded_map = {}
+        if cadenced_defs:
+            from django.db.models import Max
+            last_recorded_map = dict(
+                MetricValue.objects.filter(
+                    metric_def_id__in=cadenced_defs,
+                    progress_note_target__progress_note__client_file=client,
+                    progress_note_target__progress_note__status="default",
+                ).values("metric_def_id").annotate(
+                    last_at=Max("created_at"),
+                ).values_list("metric_def_id", "last_at")
+            )
+
         for ptm in ptm_qs:
             # Cadence check: skip metric if not yet due
             is_due = True
             sessions_until_due = 0
             if ptm.metric_def.cadence_sessions and ptm.metric_def.cadence_sessions > 1:
-                last_recorded = MetricValue.objects.filter(
-                    metric_def=ptm.metric_def,
-                    progress_note_target__progress_note__client_file=client,
-                    progress_note_target__progress_note__status="default",
-                ).order_by("-created_at").first()
-
-                if last_recorded:
+                last_at = last_recorded_map.get(ptm.metric_def_id)
+                if last_at:
                     notes_since = ProgressNote.objects.filter(
                         client_file=client,
                         status="default",
                         note_type="full",
-                        created_at__gt=last_recorded.created_at,
+                        created_at__gt=last_at,
                     ).count()
                     if notes_since < ptm.metric_def.cadence_sessions - 1:
                         is_due = False
@@ -259,7 +273,6 @@ def _build_target_forms(client, post_data=None, auto_calc=None):
             else:
                 mf.auto_calc_value = None
             # 90-day metric review check
-            import datetime
             if ptm.last_reviewed_date:
                 days_since_review = (datetime.date.today() - ptm.last_reviewed_date).days
                 mf.review_due = days_since_review >= 90
@@ -1032,6 +1045,15 @@ def note_cancel(request, note_id):
                 is_demo_context=getattr(user, "is_demo", False),
                 metadata={"reason": form.cleaned_data["status_reason"]},
             )
+            # Expire any pending portal alliance request for this note
+            try:
+                from apps.portal.models import PortalAllianceRequest
+                PortalAllianceRequest.objects.filter(
+                    progress_note=note,
+                    status="pending",
+                ).update(status="expired")
+            except Exception:
+                pass
             messages.success(request, _("Note cancelled."))
             return redirect("notes:note_list", client_id=client.pk)
     else:

--- a/apps/plans/views.py
+++ b/apps/plans/views.py
@@ -1,5 +1,6 @@
 """Phase 3: Plan editing views — sections, targets, metrics, revisions."""
 import csv
+import datetime
 import io
 from collections import OrderedDict
 
@@ -1255,12 +1256,23 @@ def metric_import(request):
 @requires_permission("plan.edit", _get_program_from_ptm)
 def confirm_metric_review(request, ptm_id):
     """HTMX endpoint: confirm a metric is still relevant (90-day review)."""
-    import datetime
-
     ptm = get_object_or_404(PlanTargetMetric, pk=ptm_id)
     if request.method == "POST":
         ptm.last_reviewed_date = datetime.date.today()
         ptm.save(update_fields=["last_reviewed_date"])
+        AuditLog.objects.using("audit").create(
+            event_timestamp=timezone.now(),
+            user_id=request.user.pk,
+            user_display=getattr(request.user, "display_name", str(request.user)),
+            action="confirm_metric_review",
+            resource_type="plan_target_metric",
+            resource_id=ptm.pk,
+            is_demo_context=getattr(request.user, "is_demo", False),
+            metadata={
+                "metric_def_id": ptm.metric_def_id,
+                "metric_name": ptm.metric_def.name,
+            },
+        )
         return HttpResponse(
             '<small class="secondary">\u2713 ' + str(_("Confirmed — still relevant")) + "</small>",
             content_type="text/html",

--- a/apps/portal/management/commands/expire_alliance_requests.py
+++ b/apps/portal/management/commands/expire_alliance_requests.py
@@ -1,0 +1,25 @@
+"""Batch-expire stale PortalAllianceRequest records past their expiry date.
+
+Run periodically (e.g. daily via cron) to clean up requests that participants
+never visited:
+
+    python manage.py expire_alliance_requests
+"""
+from django.core.management.base import BaseCommand
+from django.utils import timezone
+
+
+class Command(BaseCommand):
+    help = "Expire pending portal alliance requests that have passed their expiry date."
+
+    def handle(self, *args, **options):
+        from apps.portal.models import PortalAllianceRequest
+
+        expired_count = PortalAllianceRequest.objects.filter(
+            status="pending",
+            expires_at__lt=timezone.now(),
+        ).update(status="expired")
+
+        self.stdout.write(
+            self.style.SUCCESS(f"Expired {expired_count} stale alliance request(s).")
+        )

--- a/apps/portal/templates/portal/alliance_rating.html
+++ b/apps/portal/templates/portal/alliance_rating.html
@@ -31,6 +31,9 @@
 
         <form method="post">
             {% csrf_token %}
+            {% if rating_error %}
+            <p class="error" role="alert">{{ rating_error }}</p>
+            {% endif %}
             <fieldset>
                 <div class="alliance-pills" role="radiogroup" aria-label="{{ alliance_prompt }}">
                     {% for value, label in alliance_choices %}

--- a/apps/portal/views.py
+++ b/apps/portal/views.py
@@ -2091,6 +2091,7 @@ def portal_alliance_rating(request, request_id):
     anchors = prompt_set["anchors_fr"] if lang.startswith("fr") else prompt_set["anchors"]
     alliance_choices = list(anchors.items())
 
+    rating_error = ""
     if request.method == "POST":
         rating_str = request.POST.get("rating", "")
         try:
@@ -2114,11 +2115,14 @@ def portal_alliance_rating(request, request_id):
                     "rating": rating,
                 })
                 return render(request, "portal/alliance_rating.html", {"completed": True})
+            else:
+                rating_error = _("Please select a rating.")
         except (ValueError, TypeError):
-            pass
+            rating_error = _("Please select a rating.")
 
     return render(request, "portal/alliance_rating.html", {
         "alliance_prompt": alliance_prompt,
         "alliance_choices": alliance_choices,
         "alliance_req": alliance_req,
+        "rating_error": rating_error,
     })

--- a/apps/tenants/management/commands/provision_tenant.py
+++ b/apps/tenants/management/commands/provision_tenant.py
@@ -134,10 +134,13 @@ class Command(BaseCommand):
 
         # Default feature toggles
         FeatureToggle.objects.get_or_create(
-            name="programs", defaults={"is_enabled": True},
+            feature_key="programs", defaults={"is_enabled": True},
         )
         FeatureToggle.objects.get_or_create(
-            name="portal", defaults={"is_enabled": False},
+            feature_key="portal", defaults={"is_enabled": False},
+        )
+        FeatureToggle.objects.get_or_create(
+            feature_key="portal_alliance_ratings", defaults={"is_enabled": False},
         )
 
         self.stdout.write(self.style.SUCCESS("  Default configuration loaded."))

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -18608,6 +18608,8 @@ msgstr ""
 msgid "Recording cadence (sessions)"
 msgstr "Cadence d'enregistrement (séances)"
 
+# NOTE: This is a blocktrans string — translate_strings cannot auto-extract it.
+# If the English wording changes in note_form.html, update this msgid manually.
 #: templates/notes/note_form.html
 #, python-format
 msgid "next due in %(n)s session(s)"
@@ -18681,6 +18683,18 @@ msgstr ""
 #: apps/portal/templates/portal/alliance_rating.html
 msgid "Submit rating"
 msgstr "Soumettre l'évaluation"
+
+#: apps/portal/templates/portal/dashboard.html
+msgid ""
+"Your worker recorded a session recently. Take a moment to share how you felt "
+"about working together."
+msgstr ""
+"Votre intervenant·e a enregistré une séance récemment. Prenez un moment pour "
+"partager comment vous vous êtes senti(e) par rapport à votre collaboration."
+
+#: apps/portal/views.py
+msgid "Please select a rating."
+msgstr "Veuillez sélectionner une évaluation."
 
 #: apps/portal/templates/portal/dashboard.html
 msgid "Rate now"

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -658,3 +658,29 @@ class TestMetricReview(TestCase):
         self.ptm.refresh_from_db()
         self.assertEqual(self.ptm.last_reviewed_date, datetime.date.today())
 
+    def test_confirm_review_creates_audit_log(self):
+        """Confirming metric review creates an audit trail entry."""
+        from apps.audit.models import AuditLog
+        http_client = Client()
+        http_client.login(username="revtest", password="testpass123")
+        from django.urls import reverse
+        url = reverse("plans:confirm_metric_review", kwargs={"ptm_id": self.ptm.pk})
+        http_client.post(url)
+        log = AuditLog.objects.using("audit").filter(
+            action="confirm_metric_review",
+            resource_type="plan_target_metric",
+            resource_id=self.ptm.pk,
+        ).first()
+        self.assertIsNotNone(log)
+        self.assertEqual(log.user_id, self.user.pk)
+
+    def test_confirm_review_requires_csrf(self):
+        """POST without CSRF token is rejected (Django middleware enforces)."""
+        from django.test import Client as DjangoClient
+        from django.urls import reverse
+        http_client = DjangoClient(enforce_csrf_checks=True)
+        http_client.login(username="revtest", password="testpass123")
+        url = reverse("plans:confirm_metric_review", kwargs={"ptm_id": self.ptm.pk})
+        response = http_client.post(url)
+        self.assertEqual(response.status_code, 403)
+


### PR DESCRIPTION
## Summary

Fixes all 11 issues identified in the session review of PR #274 (metric freshness & alliance rating). Prioritised by an expert panel (Django security, nonprofit UX, bilingual QA, privacy/compliance).

**Fix now (critical):**
- Add missing French translation for dashboard alliance prompt string
- Show validation error ("Please select a rating") when portal rating submission is invalid
- Add PIPEDA-required audit log entry when worker confirms metric review

**Fix soon (important):**
- Expire pending portal alliance requests when a note is cancelled (prevents rating cancelled sessions)
- Seed `portal_alliance_ratings` feature toggle in `provision_tenant` (also fixes pre-existing `name=` → `feature_key=` bug)
- Remove redundant `import datetime` from function bodies

**Other improvements:**
- Add CSRF enforcement test for `confirm_metric_review` HTMX endpoint
- Batch cadence queries (prefetch last-recorded timestamps via aggregate, eliminates N+1)
- Document that `ALLIANCE_PROMPT_SETS` could be moved to DB-backed model
- Add `blocktrans` extraction note in .po file
- Add `expire_alliance_requests` management command for cron-based cleanup

## Test plan

- [x] All 21 metric/alliance tests pass (19 original + 2 new)
- [x] New test: `test_confirm_review_creates_audit_log` verifies PIPEDA audit trail
- [x] New test: `test_confirm_review_requires_csrf` verifies CSRF enforcement (403 without token)

🤖 Generated with [Claude Code](https://claude.com/claude-code)