### PR TITLE
Improve report preview card, demo data, and HTML template

### DIFF
--- a/apps/admin_settings/management/commands/seed.py
+++ b/apps/admin_settings/management/commands/seed.py
@@ -665,13 +665,6 @@ class Command(BaseCommand):
 
     def _seed_demo_reporting_template(self, programs):
         """Create demo report templates: a funder template and an org-wide template."""
-        from apps.reports.models import (
-            DemographicBreakdown,
-            Partner,
-            ReportMetric,
-            ReportTemplate,
-        )
-
         self._seed_ccf_funder_template(programs)
         self._seed_org_wide_template(programs)
 

--- a/apps/admin_settings/management/commands/seed.py
+++ b/apps/admin_settings/management/commands/seed.py
@@ -664,11 +664,29 @@ class Command(BaseCommand):
             self.stdout.write("  Demo registration link: already exists.")
 
     def _seed_demo_reporting_template(self, programs):
-        """Create a demo-only report template with a sample funder profile."""
-        from apps.reports.models import DemographicBreakdown, Partner, ReportTemplate
+        """Create demo report templates: a funder template and an org-wide template."""
+        from apps.reports.models import (
+            DemographicBreakdown,
+            Partner,
+            ReportMetric,
+            ReportTemplate,
+        )
+
+        self._seed_ccf_funder_template(programs)
+        self._seed_org_wide_template(programs)
+
+    def _seed_ccf_funder_template(self, programs):
+        """Demo funder report: Canadian Community Foundation quarterly outcomes."""
+        from apps.plans.models import MetricDefinition
+        from apps.reports.models import (
+            DemographicBreakdown,
+            Partner,
+            ReportMetric,
+            ReportTemplate,
+        )
 
         partner_name = "Canadian Community Foundation"
-        partner, partner_created = Partner.objects.get_or_create(
+        partner, _created = Partner.objects.get_or_create(
             name=partner_name,
             defaults={
                 "partner_type": "funder",
@@ -683,11 +701,15 @@ class Command(BaseCommand):
             name=profile_name,
             defaults={
                 "partner": partner,
+                "period_type": "quarterly",
+                "period_alignment": "fiscal",
+                "fiscal_year_start_month": 4,
+                "output_format": "mixed",
                 "description": (
-                    "Matches the demographic breakdown required by the "
-                    "Canadian Community Foundation for quarterly outcome "
-                    "reports. Groups participants by standard age categories "
-                    "(Child, Youth, Young Adult, Adult, Senior)."
+                    "Quarterly outcomes report for the Canadian Community "
+                    "Foundation. Includes participant counts, program outcomes, "
+                    "and service statistics across all funded programs, with "
+                    "participants grouped by age."
                 ),
             },
         )
@@ -697,6 +719,27 @@ class Command(BaseCommand):
             profile.save(update_fields=["partner"])
 
         if created:
+            # Metrics — representative set for a community foundation
+            CCF_METRICS = [
+                ("Goal Progress", "average", "Goal progress (average)"),
+                ("Self-Efficacy", "average", "Self-efficacy (average)"),
+                ("Satisfaction", "average", "Satisfaction (average)"),
+                ("Housing Secured", "percentage", "Housing secured (% achieving)"),
+                ("Job Placement", "percentage", "Job placement (% achieving)"),
+            ]
+            for i, (name, agg, label) in enumerate(CCF_METRICS):
+                md = MetricDefinition.objects.filter(
+                    name=name, is_enabled=True
+                ).first()
+                if md:
+                    ReportMetric.objects.create(
+                        report_template=profile,
+                        metric_definition=md,
+                        aggregation=agg,
+                        display_label=label,
+                        sort_order=i * 10,
+                    )
+
             DemographicBreakdown.objects.create(
                 report_template=profile,
                 label="Age Group",
@@ -710,14 +753,104 @@ class Command(BaseCommand):
                 ],
                 sort_order=0,
             )
-
-        if created:
             self.stdout.write(
                 f"  Demo report template: '{profile_name}' created with partner '{partner_name}'."
             )
         else:
             self.stdout.write(
                 f"  Demo report template: '{profile_name}' already exists; partner synced."
+            )
+
+    def _seed_org_wide_template(self, programs):
+        """Org-wide report: all metrics, demographics from agency defaults."""
+        from apps.clients.models import CustomFieldDefinition
+        from apps.reports.models import (
+            DemographicBreakdown,
+            Partner,
+            ReportTemplate,
+        )
+        from apps.reports.demographics import get_demographic_field_choices
+
+        # Internal partner for org-wide reports
+        partner_name = "Organization — Internal"
+        partner, _created = Partner.objects.get_or_create(
+            name=partner_name,
+            defaults={
+                "partner_type": "board",
+                "contact_name": "",
+            },
+        )
+        partner.programs.set(programs)
+
+        template_name = "Organization — All Programs Quarterly Summary"
+        template, created = ReportTemplate.objects.get_or_create(
+            name=template_name,
+            defaults={
+                "partner": partner,
+                "period_type": "quarterly",
+                "period_alignment": "fiscal",
+                "fiscal_year_start_month": 4,
+                "output_format": "mixed",
+                "include_all_metrics": True,
+                "description": (
+                    "Comprehensive quarterly summary across all programs. "
+                    "Includes every outcome metric with recorded data, "
+                    "grouped by the agency's standard demographic fields. "
+                    "Suitable for board reports, annual reviews, and "
+                    "internal planning."
+                ),
+            },
+        )
+        if not template.partner:
+            template.partner = partner
+            template.save(update_fields=["partner"])
+
+        if created:
+            # Age breakdown with standard bins
+            DemographicBreakdown.objects.create(
+                report_template=template,
+                label="Age Group",
+                source_type="age",
+                bins_json=[
+                    {"min": 0, "max": 17, "label": "Youth (0-17)"},
+                    {"min": 18, "max": 24, "label": "Young Adult (18-24)"},
+                    {"min": 25, "max": 44, "label": "Adult (25-44)"},
+                    {"min": 45, "max": 64, "label": "Older Adult (45-64)"},
+                    {"min": 65, "max": 999, "label": "Senior (65+)"},
+                ],
+                sort_order=0,
+            )
+
+            # Demographic breakdowns from agency's configured fields
+            # Skip the first two choices: "" (No grouping) and "age_range"
+            choices = get_demographic_field_choices()
+            sort = 10
+            for value, label in choices:
+                if not value or value == "age_range":
+                    continue
+                # value is "custom_<pk>" — extract the field
+                if value.startswith("custom_"):
+                    try:
+                        field_pk = int(value.split("_", 1)[1])
+                        field = CustomFieldDefinition.objects.get(pk=field_pk)
+                        DemographicBreakdown.objects.create(
+                            report_template=template,
+                            label=field.name,
+                            source_type="custom_field",
+                            custom_field=field,
+                            keep_all_categories=True,
+                            sort_order=sort,
+                        )
+                        sort += 10
+                    except (ValueError, CustomFieldDefinition.DoesNotExist):
+                        pass
+
+            self.stdout.write(
+                f"  Org-wide report template: '{template_name}' created."
+            )
+        else:
+            self.stdout.write(
+                f"  Org-wide report template: '{template_name}' already exists."
             )
 
     def _update_demo_client_fields(self):

--- a/apps/reports/export_engine.py
+++ b/apps/reports/export_engine.py
@@ -392,6 +392,7 @@ def _build_html_context(report_data, sections, metric_results, template, user):
         "suppression_threshold": getattr(
             template, "suppression_threshold", SMALL_CELL_THRESHOLD,
         ),
+        "is_draft_template": not getattr(template, "html_template_name", ""),
     }
 
     if sections:

