### PR TITLE
fix: consistent header/footer branding across all pages

### DIFF
--- a/templates/auth/login.html
+++ b/templates/auth/login.html
@@ -134,7 +134,9 @@
     <footer class="container site-footer" role="contentinfo">
         <div class="site-footer-inner">
             <div class="site-footer-brand">
-                <strong>{{ site.product_name|default:"KoNote" }}</strong>
+                {% if site.organization_name %}
+                <strong>{% if site.organization_website %}<a href="{{ site.organization_website }}" target="_blank" rel="noopener">{{ site.organization_name }}</a>{% else %}{{ site.organization_name }}{% endif %}</strong>
+                {% endif %}
                 {% if site.support_email %}<span>{% trans "Support:" %} <a href="mailto:{{ site.support_email }}">{{ site.support_email }}</a></span>{% endif %}
             </div>
             <div class="site-footer-links">

--- a/templates/base.html
+++ b/templates/base.html
@@ -90,14 +90,7 @@
     {% if not user.is_authenticated %}
     <nav class="container-fluid" aria-label="{% trans 'Main navigation' %}">
         <ul>
-            <li><a href="/" class="contrast nav-brand">
-                {% if site.logo_url %}
-                <img src="{{ site.logo_url }}" alt="" class="nav-logo" height="28" width="28">
-                {% else %}
-                <img src="{% static 'img/konote-icon.png' %}" alt="" class="nav-logo" height="28" width="28">
-                {% endif %}
-                {% trans "Home" %}
-            </a></li>
+            <li><a href="/" class="contrast">{% trans "Home" %}</a></li>
         </ul>
         <ul>
             <li><a href="{% url 'auth_app:login' %}">{% trans "Sign In" %}</a></li>
@@ -109,14 +102,7 @@
     {% if user.is_authenticated %}
     <nav class="container-fluid" aria-label="{% trans 'Main navigation' %}">
         <ul>
-            <li><a href="{% if is_admin_only %}{% url 'admin_settings:dashboard' %}{% else %}/{% endif %}" class="contrast nav-brand">
-                {% if site.logo_url %}
-                <img src="{{ site.logo_url }}" alt="" class="nav-logo" height="28" width="28">
-                {% else %}
-                <img src="{% static 'img/konote-icon.png' %}" alt="" class="nav-logo" height="28" width="28">
-                {% endif %}
-                {% trans "Home" %}
-            </a></li>
+            <li><a href="{% if is_admin_only %}{% url 'admin_settings:dashboard' %}{% else %}/{% endif %}" class="contrast">{% trans "Home" %}</a></li>
             <li>
                 <!-- Mobile menu toggle -->
                 <button type="button" id="nav-toggle" class="nav-toggle" aria-expanded="false" aria-controls="nav-menu" aria-label="{% trans 'Toggle navigation menu' %}">
@@ -312,7 +298,10 @@
                 {% if site.organization_name %}
                 <strong>{% if site.organization_website %}<a href="{{ site.organization_website }}" target="_blank" rel="noopener">{{ site.organization_name }}</a>{% else %}{{ site.organization_name }}{% endif %}</strong>
                 {% endif %}
-                <span>{% trans "Powered by" %} KoNote</span>
+                <a href="https://logicaloutcomes.github.io/konote-website/" class="powered-by" target="_blank" rel="noopener">
+                    <img src="{% static 'img/konote-icon.png' %}" alt="" width="20" height="20">
+                    {% trans "Powered by" %} KoNote
+                </a>
                 {% if site.support_email %}<span>{% trans "Support:" %} <a href="mailto:{{ site.support_email }}">{{ site.support_email }}</a></span>{% endif %}
             </div>
             <div class="site-footer-links">

--- a/templates/clients/home.html
+++ b/templates/clients/home.html
@@ -177,6 +177,7 @@
 {% endif %}
 
 <!-- Quick links — moved up for faster access (UX-TASKDASH1) -->
+{% if not is_executive %}
 {% if features.programs or user.is_admin %}
 <nav class="quick-links" aria-label="{% trans 'Quick links' %}">
     <span class="quick-links-label">{% trans "Quick links:" %}</span>
@@ -189,6 +190,7 @@
     {% endif %}
 </nav>
 {% endif %}
+{% endif %}{# not is_executive #}
 
 <!-- Two-column dashboard -->
 <div class="dashboard-grid">


### PR DESCRIPTION
## Summary
- **Nav**: Remove broken logo image from top-left nav. Show plain text "Home" matching other nav items. The `logo_url` setting often contains a website URL (not an image), causing a broken image.
- **Footer (inner pages)**: Add K-mark icon + link to "Powered by KoNote", matching the login page pattern. Agency name (bold) appears above when configured.
- **Footer (login page)**: Use `organization_name` instead of `product_name` for agency identity, aligning with inner pages.
- **Executive dashboard**: Hide Quick links section (was not gated by `is_executive`).

## Test plan
- [ ] Login page: footer shows agency name (if configured) + "Powered by KoNote" with K-mark icon
- [ ] Inner pages: same footer structure, plus session info on right
- [ ] Top-left nav shows plain text "Home" with no image on all pages
- [ ] Executive dashboard does not show Quick links section


🤖 Generated with [Claude Code](https://claude.com/claude-code)