### PR TITLE
feat: add demo_group field for instance-specific demo users

### DIFF
--- a/apps/admin_settings/management/commands/seed.py
+++ b/apps/admin_settings/management/commands/seed.py
@@ -375,6 +375,7 @@ class Command(BaseCommand):
                     "display_name": display_name,
                     "is_admin": is_admin,
                     "is_demo": True,
+                    "demo_group": "default",
                     "email": demo_email,
                     "preferred_language": "en",
                 },
@@ -383,13 +384,16 @@ class Command(BaseCommand):
                 user.set_password("demo1234")
                 user.save()
             else:
-                # Backfill email and preferred_language on existing demo users
+                # Backfill fields on existing demo users
                 changed = False
                 if not user.email and demo_email:
                     user.email = demo_email
                     changed = True
                 if not user.preferred_language:
                     user.preferred_language = "en"
+                    changed = True
+                if not user.demo_group:
+                    user.demo_group = "default"
                     changed = True
                 if changed:
                     user.save()

--- a/apps/auth_app/migrations/0010_user_demo_group.py
+++ b/apps/auth_app/migrations/0010_user_demo_group.py
@@ -1,0 +1,31 @@
+"""Add demo_group field to User model.
+
+Groups demo users by instance type so instance-specific seeds can suppress
+the default demo users on the login page automatically.
+"""
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("auth_app", "0009_seed_default_grant_reasons"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="user",
+            name="demo_group",
+            field=models.CharField(
+                blank=True,
+                help_text=(
+                    "Groups demo users by instance type (e.g. 'default', 'prosper-canada'). "
+                    "When instance-specific demo users exist, the login page suppresses "
+                    "the 'default' group automatically."
+                ),
+                max_length=50,
+                null=True,
+            ),
+        ),
+    ]

--- a/apps/auth_app/models.py
+++ b/apps/auth_app/models.py
@@ -58,6 +58,14 @@ class User(AbstractBaseUser, PermissionsMixin):
         default=False,
         help_text="Demo users see demo data only. Set at creation, never changed.",
     )
+    demo_group = models.CharField(
+        max_length=50, null=True, blank=True,
+        help_text=(
+            "Groups demo users by instance type (e.g. 'default', 'prosper-canada'). "
+            "When instance-specific demo users exist, the login page suppresses "
+            "the 'default' group automatically."
+        ),
+    )
 
     # Timestamps
     created_at = models.DateTimeField(auto_now_add=True)

--- a/apps/auth_app/views.py
+++ b/apps/auth_app/views.py
@@ -233,9 +233,13 @@ def _local_login(request):
     demo_users = []
     demo_portal_participants = []
     if settings.DEMO_MODE:
+        # Auto-detect: if instance-specific demo users exist (any group
+        # other than 'default'), show only those and suppress the defaults.
+        all_demo = User.objects.filter(is_demo=True, is_active=True)
+        instance_specific = all_demo.exclude(demo_group="default")
+        qs = instance_specific if instance_specific.exists() else all_demo
         demo_users = list(
-            User.objects.filter(is_demo=True, is_active=True)
-            .order_by("display_name")
+            qs.order_by("display_name")
             .values("username", "display_name")
         )
         from apps.portal.models import ParticipantUser


### PR DESCRIPTION
## Summary
- Adds `demo_group` CharField to User model so demo users can be tagged by instance type (e.g. `default`, `prosper-canada`)
- Tags the 6 built-in demo users as `demo_group="default"` in `seed.py`
- Updates the login view to auto-detect: when instance-specific demo users exist (any group other than `default`), only those are shown — no configuration needed

## Context
Prosper Canada instances were showing all 12 demo users (6 default + 6 Prosper Canada) on the training login page. This confused users who didn't know which accounts were theirs.

The companion PR in `konote-prosper-canada` sets `demo_group="prosper-canada"` on its demo users, which triggers the suppression automatically.

## Test plan
- [ ] Run `seed` on a fresh instance — verify 6 default demo users appear on login page
- [ ] Run `seed_prosper_canada_demo` on same instance — verify only Prosper Canada users appear
- [ ] Re-run `seed` — verify Prosper Canada users still take priority (order-independent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)