--- a/apps/reports/export_engine.py
+++ b/apps/reports/export_engine.py
@@ -392,7 +392,6 @@ def _build_html_context(report_data, sections, metric_results, template, user):
         "suppression_threshold": getattr(
             template, "suppression_threshold", SMALL_CELL_THRESHOLD,
         ),
-        "is_draft_template": not getattr(template, "html_template_name", ""),
     }
 
     if sections:

--- a/apps/reports/migrations/0017_reporttemplate_include_all_metrics.py
+++ b/apps/reports/migrations/0017_reporttemplate_include_all_metrics.py
@@ -1,0 +1,23 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("reports", "0016_reporttemplate_html_template_name"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="reporttemplate",
+            name="include_all_metrics",
+            field=models.BooleanField(
+                default=False,
+                help_text=(
+                    "When checked, the report includes every metric with recorded "
+                    "data in the selected period. Use for org-wide or board reports. "
+                    "Leave unchecked for funder reports that require specific metrics."
+                ),
+            ),
+        ),
+    ]

--- a/apps/reports/models.py
+++ b/apps/reports/models.py
@@ -209,6 +209,14 @@ class ReportTemplate(models.Model):
             "When blank, the default HTML report template is used."
         ),
     )
+    include_all_metrics = models.BooleanField(
+        default=False,
+        help_text=_(
+            "When checked, the report includes every metric with recorded "
+            "data in the selected period. Use for org-wide or board reports. "
+            "Leave unchecked for funder reports that require specific metrics."
+        ),
+    )
     is_active = models.BooleanField(default=True)
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -14501,8 +14501,20 @@ msgstr "(total)"
 msgid "All Participants"
 msgstr "Tous les participants"
 
-msgid "All metrics with data will be included."
-msgstr "Tous les indicateurs avec des données seront inclus."
+msgid "This report includes all recorded outcomes for each program."
+msgstr "Ce rapport inclut tous les résultats enregistrés pour chaque programme."
+
+msgid "Metrics are shown per program — only outcomes with data in the selected period will appear."
+msgstr "Les indicateurs sont affichés par programme — seuls les résultats avec des données dans la période sélectionnée apparaîtront."
+
+msgid "No specific metrics have been configured for this template."
+msgstr "Aucun indicateur spécifique n'a été configuré pour ce modèle."
+
+msgid "All outcomes with recorded data will be included by default."
+msgstr "Tous les résultats avec des données enregistrées seront inclus par défaut."
+
+msgid "To specify which metrics appear, ask your administrator to edit this template."
+msgstr "Pour préciser quels indicateurs apparaissent, demandez à votre administrateur de modifier ce modèle."
 
 msgid "Chart visualisation is not yet available in PDF reports."
 msgstr ""

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -6661,6 +6661,27 @@ msgstr "Taux de réussite global"
 msgid "Overall Summary"
 msgstr "Résumé général"
 
