### PR TITLE
Fix empty theme detail + date-filtered view

### DIFF
--- a/apps/admin_settings/demo_engine.py
+++ b/apps/admin_settings/demo_engine.py
@@ -32,6 +32,7 @@ from apps.notes.models import (
     ProgressNote,
     ProgressNoteTarget,
     ProgressNoteTemplateMetric,
+    SuggestionLink,
     SuggestionTheme,
 )
 from apps.plans.models import (
@@ -1070,6 +1071,31 @@ class DemoDataEngine:
                         "created_by": creator,
                     },
                 )
+
+                # Link 2-4 demo suggestions to each theme
+                if created:
+                    available_notes = (
+                        ProgressNote.objects.filter(
+                            author_program=prog,
+                            is_demo=True,
+                        )
+                        .exclude(suggestion_priority="")
+                        .exclude(
+                            pk__in=SuggestionLink.objects.filter(
+                                theme__program=prog
+                            ).values_list("progress_note_id", flat=True)
+                        )
+                        .order_by("?")[:random.randint(2, 4)]
+                    )
+                    for note in available_notes:
+                        SuggestionLink.objects.get_or_create(
+                            theme=theme,
+                            progress_note=note,
+                            defaults={
+                                "auto_linked": False,
+                                "linked_by": creator,
+                            },
+                        )
 
     # ----- Main orchestrator -----
 

--- a/apps/notes/suggestion_views.py
+++ b/apps/notes/suggestion_views.py
@@ -1,7 +1,10 @@
 """Views for suggestion theme management (UX-INSIGHT6 Phase 1)."""
+from datetime import date
+
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.db.models import Count
+from django.db.models.functions import Coalesce
 from django.http import HttpResponseForbidden
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
@@ -169,10 +172,37 @@ def theme_detail(request, pk):
             return _handle_unlink(request, theme)
 
     # ── GET: render detail page ──
+
+    # Optional date filtering (passed from Insights page)
+    date_from = None
+    date_to = None
+    is_filtered = False
+    raw_from = request.GET.get("date_from", "")
+    raw_to = request.GET.get("date_to", "")
+    if raw_from and raw_to:
+        try:
+            date_from = date.fromisoformat(raw_from)
+            date_to = date.fromisoformat(raw_to)
+            is_filtered = True
+        except ValueError:
+            pass
+
     linked_links = (
         theme.links.select_related("progress_note", "linked_by")
+        .annotate(
+            _effective_date=Coalesce(
+                "progress_note__backdate",
+                "progress_note__created_at",
+            ),
+        )
         .order_by("-linked_at")
     )
+    if is_filtered:
+        linked_links = linked_links.filter(
+            _effective_date__date__gte=date_from,
+            _effective_date__date__lte=date_to,
+        )
+
     linked_notes = []
     for link in linked_links:
         note = link.progress_note
@@ -199,6 +229,9 @@ def theme_detail(request, pk):
         "can_manage": can_manage,
         "status_choices": SuggestionTheme.STATUS_CHOICES,
         "breadcrumbs": breadcrumbs,
+        "is_filtered": is_filtered,
+        "date_from": date_from,
+        "date_to": date_to,
     })
 
 

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -19243,3 +19243,16 @@ msgstr ""
 "séance. Les catégories vont de Ne participe pas à Pleinement investi, avec "
 "une option Pas de rencontre individuelle lorsqu'il n'y a pas eu "
 "d'interaction directe. C'est l'observation de l'intervenant, pas une note."
