### PR TITLE
Fix 8 review findings for consent withdrawal

### DIFF
--- a/apps/clients/forms.py
+++ b/apps/clients/forms.py
@@ -5,7 +5,7 @@ from django.utils.translation import gettext_lazy as _
 
 from apps.programs.models import Program
 
-from .models import ClientFile, CustomFieldDefinition, CustomFieldGroup
+from .models import ClientFile, ConsentEvent, CustomFieldDefinition, CustomFieldGroup
 from .validators import normalize_phone_number, validate_phone_number
 
 
@@ -38,12 +38,10 @@ class ConsentRecordForm(forms.Form):
 class ConsentWithdrawalForm(forms.Form):
     """Form to record consent withdrawal (PIPEDA/PHIPA compliance)."""
 
-    WITHDRAWAL_REASON_CHOICES = [
-        ("participant_requested", _("Participant requested")),
-        ("guardian_requested", _("Guardian/substitute decision-maker requested")),
-        ("service_ended", _("Service relationship ended")),
-        ("transferred", _("Transferred to another agency")),
-        ("other", _("Other")),
+    REQUEST_RECEIVED_VIA_CHOICES = [
+        ("written", _("Written request")),
+        ("verbal", _("Verbal request")),
+        ("representative", _("Representative / substitute decision-maker")),
     ]
 
     withdrawal_date = forms.DateField(
@@ -51,9 +49,15 @@ class ConsentWithdrawalForm(forms.Form):
         widget=forms.DateInput(attrs={"type": "date"}),
     )
     withdrawal_reason = forms.ChoiceField(
-        choices=WITHDRAWAL_REASON_CHOICES,
+        choices=ConsentEvent.WITHDRAWAL_REASON_CHOICES[1:],  # skip blank
         label=_("Reason for withdrawal"),
         required=True,
+    )
+    request_received_via = forms.ChoiceField(
+        choices=REQUEST_RECEIVED_VIA_CHOICES,
+        label=_("Request received via"),
+        required=True,
+        initial="written",
     )
     notes = forms.CharField(
         required=False,
@@ -67,6 +71,13 @@ class ConsentWithdrawalForm(forms.Form):
         label=_("I confirm this participant has requested consent withdrawal"),
         required=True,
     )
+
+    def clean_withdrawal_date(self):
+        """Reject future dates — withdrawal must have already occurred."""
+        dt = self.cleaned_data["withdrawal_date"]
+        if dt > timezone.now().date():
+            raise forms.ValidationError(_("Withdrawal date cannot be in the future."))
+        return dt
 
 
 class ClientContactForm(forms.Form):

--- a/apps/clients/migrations/0035_consentevent_request_received_via.py
+++ b/apps/clients/migrations/0035_consentevent_request_received_via.py
@@ -1,0 +1,23 @@
+"""Add request_received_via field to ConsentEvent."""
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("clients", "0034_consentevent"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="consentevent",
+            name="request_received_via",
+            field=models.CharField(
+                blank=True,
+                default="",
+                help_text="How the withdrawal request was received (written, verbal, representative).",
+                max_length=20,
+            ),
+        ),
+    ]

--- a/apps/clients/models.py
+++ b/apps/clients/models.py
@@ -128,6 +128,11 @@ class ClientFile(models.Model):
         self._preferred_name_encrypted = encrypt_field(value)
 
     @property
