### PR TITLE
feat: add show_on_create flag for custom fields on create form

### DIFF
--- a/apps/clients/forms.py
+++ b/apps/clients/forms.py
@@ -417,7 +417,7 @@ class CustomFieldDefinitionForm(forms.ModelForm):
         fields = [
             "group", "name", "input_type", "placeholder", "is_required",
             "is_sensitive", "front_desk_access", "is_dv_sensitive",
-            "options_json", "sort_order", "status",
+            "show_on_create", "options_json", "sort_order", "status",
         ]
         widgets = {
             "options_json": forms.Textarea(attrs={"rows": 3, "placeholder": _('["Option 1", "Option 2"]')}),

--- a/apps/clients/management/commands/seed_intake_fields.py
+++ b/apps/clients/management/commands/seed_intake_fields.py
@@ -796,6 +796,13 @@ class Command(BaseCommand):
                     name=field_name,
                 ).exclude(sort_order=sort_val).update(sort_order=sort_val)
 
+            # Pronouns: show on create form by default
+            fixups += CustomFieldDefinition.objects.filter(
+                group__title="Contact Information",
+                name="Pronouns",
+                show_on_create=False,
+            ).update(show_on_create=True)
+
             if fixups:
                 self.stdout.write(f"  Updated {fixups} stale field(s) from earlier seeds.")
 

--- a/apps/clients/migrations/0037_customfielddefinition_show_on_create.py
+++ b/apps/clients/migrations/0037_customfielddefinition_show_on_create.py
@@ -1,0 +1,19 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("clients", "0036_alter_consentevent_id_and_more"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="customfielddefinition",
+            name="show_on_create",
+            field=models.BooleanField(
+                default=False,
+                help_text="Show this field on the new participant creation form.",
+            ),
+        ),
+    ]

--- a/apps/clients/models.py
+++ b/apps/clients/models.py
@@ -766,6 +766,10 @@ class CustomFieldDefinition(models.Model):
             "for participants with a DV safety flag."
         ),
     )
