### PR TITLE
fix: replace product name with Home in nav

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -96,7 +96,7 @@
                 {% else %}
                 <img src="{% static 'img/konote-logo-text.svg' %}" alt="" class="nav-logo" height="28">
                 {% endif %}
-                <strong>{{ site.product_name|default:"KoNote" }}</strong>
+                {% trans "Home" %}
             </a></li>
         </ul>
         <ul>
@@ -115,7 +115,7 @@
                 {% else %}
                 <img src="{% static 'img/konote-logo-text.svg' %}" alt="" class="nav-logo" height="28">
                 {% endif %}
-                <strong>{{ site.product_name|default:"KoNote" }}</strong>
+                {% trans "Home" %}
             </a></li>
             <li>
                 <!-- Mobile menu toggle -->


### PR DESCRIPTION
## Summary
- Replaces the product name (KoNote) in the top-left nav with a translatable "Home" label
- Removes `<strong>` tag so font weight matches other nav items (Dashboard, Programs, etc.)
- Applies to both authenticated and unauthenticated nav bars

## Test plan
- [ ] Verify "Home" appears in top-left nav instead of "KoNote"
- [ ] Verify font matches other nav links
- [ ] Verify clicking it navigates to home page
- [ ] Run `translate_strings` to add French translation ("Accueil")

🤖 Generated with [Claude Code](https://claude.com/claude-code)