+msgid "Overall achievement rate"
+msgstr "Taux de réussite global"
+
+msgid "Contents"
+msgstr "Table des matières"
+
+msgid "Report sections"
+msgstr "Sections du rapport"
+
+msgid "Increased"
+msgstr "En hausse"
+
+msgid "Decreased"
+msgstr "En baisse"
+
+msgid "from"
+msgstr "par rapport à"
+
+msgid "previous period"
+msgstr "la période précédente"
+
 msgid "PLAN SECTIONS & TARGETS"
 msgstr "SECTIONS DU PLAN ET CIBLES"
 

--- a/templates/reports/_period_options.html
+++ b/templates/reports/_period_options.html
@@ -47,8 +47,17 @@
         <li>{{ rm.translated_label }}</li>
         {% endfor %}
     </ul>
+    {% elif template.include_all_metrics %}
+    <p style="margin-bottom: 0.25rem;">
+        <strong>{% trans "This report includes all recorded outcomes for each program." %}</strong>
+        {% trans "Metrics are shown per program — only outcomes with data in the selected period will appear." %}
+    </p>
     {% else %}
-    <p><small>{% trans "All metrics with data will be included." %}</small></p>
+    <p style="margin-top: 0.5rem; padding: 0.5rem 0.75rem; background: var(--kn-warning-bg, #fff3cd); border-radius: 4px;">
+        &#9888; {% trans "No specific metrics have been configured for this template." %}
+        {% trans "All outcomes with recorded data will be included by default." %}
+        <br><small>{% trans "To specify which metrics appear, ask your administrator to edit this template." %}</small>
+    </p>
     {% endif %}
 
     {% if breakdowns %}

--- a/templates/reports/_period_options.html
+++ b/templates/reports/_period_options.html
@@ -28,7 +28,7 @@
 {# Read-only confirmation panel: shows what the template includes #}
 {% if template %}
 <article aria-label="{% trans 'Report details' %}" style="border-left: 4px solid var(--kn-info-fg); padding: 0.75rem 1rem; margin-top: 1rem;">
-    <strong>{{ template.partner.translated_name }} &mdash; {{ template.name }}</strong>
+    <strong>{% if template.partner and template.partner.translated_name not in template.name %}{{ template.partner.translated_name }} &mdash; {% endif %}{{ template.name }}</strong>
     {% if template.description %}
     <br><small class="secondary">{{ template.description }}</small>
     {% endif %}

--- a/templates/reports/html_report.html
+++ b/templates/reports/html_report.html
@@ -19,10 +19,42 @@
             margin-right: auto;
             background-color: #ffffff;
         }
+
+        /* Print: expand all details, hide toggles and no-print elements */
         @media print {
             body { padding: 0; max-width: none; }
             .no-print { display: none; }
+            details > summary { display: none; }
+            details > *:not(summary) { display: block !important; }
         }
+
+        /* Screen-reader only text */
+        .sr-only {
+            position: absolute; width: 1px; height: 1px;
+            padding: 0; margin: -1px; overflow: hidden;
+            clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0;
+        }
+
+        /* Collapsible section headers */
+        details { margin-top: 1.5rem; }
+        summary.report-header-bar {
+            list-style: none;
+            cursor: pointer;
+            user-select: none;
+        }
+        summary.report-header-bar::-webkit-details-marker { display: none; }
+        summary.report-header-bar::marker { display: none; }
+        summary.report-header-bar::after {
+            content: " \25BE";
+            float: right;
+            transition: transform 0.2s;
+        }
+        details:not([open]) > summary.report-header-bar::after {
+            transform: rotate(-90deg);
+            display: inline-block;
+        }
+
+        /* Non-collapsible section header (for always-visible sections) */
         .report-header-bar {
             background-color: #3176aa;
             color: #ffffff;
@@ -32,6 +64,8 @@
             font-weight: 600;
             border-radius: 4px 4px 0 0;
         }
+
+        /* Report header */
         .pdf-header {
             border-bottom: 3px solid #3176aa;
             padding-bottom: 0.6rem;
@@ -66,6 +100,33 @@
             border-radius: 4px;
             font-size: 0.85rem;
         }
+
+        /* Table of contents */
+        .report-toc {
+            margin: 1rem 0;
+            padding: 0.6rem 1rem;
+            background-color: #f7f8fa;
+            border-radius: 4px;
+            font-size: 0.85rem;
+        }
+        .report-toc h2 {
+            font-size: 0.9rem;
+            margin: 0 0 0.3rem 0;
+            border: none;
+            color: #4a5568;
+        }
+        .report-toc ol {
+            margin: 0;
+            padding-left: 1.5rem;
+        }
+        .report-toc li { margin-bottom: 0.15rem; }
+        .report-toc a {
+            color: #3176aa;
+            text-decoration: none;
+        }
+        .report-toc a:hover { text-decoration: underline; }
+
+        /* Typography */
         h2 {
             font-size: 1.3rem;
             color: #3176aa;
@@ -78,6 +139,8 @@
             color: #1a202c;
             margin-top: 1rem;
         }