+    def is_consent_withdrawn(self):
+        """True when consent was withdrawn and retention clock is ticking."""
+        return self.consent_given_at is None and self.retention_expires is not None
+
+    @property
     def display_name(self):
         """Return preferred name if set, otherwise first name.
 
@@ -380,6 +385,12 @@ class ConsentEvent(models.Model):
         blank=True,
         default="",
         choices=WITHDRAWAL_REASON_CHOICES,
+    )
+    request_received_via = models.CharField(
+        max_length=20,
+        blank=True,
+        default="",
+        help_text=_("How the withdrawal request was received (written, verbal, representative)."),
     )
     notes = models.TextField(blank=True, default="")
 

--- a/apps/clients/views.py
+++ b/apps/clients/views.py
@@ -480,7 +480,7 @@ def client_edit(request, client_id):
     client = get_object_or_404(base_queryset, pk=client_id)
 
     # Block edits when consent has been withdrawn (QA-R7-PRIVACY2)
-    if client.consent_given_at is None and client.retention_expires is not None:
+    if client.is_consent_withdrawn:
         messages.error(request, _("This record is read-only because consent has been withdrawn."))
         return redirect("clients:client_detail", client_id=client.pk)
 
@@ -886,7 +886,7 @@ def client_contact_edit(request, client_id):
     client = get_object_or_404(base_queryset, pk=client_id)
 
     # Block edits when consent has been withdrawn (QA-R7-PRIVACY2)
-    if client.consent_given_at is None and client.retention_expires is not None:
+    if client.is_consent_withdrawn:
         messages.error(request, _("This record is read-only because consent has been withdrawn."))
         return redirect("clients:client_detail", client_id=client.pk)
 
@@ -1211,7 +1211,7 @@ def client_save_custom_fields(request, client_id):
     client = get_object_or_404(base_queryset, pk=client_id)
 
     # Block edits when consent has been withdrawn (QA-R7-PRIVACY2)
-    if client.consent_given_at is None and client.retention_expires is not None:
+    if client.is_consent_withdrawn:
         messages.error(request, _("This record is read-only because consent has been withdrawn."))
         return redirect("clients:client_detail", client_id=client.pk)
 
@@ -1296,10 +1296,10 @@ def client_consent_display(request, client_id):
     base_queryset = get_client_queryset(request.user)
     client = get_object_or_404(base_queryset, pk=client_id)
     user_role = getattr(request, "user_program_role", None)
-    is_receptionist = user_role == "receptionist"
+    is_pm_or_admin = user_role in ("program_manager", "executive") or getattr(request.user, "is_admin", False)
     return render(request, "clients/_consent_display.html", {
         "client": client,
-        "is_receptionist": is_receptionist,
+        "is_pm_or_admin": is_pm_or_admin,
     })
 
 
@@ -1333,10 +1333,12 @@ def client_consent_save(request, client_id):
     """
     from django.utils import timezone
 
+    from apps.audit.models import AuditLog
+
     base_queryset = get_client_queryset(request.user)
     client = get_object_or_404(base_queryset, pk=client_id)
     user_role = getattr(request, "user_program_role", None)
-    is_receptionist = user_role == "receptionist"
+    is_pm_or_admin = user_role in ("program_manager", "executive") or getattr(request.user, "is_admin", False)
 
     if request.method == "POST":
         form = ConsentRecordForm(request.POST)
@@ -1352,9 +1354,11 @@ def client_consent_save(request, client_id):
                 if request.headers.get("HX-Request"):
                     return render(request, "clients/_consent_display.html", {
                         "client": client,
-                        "is_receptionist": is_receptionist,
+                        "is_pm_or_admin": is_pm_or_admin,
                     })
                 return redirect("clients:client_detail", client_id=client.pk)
+
+            is_regrant = client.retention_expires is not None
 
             # Combine date with current time for the timestamp
             consent_date = form.cleaned_data["consent_date"]
@@ -1381,6 +1385,22 @@ def client_consent_save(request, client_id):
                 consent_type=form.cleaned_data["consent_type"],
             )
 
+            # Audit log for consent grant/re-grant
+            AuditLog.objects.using("audit").create(
+                event_timestamp=timezone.now(),
+                user_id=request.user.pk,
+                user_display=str(request.user),
+                ip_address=request.META.get("REMOTE_ADDR"),
+                action="create" if not is_regrant else "update",
+                resource_type="consent",
+                resource_id=client.pk,
+                new_values={
+                    "consent_given_at": client.consent_given_at.isoformat(),
+                    "consent_type": client.consent_type,
+                    "is_regrant": is_regrant,
+                },
+            )
+
             messages.success(request, _("Consent recorded."))
         else:
             messages.error(request, _("Please correct the errors."))
@@ -1395,7 +1415,7 @@ def client_consent_save(request, client_id):
     if request.headers.get("HX-Request"):
         return render(request, "clients/_consent_display.html", {
             "client": client,
-            "is_receptionist": is_receptionist,
+            "is_pm_or_admin": is_pm_or_admin,
         })
 
     return redirect("clients:client_detail", client_id=client.pk)
@@ -1408,14 +1428,14 @@ def client_consent_withdraw_form(request, client_id):
     base_queryset = get_client_queryset(request.user)
     client = get_object_or_404(base_queryset, pk=client_id)
     user_role = getattr(request, "user_program_role", None)
-    is_receptionist = user_role == "receptionist"
+    is_pm_or_admin = user_role in ("program_manager", "executive") or getattr(request.user, "is_admin", False)
 
     if not client.consent_given_at:
         messages.info(request, _("No active consent to withdraw."))
         if request.headers.get("HX-Request"):
             return render(request, "clients/_consent_display.html", {
                 "client": client,
-                "is_receptionist": is_receptionist,
+                "is_pm_or_admin": is_pm_or_admin,
             })
         return redirect("clients:client_detail", client_id=client.pk)
 