+    show_on_create = models.BooleanField(
+        default=False,
+        help_text=_("Show this field on the new participant creation form."),
+    )
     # Determines which validation and normalisation rules apply (I18N-FIX2).
     # Auto-detected from field name on first save if not explicitly set.
     validation_type = models.CharField(

--- a/apps/clients/templatetags/client_tags.py
+++ b/apps/clients/templatetags/client_tags.py
@@ -1,0 +1,17 @@
+"""Template tags and filters for the clients app."""
+
+from django import template
+
+register = template.Library()
+
+
+@register.filter
+def get_field(form, field_name):
+    """Look up a form field by dynamic name.
+
+    Usage: {{ form|get_field:"custom_42" }}
+    """
+    try:
+        return form[field_name]
+    except (KeyError, TypeError):
+        return ""

--- a/apps/clients/views.py
+++ b/apps/clients/views.py
@@ -381,6 +381,58 @@ def client_list(request):
     return render(request, "clients/list.html", context)
 
 
+def _get_create_field_defs(user):
+    """Return CustomFieldDefinitions marked show_on_create, respecting role access."""
+    qs = CustomFieldDefinition.objects.filter(
+        status="active",
+        group__status="active",
+        show_on_create=True,
+    ).select_related("group").order_by("group__sort_order", "sort_order")
+    user_role = getattr(user, "_program_role", None) or _get_user_highest_role(user)
+    if user_role == "receptionist":
+        qs = qs.filter(front_desk_access="edit")
+    return list(qs)
+
+
+def _group_create_field_defs(field_defs):
+    """Group field defs by CustomFieldGroup for template rendering."""
+    from collections import OrderedDict
+    grouped = OrderedDict()
+    for fd in field_defs:
+        if fd.group_id not in grouped:
+            grouped[fd.group_id] = {"group": fd.group, "fields": []}
+        grouped[fd.group_id]["fields"].append({"def": fd, "key": f"custom_{fd.pk}"})
+    return list(grouped.values())
+
+
+def _save_create_custom_fields(client, custom_form, field_defs):
+    """Save custom field values from the create form into ClientDetailValue records."""
+    for field_def in field_defs:
+        raw_value = custom_form.cleaned_data.get(f"custom_{field_def.pk}", "")
+        if field_def.input_type == "select_other" and raw_value == "__other__":
+            raw_value = custom_form.cleaned_data.get(f"custom_{field_def.pk}_other", "").strip()
+        elif field_def.input_type == "multi_select":
+            raw_value = json.dumps(raw_value) if raw_value else ""
+        elif field_def.input_type == "multi_select_other":
+            selected = raw_value if isinstance(raw_value, list) else []
+            other_text = custom_form.cleaned_data.get(f"custom_{field_def.pk}_other", "").strip()
+            if other_text:
+                selected = list(selected) + [other_text]
+            raw_value = json.dumps(selected) if selected else ""
+        # Validate and normalise Canadian-specific fields
+        if field_def.validation_type == "postal_code" and raw_value:
+            validate_postal_code(raw_value)
+            raw_value = normalize_postal_code(raw_value)
+        if field_def.validation_type == "phone" and raw_value:
+            validate_phone_number(raw_value)
+            raw_value = normalize_phone_number(raw_value)
+        if not raw_value:
+            continue
+        cdv = ClientDetailValue(client_file=client, field_def=field_def)
+        cdv.set_value(raw_value)
+        cdv.save()
+
+
 @login_required
 @requires_permission("client.create")
 def client_create(request):
@@ -394,9 +446,15 @@ def client_create(request):
         visible = get_visible_circles(request.user)
         circle_choices = [(c.pk, c.name) for c in visible]
 
+    # Custom fields marked show_on_create
+    create_field_defs = _get_create_field_defs(request.user)
+    custom_groups = _group_create_field_defs(create_field_defs)
+
     if request.method == "POST":
         form = ClientFileForm(request.POST, available_programs=available_programs, circle_choices=circle_choices)
-        if form.is_valid():
+        custom_form = CustomFieldValuesForm(request.POST, field_definitions=create_field_defs) if create_field_defs else None
+        forms_valid = form.is_valid() and (custom_form is None or custom_form.is_valid())
+        if forms_valid:
             # BUG-7: Wrap in transaction so client + enrollments commit
             # atomically. Prevents a half-created client if enrollment
             # creation fails, and ensures the redirect sees all data.
@@ -428,6 +486,9 @@ def client_create(request):
                 # Security: is_demo is immutable after creation
                 client.is_demo = request.user.is_demo
                 client.save()
+                # Save custom fields (Pronouns, Emergency Contact, etc.)
+                if custom_form:
+                    _save_create_custom_fields(client, custom_form, create_field_defs)
                 # Enrol in selected programs
                 for program in form.cleaned_data["programs"]:
                     ClientProgramEnrolment.objects.create(
@@ -470,7 +531,13 @@ def client_create(request):
             return redirect("clients:client_detail", client_id=client.pk)
     else:
         form = ClientFileForm(available_programs=available_programs, circle_choices=circle_choices)
-    return render(request, "clients/form.html", {"form": form, "editing": False})
+        custom_form = CustomFieldValuesForm(field_definitions=create_field_defs) if create_field_defs else None
+    return render(request, "clients/form.html", {
+        "form": form,
+        "editing": False,
+        "custom_form": custom_form,
+        "custom_groups": custom_groups,
+    })
 
 
 @login_required

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -810,8 +810,8 @@ msgstr "Tout sélectionner"
 msgid "Deselect all"
 msgstr "Tout désélectionner"
 
-msgid "Generate Report"
-msgstr "Générer le rapport"
+msgid "Standard Report"
+msgstr "Rapport standard"
 
 msgid "Additional Options"
 msgstr "Options supplémentaires"
@@ -14636,14 +14636,17 @@ msgstr "Ajouter un objectif"
 msgid "Attendance Rate"
 msgstr "Taux de présence"
 
-msgid "Create a custom export"
-msgstr "Créer une exportation personnalisée"
+msgid "Build your own report"
+msgstr "Créer votre propre rapport"
 
-msgid "Custom Export"
-msgstr "Exportation personnalisée"
+msgid "Generate"
+msgstr "Générer"
 
-msgid "Go to Custom Export"
-msgstr "Aller à l’exportation personnalisée"
+msgid "Build a Report"
+msgstr "Créer un rapport"
+
+msgid "Go to Build a Report"
+msgstr "Aller à Créer un rapport"
 
 msgid "Listen"
 msgstr "Écouter"
@@ -14756,13 +14759,13 @@ msgstr ""
 " pour en créer un."
 
 msgid ""
-"In the meantime, you can create a one-off report using <strong>Custom "
-"Export</strong>, where you choose the program, metrics, and date range "
+"In the meantime, you can create a one-off report using <strong>Build a "
+"Report</strong>, where you choose the program, metrics, and date range "
 "yourself."
 msgstr ""
-"En attendant, vous pouvez créer un rapport ponctuel avec "
-"l'<strong>exportation personnalisée</strong>, où vous choisissez vous-même "
-"le programme, les indicateurs et la période."
+"En attendant, vous pouvez créer un rapport ponctuel avec <strong>Créer un "
+"rapport</strong>, où vous choisissez vous-même le programme, les indicateurs "
+"et la période."
 
 msgid ""
 "All forms. For programs doing both group sessions and individual visits."
@@ -15681,11 +15684,11 @@ msgstr "Heures de contact moyennes par participant"
 msgid "Average Sessions per Participant"
 msgstr "Séances moyennes par participant"
 
-msgid "Back to Custom Export"
-msgstr "Retour à l’exportation personnalisée"
+msgid "Back to Build a Report"
+msgstr "Retour à Créer un rapport"
 
-msgid "Back to Generate Report"
-msgstr "Retour à la génération de rapport"
+msgid "Back to Standard Report"
+msgstr "Retour au rapport standard"
 
 msgid "Breakdowns by session type and modality"
 msgstr "Répartition par type de séance et modalité"
@@ -17885,8 +17888,8 @@ msgstr "Signalements d'anomalies"
 msgid "Bulk record access"
 msgstr "Accès massif aux dossiers"
 
-msgid "Compliance Summary"
-msgstr "Résumé de conformité"
+msgid "Privacy & Access Audit"
+msgstr "Audit de confidentialité et d'accès"
 
 msgid "Conservative (< 10)"
 msgstr "Prudent (< 10)"
@@ -19275,4 +19278,13 @@ msgstr "Afficher toutes les suggestions"
 #, python-format
 msgid "Showing suggestions from %(start)s to %(end)s."
 msgstr "Suggestions du %(start)s au %(end)s."
+
+msgid "Show this field on the new participant creation form."
+msgstr "Afficher ce champ sur le formulaire de création de nouveau participant."
+
+msgid "On create"
+msgstr "À la création"
+
+msgid "Show on create form"
+msgstr "Afficher au formulaire de création"
 

--- a/templates/clients/_custom_fields_create.html
+++ b/templates/clients/_custom_fields_create.html
@@ -1,0 +1,126 @@
+{% load i18n client_tags %}
+{# Partial: Custom fields marked show_on_create, rendered on the New Participant form.
+   Context: custom_groups — list of {"group": CustomFieldGroup, "fields": [{"def": fd, "key": "custom_<pk>"}]}
+            custom_form  — CustomFieldValuesForm instance #}
+{% for group in custom_groups %}
+<fieldset aria-labelledby="create-group-{{ group.group.pk }}">
+    <legend id="create-group-{{ group.group.pk }}">{{ group.group.title }}</legend>
+    {% for item in group.fields %}
+    {% with bound=custom_form|get_field:item.key %}
+    <div class="form-row">
+        <label for="id_{{ item.key }}">
+            {{ item.def.name }}
+            {% if item.def.is_required %}<abbr title="{% trans 'required' %}">*</abbr>{% endif %}
+        </label>
+
+        {% if item.def.input_type == "textarea" %}
+            <textarea name="{{ item.key }}"
+                      id="id_{{ item.key }}"
+                      rows="3"
+                      placeholder="{{ item.def.placeholder }}"
+                      {% if item.def.is_required %}required aria-required="true"{% endif %}
+                      {% if bound.errors %}aria-invalid="true" aria-describedby="err_{{ item.key }}"{% endif %}>{{ bound.value|default:"" }}</textarea>
+
+        {% elif item.def.input_type == "select" %}
+            <select name="{{ item.key }}"
+                    id="id_{{ item.key }}"
+                    {% if item.def.is_required %}required aria-required="true"{% endif %}
+                    {% if bound.errors %}aria-invalid="true" aria-describedby="err_{{ item.key }}"{% endif %}>
+                <option value="">{% trans "Select…" %}</option>
+                {% for opt in item.def.options_json %}
+                <option value="{{ opt }}" {% if bound.value == opt %}selected{% endif %}>{{ opt }}</option>
+                {% endfor %}
+            </select>
+
+        {% elif item.def.input_type == "select_other" %}
+            <select name="{{ item.key }}"
+                    id="id_{{ item.key }}"
+                    {% if item.def.is_required %}required aria-required="true"{% endif %}
+                    {% if bound.errors %}aria-invalid="true" aria-describedby="err_{{ item.key }}"{% endif %}
+                    onchange="document.getElementById('other_wrap_{{ item.def.pk }}').style.display = this.value === '__other__' ? '' : 'none';">
+                <option value="">{% trans "Select…" %}</option>
+                {% for opt in item.def.options_json %}
+                <option value="{{ opt }}" {% if bound.value == opt %}selected{% endif %}>{{ opt }}</option>
+                {% endfor %}
+                <option value="__other__" {% if bound.value == "__other__" %}selected{% endif %}>{% trans "Other" %}</option>
+            </select>
+            {% with other_key=item.key|add:"_other" %}
+            <div id="other_wrap_{{ item.def.pk }}"
+                 style="margin-top: 0.5rem;{% if bound.value != '__other__' %} display: none;{% endif %}">
+                <label for="{{ other_key }}" class="sr-only">{% trans "Other (please specify)" %}</label>
+                <input type="text"
+                       name="{{ other_key }}"
+                       id="{{ other_key }}"
+                       value="{{ custom_form|get_field:other_key }}"
+                       placeholder="{% trans 'Please specify…' %}">
+            </div>
+            {% endwith %}
+
+        {% elif item.def.input_type == "multi_select" %}
+            <fieldset role="group" aria-labelledby="id_{{ item.key }}">
+                {% for opt in item.def.options_json %}
+                <label>
+                    <input type="checkbox"
+                           name="{{ item.key }}"
+                           value="{{ opt }}">
+                    {{ opt }}
+                </label>
+                {% endfor %}
+            </fieldset>
+
+        {% elif item.def.input_type == "multi_select_other" %}
+            <fieldset role="group" aria-labelledby="id_{{ item.key }}">
+                {% for opt in item.def.options_json %}
+                <label>
+                    <input type="checkbox"
+                           name="{{ item.key }}"
+                           value="{{ opt }}">
+                    {{ opt }}
+                </label>
+                {% endfor %}
+            </fieldset>
+            {% with other_key=item.key|add:"_other" %}
+            <div style="margin-top: 0.5rem;">
+                <label for="{{ other_key }}">{% trans "Other (please specify)" %}</label>
+                <input type="text"
+                       name="{{ other_key }}"
+                       id="{{ other_key }}"
+                       placeholder="{% trans 'Please specify…' %}">
+            </div>
+            {% endwith %}
+
+        {% elif item.def.input_type == "date" %}
+            <input type="date"
+                   name="{{ item.key }}"
+                   id="id_{{ item.key }}"
+                   value="{{ bound.value|default:"" }}"
+                   {% if item.def.is_required %}required aria-required="true"{% endif %}
+                   {% if bound.errors %}aria-invalid="true" aria-describedby="err_{{ item.key }}"{% endif %}>
+
+        {% elif item.def.input_type == "number" %}
+            <input type="number"
+                   name="{{ item.key }}"
+                   id="id_{{ item.key }}"
+                   value="{{ bound.value|default:"" }}"
+                   placeholder="{{ item.def.placeholder }}"
+                   {% if item.def.is_required %}required aria-required="true"{% endif %}
+                   {% if bound.errors %}aria-invalid="true" aria-describedby="err_{{ item.key }}"{% endif %}>
+
+        {% else %}
+            <input type="text"
+                   name="{{ item.key }}"
+                   id="id_{{ item.key }}"
+                   value="{{ bound.value|default:"" }}"
+                   placeholder="{{ item.def.placeholder }}"
+                   {% if item.def.is_required %}required aria-required="true"{% endif %}
+                   {% if bound.errors %}aria-invalid="true" aria-describedby="err_{{ item.key }}"{% endif %}>
+        {% endif %}
+
+        {% if bound.errors %}
+        <small class="error" id="err_{{ item.key }}" role="alert">{{ bound.errors.0 }}</small>
+        {% endif %}
+    </div>
+    {% endwith %}
+    {% endfor %}
+</fieldset>
+{% endfor %}

--- a/templates/clients/custom_fields_admin.html
+++ b/templates/clients/custom_fields_admin.html
@@ -32,6 +32,7 @@
                 <th scope="col">{% trans "Type" %}</th>
                 <th scope="col">{% trans "Required" %}</th>
                 <th scope="col">{% trans "Sensitive" %}</th>
+                <th scope="col">{% trans "On create" %}</th>
                 <th scope="col"></th>
             </tr>
         </thead>
@@ -42,6 +43,7 @@
                 <td>{{ field.get_input_type_display }}</td>
                 <td>{% if field.is_required %}{% trans "Yes" %}{% else %}{% trans "No" %}{% endif %}</td>
                 <td>{% if field.is_sensitive %}{% trans "Yes" %}{% else %}{% trans "No" %}{% endif %}</td>
+                <td>{% if field.show_on_create %}{% trans "Yes" %}{% else %}{% trans "No" %}{% endif %}</td>
                 <td><a href="{% url 'clients:custom_field_def_edit' field_id=field.pk %}">{% trans "Edit" %}</a></td>
             </tr>
             {% endfor %}

--- a/templates/clients/form.html
+++ b/templates/clients/form.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load i18n %}
+{% load i18n client_tags %}
 
 {% block title %}{% if editing %}{% blocktrans with client=term.client|default:"Participant" %}Edit {{ client }}{% endblocktrans %}{% else %}{% blocktrans with client=term.client|default:"Participant" %}New {{ client }}{% endblocktrans %}{% endif %} — {{ site.product_name|default:"KoNote" }}{% endblock %}
 
@@ -90,6 +90,10 @@
         </div>
         <div></div>
     </div>
+
+    {% if custom_groups %}
+        {% include "clients/_custom_fields_create.html" %}
+    {% endif %}
 
     {% if form.programs.field.queryset.exists %}
     <fieldset>

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -634,6 +634,107 @@ class CustomFieldTest(TestCase):
 
 
 @override_settings(FIELD_ENCRYPTION_KEY=TEST_KEY)
+class ShowOnCreateFieldTest(TestCase):
+    """Tests for custom fields with show_on_create=True on the New Participant form."""
+
+    databases = {"default", "audit"}
+
+    def setUp(self):
+        enc_module._fernet = None
+        self.client = Client()
+        self.admin = User.objects.create_user(username="admin", password="testpass123", is_admin=True)
+        self.receptionist = User.objects.create_user(username="recep", password="testpass123", is_admin=False)
+        self.prog = Program.objects.create(name="Test Program", colour_hex="#10B981")
+        UserProgramRole.objects.create(user=self.admin, program=self.prog, role="program_manager")
+        UserProgramRole.objects.create(user=self.receptionist, program=self.prog, role="receptionist")
+        self.group = CustomFieldGroup.objects.create(title="Identity", sort_order=10)
+        self.pronouns = CustomFieldDefinition.objects.create(
+            group=self.group, name="Pronouns", input_type="select_other",
+            is_required=False, show_on_create=True, front_desk_access="edit",
+            options_json=["He/him", "She/her", "They/them"],
+        )
+
+    def _base_post_data(self, **extra):
+        data = {
+            "first_name": "Test", "last_name": "User",
+            "preferred_name": "", "middle_name": "",
+            "birth_date": "", "record_id": "", "status": "active",
+            "preferred_language": "en", "programs": [self.prog.pk],
+        }
+        data.update(extra)
+        return data
+
+    def test_create_renders_show_on_create_field(self):
+        """GET create page includes custom fields marked show_on_create."""
+        self.client.login(username="admin", password="testpass123")
+        resp = self.client.get("/participants/create/")
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, "Pronouns")
+        self.assertContains(resp, "He/him")
+
+    def test_create_saves_custom_field_value(self):
+        """POST with a custom field value saves a ClientDetailValue."""
+        self.client.login(username="admin", password="testpass123")
+        resp = self.client.post("/participants/create/", self._base_post_data(
+            **{f"custom_{self.pronouns.pk}": "They/them"},
+        ))
+        self.assertEqual(resp.status_code, 302)
+        cf = ClientFile.objects.last()
+        cdv = ClientDetailValue.objects.get(client_file=cf, field_def=self.pronouns)
+        self.assertEqual(cdv.get_value(), "They/them")
+
+    def test_create_skips_empty_custom_field(self):
+        """Empty custom field values don't create ClientDetailValue records."""
+        self.client.login(username="admin", password="testpass123")
+        resp = self.client.post("/participants/create/", self._base_post_data(
+            **{f"custom_{self.pronouns.pk}": ""},
+        ))
+        self.assertEqual(resp.status_code, 302)
+        cf = ClientFile.objects.last()
+        self.assertFalse(ClientDetailValue.objects.filter(client_file=cf).exists())
+
+    def test_create_receptionist_sees_edit_fields_only(self):
+        """Receptionist sees show_on_create fields with front_desk_access='edit' only."""
+        hidden_field = CustomFieldDefinition.objects.create(
+            group=self.group, name="Secret Field", input_type="text",
+            show_on_create=True, front_desk_access="none",
+        )
+        self.client.login(username="recep", password="testpass123")
+        resp = self.client.get("/participants/create/")
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, "Pronouns")
+        self.assertNotContains(resp, "Secret Field")
+
+    def test_create_does_not_show_non_flagged_fields(self):
+        """Fields with show_on_create=False don't appear on the create form."""
+        hidden = CustomFieldDefinition.objects.create(
+            group=self.group, name="Hidden Field", input_type="text",
+            show_on_create=False, front_desk_access="edit",
+        )
+        self.client.login(username="admin", password="testpass123")
+        resp = self.client.get("/participants/create/")
+        self.assertNotContains(resp, "Hidden Field")
+
+    def test_create_sensitive_field_encrypted(self):
+        """Sensitive custom field values are stored encrypted."""
+        sensitive = CustomFieldDefinition.objects.create(
+            group=self.group, name="SIN", input_type="text",
+            is_required=False, is_sensitive=True,
+            show_on_create=True, front_desk_access="edit",
+        )
+        self.client.login(username="admin", password="testpass123")
+        resp = self.client.post("/participants/create/", self._base_post_data(
+            **{f"custom_{sensitive.pk}": "123-456-789"},
+        ))
+        self.assertEqual(resp.status_code, 302)
+        cf = ClientFile.objects.last()
+        cdv = ClientDetailValue.objects.get(client_file=cf, field_def=sensitive)
+        self.assertEqual(cdv.get_value(), "123-456-789")
+        self.assertEqual(cdv.value, "")  # Plain text field empty
+        self.assertTrue(cdv._value_encrypted)  # Encrypted field populated
+
+
+@override_settings(FIELD_ENCRYPTION_KEY=TEST_KEY)
 class SelectOtherFieldTest(TestCase):
     """Tests for the select_other input type (dropdown with free-text Other option)."""
 


