### PR TITLE
feat: skip demographics sections for identified participants

### DIFF
--- a/apps/portal/survey_helpers.py
+++ b/apps/portal/survey_helpers.py
@@ -17,18 +17,22 @@ def group_sections_into_pages(sections):
     return pages
 
 
-def filter_visible_sections(sections, partial_answers):
+def filter_visible_sections(sections, partial_answers, is_identified=False):
     """Filter sections based on conditional visibility.
 
     Args:
         sections: list of SurveySection objects (ordered by sort_order)
         partial_answers: dict of {question_pk: value_string} from PartialAnswer
+        is_identified: if True, hide sections flagged skip_for_identified
+            (portal and staff-entered surveys for known participants)
 
     Returns:
         list of visible SurveySection objects
     """
     visible = []
     for section in sections:
+        if is_identified and section.skip_for_identified:
+            continue
         if section.condition_question_id is None:
             visible.append(section)
         else:

--- a/apps/portal/views.py
+++ b/apps/portal/views.py
@@ -1687,7 +1687,7 @@ def portal_survey_fill(request, assignment_id):
         .order_by("sort_order")
     )
     partial_answers = get_partial_answers_dict(assignment)
-    visible_sections = filter_visible_sections(all_sections, partial_answers)
+    visible_sections = filter_visible_sections(all_sections, partial_answers, is_identified=True)
     pages = group_sections_into_pages(visible_sections)
     is_multi_page = len(pages) > 1
 
@@ -1729,7 +1729,7 @@ def portal_survey_fill(request, assignment_id):
                 })
             # Refresh partial answers and page structure after save
             partial_answers = get_partial_answers_dict(assignment)
-            visible_sections = filter_visible_sections(all_sections, partial_answers)
+            visible_sections = filter_visible_sections(all_sections, partial_answers, is_identified=True)
             pages = group_sections_into_pages(visible_sections)
             next_page = min(page_num + 1, len(pages))
             return redirect(f"{request.path}?page={next_page}")
@@ -1759,7 +1759,7 @@ def portal_survey_fill(request, assignment_id):
 
         # Refresh and validate ALL required questions across all pages
         partial_answers = get_partial_answers_dict(assignment)
-        visible_sections = filter_visible_sections(all_sections, partial_answers)
+        visible_sections = filter_visible_sections(all_sections, partial_answers, is_identified=True)
         all_errors = []
         for section in visible_sections:
             for question in section.questions.all().order_by("sort_order"):
@@ -1981,7 +1981,7 @@ def portal_survey_review(request, assignment_id):
         .prefetch_related("questions")
         .order_by("sort_order")
     )
-    visible_sections = filter_visible_sections(all_sections, answers_dict)
+    visible_sections = filter_visible_sections(all_sections, answers_dict, is_identified=True)
 
     # Calculate scores if configured
     scores = []
@@ -2034,7 +2034,7 @@ def portal_survey_thank_you(request, assignment_id):
                 .prefetch_related("questions")
                 .order_by("sort_order")
             )
-            visible = filter_visible_sections(all_sections, answers_dict)
+            visible = filter_visible_sections(all_sections, answers_dict, is_identified=True)
             scores = calculate_section_scores(visible, answers_dict)
 
     return render(request, "portal/survey_thank_you.html", {

--- a/apps/surveys/forms.py
+++ b/apps/surveys/forms.py
@@ -63,7 +63,8 @@ class SurveySectionForm(forms.ModelForm):
         model = SurveySection
         fields = [
             "title", "title_fr", "instructions", "instructions_fr",
-            "sort_order", "page_break", "scoring_method", "max_score",
+            "sort_order", "page_break", "skip_for_identified",
+            "scoring_method", "max_score",
             "condition_question", "condition_value",
         ]
         widgets = {
@@ -77,12 +78,18 @@ class SurveySectionForm(forms.ModelForm):
             "instructions_fr": _("Instructions (French)"),
             "sort_order": _("Display order"),
             "page_break": _("Start new page"),
+            "skip_for_identified": _("Skip for identified participants"),
             "scoring_method": _("Scoring method"),
             "max_score": _("Maximum score"),
             "condition_question": _("Show only when"),
             "condition_value": _("is answered"),
         }
         help_texts = {
+            "skip_for_identified": _(
+                "Check this for demographics sections. When the survey is "
+                "assigned to a participant or entered by staff, this section "
+                "will be hidden — that data is already on file."
+            ),
             "condition_question": _("Leave blank to always show this section."),
             "condition_value": _("The answer value that makes this section visible."),
         }

--- a/apps/surveys/migrations/0009_surveysection_skip_for_identified.py
+++ b/apps/surveys/migrations/0009_surveysection_skip_for_identified.py
@@ -1,0 +1,24 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("surveys", "0008_surveyresponse_consent_withdrawn_at"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="surveysection",
+            name="skip_for_identified",
+            field=models.BooleanField(
+                default=False,
+                help_text=(
+                    "Hide this section when the survey is filled by or for "
+                    "an identified participant (portal or staff-entered). "
+                    "Use for demographics sections \u2014 that data is already "
+                    "in the participant record."
+                ),
+            ),
+        ),
+    ]

--- a/apps/surveys/models.py
+++ b/apps/surveys/models.py
@@ -111,6 +111,15 @@ class SurveySection(models.Model):
     )
     condition_value = models.CharField(max_length=255, blank=True, default="")
     is_active = models.BooleanField(default=True)