@@ -1440,7 +1460,7 @@ def client_consent_withdraw(request, client_id):
     base_queryset = get_client_queryset(request.user)
     client = get_object_or_404(base_queryset, pk=client_id)
     user_role = getattr(request, "user_program_role", None)
-    is_receptionist = user_role == "receptionist"
+    is_pm_or_admin = user_role in ("program_manager", "executive") or getattr(request.user, "is_admin", False)
 
     if request.method != "POST":
         return redirect("clients:client_detail", client_id=client.pk)
@@ -1450,7 +1470,7 @@ def client_consent_withdraw(request, client_id):
         if request.headers.get("HX-Request"):
             return render(request, "clients/_consent_display.html", {
                 "client": client,
-                "is_receptionist": is_receptionist,
+                "is_pm_or_admin": is_pm_or_admin,
             })
         return redirect("clients:client_detail", client_id=client.pk)
 
@@ -1471,6 +1491,7 @@ def client_consent_withdraw(request, client_id):
             recorded_by_display=str(request.user),
             consent_type=old_consent_type,
             withdrawal_reason=form.cleaned_data["withdrawal_reason"],
+            request_received_via=form.cleaned_data["request_received_via"],
             notes=form.cleaned_data.get("notes", ""),
         )
 
@@ -1505,6 +1526,7 @@ def client_consent_withdraw(request, client_id):
                 "consent_given_at": None,
                 "consent_type": "",
                 "withdrawal_reason": form.cleaned_data["withdrawal_reason"],
+                "request_received_via": form.cleaned_data["request_received_via"],
                 "retention_expires": client.retention_expires.isoformat(),
             },
         )
@@ -1523,7 +1545,7 @@ def client_consent_withdraw(request, client_id):
     if request.headers.get("HX-Request"):
         return render(request, "clients/_consent_display.html", {
             "client": client,
-            "is_receptionist": is_receptionist,
+            "is_pm_or_admin": is_pm_or_admin,
         })
     return redirect("clients:client_detail", client_id=client.pk)
 

--- a/apps/events/views.py
+++ b/apps/events/views.py
@@ -358,6 +358,11 @@ def event_create(request, client_id):
     if client is None:
         return HttpResponseForbidden("You do not have access to this client.")
 
+    # Block edits when consent has been withdrawn (QA-R7-PRIVACY2)
+    if client.is_consent_withdrawn:
+        messages.error(request, _("This record is read-only because consent has been withdrawn."))
+        return redirect("events:event_list", client_id=client.pk)
+
     can_flag_sre = _user_can_flag_sre(request.user)
 
     if request.method == "POST":
@@ -417,6 +422,12 @@ def event_edit(request, client_id, event_id):
     client = _get_client_or_403(request, client_id)
     if client is None:
         return HttpResponseForbidden("You do not have access to this client.")
+
+    # Block edits when consent has been withdrawn (QA-R7-PRIVACY2)
+    if client.is_consent_withdrawn:
+        messages.error(request, _("This record is read-only because consent has been withdrawn."))
+        return redirect("events:event_list", client_id=client.pk)
+
     event = get_object_or_404(Event, pk=event_id, client_file=client)
 
     can_flag_sre = _user_can_flag_sre(request.user)

--- a/apps/plans/views.py
+++ b/apps/plans/views.py
@@ -292,7 +292,7 @@ def target_create(request, section_id):
 
     # Block edits when consent has been withdrawn (QA-R7-PRIVACY2)
     client = section.client_file
-    if client.consent_given_at is None and client.retention_expires is not None:
+    if client.is_consent_withdrawn:
         messages.error(request, _("This record is read-only because consent has been withdrawn."))
         return redirect("plans:plan_view", client_id=client.pk)
 
@@ -340,7 +340,7 @@ def target_edit(request, target_id):
 
     # Block edits when consent has been withdrawn (QA-R7-PRIVACY2)
     client = target.client_file
-    if client.consent_given_at is None and client.retention_expires is not None:
+    if client.is_consent_withdrawn:
         messages.error(request, _("This record is read-only because consent has been withdrawn."))
         return redirect("plans:plan_view", client_id=client.pk)
 
@@ -389,7 +389,7 @@ def target_status(request, target_id):
 
     # Block edits when consent has been withdrawn (QA-R7-PRIVACY2)
     client = target.client_file
-    if client.consent_given_at is None and client.retention_expires is not None:
+    if client.is_consent_withdrawn:
         messages.error(request, _("This record is read-only because consent has been withdrawn."))
         return redirect("plans:plan_view", client_id=client.pk)
 

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -18790,3 +18790,21 @@ msgstr "Consentement retiré"
 
 msgid "Date the consent event occurred."
 msgstr "Date à laquelle l'événement de consentement s'est produit."
