### PR TITLE
fix: filter demographics sections on staff data entry GET path

### DIFF
--- a/apps/surveys/views.py
+++ b/apps/surveys/views.py
@@ -557,11 +557,13 @@ def staff_data_entry(request, client_id, survey_id):
         is_active=True,
     ).prefetch_related("questions").select_related("condition_question").order_by("sort_order")
 
-    if request.method == "POST":
-        from apps.portal.survey_helpers import filter_visible_sections
+    from apps.portal.survey_helpers import filter_visible_sections
 
-        # Materialise queryset once to avoid duplicate DB hits
-        sections_list = list(sections)
+    # Materialise queryset once to avoid duplicate DB hits
+    sections_list = list(sections)
+    visible_sections = filter_visible_sections(sections_list, {}, is_identified=True)
+
+    if request.method == "POST":
 
         # 1. Collect all submitted answers
         all_answers = {}
@@ -601,7 +603,7 @@ def staff_data_entry(request, client_id, survey_id):
             return render(request, "surveys/staff_data_entry.html", {
                 "client": client,
                 "survey": survey,
-                "sections": sections,
+                "sections": visible_sections,
                 "posted": request.POST,
                 "breadcrumbs": _staff_entry_breadcrumbs(request, client, survey),
             })
@@ -637,7 +639,7 @@ def staff_data_entry(request, client_id, survey_id):
     return render(request, "surveys/staff_data_entry.html", {
         "client": client,
         "survey": survey,
-        "sections": sections,
+        "sections": visible_sections,
         "posted": {},
         "breadcrumbs": _staff_entry_breadcrumbs(request, client, survey),
     })


### PR DESCRIPTION
## Summary
- Moves `filter_visible_sections` import and initial filtering outside the POST block so the GET render and validation-error re-render also hide `skip_for_identified` sections
- Previously, staff saw demographics questions on initial page load even when the section was tagged to skip for identified participants

Follow-up to PR #313.

## Test plan
- [ ] Open staff data entry for a survey with a demographics section marked "Skip for identified participants" — section should be hidden on initial load
- [ ] Submit with validation errors — demographics section should stay hidden on re-render

🤖 Generated with [Claude Code](https://claude.com/claude-code)