### PR TITLE
fix: use K-mark icon instead of text logo in nav

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -94,7 +94,7 @@
                 {% if site.logo_url %}
                 <img src="{{ site.logo_url }}" alt="" class="nav-logo" height="28" width="28">
                 {% else %}
-                <img src="{% static 'img/konote-logo-text.svg' %}" alt="" class="nav-logo" height="28">
+                <img src="{% static 'img/konote-icon.png' %}" alt="" class="nav-logo" height="28" width="28">
                 {% endif %}
                 {% trans "Home" %}
             </a></li>
@@ -113,7 +113,7 @@
                 {% if site.logo_url %}
                 <img src="{{ site.logo_url }}" alt="" class="nav-logo" height="28" width="28">
                 {% else %}
-                <img src="{% static 'img/konote-logo-text.svg' %}" alt="" class="nav-logo" height="28">
+                <img src="{% static 'img/konote-icon.png' %}" alt="" class="nav-logo" height="28" width="28">
                 {% endif %}
                 {% trans "Home" %}
             </a></li>


### PR DESCRIPTION
## Summary
- The nav header showed "KoNote" because the fallback logo was `konote-logo-text.svg` (which contains the word "KoNote" as part of the image)
- Swapped to `konote-icon.png` (the K-mark without text) so users see the K-mark icon + "Home" text

## Test plan
- [ ] Verify nav shows K-mark icon + "Home" text (not the full KoNote text logo)
- [ ] Check both logged-in and logged-out nav states


🤖 Generated with [Claude Code](https://claude.com/claude-code)