### PR TITLE
fix: address 11 review findings from PR #283 session review

### DIFF
--- a/apps/admin_settings/management/commands/seed.py
+++ b/apps/admin_settings/management/commands/seed.py
@@ -112,12 +112,19 @@ class Command(BaseCommand):
                     "name_fr": m.get("name_fr", ""),
                     "definition_fr": m.get("definition_fr", ""),
                     "unit_fr": m.get("unit_fr", ""),
+                    # Rationale & assessment fields
+                    "rationale_log": m.get("rationale_log", []),
+                    "is_standardized_instrument": m.get("is_standardized_instrument", False),
+                    "scoring_bands": m.get("scoring_bands"),
+                    "assessment_interval_days": m.get("assessment_interval_days"),
+                    "assessment_at_intake": m.get("assessment_at_intake", False),
+                    "assessment_at_discharge": m.get("assessment_at_discharge", False),
                 },
             )
             if was_created:
                 created += 1
             else:
-                # Backfill French translations and is_universal for existing metrics
+                # Backfill French translations, is_universal, and new fields
                 changed = False
                 for fr_field in ("name_fr", "definition_fr", "unit_fr"):
                     new_val = m.get(fr_field, "")
@@ -126,6 +133,25 @@ class Command(BaseCommand):
                         changed = True
                 if m.get("is_universal") and not obj.is_universal:
                     obj.is_universal = True
+                    changed = True
+                # Backfill rationale and assessment fields
+                if m.get("rationale_log") and not obj.rationale_log:
+                    obj.rationale_log = m["rationale_log"]
+                    changed = True
+                if m.get("is_standardized_instrument") and not obj.is_standardized_instrument:
+                    obj.is_standardized_instrument = True
+                    changed = True
+                if m.get("scoring_bands") and not obj.scoring_bands:
+                    obj.scoring_bands = m["scoring_bands"]
+                    changed = True
+                if m.get("assessment_interval_days") and not obj.assessment_interval_days:
+                    obj.assessment_interval_days = m["assessment_interval_days"]
+                    changed = True
+                if m.get("assessment_at_intake") and not obj.assessment_at_intake:
+                    obj.assessment_at_intake = True
+                    changed = True
+                if m.get("assessment_at_discharge") and not obj.assessment_at_discharge:
+                    obj.assessment_at_discharge = True
                     changed = True
                 if changed:
                     obj.save()

--- a/apps/clients/views.py
+++ b/apps/clients/views.py
@@ -1106,7 +1106,12 @@ def client_detail(request, client_id):
 
 @login_required
 def assessment_due_banner(request, client_id):
-    """HTMX partial: show assessments due for this client."""
+    """HTMX partial: show assessments due for this client.
+
+    No @requires_permission needed — get_client_or_403 already enforces
+    program-scoped access. This view returns read-only assessment-due status
+    (no PII beyond what client_detail already shows).
+    """
     from apps.programs.access import get_client_or_403, get_user_program_ids
     from apps.plans.assessment import get_assessments_due
 

--- a/apps/plans/views.py
+++ b/apps/plans/views.py
@@ -10,6 +10,7 @@ from django.utils import timezone
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import PermissionDenied
 from django.http import HttpResponse, HttpResponseForbidden
+from django.views.decorators.http import require_POST
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils.translation import gettext as _
@@ -1020,6 +1021,7 @@ def metric_edit(request, metric_id):
 # ---------------------------------------------------------------------------
 
 
+@require_POST
 @login_required
 @requires_permission("metric.manage", allow_admin=True)
 def metric_rationale_add(request, metric_id):
@@ -1028,16 +1030,28 @@ def metric_rationale_add(request, metric_id):
     if not _can_edit_metric(request.user, metric):
         return HttpResponseForbidden(_("Access denied."))
 
-    if request.method == "POST":
-        note = request.POST.get("note", "").strip()
-        if note:
-            author = getattr(request.user, "display_name", str(request.user))
-            metric.append_rationale(note=note, author=author)
-            metric.save(update_fields=["rationale_log"])
+    note = request.POST.get("note", "").strip()
+    if note:
+        author = getattr(request.user, "display_name", str(request.user))
+        metric.append_rationale(note=note, author=author)
+        metric.save(update_fields=["rationale_log"])
+
+        AuditLog.objects.using("audit").create(
+            event_timestamp=timezone.now(),
+            user_id=request.user.pk,
+            user_display=author,
+            action="update",
+            resource_type="MetricDefinition",
+            resource_id=str(metric.pk),
+            ip_address=request.META.get("REMOTE_ADDR", ""),
+            is_demo_context=getattr(request.user, "is_demo", False),
+            metadata={"detail": f"Added rationale note to '{metric.name}'"},
+        )
 
     return render(request, "plans/includes/metric_rationale.html", {"metric": metric})
 
 