+    skip_for_identified = models.BooleanField(
+        default=False,
+        help_text=_(
+            "Hide this section when the survey is filled by or for "
+            "an identified participant (portal or staff-entered). "
+            "Use for demographics sections — that data is already "
+            "in the participant record."
+        ),
+    )
 
     class Meta:
         app_label = "surveys"

--- a/apps/surveys/views.py
+++ b/apps/surveys/views.py
@@ -577,7 +577,7 @@ def staff_data_entry(request, client_id, survey_id):
                     all_answers[question.pk] = raw_value
 
         # 2. Determine which sections are visible based on answers
-        visible_sections = filter_visible_sections(sections_list, all_answers)
+        visible_sections = filter_visible_sections(sections_list, all_answers, is_identified=True)
         visible_section_pks = {s.pk for s in visible_sections}
 
         # 3. Validate required fields only in visible sections

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -12560,6 +12560,28 @@ msgstr "Commencer"
 msgid "Start new page"
 msgstr "Commencer une nouvelle page"
 
+msgid "Skip for identified participants"
+msgstr "Masquer pour les participants identifiés"
+
+msgid ""
+"Check this for demographics sections. When the survey is assigned to a "
+"participant or entered by staff, this section will be hidden — that data is "
+"already on file."
+msgstr ""
+"Cochez cette case pour les sections démographiques. Lorsque le sondage est "
+"attribué à un participant ou saisi par le personnel, cette section sera "
+"masquée — ces données sont déjà au dossier."
+
+msgid ""
+"Hide this section when the survey is filled by or for an identified "
+"participant (portal or staff-entered). Use for demographics sections — that "
+"data is already in the participant record."
+msgstr ""
+"Masquer cette section lorsque le sondage est rempli par ou pour un "
+"participant identifié (portail ou saisie par le personnel). Utilisez pour "
+"les sections démographiques — ces données sont déjà au dossier du "
+"participant."
+
 msgid "Submit"
 msgstr "Soumettre"
 

--- a/tests/test_portal_surveys.py
+++ b/tests/test_portal_surveys.py
@@ -120,6 +120,43 @@ class PageGroupingTests(TestCase):
         )
         self.assertEqual(len(visible), 2)
 
+    def test_skip_for_identified_hidden(self):
+        """Sections with skip_for_identified are hidden when is_identified=True."""
+        from apps.portal.survey_helpers import filter_visible_sections
+
+        survey = Survey.objects.create(
+            name="Demographics", created_by=self.staff, status="active",
+        )
+        SurveySection.objects.create(
+            survey=survey, title="About You", sort_order=1,
+            skip_for_identified=True,
+        )
+        SurveySection.objects.create(
+            survey=survey, title="Feedback", sort_order=2,
+        )
+        sections = list(survey.sections.filter(is_active=True).order_by("sort_order"))
+        visible = filter_visible_sections(sections, partial_answers={}, is_identified=True)
+        self.assertEqual(len(visible), 1)
+        self.assertEqual(visible[0].title, "Feedback")
+
+    def test_skip_for_identified_shown_anonymous(self):
+        """Sections with skip_for_identified are shown for anonymous responses."""
+        from apps.portal.survey_helpers import filter_visible_sections
+
+        survey = Survey.objects.create(
+            name="Demographics2", created_by=self.staff, status="active",
+        )
+        SurveySection.objects.create(
+            survey=survey, title="About You", sort_order=1,
+            skip_for_identified=True,
+        )
+        SurveySection.objects.create(
+            survey=survey, title="Feedback", sort_order=2,
+        )
+        sections = list(survey.sections.filter(is_active=True).order_by("sort_order"))
+        visible = filter_visible_sections(sections, partial_answers={}, is_identified=False)
+        self.assertEqual(len(visible), 2)
+
 
 @override_settings(
     FIELD_ENCRYPTION_KEY=TEST_KEY,


### PR DESCRIPTION
## Summary
- Adds a `skip_for_identified` boolean on SurveySection so admins can tag demographics sections
- When a survey is filled in the portal (identified participant) or via staff data entry, tagged sections are automatically hidden
- Anonymous link responses still see all sections — same survey works both ways
- Includes migration, French translations, and 2 unit tests

## Test plan
- [ ] Create a survey with a section marked "Skip for identified participants"
- [ ] Assign it to a participant — confirm the tagged section is hidden in the portal
- [ ] Open the same survey via a public link — confirm all sections appear
- [ ] Staff data entry for a participant — confirm tagged section is hidden
- [ ] Run `pytest tests/test_portal_surveys.py` — 2 new tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)