+
+        /* Tables */
         table {
             width: 100%;
             border-collapse: collapse;
@@ -96,6 +159,8 @@
             border-bottom: 1px solid #e5e7eb;
         }
         tbody tr:nth-child(even) { background-color: #f7f8fa; }
+
+        /* Stat boxes */
         .stat-grid {
             display: grid;
             grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
@@ -118,6 +183,13 @@
             color: #718096;
             margin-top: 0.2rem;
         }
+        .stat-box .change {
+            font-size: 0.75rem;
+            color: #4a5568;
+            margin-top: 0.15rem;
+        }
+
+        /* Outcome cards */
         .outcome-card {
             border: 2px solid #3176aa;
             border-radius: 6px;
@@ -138,6 +210,29 @@
             color: #4a5568;
             margin-top: 0.3rem;
         }
+
+        /* Achievement progress bar */
+        .achievement-bar {
+            background-color: #e5e7eb;
+            height: 10px;
+            border-radius: 5px;
+            margin-top: 0.4rem;
+            overflow: hidden;
+        }
+        .achievement-bar-fill {
+            background-color: #3176aa;
+            height: 100%;
+            border-radius: 5px;
+            transition: width 0.3s;
+        }
+        /* Inline achievement bar for tables */
+        td .achievement-bar {
+            height: 6px;
+            margin-top: 2px;
+            min-width: 60px;
+        }
+
+        /* Demographic rows and bars */
         .demo-row {
             display: grid;
             grid-template-columns: 1fr 80px 80px;
@@ -153,12 +248,15 @@
             height: 8px;
             border-radius: 4px;
             margin-top: 4px;
+            overflow: hidden;
         }
         .demo-bar-fill {
             background-color: #3176aa;
             height: 100%;
             border-radius: 4px;
         }
+
+        /* Metrics table */
         .metrics-table {
             width: 100%;
             border-collapse: collapse;
@@ -176,6 +274,8 @@
             background-color: #f7f8fa;
             font-weight: 600;
         }
+
+        /* Narrative sections */
         .narrative-section {
             border-left: 4px solid #3176aa;
             padding: 0.8rem 1rem;
@@ -186,6 +286,8 @@
             font-style: italic;
             color: #718096;
         }
+
+        /* Chart sections */
         .chart-section { margin: 0.8rem 0; }
         .chart-container {
             margin: 0.6rem 0;
@@ -201,6 +303,8 @@
             margin-top: 0.2rem;
             font-style: italic;
         }
+
+        /* Summary cards */
         .summary-grid {
             display: grid;
             grid-template-columns: 1fr 1fr;
@@ -222,6 +326,8 @@
             font-size: 0.8rem;
             color: #718096;
         }
+
+        /* Footer */
         .footer-note {
             font-size: 0.85rem;
             color: #718096;
@@ -259,33 +365,94 @@
         <dt>{% trans "Generated" %}</dt>
         <dd>{% blocktrans with date=report_data.generated_at|date:"Y-m-d" author=generated_by %}{{ date }} by {{ author }}{% endblocktrans %}</dd>
     </dl>
+    {% if is_draft_template %}
     <div class="draft-notice">
         <strong>{% trans "Draft Template:" %}</strong> {% trans "Verify this format matches the specific reporting requirements before submission." %}
     </div>
+    {% endif %}
 </div>
 
 {% if sections %}
-{# Section-driven layout: render in ReportSection.sort_order #}
+{# ===== SECTION-DRIVEN LAYOUT ===== #}
+
+{# Table of contents (5+ sections only) #}
+{% with section_count=sections|length %}
+{% if section_count >= 5 %}
+<nav class="report-toc no-print" aria-label="{% trans 'Report sections' %}">
+    <h2>{% trans "Contents" %}</h2>
+    <ol>
+    {% for section in sections %}
+        <li><a href="#section-{{ forloop.counter }}">{{ section.title }}</a></li>
+    {% endfor %}
+    {% if report_data.achievement_summary.total_clients > 0 %}
+        <li><a href="#section-summary">{% trans "Overall Summary" %}</a></li>
+    {% endif %}
+    </ol>
+</nav>
+{% endif %}
+{% endwith %}
+
 {% for section in sections %}
+
 {% if section.section_type == "service_stats" %}
-<div class="report-header-bar">{{ section.title }}</div>
+{# Service stats: always visible — never collapsible #}
+<div class="report-header-bar" id="section-{{ forloop.counter }}">{{ section.title }}</div>
 <div class="stat-grid">
     <div class="stat-box">
         <div class="value">{{ report_data.total_individuals_served|default:"0" }}</div>
         <div class="label">{% trans "Total Individuals Served" %}</div>
+        {% if report_data.prev_total_individuals_served is not None %}
+        <div class="change">
+            {% widthratio report_data.total_individuals_served 1 1 as current_val %}
+            {% if report_data.total_individuals_served > report_data.prev_total_individuals_served %}
+            <span aria-hidden="true">&#9650;</span>
+            <span class="sr-only">{% trans "Increased" %}</span>
+            {% elif report_data.total_individuals_served < report_data.prev_total_individuals_served %}
+            <span aria-hidden="true">&#9660;</span>
+            <span class="sr-only">{% trans "Decreased" %}</span>
+            {% endif %}
+            {% trans "from" %} {{ report_data.prev_total_individuals_served }} {% trans "previous period" %}
+        </div>
+        {% endif %}
     </div>
     <div class="stat-box">
         <div class="value">{{ report_data.new_clients_this_period|default:"0" }}</div>
         <div class="label">{% trans "New Participants This Period" %}</div>
+        {% if report_data.prev_new_clients_this_period is not None %}
+        <div class="change">
+            {% if report_data.new_clients_this_period > report_data.prev_new_clients_this_period %}
+            <span aria-hidden="true">&#9650;</span>
+            <span class="sr-only">{% trans "Increased" %}</span>
+            {% elif report_data.new_clients_this_period < report_data.prev_new_clients_this_period %}
+            <span aria-hidden="true">&#9660;</span>
+            <span class="sr-only">{% trans "Decreased" %}</span>
+            {% endif %}
+            {% trans "from" %} {{ report_data.prev_new_clients_this_period }} {% trans "previous period" %}
+        </div>
+        {% endif %}
     </div>
     <div class="stat-box">
         <div class="value">{{ report_data.total_contacts|default:"0" }}</div>
         <div class="label">{% trans "Total Service Contacts" %}</div>
+        {% if report_data.prev_total_contacts is not None %}
+        <div class="change">
+            {% if report_data.total_contacts > report_data.prev_total_contacts %}
+            <span aria-hidden="true">&#9650;</span>
+            <span class="sr-only">{% trans "Increased" %}</span>
+            {% elif report_data.total_contacts < report_data.prev_total_contacts %}
+            <span aria-hidden="true">&#9660;</span>
+            <span class="sr-only">{% trans "Decreased" %}</span>
+            {% endif %}
+            {% trans "from" %} {{ report_data.prev_total_contacts }} {% trans "previous period" %}
+        </div>
+        {% endif %}
     </div>
 </div>
 
 {% elif section.section_type == "metrics_table" %}
-<div class="report-header-bar">{{ section.title }}</div>
+{# Metrics table: collapsible #}
+<details open id="section-{{ forloop.counter }}">
+<summary class="report-header-bar">{{ section.title }}</summary>
 {% if metric_results %}
 <table class="metrics-table">
     <thead>
@@ -310,6 +477,9 @@
                 &lt; {{ suppression_threshold }}
                 {% elif mr.aggregation == "threshold_percentage" or mr.aggregation == "percentage" %}
                 {{ group_data.value }}%
+                <div class="achievement-bar" role="progressbar" aria-valuenow="{{ group_data.value }}" aria-valuemin="0" aria-valuemax="100">
+                    <div class="achievement-bar-fill" style="width: {{ group_data.value }}%;"></div>
+                </div>
                 {% else %}
                 {{ group_data.value }}
                 {% endif %}
@@ -324,6 +494,9 @@
 <div class="outcome-card">
     <h4>{{ report_data.primary_outcome.name }}</h4>
     <div class="rate">{{ report_data.primary_outcome.achievement_rate }}%</div>
+    <div class="achievement-bar" role="progressbar" aria-valuenow="{{ report_data.primary_outcome.achievement_rate }}" aria-valuemin="0" aria-valuemax="100" aria-label="{{ report_data.primary_outcome.name }}">
+        <div class="achievement-bar-fill" style="width: {{ report_data.primary_outcome.achievement_rate }}%;"></div>
+    </div>
     <div class="details">
         <strong>{% trans "Target:" %}</strong> {{ report_data.primary_outcome.target_value }}<br>
         <strong>{% trans "Clients Measured:" %}</strong> {{ report_data.primary_outcome.clients_measured }}
@@ -348,16 +521,24 @@
             <td>{{ outcome.target_value }}</td>
             <td>{{ outcome.clients_measured }}</td>
             <td>{{ outcome.clients_achieved }}</td>
-            <td>{{ outcome.achievement_rate }}%</td>
+            <td>
+                {{ outcome.achievement_rate }}%
+                <div class="achievement-bar" role="progressbar" aria-valuenow="{{ outcome.achievement_rate }}" aria-valuemin="0" aria-valuemax="100">
+                    <div class="achievement-bar-fill" style="width: {{ outcome.achievement_rate }}%;"></div>
+                </div>
+            </td>
         </tr>
         {% endfor %}
     </tbody>
 </table>
 {% endif %}
 {% endif %}
+</details>
 
 {% elif section.section_type == "demographic_summary" %}
-<div class="report-header-bar">{{ section.title }}</div>
+{# Demographics: collapsible, summary shows total count #}
+<details open id="section-{{ forloop.counter }}">
+<summary class="report-header-bar">{{ section.title }} &mdash; {{ report_data.age_demographics_total }} {% trans "participants" %}</summary>
 <div style="margin: 0.8rem 0;">
     <div class="demo-row header">
         <div>{% trans "Age Group" %}</div>
@@ -369,7 +550,7 @@
         <div>
             {{ age_group }}
             {% if report_data.age_demographics_total > 0 %}
-            <div class="demo-bar">
+            <div class="demo-bar" role="progressbar" aria-valuenow="{% widthratio count report_data.age_demographics_total 100 %}" aria-valuemin="0" aria-valuemax="100" aria-label="{{ age_group }}">
                 <div class="demo-bar-fill" style="width: {% widthratio count report_data.age_demographics_total 100 %}%;"></div>
             </div>
             {% endif %}
@@ -390,18 +571,24 @@
         <div style="text-align: right;">100%</div>
     </div>
 </div>
+</details>
 
 {% elif section.section_type == "narrative" %}
-<div class="report-header-bar">{{ section.title }}</div>
+{# Narrative: collapsible #}
+<details open id="section-{{ forloop.counter }}">
+<summary class="report-header-bar">{{ section.title }}</summary>
 <div class="narrative-section">
     {% if section.instructions %}
     <p>{{ section.instructions }}</p>
     {% endif %}
     <p class="placeholder">{% trans "[To be added during review]" %}</p>
 </div>
+</details>
 
 {% elif section.section_type == "chart" %}
-<div class="report-header-bar">{{ section.title }}</div>
+{# Charts: collapsible #}
+<details open id="section-{{ forloop.counter }}">
+<summary class="report-header-bar">{{ section.title }}</summary>
 {% if chart_images %}
 <div class="chart-section">
     {% for chart in chart_images %}
@@ -416,9 +603,12 @@
     <p class="placeholder">{% trans "No chart data available for this report." %}</p>
 </div>
 {% endif %}
+</details>
 
 {% elif section.section_type == "standards_alignment" %}
-<div class="report-header-bar">{{ section.title }}</div>
+{# Standards alignment: collapsible #}
+<details id="section-{{ forloop.counter }}">
+<summary class="report-header-bar">{{ section.title }}</summary>
 {% if report_data.cids_alignment %}
 <p style="font-size: 0.85rem; color: #718096; margin-bottom: 0.8rem;">
     {% blocktrans with version=report_data.cids_alignment.cids_version %}Aligned with Common Impact Data Standard (CIDS) v{{ version }}.{% endblocktrans %}
@@ -467,16 +657,20 @@
     <p class="placeholder">{% trans "No CIDS standards alignment data available. Import code lists and tag metrics to populate this section." %}</p>
 </div>
 {% endif %}
+</details>
 
 {% endif %}
 {% endfor %}
 
-{# Overall summary after all sections #}
+{# Overall summary: always visible — never collapsible #}
 {% if report_data.achievement_summary.total_clients > 0 %}
-<div class="report-header-bar">{% trans "Overall Summary" %}</div>
+<div class="report-header-bar" id="section-summary">{% trans "Overall Summary" %}</div>
 <div class="summary-grid">
     <div class="summary-card">
         <div class="number">{{ report_data.achievement_summary.overall_rate }}%</div>
+        <div class="achievement-bar" role="progressbar" aria-valuenow="{{ report_data.achievement_summary.overall_rate }}" aria-valuemin="0" aria-valuemax="100" aria-label="{% trans 'Overall achievement rate' %}">
+            <div class="achievement-bar-fill" style="width: {{ report_data.achievement_summary.overall_rate }}%;"></div>
+        </div>
         <div class="label">{% trans "Overall Achievement Rate" %}</div>
     </div>
     <div class="summary-card">
@@ -487,13 +681,25 @@
 {% endif %}
 
 {% else %}
-{# Legacy layout: no ReportSection records #}
+{# ===== LEGACY LAYOUT (no ReportSection records) ===== #}
 
 <div class="report-header-bar">{% trans "Service Statistics" %}</div>
 <div class="stat-grid">
     <div class="stat-box">
         <div class="value">{{ report_data.total_individuals_served|default:"0" }}</div>
         <div class="label">{% trans "Total Individuals Served" %}</div>
+        {% if report_data.prev_total_individuals_served is not None %}
+        <div class="change">
+            {% if report_data.total_individuals_served > report_data.prev_total_individuals_served %}
+            <span aria-hidden="true">&#9650;</span>
+            <span class="sr-only">{% trans "Increased" %}</span>
+            {% elif report_data.total_individuals_served < report_data.prev_total_individuals_served %}
+            <span aria-hidden="true">&#9660;</span>
+            <span class="sr-only">{% trans "Decreased" %}</span>
+            {% endif %}
+            {% trans "from" %} {{ report_data.prev_total_individuals_served }} {% trans "previous period" %}
+        </div>
+        {% endif %}
     </div>
     <div class="stat-box">
         <div class="value">{{ report_data.new_clients_this_period|default:"0" }}</div>
@@ -505,7 +711,8 @@
     </div>
 </div>
 
-<div class="report-header-bar">{% trans "Age Demographics" %}</div>
+<details open>
+<summary class="report-header-bar">{% trans "Age Demographics" %} &mdash; {{ report_data.age_demographics_total }} {% trans "participants" %}</summary>
 <div style="margin: 0.8rem 0;">
     <div class="demo-row header">
         <div>{% trans "Age Group" %}</div>
@@ -517,7 +724,7 @@
         <div>
             {{ age_group }}
             {% if report_data.age_demographics_total > 0 %}
-            <div class="demo-bar">
+            <div class="demo-bar" role="progressbar" aria-valuenow="{% widthratio count report_data.age_demographics_total 100 %}" aria-valuemin="0" aria-valuemax="100" aria-label="{{ age_group }}">
                 <div class="demo-bar-fill" style="width: {% widthratio count report_data.age_demographics_total 100 %}%;"></div>
             </div>
             {% endif %}
@@ -538,6 +745,7 @@
         <div style="text-align: right;">100%</div>
     </div>
 </div>
+</details>
 
 <h2>{% trans "Outcome Indicators" %}</h2>
 
@@ -546,6 +754,9 @@
 <div class="outcome-card">
     <h4>{{ report_data.primary_outcome.name }}</h4>
     <div class="rate">{{ report_data.primary_outcome.achievement_rate }}%</div>
+    <div class="achievement-bar" role="progressbar" aria-valuenow="{{ report_data.primary_outcome.achievement_rate }}" aria-valuemin="0" aria-valuemax="100" aria-label="{{ report_data.primary_outcome.name }}">
+        <div class="achievement-bar-fill" style="width: {{ report_data.primary_outcome.achievement_rate }}%;"></div>
+    </div>
     <div class="details">
         <strong>{% trans "Target:" %}</strong> {{ report_data.primary_outcome.target_value }}<br>
         <strong>{% trans "Clients Measured:" %}</strong> {{ report_data.primary_outcome.clients_measured }}<br>
@@ -573,7 +784,12 @@
             <td>{{ outcome.target_value }}</td>
             <td>{{ outcome.clients_measured }}</td>
             <td>{{ outcome.clients_achieved }}</td>
-            <td>{{ outcome.achievement_rate }}%</td>
+            <td>
+                {{ outcome.achievement_rate }}%
+                <div class="achievement-bar" role="progressbar" aria-valuenow="{{ outcome.achievement_rate }}" aria-valuemin="0" aria-valuemax="100">
+                    <div class="achievement-bar-fill" style="width: {{ outcome.achievement_rate }}%;"></div>
+                </div>
+            </td>
         </tr>
         {% endfor %}
     </tbody>
@@ -589,6 +805,9 @@
 <div class="summary-grid">
     <div class="summary-card">
         <div class="number">{{ report_data.achievement_summary.overall_rate }}%</div>
+        <div class="achievement-bar" role="progressbar" aria-valuenow="{{ report_data.achievement_summary.overall_rate }}" aria-valuemin="0" aria-valuemax="100" aria-label="{% trans 'Overall achievement rate' %}">
+            <div class="achievement-bar-fill" style="width: {{ report_data.achievement_summary.overall_rate }}%;"></div>
+        </div>
         <div class="label">{% trans "Overall Achievement Rate" %}</div>
     </div>
     <div class="summary-card">
@@ -601,7 +820,8 @@
 
 {# CIDS Standards Alignment appendix (legacy layout) #}
 {% if report_data.cids_alignment and report_data.cids_alignment.mapped_count > 0 %}
-<div class="report-header-bar">{% trans "Standards Alignment" %}</div>
+<details>
+<summary class="report-header-bar">{% trans "Standards Alignment" %}</summary>
 <p style="font-size: 0.85rem; color: #718096; margin-bottom: 0.8rem;">
     {% blocktrans with version=report_data.cids_alignment.cids_version %}Aligned with Common Impact Data Standard (CIDS) v{{ version }}.{% endblocktrans %}
 </p>
@@ -641,11 +861,11 @@
     {% endfor %}
 </ul>
 {% endif %}
+</details>
 {% endif %}
 
 <div class="footer-note">
-    <strong>{% trans "Draft Template:" %}</strong> {% trans "This report was generated using KoNote's Program Outcome Report Template." %}
-    {% trans "Verify this format matches the specific reporting requirements before submission." %}
+    {% trans "This report was generated using KoNote's Program Outcome Report Template." %}
     {% blocktrans with period=report_data.reporting_period %}Data reflects client outcomes recorded during the {{ period }} reporting period.{% endblocktrans %}
 </div>
 

--- a/templates/reports/html_report.html
+++ b/templates/reports/html_report.html
@@ -93,13 +93,6 @@
             color: #4a5568;
         }
         .pdf-header .meta-grid dd { margin: 0; }
-        .pdf-header .draft-notice {
-            margin-top: 0.5rem;
-            padding: 0.4rem 0.6rem;
-            background-color: #fef3c7;
-            border-radius: 4px;
-            font-size: 0.85rem;
-        }
 
         /* Table of contents */
         .report-toc {
@@ -365,11 +358,6 @@
         <dt>{% trans "Generated" %}</dt>
         <dd>{% blocktrans with date=report_data.generated_at|date:"Y-m-d" author=generated_by %}{{ date }} by {{ author }}{% endblocktrans %}</dd>
     </dl>
-    {% if is_draft_template %}
-    <div class="draft-notice">
-        <strong>{% trans "Draft Template:" %}</strong> {% trans "Verify this format matches the specific reporting requirements before submission." %}
-    </div>
-    {% endif %}
 </div>
 
 {% if sections %}
@@ -403,7 +391,6 @@
         <div class="label">{% trans "Total Individuals Served" %}</div>
         {% if report_data.prev_total_individuals_served is not None %}
         <div class="change">
-            {% widthratio report_data.total_individuals_served 1 1 as current_val %}
             {% if report_data.total_individuals_served > report_data.prev_total_individuals_served %}
             <span aria-hidden="true">&#9650;</span>
             <span class="sr-only">{% trans "Increased" %}</span>
@@ -704,10 +691,34 @@
     <div class="stat-box">
         <div class="value">{{ report_data.new_clients_this_period|default:"0" }}</div>
         <div class="label">{% trans "New Participants This Period" %}</div>
+        {% if report_data.prev_new_clients_this_period is not None %}
+        <div class="change">
+            {% if report_data.new_clients_this_period > report_data.prev_new_clients_this_period %}
+            <span aria-hidden="true">&#9650;</span>
+            <span class="sr-only">{% trans "Increased" %}</span>
+            {% elif report_data.new_clients_this_period < report_data.prev_new_clients_this_period %}
+            <span aria-hidden="true">&#9660;</span>
+            <span class="sr-only">{% trans "Decreased" %}</span>
+            {% endif %}
+            {% trans "from" %} {{ report_data.prev_new_clients_this_period }} {% trans "previous period" %}
+        </div>
+        {% endif %}
     </div>
     <div class="stat-box">
         <div class="value">{{ report_data.total_contacts|default:"0" }}</div>
         <div class="label">{% trans "Total Service Contacts" %}</div>
+        {% if report_data.prev_total_contacts is not None %}
+        <div class="change">
+            {% if report_data.total_contacts > report_data.prev_total_contacts %}
+            <span aria-hidden="true">&#9650;</span>
+            <span class="sr-only">{% trans "Increased" %}</span>
+            {% elif report_data.total_contacts < report_data.prev_total_contacts %}
+            <span aria-hidden="true">&#9660;</span>
+            <span class="sr-only">{% trans "Decreased" %}</span>
+            {% endif %}
+            {% trans "from" %} {{ report_data.prev_total_contacts }} {% trans "previous period" %}
+        </div>
+        {% endif %}
     </div>
 </div>
 

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -2309,6 +2309,64 @@ class TemplatePeriodOptionsViewTest(TestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(resp.content, b"")
 
+    def test_include_all_metrics_shows_reassuring_text(self):
+        """Template with include_all_metrics=True and no explicit metrics shows all-outcomes message."""
+        from apps.reports.models import ReportTemplate, Partner
+        partner = Partner.objects.create(name="Board", partner_type="board")
+        partner.programs.add(self.program)
+        all_metrics_tmpl = ReportTemplate.objects.create(
+            name="Org-Wide Summary",
+            partner=partner,
+            period_type="quarterly",
+            period_alignment="fiscal",
+            fiscal_year_start_month=4,
+            include_all_metrics=True,
+            is_active=True,
+        )
+        self.client_http.login(username="admin", password="testpass123")
+        resp = self.client_http.get(
+            "/reports/generate/period-options/",
+            {"report_template": all_metrics_tmpl.pk},
+        )
+        content = resp.content.decode()
+        self.assertIn("all recorded outcomes", content)
+        self.assertNotIn("No specific metrics", content)
+
+    def test_no_metrics_shows_warning(self):
+        """Template with no metrics and include_all_metrics=False shows warning."""
+        from apps.reports.models import ReportTemplate, Partner
+        partner = Partner.objects.create(name="Misc Funder", partner_type="funder")
+        partner.programs.add(self.program)
+        empty_tmpl = ReportTemplate.objects.create(
+            name="Empty Template",
+            partner=partner,
+            period_type="quarterly",
+            period_alignment="fiscal",
+            fiscal_year_start_month=4,
+            include_all_metrics=False,
+            is_active=True,
+        )
+        self.client_http.login(username="admin", password="testpass123")
+        resp = self.client_http.get(
+            "/reports/generate/period-options/",
+            {"report_template": empty_tmpl.pk},
+        )
+        content = resp.content.decode()
+        self.assertIn("No specific metrics", content)
+        self.assertNotIn("all recorded outcomes", content)
+
+    def test_explicit_metrics_shows_list(self):
+        """Template with explicit ReportMetric objects shows 'This report includes:' list."""
+        self.client_http.login(username="admin", password="testpass123")
+        resp = self.client_http.get(
+            "/reports/generate/period-options/",
+            {"report_template": self.template.pk},
+        )
+        content = resp.content.decode()
+        self.assertIn("Employment Outcome", content)
+        self.assertNotIn("all recorded outcomes", content)
+        self.assertNotIn("No specific metrics", content)
+
 
 # =============================================================================
 # Security Tests: Demo/Real Data Separation in Exports (EXP0d)


### PR DESCRIPTION
## Summary
- Add `include_all_metrics` boolean on ReportTemplate for org-wide reports that include all outcomes
- Three-state preview card: explicit metrics list, intentional all-metrics message, or amber warning for misconfigured templates
- Fix duplicate partner name in preview card header
- Enrich CCF demo template with 5 metrics and user-facing description
- New org-wide quarterly summary template with agency demographic defaults
- HTML report template redesign: collapsible sections (details/summary), CSS progress bars, conditional TOC, ARIA accessibility
- Period-over-period comparison placeholders on all stat boxes (section + legacy layouts)
- Code review fixes: removed unused imports, dead variables, flawed draft notice logic
- 3 new tests for include_all_metrics preview states
- French translations for all new strings

## Test plan
- [ ] Verify preview card shows metric list for CCF template
- [ ] Verify preview card shows "all recorded outcomes" for org-wide template
- [ ] Verify preview card shows amber warning for template with no metrics
- [ ] Verify HTML report collapsible sections work (click to toggle)
- [ ] Verify progress bars render for achievement rates
- [ ] Run `pytest tests/test_reports.py::TemplatePeriodOptionsViewTest` — 7 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)