### PR TITLE
Remove redundant cursor:pointer from insights about block

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -4093,7 +4093,6 @@ article[aria-label="notification"].fading-out {
     color: var(--kn-text-muted, #666);
 }
 .insights-about summary {
-    cursor: pointer;
     list-style: revert;
 }
 .insights-about-body {


### PR DESCRIPTION
## Summary
- Removes unnecessary `cursor: pointer` on `<summary>` element — native browser behaviour already handles this
- Caught by /simplify review of PR #308

## Test plan
- [ ] Verify the "About these insights" toggle still shows a pointer cursor on hover (browser default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)