### PR TITLE
fix: instrument reporting accessibility and demo data improvements

### DIFF
--- a/apps/admin_settings/management/commands/seed_demo_data.py
+++ b/apps/admin_settings/management/commands/seed_demo_data.py
@@ -4571,13 +4571,82 @@ class Command(BaseCommand):
                     participant_user=participant,
                     client_file=client,
                     defaults={
-                        "status": "pending",
+                        "status": "completed" if record_id == "DEMO-001" else "pending",
                         "assigned_by": assigned_by,
                         "due_date": (now + timedelta(days=21)).date(),
                     },
                 )
                 if fb_created:
                     assignments_created += 1
+
+                # Create a completed response for DEMO-001 (Jordan) on feedback survey
+                if record_id == "DEMO-001" and fb_created:
+                    fb_questions = list(SurveyQuestion.objects.filter(
+                        section__survey=feedback,
+                    ).order_by("section__sort_order", "sort_order"))
+
+                    submit_time = now - timedelta(days=15)
+                    consent_time = submit_time - timedelta(minutes=2)
+
+                    jordan_fb_response = SurveyResponse.objects.create(
+                        survey=feedback,
+                        assignment=assign_fb,
+                        client_file=client,
+                        channel="portal",
+                        consent_given_at=consent_time,
+                    )
+                    SurveyResponse.objects.filter(pk=jordan_fb_response.pk).update(
+                        submitted_at=submit_time,
+                    )
+
+                    # Answer questions — fb_questions order:
+                    # attendance, helpfulness, useful_aspects, suggestion
+                    if len(fb_questions) >= 4:
+                        # Q1: attendance (single_choice)
+                        a1 = SurveyAnswer(
+                            response=jordan_fb_response,
+                            question=fb_questions[0],
+                            numeric_value=5,
+                        )
+                        a1.value = "weekly"
+                        a1.save()
+
+                        # Q2: helpfulness (rating_scale)
+                        a2 = SurveyAnswer(
+                            response=jordan_fb_response,
+                            question=fb_questions[1],
+                            numeric_value=5,
+                        )
+                        a2.value = "5"
+                        a2.save()
+
+                        # Q3: useful aspects (multiple_choice)
+                        a3 = SurveyAnswer(
+                            response=jordan_fb_response,
+                            question=fb_questions[2],
+                        )
+                        a3.value = "one_on_one,goal_setting"
+                        a3.save()
+
+                        # Q4: suggestion (short_text)
+                        a4 = SurveyAnswer(
+                            response=jordan_fb_response,
+                            question=fb_questions[3],
+                        )
+                        a4.value = (
+                            "More evening sessions would help because I can't "
+                            "always take time off work for appointments during the day."
+                        )
+                        a4.save()
+
+                    responses_created += 1
+
+                    # Mark assignment as completed
+                    SurveyAssignment.objects.filter(pk=assign_fb.pk).update(
+                        status="completed",
+                        completed_at=submit_time,
+                        started_at=submit_time - timedelta(minutes=10),
+                    )
 
         # --- Staff-entered response for DEMO-004 (Sam) on satisfaction ---
         sam_client = ClientFile.objects.filter(record_id="DEMO-004").first()

--- a/apps/reports/metric_insights.py
+++ b/apps/reports/metric_insights.py
@@ -484,6 +484,9 @@ def get_instrument_aggregates(program, date_from, date_to):
             total_top_two += item_top_two
             total_responses += item_total
 
+        # Count items suppressed due to low N (below MIN_N_FOR_DISTRIBUTION)
+        suppressed_count = len(metrics_by_id) - len(items)
+
         if not items:
             continue
 
@@ -495,6 +498,7 @@ def get_instrument_aggregates(program, date_from, date_to):
             "aggregate_top_two_box_pct": aggregate_pct,
             "total_responses": total_responses,
             "is_multi_item": is_multi_item,
+            "suppressed_count": suppressed_count,
         }
 
     return results

--- a/apps/reports/metric_insights.py
+++ b/apps/reports/metric_insights.py
@@ -449,7 +449,11 @@ def get_instrument_aggregates(program, date_from, date_to):
                 continue
 
             # Compute top-two-box for this item
-            # Top-two-box: % of responses scoring >= 3 on a 4-point scale
+            # Top-two-box threshold: >= 3 on a 4-point scale (1=Not true,
+            # 2=Somewhat false, 3=Somewhat true, 4=Very true).
+            # This threshold is specific to 4-point Likert scales.
+            # If instruments with other scale ranges are added, this
+            # logic must be updated to derive the threshold from max_value.
             item_top_two = 0
             item_total = 0
 