+
+msgid "How the withdrawal request was received (written, verbal, representative)."
+msgstr "Comment la demande de retrait a été reçue (écrite, verbale, représentant)."
+
+msgid "Written request"
+msgstr "Demande écrite"
+
+msgid "Verbal request"
+msgstr "Demande verbale"
+
+msgid "Representative / substitute decision-maker"
+msgstr "Représentant / mandataire spécial"
+
+msgid "Request received via"
+msgstr "Demande reçue par"
+
+msgid "Withdrawal date cannot be in the future."
+msgstr "La date de retrait ne peut pas être dans le futur."

--- a/templates/clients/_consent_display.html
+++ b/templates/clients/_consent_display.html
@@ -11,7 +11,7 @@
         <dt>{% trans "Recorded" %}</dt>
         <dd>{{ client.consent_given_at|date:"Y-m-d" }}</dd>
     </div>
-    {% if not is_receptionist %}
+    {% if is_pm_or_admin %}
     <div class="quick-info-item">
         <dd>
             <button type="button"
@@ -43,7 +43,7 @@
         <strong>{% trans "Consent has been withdrawn." %}</strong>
         {% trans "This record is read-only. Data will be retained until" %} {{ client.retention_expires|date:"Y-m-d" }}.
     </p>
-    {% if not is_receptionist %}
+    {% if is_pm_or_admin %}
     <button type="button"
             class="outline"
             hx-get="{% url 'clients:client_consent_edit' client_id=client.pk %}"

--- a/templates/clients/_consent_withdraw.html
+++ b/templates/clients/_consent_withdraw.html
@@ -42,6 +42,12 @@
         <small class="error" role="alert">{{ form.withdrawal_reason.errors.0 }}</small>
         {% endif %}
 
+        <label for="{{ form.request_received_via.id_for_label }}">{{ form.request_received_via.label }}</label>
+        {{ form.request_received_via }}
+        {% if form.request_received_via.errors %}
+        <small class="error" role="alert">{{ form.request_received_via.errors.0 }}</small>
+        {% endif %}
+
         <label for="{{ form.notes.id_for_label }}">{{ form.notes.label }}</label>
         {{ form.notes }}
         {% if form.notes.errors %}

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -867,6 +867,7 @@ class ConsentWithdrawalTest(TestCase):
         resp = self.http.post(f"/participants/{self.cf.pk}/consent/withdraw/save/", {
             "withdrawal_date": today,
             "withdrawal_reason": "participant_requested",
+            "request_received_via": "written",
             "notes": "Participant called to withdraw.",
             "confirm": "on",
         })
@@ -942,6 +943,7 @@ class ConsentWithdrawalTest(TestCase):
         resp = self.http.post(f"/participants/{self.cf.pk}/consent/withdraw/save/", {
             "withdrawal_date": timezone.now().strftime("%Y-%m-%d"),
             "withdrawal_reason": "participant_requested",
+            "request_received_via": "written",
             "confirm": "on",
         })
         self.assertEqual(resp.status_code, 403)
@@ -954,6 +956,7 @@ class ConsentWithdrawalTest(TestCase):
         resp = self.http.post(f"/participants/{self.cf.pk}/consent/withdraw/save/", {
             "withdrawal_date": today.isoformat(),
             "withdrawal_reason": "service_ended",
+            "request_received_via": "verbal",
             "confirm": "on",
         })
         self.assertIn(resp.status_code, [200, 302])
@@ -970,6 +973,7 @@ class ConsentWithdrawalTest(TestCase):
         self.http.post(f"/participants/{self.cf.pk}/consent/withdraw/save/", {
             "withdrawal_date": today,
             "withdrawal_reason": "participant_requested",
+            "request_received_via": "written",
             "confirm": "on",
         })
         # Re-grant


### PR DESCRIPTION
## Summary
- Validate withdrawal_date not in future
- Add AuditLog entry on consent grant/re-grant (was missing)
- Extract `is_consent_withdrawn` property on ClientFile (replaces 6 duplicated checks)
- Gate Withdraw/Re-record buttons on `is_pm_or_admin` (was `not is_receptionist`)
- Add consent-withdrawn guard to `event_create` and `event_edit`
- DRY up WITHDRAWAL_REASON_CHOICES (form references model choices)
- Add `request_received_via` field (written/verbal/representative) with migration
- Update SCN-070 step 4 actions to match new withdrawal UI

## Test plan
- [x] All 10 ConsentWithdrawalTest tests pass
- [ ] Verify withdrawal form shows request_received_via field
- [ ] Verify Withdraw button only visible to PM/admin roles
- [ ] Verify event create/edit blocked for withdrawn-consent clients

🤖 Generated with [Claude Code](https://claude.com/claude-code)