### PR TITLE
feat: improve Add Group page clarity and add help section

### DIFF
--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -3508,6 +3508,77 @@ msgstr ""
 "d'inactivité. Reconnectez-vous pour continuer. Votre travail non enregistré "
 "pourrait être perdu."
 
+#: templates/pages/help.html — Groups, Projects, and Circles section
+msgid "Groups, Projects, and Circles"
+msgstr "Groupes, projets et cercles"
+
+msgid "KoNote gives you three ways to work with multiple people:"
+msgstr "KoNote vous offre trois façons de travailler avec plusieurs personnes :"
+
+msgid "Use when"
+msgstr "À utiliser quand"
+
+msgid "Examples"
+msgstr "Exemples"
+
+msgid "You'll track"
+msgstr "Vous suivrez"
+
+msgid "How to create"
+msgstr "Comment créer"
+
+msgid "You meet regularly as a group"
+msgstr "Vous vous réunissez régulièrement en groupe"
+
+msgid "You're working toward a goal with a deadline"
+msgstr "Vous travaillez vers un objectif avec une échéance"
+
+msgid "People are connected by family or caregiving"
+msgstr "Les personnes sont liées par la famille ou les soins"
+
+msgid "Parenting class, peer support group, drop-in program"
+msgstr "Cours de parentalité, groupe de soutien par les pairs, programme sans rendez-vous"
+
+msgid "Community garden, fundraiser, advocacy campaign"
+msgstr "Jardin communautaire, collecte de fonds, campagne de plaidoyer"
+
+msgid "The Garcia family, a child's care team"
+msgstr "La famille Garcia, l'équipe de soins d'un enfant"
+
+msgid "Attendance, session notes, individual highlights"
+msgstr "Présence, notes de séance, faits saillants individuels"
+
+msgid "Milestones, deadlines, outcomes with evidence"
+msgstr "Jalons, échéances, résultats avec preuves"
+
+msgid "Relationships and who to contact first"
+msgstr "Relations et qui contacter en premier"
+
+msgid "%(groups)s → Add → choose \"A recurring group\""
+msgstr "%(groups)s → Ajouter → choisir « Un groupe récurrent »"
+
+msgid "%(groups)s → Add → choose \"A project\""
+msgstr "%(groups)s → Ajouter → choisir « Un projet »"
+
+msgid "%(circles)s → New %(circle)s"
+msgstr "%(circles)s → Nouveau %(circle)s"
+
+msgid "Still not sure?"
+msgstr "Vous hésitez encore?"
+
+msgid "<em>\"Do we meet as a group?\"</em> → Create a Group"
+msgstr "<em>« Est-ce qu'on se réunit en groupe? »</em> → Créer un groupe"
+
+msgid "<em>\"Are we working toward a specific result?\"</em> → Create a Project"
+msgstr "<em>« Est-ce qu'on travaille vers un résultat précis? »</em> → Créer un projet"
+
+msgid ""
+"<em>\"Are these people connected to each other outside our agency?\"</em> → "
+"Create a %(circle)s"
+msgstr ""
+"<em>« Est-ce que ces personnes sont liées entre elles en dehors de notre "
+"organisme? »</em> → Créer un %(circle)s"
+
 #: templates/pages/help.html — Getting More Help and Quick Reference
 msgid "Getting More Help"
 msgstr "Obtenir plus d'aide"
@@ -3752,14 +3823,29 @@ msgid "Project"
 msgstr "Projet"
 
 # groups/group_form.html — Group type selection
-msgid "What type of group is this?"
-msgstr "Quel type de groupe est-ce?"
+msgid "What are you setting up?"
+msgstr "Que souhaitez-vous créer?"
 
-msgid "Attendance tracking and session notes."
-msgstr "Suivi de présence et notes de séance."
+msgid "A recurring group"
+msgstr "Un groupe récurrent"
 
-msgid "Milestones, outcomes, and deadlines."
-msgstr "Jalons, résultats et échéances."
+msgid "For regular meetings — like a support group, workshop series, or drop-in program. You'll track attendance and record what happens each session."
+msgstr "Pour des rencontres régulières — comme un groupe de soutien, une série d'ateliers ou un programme sans rendez-vous. Vous ferez le suivi de la présence et noterez ce qui se passe à chaque séance."
+
+msgid "A project"
+msgstr "Un projet"
+
+msgid "For goal-oriented work with a deadline — like a community event, fundraiser, or advocacy initiative. You'll track milestones and progress toward outcomes."
+msgstr "Pour un travail axé sur un objectif avec une échéance — comme un événement communautaire, une collecte de fonds ou une initiative de plaidoyer. Vous ferez le suivi des jalons et des progrès vers les résultats."
+
+msgid "Tracking a family or care team?"
+msgstr "Vous suivez une famille ou une équipe de soins?"
+
+msgid "instead — for people connected by relationships, not a shared activity."
+msgstr "plutôt — pour des personnes liées par des relations, pas par une activité commune."
+
+msgid "Type"
+msgstr "Type"
 
 msgid "Member"
 msgstr "Membre"