--- a/apps/reports/metric_insights.py
+++ b/apps/reports/metric_insights.py
@@ -382,6 +382,11 @@ def get_two_lenses(program, date_from, date_to, structured=None, distributions=N
 def get_instrument_aggregates(program, date_from, date_to):
     """Compute aggregate scores for multi-item instrument batteries.
 
+    Note: This function loads all matching MetricValues into Python memory.
+    At current scale (<2,000 clients) this is performant. If the system
+    scales beyond 2,000 clients with instrument metrics, consider replacing
+    with a SQL aggregate query (COUNT + CASE WHEN) for efficiency.
+
     Groups metrics by instrument_name and computes:
     - For inclusivity-style batteries (4-point scale): top-two-box %
       (count of values >= 3 / total * 100)
@@ -406,7 +411,8 @@ def get_instrument_aggregates(program, date_from, date_to):
     instrument_data = defaultdict(lambda: defaultdict(lambda: defaultdict(list)))
     metric_defs = {}
 
-    values_data = qs.select_related("metric_def").values_list(
+    # Note: select_related is not needed here — values_list bypasses it.
+    values_data = qs.values_list(
         "pk",
         "metric_def_id",
         "metric_def__instrument_name",

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -19132,8 +19132,9 @@ msgid "positive (top-two-box)"
 msgstr "positif (top-two-box)"
 
 #: templates/reports/_insights_instruments.html
-msgid "View item breakdown"
-msgstr "Voir le détail par item"
+#, python-format
+msgid "View item breakdown for %(name)s"
+msgstr "Voir le détail par item pour %(name)s"
 
 #: templates/reports/_insights_instruments.html
 msgid "Item"
@@ -19161,3 +19162,8 @@ msgstr "Pourcentage top-two-box pour %(name)s"
 #, python-format
 msgid "Item breakdown for %(name)s"
 msgstr "Détail par item pour %(name)s"
+
+#: templates/reports/_insights_instruments.html
+#, python-format
+msgid "%(count)s item(s) not shown due to insufficient responses for privacy."
+msgstr "%(count)s item(s) non affiché(s) en raison d'un nombre insuffisant de réponses pour la confidentialité."

--- a/templates/reports/_insights_instruments.html
+++ b/templates/reports/_insights_instruments.html
@@ -20,7 +20,7 @@
 
     {# Per-item breakdown #}
     <details class="chart-data-table">
-        <summary>{% trans "View item breakdown" %}</summary>
+        <summary>{% blocktrans with name=inst.name %}View item breakdown for {{ name }}{% endblocktrans %}</summary>
         <table role="table" aria-label="{% blocktrans with name=inst.name %}Item breakdown for {{ name }}{% endblocktrans %}">
             <thead>
                 <tr>
@@ -40,5 +40,8 @@
             </tbody>
         </table>
     </details>
+    {% if inst.suppressed_count %}
+    <p><small class="muted">{% blocktrans with count=inst.suppressed_count %}{{ count }} item(s) not shown due to insufficient responses for privacy.{% endblocktrans %}</small></p>
+    {% endif %}
 </div>
 {% endfor %}

--- a/templates/reports/_insights_instruments.html
+++ b/templates/reports/_insights_instruments.html
@@ -9,13 +9,11 @@
     <h4>{{ inst.name }} <small class="muted">({% blocktrans with count=inst.total_responses %}{{ count }} responses{% endblocktrans %})</small></h4>
 
     {# Aggregate top-two-box bar #}
-    <div class="insights-distribution-bar" role="img"
-         aria-label="{% blocktrans with name=inst.name %}Top-two-box percentage for {{ name }}{% endblocktrans %}">
-        <div class="insights-bar-segment band-high" style="width: {{ inst.aggregate_top_two_box_pct }}%;"
-             title="{% trans 'Positive' %}: {{ inst.aggregate_top_two_box_pct }}%">
+    <div class="insights-distribution-bar" aria-hidden="true">
+        <div class="insights-bar-segment band-high" style="width: {{ inst.aggregate_top_two_box_pct }}%;">
+            <span style="font-size: 0.75em; padding-left: 0.3em;">{{ inst.aggregate_top_two_box_pct }}%</span>
         </div>
-        <div class="insights-bar-segment band-low" style="width: calc(100% - {{ inst.aggregate_top_two_box_pct }}%);"
-             title="{% trans 'Other' %}">
+        <div class="insights-bar-segment band-low" style="width: calc(100% - {{ inst.aggregate_top_two_box_pct }}%);">
         </div>
     </div>
     <p><strong>{{ inst.aggregate_top_two_box_pct }}%</strong> {% trans "positive (top-two-box)" %}</p>


### PR DESCRIPTION
## Summary
- **Fix 1**: Add Jordan's (DEMO-001) completed survey response on Programme Feedback Survey to demo data — Jordan is the showcase portal participant but had no feedback response
- **Fix 4**: Replace unreliable `title` attributes on instrument bar chart with visible percentage text and `aria-hidden` for WCAG compliance
- **Fix 5**: Include instrument name in `<details>` summary for screen reader context
- **Fix 6**: Track suppressed item count in `get_instrument_aggregates()` and display a privacy note when items are hidden due to low N
- **Fix 7**: Document the top-two-box threshold assumption (>= 3 on 4-point Likert scale) with a note to update if other scales are added
- **Fix 10**: Add scalability comment to `get_instrument_aggregates()` noting the ~2,000 client ceiling; remove redundant `select_related` from `values_list` query
- French translations added for new template strings

## Test plan
- [x] `pytest tests/test_plans.py` — 75 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)