+
+msgid "No suggestions linked to this theme in this period."
+msgstr "Aucune suggestion liée à ce thème pour cette période."
+
+msgid "Show all suggestions"
+msgstr "Afficher toutes les suggestions"
+
+#, python-format
+msgid "Showing suggestions from %(start)s to %(end)s."
+msgstr "Suggestions du %(start)s au %(end)s."
+
+msgid "Show all"
+msgstr "Tout afficher"

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -4093,7 +4093,6 @@ article[aria-label="notification"].fading-out {
     color: var(--kn-text-muted, #666);
 }
 .insights-about summary {
-    cursor: pointer;
     list-style: revert;
 }
 .insights-about-body {

--- a/templates/notes/suggestions/_linked_list.html
+++ b/templates/notes/suggestions/_linked_list.html
@@ -38,5 +38,11 @@
 </article>
 {% endfor %}
 {% else %}
+{% if is_filtered %}
+<p class="muted">{% trans "No suggestions linked to this theme in this period." %}
+    <a href="{% url 'suggestion_themes:theme_detail' theme.pk %}">{% trans "Show all suggestions" %}</a>
+</p>
+{% else %}
 <p class="muted">{% trans "No suggestions linked to this theme yet." %}{% if can_manage %} {% trans "Click \"Link More\" to find suggestions to add." %}{% endif %}</p>
+{% endif %}
 {% endif %}

--- a/templates/notes/suggestions/theme_detail.html
+++ b/templates/notes/suggestions/theme_detail.html
@@ -37,6 +37,13 @@
 <p>{{ theme.description }}</p>
 {% endif %}
 
+{% if is_filtered %}
+<p class="muted" style="font-size:0.9rem;">
+    {% blocktrans with start=date_from|date:"M j, Y" end=date_to|date:"M j, Y" %}Showing suggestions from {{ start }} to {{ end }}.{% endblocktrans %}
+    <a href="{% url 'suggestion_themes:theme_detail' theme.pk %}">{% trans "Show all" %}</a>
+</p>
+{% endif %}
+
 {% if theme.status == "addressed" and theme.addressed_note %}
 <article class="theme-resolution">
     <strong>{% trans "Resolution:" %}</strong>

--- a/templates/reports/_insights_basic.html
+++ b/templates/reports/_insights_basic.html
@@ -275,7 +275,7 @@
         <ul class="addressed-themes-list">
             {% for theme in addressed_themes %}
             <li>
-                <a href="{% url 'suggestion_themes:theme_detail' theme.pk %}">{{ theme.name }}</a>
+                <a href="{% url 'suggestion_themes:theme_detail' theme.pk %}{% if date_from and date_to %}?date_from={{ date_from|date:"Y-m-d" }}&amp;date_to={{ date_to|date:"Y-m-d" }}{% endif %}">{{ theme.name }}</a>
                 <span class="muted">({{ theme.link_count }})</span>
             </li>
             {% endfor %}

--- a/templates/reports/_theme_row.html
+++ b/templates/reports/_theme_row.html
@@ -22,7 +22,7 @@
 {% else %}
 <tr id="theme-{{ theme.pk }}">
     <td>
-        <a href="{% url 'suggestion_themes:theme_detail' theme.pk %}">{{ theme.name }}</a>{% if theme.was_reopened %} <span class="badge badge-neutral badge-sm" title="{% trans 'Previously addressed, reopened by new suggestions' %}">{% trans "Reopened" %}</span>{% endif %}
+        <a href="{% url 'suggestion_themes:theme_detail' theme.pk %}{% if date_from and date_to %}?date_from={{ date_from|date:"Y-m-d" }}&amp;date_to={{ date_to|date:"Y-m-d" }}{% endif %}">{{ theme.name }}</a>{% if theme.was_reopened %} <span class="badge badge-neutral badge-sm" title="{% trans 'Previously addressed, reopened by new suggestions' %}">{% trans "Reopened" %}</span>{% endif %}
     </td>
     <td style="text-align:right;">{{ theme.link_count }}</td>
     <td>


### PR DESCRIPTION
## Summary
- Demo data now links 2-4 suggestions to each theme via `SuggestionLink` records, so themes no longer appear empty
- Insights page now passes `date_from` and `date_to` query params when linking to theme detail pages
- Theme detail view filters linked suggestions by date range when params are present
- Empty state message distinguishes between "no suggestions yet" (unfiltered) and "no suggestions in this period" (filtered), with a "Show all" link
- French translations added for new strings

## Test plan
- [ ] Run `generate_demo_data --force` and verify themes have linked suggestions
- [ ] On Insights page, click a theme name — URL should include `?date_from=...&date_to=...`
- [ ] Theme detail with date params shows filtered suggestions and date range notice
- [ ] Theme detail without date params shows all suggestions (existing behaviour)
- [ ] "Show all" link strips date params and shows full list
- [ ] Verify French translations render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)