### PR TITLE
fix: plan page table bug + card layout redesign

### DIFF
--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -743,6 +743,11 @@ msgstr ""
 msgid "None"
 msgstr "Aucun"
 
+#: templates/plans/_target.html
+#, python-format
+msgid "No %(metrics)s assigned"
+msgstr "Aucune %(metrics)s attribuée"
+
 msgid "History"
 msgstr "Historique"
 

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -2762,6 +2762,12 @@ p.notice.warning {
     align-items: center;
     gap: 0.25rem;
 }
+.goal-card-metrics .badge {
+    max-width: 12rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
 .goal-card-more-metrics {
     font-size: 0.75rem;
 }

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -2654,13 +2654,15 @@ p.notice.warning {
     width: 100%;
 }
 .plan-targets-table th:nth-child(1),
-.plan-targets-table td:nth-child(1) { width: 50%; }
+.plan-targets-table td:nth-child(1) { width: 40%; }
 .plan-targets-table th:nth-child(2),
-.plan-targets-table td:nth-child(2) { width: 13%; }
+.plan-targets-table td:nth-child(2) { width: 10%; }
 .plan-targets-table th:nth-child(3),
-.plan-targets-table td:nth-child(3) { width: 25%; }
+.plan-targets-table td:nth-child(3) { width: 15%; }
 .plan-targets-table th:nth-child(4),
-.plan-targets-table td:nth-child(4) { width: 12%; }
+.plan-targets-table td:nth-child(4) { width: 20%; }
+.plan-targets-table th:nth-child(5),
+.plan-targets-table td:nth-child(5) { width: 15%; }
 .plan-targets-table td:nth-child(1) {
     overflow: hidden;
 }

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -2693,6 +2693,95 @@ p.notice.warning {
     margin: 0;
     font-size: 1.0625rem;
 }
+.section-card-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: var(--kn-space-sm);
+    flex: 1;
+    min-width: 0;
+}
+.section-actions {
+    white-space: nowrap;
+    font-size: 0.8125rem;
+}
+.section-action-link {
+    text-decoration: none;
+}
+.section-action-sep {
+    margin: 0 0.25rem;
+    color: var(--kn-text-muted, #999);
+}
+
+/* ---- Goal card list (plan) ---- */
+.goal-card-list {
+    display: flex;
+    flex-direction: column;
+    gap: var(--kn-space-sm);
+}
+.goal-card-row {
+    padding: var(--kn-space-sm) var(--kn-space-base);
+    border: 1px solid var(--kn-border, #ddd);
+    border-radius: var(--kn-radius-card);
+    background: var(--kn-surface, #fff);
+}
+.goal-card-row:hover {
+    border-color: var(--kn-primary, #3176aa);
+    box-shadow: 0 1px 4px rgba(0, 0, 0, 0.06);
+}
+.goal-card-top {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: var(--kn-space-sm);
+}
+.goal-card-name {
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 0.375rem;
+    min-width: 0;
+}
+.goal-card-name h3 {
+    margin: 0;
+    font-size: 0.9375rem;
+    font-weight: 600;
+    line-height: 1.3;
+}
+.goal-card-badges {
+    display: inline-flex;
+    flex-wrap: wrap;
+    gap: 0.25rem;
+    align-items: center;
+}
+.goal-card-actions {
+    flex-shrink: 0;
+}
+.goal-card-quote {
+    margin: 0.375rem 0 0.25rem 0;
+    padding: 0.375rem 0 0.375rem 0.75rem;
+    border-left: 2px solid var(--kn-primary, #3176aa);
+    font-size: 0.8125rem;
+    font-style: italic;
+    color: var(--kn-text-muted, #666);
+    line-height: 1.4;
+}
+.goal-card-description {
+    margin: 0.25rem 0 0;
+    font-size: 0.8125rem;
+    color: var(--kn-text-muted, #666);
+    line-height: 1.4;
+}
+.goal-card-metrics {
+    margin-top: 0.375rem;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.25rem;
+}
+.goal-card-more-metrics {
+    font-size: 0.75rem;
+}
 
 /* ---- Loading indicator ---- */
 .htmx-indicator {
@@ -3327,13 +3416,20 @@ article[aria-label="notification"].fading-out {
     }
 }
 
-/* ---- Section card mobile ---- */
+/* ---- Section card & goal card mobile ---- */
 @media (max-width: 480px) {
     .section-card header {
         flex-direction: column;
         align-items: flex-start;
     }
     .section-card-header {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+    .goal-card-top {
+        flex-direction: column;
+    }
+    .goal-card-name {
         flex-direction: column;
         align-items: flex-start;
     }

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -2648,25 +2648,6 @@ p.notice.warning {
     border-left-color: var(--kn-warning-fg);
 }
 
-/* ---- Plan targets table ---- */
-.plan-targets-table {
-    table-layout: fixed;
-    width: 100%;
-}
-.plan-targets-table th:nth-child(1),
-.plan-targets-table td:nth-child(1) { width: 40%; }
-.plan-targets-table th:nth-child(2),
-.plan-targets-table td:nth-child(2) { width: 10%; }
-.plan-targets-table th:nth-child(3),
-.plan-targets-table td:nth-child(3) { width: 15%; }
-.plan-targets-table th:nth-child(4),
-.plan-targets-table td:nth-child(4) { width: 20%; }
-.plan-targets-table th:nth-child(5),
-.plan-targets-table td:nth-child(5) { width: 15%; }
-.plan-targets-table td:nth-child(1) {
-    overflow: hidden;
-}
-
 /* ---- Note metric values table ---- */
 .metric-values-table {
     width: auto;
@@ -2758,6 +2739,8 @@ p.notice.warning {
     flex-shrink: 0;
 }
 .goal-card-quote {
+    /* Reset Pico CSS blockquote defaults */
+    border-right: none;
     margin: 0.375rem 0 0.25rem 0;
     padding: 0.375rem 0 0.375rem 0.75rem;
     border-left: 2px solid var(--kn-primary, #3176aa);

--- a/templates/plans/_section.html
+++ b/templates/plans/_section.html
@@ -38,26 +38,15 @@
     {% endif %}
 </header>
 
-<!-- Targets within this section -->
+<!-- Goals within this section -->
 {% if section.targets.all %}
-<table class="plan-targets-table" role="grid" aria-labelledby="section-heading-{{ section.pk }}">
-    <thead>
-        <tr>
-            <th scope="col">{{ term.target|default:"Target" }}</th>
-            <th scope="col">{% trans "Status" %}</th>
-            <th scope="col">{% trans "Progress" %}</th>
-            <th scope="col">{{ term.metric_plural|default:"Metrics" }}</th>
-            {% if can_edit %}<th scope="col">{% trans "Actions" %}</th>{% endif %}
-        </tr>
-    </thead>
-    <tbody>
-        {% for target in section.targets.all %}
-        <tr id="target-{{ target.pk }}">
-            {% include "plans/_target.html" with target=target can_edit=can_edit %}
-        </tr>
-        {% endfor %}
-    </tbody>
-</table>
+<div class="goal-card-list" aria-labelledby="section-heading-{{ section.pk }}">
+    {% for target in section.targets.all %}
+    <div id="target-{{ target.pk }}">
+        {% include "plans/_target.html" with target=target can_edit=can_edit %}
+    </div>
+    {% endfor %}
+</div>
 {% else %}
 <p><em>{% blocktrans with targets=term.target_plural|default:"targets" section=term.section|default:"section" %}No {{ targets }} in this {{ section }}.{% endblocktrans %}</em></p>
 {% endif %}

--- a/templates/plans/_target.html
+++ b/templates/plans/_target.html
@@ -48,7 +48,7 @@
     </div>
 
     {% if target.client_goal %}
-    <blockquote class="goal-card-quote">
+    <blockquote class="goal-card-quote" aria-label="{% trans 'In their words' %}">
         "{{ target.client_goal|truncatewords:50 }}"
     </blockquote>
     {% endif %}
@@ -61,7 +61,7 @@
         {% with all_metrics=target.metrics.all %}
         {% for metric in all_metrics %}
             {% if forloop.counter <= 2 %}
-                <span class="badge badge-neutral">{{ metric.translated_name }}</span>
+                <span class="badge badge-neutral" title="{{ metric.translated_name }}">{{ metric.translated_name }}</span>
             {% endif %}
         {% empty %}
             <small class="secondary">{% blocktrans with metrics=term.metric_plural|default:"metrics" %}No {{ metrics }} assigned{% endblocktrans %}</small>

--- a/templates/plans/_target.html
+++ b/templates/plans/_target.html
@@ -1,64 +1,76 @@
 {% load i18n %}
-<td>
-    <strong>{{ target.name }}</strong>
-    {% if target.client_goal %}
-    <br><small><strong>{% trans "In their words:" %}</strong> "{{ target.client_goal|truncatewords:50 }}"</small>
-    {% else %}
-    <br><small class="secondary"><em>{% trans "No participant words recorded yet" %}</em></small>
-    {% endif %}
-    {% if target.description %}
-    <br><small class="secondary">{{ target.description|truncatewords:30 }}</small>
-    {% endif %}
-</td>
-<td>
-    {% if target.status == "default" %}
-        <span class="badge badge-success">{% trans "Active" %}</span>
-    {% elif target.status == "completed" %}
-        <span class="badge badge-info">{% trans "Completed" %}</span>
-    {% else %}
-        <span class="badge badge-neutral">{% trans "Deactivated" %}</span>
-    {% endif %}
-</td>
-<td>
-    {% if target.achievement_status %}
-        {% if target.achievement_status == "achieved" or target.achievement_status == "sustaining" %}
-            <span class="badge badge-success">{{ target.get_achievement_status_display }}</span>
-        {% elif target.achievement_status == "improving" %}
-            <span class="badge badge-info">{{ target.get_achievement_status_display }}</span>
-        {% elif target.achievement_status == "worsening" or target.achievement_status == "not_attainable" %}
-            <span class="badge badge-warning">{{ target.get_achievement_status_display }}</span>
-        {% else %}
-            <span class="badge badge-neutral">{{ target.get_achievement_status_display }}</span>
+<div class="goal-card-row" aria-label="{{ target.name }}">
+    <div class="goal-card-top">
+        <div class="goal-card-name">
+            <h3>{{ target.name }}</h3>
+            <span class="goal-card-badges">
+                {% if target.status != "default" %}
+                    {% if target.status == "completed" %}
+                        <span class="badge badge-info">{% trans "Completed" %}</span>
+                    {% else %}
+                        <span class="badge badge-neutral">{% trans "Deactivated" %}</span>
+                    {% endif %}
+                {% endif %}
+                {% if target.achievement_status %}
+                    {% if target.achievement_status == "achieved" or target.achievement_status == "sustaining" %}
+                        <span class="badge badge-success">{{ target.get_achievement_status_display }}</span>
+                    {% elif target.achievement_status == "improving" %}
+                        <span class="badge badge-info">{{ target.get_achievement_status_display }}</span>
+                    {% elif target.achievement_status == "worsening" or target.achievement_status == "not_attainable" %}
+                        <span class="badge badge-warning">{{ target.get_achievement_status_display }}</span>
+                    {% else %}
+                        <span class="badge badge-neutral">{{ target.get_achievement_status_display }}</span>
+                    {% endif %}
+                    {% if target.achievement_status_source == "auto_computed" %}
+                        <small class="secondary">{% trans "(auto)" %}</small>
+                    {% endif %}
+                {% endif %}
+            </span>
+        </div>
+        {% if can_edit %}
+        <div class="goal-card-actions">
+            <div class="actions-dropdown">
+                <button class="outline small actions-dropdown-toggle" aria-expanded="false" aria-haspopup="true" aria-label="{% blocktrans with name=target.name %}Actions for {{ name }}{% endblocktrans %}">{% trans "Actions" %} &#9662;</button>
+                <ul class="actions-dropdown-menu" role="menu" hidden>
+                    <li role="none"><a role="menuitem" href="{% url 'plans:target_edit' target_id=target.pk %}">{% trans "Edit" %}<small>{% blocktrans with target=term.target|default:"goal" %}Edit this {{ target }}{% endblocktrans %}</small></a></li>
+                    <li role="none"><a role="menuitem" href="#"
+                        hx-get="{% url 'plans:target_status' target_id=target.pk %}"
+                        hx-target="#target-{{ target.pk }}"
+                        hx-swap="innerHTML"
+                        hx-confirm="{% if target.status == 'default' %}{% trans 'Change the status of this goal? You can reactivate it later if needed.' %}{% else %}{% trans 'Reactivate this goal?' %}{% endif %}">{% if target.status == "default" %}{% trans "Mark Complete" %}{% elif target.status == "completed" %}{% trans "Reactivate" %}{% else %}{% trans "Reactivate" %}{% endif %}<small>{% if target.status == "default" %}{% trans "Change status to completed or deactivated" %}{% else %}{% trans "Set back to active" %}{% endif %}</small></a></li>
+                    <li class="dropdown-divider" role="separator"></li>
+                    <li role="none"><a role="menuitem" href="{% url 'plans:target_metrics' target_id=target.pk %}">{{ term.metric_plural|default:"Metrics" }}<small>{% trans "Choose how to measure progress" %}</small></a></li>
+                    <li role="none"><a role="menuitem" href="{% url 'plans:target_history' target_id=target.pk %}">{% trans "History" %}<small>{% trans "View past changes" %}</small></a></li>
+                </ul>
+            </div>
+        </div>
         {% endif %}
-        {% if target.achievement_status_source == "auto_computed" %}
-            <small class="secondary">{% trans "(auto)" %}</small>
-        {% endif %}
-    {% else %}
-        <small class="secondary">—</small>
-    {% endif %}
-</td>
-<td>
-    {% for metric in target.metrics.all %}
-        <span class="badge badge-neutral" title="{{ metric.translated_definition|truncatewords:10 }}">{{ metric.translated_name }}</span>
-    {% empty %}
-        <small class="secondary">{% trans "None" %}</small>
-    {% endfor %}
-</td>
-{% if can_edit %}
-<td>
-    <div class="actions-dropdown">
-        <button class="outline small actions-dropdown-toggle" aria-expanded="false" aria-haspopup="true" aria-label="{% blocktrans with name=target.name %}Actions for {{ name }}{% endblocktrans %}">{% trans "Actions" %} &#9662;</button>
-        <ul class="actions-dropdown-menu" role="menu" hidden>
-            <li role="none"><a role="menuitem" href="{% url 'plans:target_edit' target_id=target.pk %}">{% trans "Edit" %}<small>{% blocktrans with target=term.target|default:"goal" %}Edit this {{ target }}{% endblocktrans %}</small></a></li>
-            <li role="none"><a role="menuitem" href="#"
-                hx-get="{% url 'plans:target_status' target_id=target.pk %}"
-                hx-target="#target-{{ target.pk }}"
-                hx-swap="innerHTML"
-                hx-confirm="{% if target.status == 'default' %}{% trans 'Change the status of this goal? You can reactivate it later if needed.' %}{% else %}{% trans 'Reactivate this goal?' %}{% endif %}">{% if target.status == "default" %}{% trans "Mark Complete" %}{% elif target.status == "completed" %}{% trans "Reactivate" %}{% else %}{% trans "Reactivate" %}{% endif %}<small>{% if target.status == "default" %}{% trans "Change status to completed or deactivated" %}{% else %}{% trans "Set back to active" %}{% endif %}</small></a></li>
-            <li class="dropdown-divider" role="separator"></li>
-            <li role="none"><a role="menuitem" href="{% url 'plans:target_metrics' target_id=target.pk %}">{{ term.metric_plural|default:"Metrics" }}<small>{% trans "Choose how to measure progress" %}</small></a></li>
-            <li role="none"><a role="menuitem" href="{% url 'plans:target_history' target_id=target.pk %}">{% trans "History" %}<small>{% trans "View past changes" %}</small></a></li>
-        </ul>
     </div>
-</td>
-{% endif %}
+
+    {% if target.client_goal %}
+    <blockquote class="goal-card-quote">
+        "{{ target.client_goal|truncatewords:50 }}"
+    </blockquote>
+    {% endif %}
+
+    {% if target.description %}
+    <p class="goal-card-description">{{ target.description|truncatewords:30 }}</p>
+    {% endif %}
+
+    <div class="goal-card-metrics">
+        {% with all_metrics=target.metrics.all %}
+        {% for metric in all_metrics %}
+            {% if forloop.counter <= 2 %}
+                <span class="badge badge-neutral">{{ metric.translated_name }}</span>
+            {% endif %}
+        {% empty %}
+            <small class="secondary">{% blocktrans with metrics=term.metric_plural|default:"metrics" %}No {{ metrics }} assigned{% endblocktrans %}</small>
+        {% endfor %}
+        {% with metric_count=all_metrics|length %}
+        {% if metric_count > 2 %}
+            <a href="{% url 'plans:target_metrics' target_id=target.pk %}" class="secondary goal-card-more-metrics">+{{ metric_count|add:"-2" }} {% trans "more" %}</a>
+        {% endif %}
+        {% endwith %}
+        {% endwith %}
+    </div>
+</div>

--- a/templates/plans/_target_status.html
+++ b/templates/plans/_target_status.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-<td colspan="4">
+<div class="goal-card-row">
     <form method="post"
           hx-post="{% url 'plans:target_status' target_id=target.pk %}"
           hx-target="#target-{{ target.pk }}"
@@ -32,4 +32,4 @@
                     hx-vals='{"cancel": "1"}'>{% trans "Cancel" %}</button>
         </footer>
     </form>
-</td>
+</div>


### PR DESCRIPTION
## Summary
- **Bug fix**: Actions column was crushed to 0px width because column widths summed to 100% with `table-layout: fixed`, leaving nothing for the 5th column. "Actions" rendered vertically letter-by-letter.
- **Card redesign**: Replaced the 5-column fixed-width table with stacked goal cards. Each card shows the goal name with inline status/progress badges, participant quote as a styled blockquote, and metrics (first 2 names + "+N more" link). Actions dropdown always visible at top-right.
- **Responsive**: Cards naturally reflow on mobile — no more broken table layout on narrow screens.
- **Translation**: Added French translation for new "No metrics assigned" string.

## Design decisions (from expert panel review)
- Active goals in the active section no longer show an "Active" badge (redundant — they're in the active section)
- Status badge only shown for completed/deactivated goals
- Metric badges limited to first 2, with expandable "+N more" link to reduce visual noise
- Participant quote styled as a blockquote with left border accent
- HTMX swap targets updated (`_target_status.html` changed from `<td>` to `<div>`)

## Test plan
- [ ] Verify plan page loads with goals displayed as cards
- [ ] Check Actions dropdown opens and all menu items work
- [ ] Test HTMX status change (mark complete/reactivate) works within new card structure
- [ ] Verify metrics display: 1-2 metrics inline, 3+ shows "+N more" link
- [ ] Test on mobile viewport (cards should stack naturally)
- [ ] Verify inactive sections still render correctly
- [ ] Check screen reader announces goal cards properly

🤖 Generated with [Claude Code](https://claude.com/claude-code)