### PR TITLE
feat: bilingual portal resource URLs + demo seed

### DIFF
--- a/apps/admin_settings/management/commands/seed_demo_data.py
+++ b/apps/admin_settings/management/commands/seed_demo_data.py
@@ -1568,6 +1568,10 @@ class Command(BaseCommand):
         except User.DoesNotExist:
             pass
 
+        # Always ensure portal resources exist (idempotent via get_or_create).
+        if programs_by_name and created_by:
+            self._create_demo_portal_resources(programs_by_name, created_by)
+
         # Always ensure DV-safe flags are set (idempotent — just sets a boolean).
         self._set_dv_safe_flags()
 
@@ -4921,3 +4925,41 @@ class Command(BaseCommand):
             self.stdout.write(
                 f"  PERM demo data: {', '.join(created_items)}."
             )
+
+    def _create_demo_portal_resources(self, programs_by_name, created_by):
+        """Seed program-level portal resources for the demo."""
+        from apps.portal.models import PortalResourceLink
+
+        # Default resources visible to participants in every demo program.
+        # Each tuple: (title, title_fr, url, url_fr, description, description_fr)
+        default_resources = [
+            (
+                "Career Planning Resources",
+                "Ressources de planification de carrière",
+                "https://www.jobbank.gc.ca/career-planning/school-work-transition",
+                "https://www.guichetemplois.gc.ca/planification-carriere/transition-etudes-travail",
+                "Government of Canada tools for career planning and work transition.",
+                "Outils du gouvernement du Canada pour la planification de carrière et la transition vers le travail.",
+            ),
+        ]
+
+        created_count = 0
+        for program in programs_by_name.values():
+            for title, title_fr, url, url_fr, desc, desc_fr in default_resources:
+                _, created = PortalResourceLink.objects.get_or_create(
+                    program=program,
+                    url=url,
+                    defaults={
+                        "title": title,
+                        "title_fr": title_fr,
+                        "url_fr": url_fr,
+                        "description": desc,
+                        "description_fr": desc_fr,
+                        "created_by": created_by,
+                    },
+                )
+                if created:
+                    created_count += 1
+
+        if created_count:
+            self.stdout.write(f"  Created {created_count} portal resource links.")

--- a/apps/portal/forms.py
+++ b/apps/portal/forms.py
@@ -411,11 +411,12 @@ class ProgramResourceForm(forms.ModelForm):
     class Meta:
         from apps.portal.models import PortalResourceLink
         model = PortalResourceLink
