### PR TITLE
fix: add portal_resources to feature toggle seed

### DIFF
--- a/apps/admin_settings/management/commands/seed.py
+++ b/apps/admin_settings/management/commands/seed.py
@@ -216,6 +216,7 @@ class Command(BaseCommand):
             ("messaging_email", True),
             ("surveys", False),
             ("circles", False),
+            ("portal_resources", False),
         ]
         created = 0
         for key, enabled in defaults:
@@ -246,8 +247,11 @@ class Command(BaseCommand):
             FeatureToggle.objects.filter(feature_key="circles").update(
                 is_enabled=True
             )
+            FeatureToggle.objects.filter(feature_key="portal_resources").update(
+                is_enabled=True
+            )
             self.stdout.write(
-                "  Demo mode: participant_portal, messaging_email, ai_assist_tools_only, ai_assist_participant_data, surveys, circles enabled."
+                "  Demo mode: participant_portal, messaging_email, ai_assist_tools_only, ai_assist_participant_data, surveys, circles, portal_resources enabled."
             )
 
     def _seed_instance_settings(self):


### PR DESCRIPTION
## Summary
- Adds `portal_resources` to the feature toggle seed defaults list (disabled by default, like other portal features)
- Enables it automatically in demo mode so the My Resources page works out of the box
- Without this, the portal resources view raised Http404 because the toggle didn't exist in the database

## Test plan
- [ ] Fresh seed creates the `portal_resources` toggle
- [ ] Demo mode enables it alongside other portal features

🤖 Generated with [Claude Code](https://claude.com/claude-code)