### PR DESCRIPTION
## Summary
- Adds `show_on_create` boolean to `CustomFieldDefinition` so admins can configure which custom fields appear on the New Participant creation form
- Pronouns field defaults to showing on create (via seed command)
- Admin UI shows the new toggle in the field definition form and an "On create" column in the field list
- Respects `front_desk_access` — receptionists only see fields with `edit` access

## How it works
1. Admin toggles `show_on_create` on any custom field definition (Admin > Custom Fields > Edit Field)
2. The New Participant form dynamically includes those fields between Status and Programs
3. Values are saved as `ClientDetailValue` records in the same transaction as the participant

## Files changed
- `apps/clients/models.py` — `show_on_create` field on `CustomFieldDefinition`
- `apps/clients/forms.py` — Added to `CustomFieldDefinitionForm`
- `apps/clients/views.py` — Helper functions + updated `client_create` view
- `templates/clients/form.html` — Includes new partial
- `templates/clients/_custom_fields_create.html` — New partial for all 8 input types
- `templates/clients/custom_fields_admin.html` — "On create" column
- `apps/clients/templatetags/client_tags.py` — `get_field` filter
- `apps/clients/management/commands/seed_intake_fields.py` — Pronouns default
- `tests/test_clients.py` — 6 new tests

## Test plan
- [ ] Run `seed_intake_fields` — Pronouns should get `show_on_create=True`
- [ ] Visit New Participant page — Pronouns dropdown appears between Status and Programs
- [ ] Create participant with pronouns — check value saved in profile
- [ ] As admin, toggle `show_on_create` on Emergency Contact Name — verify it appears
- [ ] As receptionist, verify fields with `front_desk_access="none"` are hidden
- [ ] Run `pytest tests/test_clients.py -k "ShowOnCreate"` — 6 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)