### PR TITLE
Fix review findings for theme detail date filtering

### DIFF
--- a/apps/notes/suggestion_views.py
+++ b/apps/notes/suggestion_views.py
@@ -3,7 +3,7 @@ from datetime import date
 
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
-from django.db.models import Count
+from django.db.models import Count, DateTimeField
 from django.db.models.functions import Coalesce
 from django.http import HttpResponseForbidden
 from django.shortcuts import get_object_or_404, redirect, render
@@ -183,7 +183,8 @@ def theme_detail(request, pk):
         try:
             date_from = date.fromisoformat(raw_from)
             date_to = date.fromisoformat(raw_to)
-            is_filtered = True
+            if date_from <= date_to:
+                is_filtered = True
         except ValueError:
             pass
 
@@ -193,6 +194,7 @@ def theme_detail(request, pk):
             _effective_date=Coalesce(
                 "progress_note__backdate",
                 "progress_note__created_at",
+                output_field=DateTimeField(),
             ),
         )
         .order_by("-linked_at")

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -19254,5 +19254,3 @@ msgstr "Afficher toutes les suggestions"
 msgid "Showing suggestions from %(start)s to %(end)s."
 msgstr "Suggestions du %(start)s au %(end)s."
 
-msgid "Show all"
-msgstr "Tout afficher"

--- a/templates/notes/suggestions/theme_detail.html
+++ b/templates/notes/suggestions/theme_detail.html
@@ -40,7 +40,7 @@
 {% if is_filtered %}
 <p class="muted" style="font-size:0.9rem;">
     {% blocktrans with start=date_from|date:"M j, Y" end=date_to|date:"M j, Y" %}Showing suggestions from {{ start }} to {{ end }}.{% endblocktrans %}
-    <a href="{% url 'suggestion_themes:theme_detail' theme.pk %}">{% trans "Show all" %}</a>
+    <a href="{% url 'suggestion_themes:theme_detail' theme.pk %}">{% trans "Show all suggestions" %}</a>
 </p>
 {% endif %}
 


### PR DESCRIPTION
## Summary
Follow-up to PR #311. Addresses code review findings:
- Add `output_field=DateTimeField()` to `Coalesce` annotation to match `insights.py` pattern and prevent ORM type mismatch
- Unify "Show all" / "Show all suggestions" link text for screen reader consistency
- Guard against reversed date ranges (`date_from > date_to`) by skipping filtering

## Test plan
- [ ] Theme detail with valid date params still filters correctly
- [ ] Theme detail with reversed date params shows all suggestions (unfiltered)
- [ ] Both "Show all suggestions" links use the same text

🤖 Generated with [Claude Code](https://claude.com/claude-code)