--- a/templates/groups/group_form.html
+++ b/templates/groups/group_form.html
@@ -5,26 +5,27 @@
 
 {% block content %}
 <hgroup>
-    <h1>{% if editing %}{% blocktrans with name=group.name %}Edit {{ name }}{% endblocktrans %}{% else %}{% blocktrans with group=term.group|default:"Group" %}Add {{ group }}{% endblocktrans %}{% endif %}</h1>
+    <h1>{% if editing %}{% blocktrans with name=group.name %}Edit {{ name }}{% endblocktrans %}{% else %}{% trans "What are you setting up?" %}{% endif %}</h1>
 </hgroup>
 
 <form method="post">
     {% csrf_token %}
 
-    {# Group type — radio buttons with descriptions #}
+    {# Group type — descriptive cards #}
+    {% if not editing %}
     <fieldset>
-        <legend><strong>{% trans "What type of group is this?" %}</strong></legend>
         {% for radio in form.group_type %}
-        <label style="display: flex; align-items: flex-start; gap: 0.5rem; margin-bottom: 0.5rem;">
+        <label class="type-card" style="display: flex; align-items: flex-start; gap: 0.75rem; padding: 1rem; margin-bottom: 0.75rem; border: 2px solid var(--pico-muted-border-color); border-radius: 8px; cursor: pointer;">
             <input type="radio" name="{{ form.group_type.html_name }}" value="{{ radio.choice_value }}"
                    {% if radio.is_checked %}checked{% endif %}
                    style="margin-top: 0.25rem;">
             <span>
-                {{ radio.choice_label }}
                 {% if radio.choice_value == "group" %}
-                <br><small class="secondary">{% trans "Attendance tracking and session notes." %}</small>
+                <strong>{% trans "A recurring group" %}</strong>
+                <br><small class="secondary">{% trans "For regular meetings — like a support group, workshop series, or drop-in program. You'll track attendance and record what happens each session." %}</small>
                 {% elif radio.choice_value == "project" %}
-                <br><small class="secondary">{% trans "Milestones, outcomes, and deadlines." %}</small>
+                <strong>{% trans "A project" %}</strong>
+                <br><small class="secondary">{% trans "For goal-oriented work with a deadline — like a community event, fundraiser, or advocacy initiative. You'll track milestones and progress toward outcomes." %}</small>
                 {% endif %}
             </span>
         </label>
@@ -33,6 +34,27 @@
         <small class="badge badge-danger">{{ form.group_type.errors.0 }}</small>
         {% endif %}
     </fieldset>
+
+    {% if features.circles %}
+    <p><small class="secondary">{% trans "Tracking a family or care team?" %} <a href="{% url 'circles:circle_create' %}">{% blocktrans with circle=term.circle|default:"Circle" %}Create a {{ circle }}{% endblocktrans %}</a> {% trans "instead — for people connected by relationships, not a shared activity." %}</small></p>
+    {% endif %}
+
+    {% else %}{# editing — simple dropdown, no type cards #}
+    <fieldset>
+        <legend><strong>{% trans "Type" %}</strong></legend>
+        {% for radio in form.group_type %}
+        <label style="display: flex; align-items: flex-start; gap: 0.5rem; margin-bottom: 0.5rem;">
+            <input type="radio" name="{{ form.group_type.html_name }}" value="{{ radio.choice_value }}"
+                   {% if radio.is_checked %}checked{% endif %}
+                   style="margin-top: 0.25rem;">
+            <span>{{ radio.choice_label }}</span>
+        </label>
+        {% endfor %}
+        {% if form.group_type.errors %}
+        <small class="badge badge-danger">{{ form.group_type.errors.0 }}</small>
+        {% endif %}
+    </fieldset>
+    {% endif %}
 
     {# Remaining fields (name, program, description) #}
     {% for field in form %}

--- a/templates/pages/help.html
+++ b/templates/pages/help.html
@@ -22,6 +22,7 @@
             <li><a href="#plans">{{ term.plan }}s</a></li>
             <li><a href="#reports">{% trans "Analysis and Reports" %}</a></li>
             <li><a href="#insights">{% trans "Outcome Insights" %}</a></li>
+            <li><a href="#groups-circles">{% trans "Groups, Projects, and Circles" %}</a></li>
             <li><a href="#roles">{% trans "Roles" %}</a></li>
             <li><a href="#shortcuts">{% trans "Keyboard Shortcuts" %}</a></li>
             <li><a href="#troubleshooting">{% trans "Troubleshooting" %}</a></li>
@@ -350,6 +351,57 @@
 
         <h3>{% blocktrans with client=term.client|default:"Participant" %}{{ client }}-Level Insights{% endblocktrans %}</h3>
         <p>{% blocktrans with client=term.client|default:"Participant" file=term.file|default:"File" %}You can also see insights for an individual {{ client }}. Open their {{ file }}, go to the Analysis tab, and scroll down to Qualitative Insights.{% endblocktrans %}</p>
+    </section>
+
+    <!-- Groups, Projects, and Circles -->
+    <section id="groups-circles">
+        <h2>{% trans "Groups, Projects, and Circles" %}</h2>
+
+        <p>{% trans "KoNote gives you three ways to work with multiple people:" %}</p>
+
+        <table>
+            <thead>
+                <tr>
+                    <th scope="col"></th>
+                    <th scope="col">{% blocktrans with group=term.group|default:"Group" %}{{ group }}{% endblocktrans %}</th>
+                    <th scope="col">{% trans "Project" %}</th>
+                    <th scope="col">{% blocktrans with circle=term.circle|default:"Circle" %}{{ circle }}{% endblocktrans %}</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td><strong>{% trans "Use when" %}</strong></td>
+                    <td>{% trans "You meet regularly as a group" %}</td>
+                    <td>{% trans "You're working toward a goal with a deadline" %}</td>
+                    <td>{% trans "People are connected by family or caregiving" %}</td>
+                </tr>
+                <tr>
+                    <td><strong>{% trans "Examples" %}</strong></td>
+                    <td>{% trans "Parenting class, peer support group, drop-in program" %}</td>
+                    <td>{% trans "Community garden, fundraiser, advocacy campaign" %}</td>
+                    <td>{% trans "The Garcia family, a child's care team" %}</td>
+                </tr>
+                <tr>
+                    <td><strong>{% trans "You'll track" %}</strong></td>
+                    <td>{% trans "Attendance, session notes, individual highlights" %}</td>
+                    <td>{% trans "Milestones, deadlines, outcomes with evidence" %}</td>
+                    <td>{% trans "Relationships and who to contact first" %}</td>
+                </tr>
+                <tr>
+                    <td><strong>{% trans "How to create" %}</strong></td>
+                    <td>{% blocktrans with groups=term.group_plural|default:"Groups" %}{{ groups }} → Add → choose "A recurring group"{% endblocktrans %}</td>
+                    <td>{% blocktrans with groups=term.group_plural|default:"Groups" %}{{ groups }} → Add → choose "A project"{% endblocktrans %}</td>
+                    <td>{% blocktrans with circles=term.circle_plural|default:"Circles" circle=term.circle|default:"Circle" %}{{ circles }} → New {{ circle }}{% endblocktrans %}</td>
+                </tr>
+            </tbody>
+        </table>
+
+        <h3>{% trans "Still not sure?" %}</h3>
+        <ul>
+            <li>{% trans "<em>\"Do we meet as a group?\"</em> → Create a Group" %}</li>
+            <li>{% trans "<em>\"Are we working toward a specific result?\"</em> → Create a Project" %}</li>
+            <li>{% blocktrans with circle=term.circle|default:"Circle" %}<em>"Are these people connected to each other outside our agency?"</em> → Create a {{ circle }}{% endblocktrans %}</li>
+        </ul>
     </section>
 
     <!-- Keyboard Shortcuts -->


### PR DESCRIPTION
## Summary
- Redesigned the "Add Group" type selector with descriptive cards that explain each option in plain language with concrete nonprofit examples (support group, workshop, fundraiser, etc.)
- Changed page title from "Add Group" to "What are you setting up?" to frame the choice as intent-based
- Added a Circle cross-reference link so users who land on the wrong page can find Circles
- Added a new "Groups, Projects, and Circles" section to the help page with a comparison table and decision-tree guidance
- Added French translations for all new strings

## Context
Users were confused by the two radio buttons ("Group" / "Project") with only brief feature-level descriptions. They also had no guidance on when to use a Circle instead. An expert panel (UX designer, information architect, nonprofit program director, plain language specialist) recommended these changes.

## Test plan
- [ ] Visit Add Group page — verify descriptive cards appear with examples
- [ ] Verify Circle redirect link appears when circles feature is enabled
- [ ] Visit Edit Group page — verify it shows the original edit form (not the cards)
- [ ] Visit Help page — verify new "Groups, Projects, and Circles" section appears in nav and content
- [ ] Switch to French — verify all new strings are translated

🤖 Generated with [Claude Code](https://claude.com/claude-code)