### PR TITLE
Register localhost as tenant domain for health checks

### DIFF
--- a/apps/tenants/management/commands/setup_public_tenant.py
+++ b/apps/tenants/management/commands/setup_public_tenant.py
@@ -119,6 +119,21 @@ class Command(BaseCommand):
         self.stdout.write(
             self.style.SUCCESS(f"  Domain '{domain}' registered.")
         )
+
+        # Register 'localhost' as a secondary domain so Docker health checks
+        # (curl http://localhost:8000/auth/login/) can resolve to a tenant.
+        if domain != "localhost" and not AgencyDomain.objects.filter(
+            domain="localhost"
+        ).exists():
+            AgencyDomain.objects.create(
+                domain="localhost",
+                tenant=agency,
+                is_primary=False,
+            )
+            self.stdout.write(
+                "  Secondary domain 'localhost' registered (for health checks)."
+            )
+
         self.stdout.write(
             self.style.SUCCESS(
                 f"Setup complete. Site is accessible at https://{domain}/"


### PR DESCRIPTION
## Summary
- `setup_public_tenant` now registers `localhost` as a secondary `AgencyDomain` alongside the real domain
- Fixes Docker health checks (`curl http://localhost:8000/auth/login/`) returning 404 because django-tenants can't resolve `localhost` to any tenant
- Without this, fresh deployments get stuck with the web container in "health: starting" indefinitely

## Context
Discovered during the March 2026 VPS update — after migrating to django-tenants on develop, the health check never passed because `localhost` wasn't a registered tenant domain.

## Test plan
- [ ] Fresh deploy: verify `agency_domains` table has both the real domain and `localhost`
- [ ] `docker compose ps` shows web as healthy (not stuck in "health: starting")

🤖 Generated with [Claude Code](https://claude.com/claude-code)