-        fields = ["title", "title_fr", "url", "description", "description_fr", "display_order"]
+        fields = ["title", "title_fr", "url", "url_fr", "description", "description_fr", "display_order"]
         widgets = {
             "title": forms.TextInput(attrs={"placeholder": _("e.g. Crisis Support Line")}),
             "title_fr": forms.TextInput(attrs={"placeholder": _("e.g. Ligne de soutien en situation de crise")}),
             "url": forms.URLInput(attrs={"placeholder": "https://"}),
+            "url_fr": forms.URLInput(attrs={"placeholder": _("https:// (leave blank if same as English)")}),
             "description": forms.Textarea(attrs={"rows": 2, "placeholder": _("Brief description (optional)")}),
             "description_fr": forms.Textarea(attrs={"rows": 2, "placeholder": _("Description en français (optionnel)")}),
             "display_order": forms.NumberInput(attrs={"min": 0, "style": "width: 5em"}),
@@ -423,7 +424,8 @@ class ProgramResourceForm(forms.ModelForm):
         labels = {
             "title": _("Title (English)"),
             "title_fr": _("Title (French)"),
-            "url": _("Website URL"),
+            "url": _("Website URL (English)"),
+            "url_fr": _("Website URL (French)"),
             "description": _("Description (English)"),
             "description_fr": _("Description (French)"),
             "display_order": _("Display order"),

--- a/apps/portal/migrations/0007_portalresourcelink_url_fr.py
+++ b/apps/portal/migrations/0007_portalresourcelink_url_fr.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("portal", "0006_portalalliancerequest"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="portalresourcelink",
+            name="url_fr",
+            field=models.URLField(blank=True, default=""),
+        ),
+    ]

--- a/apps/portal/models.py
+++ b/apps/portal/models.py
@@ -628,6 +628,7 @@ class PortalResourceLink(models.Model):
     title = models.CharField(max_length=255)
     title_fr = models.CharField(max_length=255, blank=True, default="")
     url = models.URLField()
+    url_fr = models.URLField(blank=True, default="")
     description = models.TextField(blank=True, default="")
     description_fr = models.TextField(blank=True, default="")
     display_order = models.PositiveIntegerField(default=0)
@@ -656,6 +657,12 @@ class PortalResourceLink(models.Model):
         if lang.startswith("fr") and self.title_fr:
             return self.title_fr
         return self.title
+
+    def get_url(self, lang="en"):
+        """Return the URL in the requested language, falling back to English."""
+        if lang.startswith("fr") and self.url_fr:
+            return self.url_fr
+        return self.url
 
     def get_description(self, lang="en"):
         """Return the description in the requested language, falling back to English."""

--- a/apps/portal/templates/portal/staff_program_resources.html
+++ b/apps/portal/templates/portal/staff_program_resources.html
@@ -41,7 +41,10 @@
                 {{ resource.title }}
                 {% if resource.title_fr %}<br><small>FR: {{ resource.title_fr }}</small>{% endif %}
             </td>
-            <td><a href="{{ resource.url }}" target="_blank" rel="noopener noreferrer">{{ resource.url|truncatechars:40 }}</a></td>
+            <td>
+                <a href="{{ resource.url }}" target="_blank" rel="noopener noreferrer">{{ resource.url|truncatechars:40 }}</a>
+                {% if resource.url_fr %}<br><small>FR: <a href="{{ resource.url_fr }}" target="_blank" rel="noopener noreferrer">{{ resource.url_fr|truncatechars:40 }}</a></small>{% endif %}
+            </td>
             <td>{{ resource.display_order }}</td>
             <td>
                 <a href="{% url 'programs:program_resource_edit' program_id=program.pk resource_id=resource.pk %}">{% trans "Edit" %}</a>

--- a/apps/portal/views.py
+++ b/apps/portal/views.py
@@ -764,7 +764,7 @@ def resources_list(request):
             program_groups[pname] = []
         program_groups[pname].append({
             "title": r.get_title(lang),
-            "url": r.url,
+            "url": r.get_url(lang),
             "description": r.get_description(lang),
         })
 

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -16938,6 +16938,15 @@ msgstr "URL"
 msgid "Website URL"
 msgstr "URL du site Web"
 
+msgid "Website URL (English)"
+msgstr "URL du site Web (anglais)"
+
+msgid "Website URL (French)"
+msgstr "URL du site Web (français)"
+
+msgid "https:// (leave blank if same as English)"
+msgstr "https:// (laisser vide si identique à l'anglais)"
+
 msgid "client resource link"
 msgstr "lien de ressource pour le participant"
 


### PR DESCRIPTION
## Summary
- Adds `url_fr` field to `PortalResourceLink` model so bilingual sites can link to the correct language version of external resources (e.g. jobbank.gc.ca → guichetemplois.gc.ca)
- Portal view now serves the URL matching the participant's language preference
- Seeds a default "Career Planning Resources" link (Job Bank Canada EN/FR) for all demo programs — fixes the 404 on the My Resources portal page
- Updates staff resource form and table to show/edit the French URL

## Test plan
- [ ] Deploy to demo VPS, re-run seed, verify My Resources page shows the Job Bank link
- [ ] Switch language to French, verify the French URL is used
- [ ] Check staff resource management form includes the new URL (French) field
- [ ] Verify existing resources without `url_fr` still work (falls back to English URL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)