+@require_POST
 @login_required
 @requires_permission("metric.manage", allow_admin=True)
 def metric_rationale_generate(request, metric_id):
@@ -1046,34 +1060,46 @@ def metric_rationale_generate(request, metric_id):
     if not _can_edit_metric(request.user, metric):
         return HttpResponseForbidden(_("Access denied."))
 
-    if request.method == "POST":
-        from konote.ai import default_metric_rationale, generate_metric_rationale
+    from konote.ai import default_metric_rationale, generate_metric_rationale
 
-        scale_range = ""
-        if metric.min_value is not None and metric.max_value is not None:
-            scale_range = f"{metric.min_value}–{metric.max_value}"
+    scale_range = ""
+    if metric.min_value is not None and metric.max_value is not None:
+        scale_range = f"{metric.min_value}–{metric.max_value}"
 
-        result = generate_metric_rationale(
+    result = generate_metric_rationale(
+        name=metric.name,
+        definition=metric.definition or "",
+        category=metric.get_category_display(),
+        metric_type=metric.get_metric_type_display(),
+        scale_range=scale_range,
+    )
+    if result is None:
+        result = default_metric_rationale(
             name=metric.name,
-            definition=metric.definition or "",
             category=metric.get_category_display(),
             metric_type=metric.get_metric_type_display(),
-            scale_range=scale_range,
+            date_str=datetime.date.today().isoformat(),
         )
-        if result is None:
-            result = default_metric_rationale(
-                name=metric.name,
-                category=metric.get_category_display(),
-                metric_type=metric.get_metric_type_display(),
-                date_str=datetime.date.today().isoformat(),
-            )
 
-        metric.append_rationale(
-            note=result["note"],
-            note_fr=result.get("note_fr", ""),
-            author="AI",
-        )
-        metric.save(update_fields=["rationale_log"])
+    source = "AI" if result.get("note_fr") else "template"
+    metric.append_rationale(
+        note=result["note"],
+        note_fr=result.get("note_fr", ""),
+        author="AI",
+    )
+    metric.save(update_fields=["rationale_log"])
+
+    AuditLog.objects.using("audit").create(
+        event_timestamp=timezone.now(),
+        user_id=request.user.pk,
+        user_display=getattr(request.user, "display_name", str(request.user)),
+        action="update",
+        resource_type="MetricDefinition",
+        resource_id=str(metric.pk),
+        ip_address=request.META.get("REMOTE_ADDR", ""),
+        is_demo_context=getattr(request.user, "is_demo", False),
+        metadata={"detail": f"Auto-generated rationale ({source}) for '{metric.name}'"},
+    )
 
     return render(request, "plans/includes/metric_rationale.html", {"metric": metric})
 

--- a/konote/ai.py
+++ b/konote/ai.py
@@ -78,6 +78,54 @@ def _call_openrouter(system_prompt, user_message=None, max_tokens=1024, messages
 # ── Public functions ────────────────────────────────────────────────
 
 
+def generate_metric_rationale(name, definition, category, metric_type, scale_range):
+    """Generate a rationale for a metric using AI.
+
+    Returns {"note": "...", "note_fr": "..."} or None on failure.
+    """
+    system = (
+        "You help Canadian nonprofit administrators document why they use specific "
+        "outcome metrics. Given a metric name, definition, category, and type, write "
+        "a 1-2 sentence rationale explaining why an organisation would track this metric. "
+        "If the name matches a known standardized instrument (PHQ-9, GAD-7, K10, OARS, "
+        "AUDIT, etc.), include the original citation. Otherwise, describe what it measures "
+        "and suggest what evidence or funder requirement might support its use.\n\n"
+        'Return a JSON object: {"note": "English rationale", "note_fr": "French rationale"}.\n'
+        "Return ONLY the JSON object, no other text."
+    )
+    user_msg = (
+        f"Metric: {name}\n"
+        f"Definition: {definition}\n"
+        f"Category: {category}\n"
+        f"Type: {metric_type}\n"
+        f"Scale: {scale_range or 'not specified'}"
+    )
+    result = _call_openrouter(system, user_msg, max_tokens=512)
+    if result is None:
+        return None
+    try:
+        parsed = json.loads(result)
+        if isinstance(parsed, dict) and "note" in parsed:
+            return parsed
+    except (json.JSONDecodeError, TypeError):
+        logger.warning("Could not parse metric rationale: %s", result[:200])
+    return None
+
+
+def default_metric_rationale(name, category, metric_type, date_str):
+    """Template-based rationale fallback when AI is unavailable."""
+    type_label = "scale" if metric_type == "scale" else "achievement"
+    note = (
+        f"Added on {date_str} during initial configuration. "
+        f"{category.title()}-category {type_label} metric."
+    )
+    note_fr = (
+        f"Ajouté le {date_str} lors de la configuration initiale. "
+        f"Mesure de type {type_label} dans la catégorie {category}."
+    )
+    return {"note": note, "note_fr": note_fr}
+
+
 def suggest_metrics(target_description, metric_catalogue):
     """
     Given a plan target description and the full metric catalogue,

--- a/templates/plans/includes/metric_rationale.html
+++ b/templates/plans/includes/metric_rationale.html
@@ -5,15 +5,15 @@
     <h3 id="rationale-heading">{% trans "Rationale & History" %}</h3>
 
     {% if metric.rationale_log %}
-    {# Most recent entry displayed prominently #}
-    {% with metric.rationale_log|last as current %}
+    {# Most recent entry — use current_rationale property for language awareness #}
     <blockquote>
-        <p>{{ current.note }}</p>
+        <p>{{ metric.current_rationale }}</p>
+        {% with metric.rationale_log|last as current %}
         <footer>
             <small>{{ current.author }} — {{ current.date }}</small>
         </footer>
+        {% endwith %}
     </blockquote>
-    {% endwith %}
 
     {# Older entries collapsed #}
     {% if metric.rationale_log|length > 1 %}

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -899,3 +899,149 @@ class AssessmentDueDetectionTest(TestCase):
         results = get_assessments_due(self.client_file)
         self.assertEqual(len(results), 0)
 
+
+# ---------------------------------------------------------------------------
+# HTTP-level view tests for rationale and assessment endpoints
+# ---------------------------------------------------------------------------
+
+
+@override_settings(FIELD_ENCRYPTION_KEY=TEST_KEY)
+class MetricRationaleViewTest(TestCase):
+    """HTTP-level tests for rationale add/generate HTMX endpoints."""
+
+    databases = {"default", "audit"}
+
+    def setUp(self):
+        enc_module._fernet = None
+        self.user = User.objects.create_user(
+            username="rationale_admin", password="testpass123", is_admin=True,
+        )
+        self.metric = MetricDefinition.objects.create(
+            name="Rationale Test Metric",
+            definition="A test metric",
+            category="wellbeing",
+            metric_type="scale",
+        )
+        self.http_client = self.client
+        self.http_client.login(username="rationale_admin", password="testpass123")
+
+    def tearDown(self):
+        enc_module._fernet = None
+
+    def test_rationale_add_requires_post(self):
+        """GET to rationale/add/ should return 405."""
+        from django.urls import reverse
+        url = reverse("metrics:metric_rationale_add", kwargs={"metric_id": self.metric.pk})
+        response = self.http_client.get(url)
+        self.assertEqual(response.status_code, 405)
+
+    def test_rationale_add_appends_entry(self):
+        """POST with note text appends to rationale_log."""
+        from django.urls import reverse
+        url = reverse("metrics:metric_rationale_add", kwargs={"metric_id": self.metric.pk})
+        response = self.http_client.post(url, {"note": "Test rationale note"})
+        self.assertEqual(response.status_code, 200)
+        self.metric.refresh_from_db()
+        self.assertEqual(len(self.metric.rationale_log), 1)
+        self.assertEqual(self.metric.rationale_log[0]["note"], "Test rationale note")
+
+    def test_rationale_add_creates_audit_log(self):
+        """Rationale add should create an audit log entry."""
+        from django.urls import reverse
+        from apps.audit.models import AuditLog
+        url = reverse("metrics:metric_rationale_add", kwargs={"metric_id": self.metric.pk})
+        self.http_client.post(url, {"note": "Audited note"})
+        log = AuditLog.objects.using("audit").filter(
+            resource_type="MetricDefinition",
+            resource_id=str(self.metric.pk),
+            action="update",
+        ).last()
+        self.assertIsNotNone(log)
+        self.assertIn("rationale", log.metadata.get("detail", ""))
+
+    def test_rationale_add_ignores_empty_note(self):
+        """POST with empty note should not append."""
+        from django.urls import reverse
+        url = reverse("metrics:metric_rationale_add", kwargs={"metric_id": self.metric.pk})
+        self.http_client.post(url, {"note": "  "})
+        self.metric.refresh_from_db()
+        self.assertEqual(len(self.metric.rationale_log), 0)
+
+    def test_rationale_generate_requires_post(self):
+        """GET to rationale/generate/ should return 405."""
+        from django.urls import reverse
+        url = reverse("metrics:metric_rationale_generate", kwargs={"metric_id": self.metric.pk})
+        response = self.http_client.get(url)
+        self.assertEqual(response.status_code, 405)
+
+    def test_rationale_generate_creates_entry(self):
+        """POST to generate uses template fallback (no AI in test) and appends entry."""
+        from django.urls import reverse
+        url = reverse("metrics:metric_rationale_generate", kwargs={"metric_id": self.metric.pk})
+        response = self.http_client.post(url)
+        self.assertEqual(response.status_code, 200)
+        self.metric.refresh_from_db()
+        self.assertEqual(len(self.metric.rationale_log), 1)
+        self.assertEqual(self.metric.rationale_log[0]["author"], "AI")
+        self.assertIn("initial configuration", self.metric.rationale_log[0]["note"])
+
+
+@override_settings(FIELD_ENCRYPTION_KEY=TEST_KEY)
+class AssessmentDueBannerViewTest(TestCase):
+    """HTTP-level test for assessment-due banner HTMX partial."""
+
+    databases = {"default", "audit"}
+
+    def setUp(self):
+        enc_module._fernet = None
+        self.user = User.objects.create_user(
+            username="banner_user", password="testpass123", is_admin=True,
+        )
+        self.program = Program.objects.create(name="Banner Program", status="active")
+        UserProgramRole.objects.create(
+            user=self.user, program=self.program, role="staff", status="active",
+        )
+        self.client_file = ClientFile()
+        self.client_file.first_name = "Banner"
+        self.client_file.last_name = "Test"
+        self.client_file.status = "active"
+        self.client_file.save()
+        ClientProgramEnrolment.objects.create(
+            client_file=self.client_file,
+            program=self.program,
+            status="active",
+        )
+        self.http_client = self.client
+        self.http_client.login(username="banner_user", password="testpass123")
+
+    def tearDown(self):
+        enc_module._fernet = None
+
+    def test_banner_renders_empty_when_no_instruments(self):
+        """Banner partial returns 200 with no content when no standardized instruments assigned."""
+        from django.urls import reverse
+        url = reverse("clients:assessment_due_banner", kwargs={"client_id": self.client_file.pk})
+        response = self.http_client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertNotContains(response, "Assessment due")
+
+    def test_banner_shows_intake_due(self):
+        """Banner shows assessment-due when PHQ-9 assigned with assessment_at_intake."""
+        from django.urls import reverse
+        phq9 = MetricDefinition.objects.create(
+            name="PHQ-9", category="wellbeing", metric_type="scale",
+            is_standardized_instrument=True, assessment_at_intake=True,
+        )
+        section = PlanSection.objects.create(
+            client_file=self.client_file, name="Health", program=self.program,
+        )
+        target = PlanTarget(plan_section=section, client_file=self.client_file)
+        target.name = "Mental health"
+        target.save()
+        PlanTargetMetric.objects.create(plan_target=target, metric_def=phq9)
+
+        url = reverse("clients:assessment_due_banner", kwargs={"client_id": self.client_file.pk})
+        response = self.http_client.get(url)
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Assessment due")
+


### PR DESCRIPTION
## Summary
- Fixed French rationale display: template now uses `current_rationale` property (language-aware) instead of raw JSON `note` field
- Added `@require_POST` to both HTMX rationale endpoints (previously accepted GET)
- Added `AuditLog` entries for all rationale changes (compliance requirement)
- Added docstring explaining why `assessment_due_banner` uses `get_client_or_403` instead of `@requires_permission`
- **Restored missing `generate_metric_rationale()` and `default_metric_rationale()` in `ai.py`** — these were in the worktree but never included in PR #283
- **Restored missing seed.py rationale/assessment field handling** — same worktree gap
- Added 8 HTTP-level view tests for rationale and assessment endpoints

## Review findings addressed
| # | Finding | Status |
|---|---------|--------|
| 1 | `assessment_due_banner` missing `@requires_permission` | Documented — `get_client_or_403` provides program-scoped access |
| 2 | French users see English rationale in edit form | **Fixed** — uses `current_rationale` property |
| 3 | HTMX endpoints accept GET requests | **Fixed** — `@require_POST` added |
| 4 | No audit log for rationale changes | **Fixed** — `AuditLog` entries added |
| 5 | Breadcrumb contains display_name + last_name | Consistent with app pattern — no change |
| 6 | Two validation paths in assessment form | Noted — works correctly, revisit if UX issues arise |
| 7 | AI call blocks synchronously | Already has 30s timeout + exception handling |
| 8 | Assessment-due queries on every page load | Deferred — no performance concern pre-launch |
| 9 | No HTTP-level tests for new endpoints | **Fixed** — 8 tests added |

## Critical fix
`generate_metric_rationale()` and `default_metric_rationale()` were committed in the worktree but never merged via PR #283. Without these, `metric_create` and `metric_rationale_generate` views would raise `ImportError` at runtime.

## Test plan
- [x] `pytest tests/test_plans.py -v` — all 44 tests pass (18 new from PR #283 + 8 new view tests)
- [ ] Verify French rationale display manually (create metric, switch to FR locale)
- [ ] Verify `GET /metrics/1/rationale/add/` returns 405

🤖 Generated with [Claude Code](https://claude.com/claude-code)