### PR TITLE
fix: broken link to deleted canadian-hosting-research.md

### DIFF
--- a/tasks/setup-wizard-design.md
+++ b/tasks/setup-wizard-design.md
@@ -21,7 +21,7 @@ A consultant-assisted setup workflow that uses Claude to analyze agency document
 │    • Do you need to demonstrate government references?      │
 │                                                             │
 │  Output: Recommended hosting provider + deployment guide    │
-│  Reference: tasks/canadian-hosting-research.md              │
+│  Reference: tasks/design-rationale/ovhcloud-deployment.md   │
 └─────────────────────────────────────────────────────────────┘
                            ↓
 ┌─────────────────────────────────────────────────────────────┐
@@ -86,7 +86,7 @@ A consultant-assisted setup workflow that uses Claude to analyze agency document
 
 ## Phase 0: Hosting Selection Guide
 
-Before deploying KoNote, help the organisation choose the right hosting provider. See [canadian-hosting-research.md](canadian-hosting-research.md) for detailed research.
+Before deploying KoNote, help the organisation choose the right hosting provider. See [ovhcloud-deployment.md](design-rationale/ovhcloud-deployment.md) for hosting architecture details.
 
 ### Decision Questions
 


### PR DESCRIPTION
## Summary
- `setup-wizard-design.md` referenced `canadian-hosting-research.md` which was deleted in PR #281
- Updated 2 references to point to `design-rationale/ovhcloud-deployment.md`

Found during session review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)