### PR TITLE
feat: group participant list by user role (caseload vs oversight)

### DIFF
--- a/apps/clients/views.py
+++ b/apps/clients/views.py
@@ -266,6 +266,22 @@ def client_list(request):
         .values_list("program_id", flat=True)
     )
 
+    # Compute role-to-program mappings for grouped display.
+    # When a user has both staff and PM roles, we split the list into
+    # "Your caseload" (staff programs) and "Programs you manage" (PM programs).
+    _user_role_qs = UserProgramRole.objects.filter(
+        user=request.user, status="active"
+    ).select_related("program")
+    staff_programs = []
+    pm_programs = []
+    for upr in _user_role_qs:
+        if upr.role == "staff":
+            staff_programs.append(upr.program)
+        elif upr.role == "program_manager":
+            pm_programs.append(upr.program)
+    staff_program_ids = {p.pk for p in staff_programs}
+    has_mixed_roles = bool(staff_program_ids) and bool(pm_programs)
+
     # Get filter values from query params
     status_filter = request.GET.get("status", "")
     program_filter = request.GET.get("program", "")
@@ -337,19 +353,16 @@ def client_list(request):
         for cid in note_matched_ids:
             client_data.append(unmatched[cid])
 
-    # Sort by name or last contact
+    # Sort helper — reused for both single and split lists
     if sort_by == "last_contact":
         from datetime import datetime as dt
         epoch = dt(2000, 1, 1, 0, 0)
         min_dt = timezone.make_aware(epoch) if timezone.is_aware(timezone.now()) else epoch
-        client_data.sort(
-            key=lambda c: c["last_contact"] or min_dt,
-            reverse=True,
-        )
+        _sort_fn = lambda c: c["last_contact"] or min_dt  # noqa: E731
+        _sort_reverse = True
     else:
-        client_data.sort(key=lambda c: c["name"].lower())
-    paginator = Paginator(client_data, 25)
-    page = paginator.get_page(request.GET.get("page"))
+        _sort_fn = lambda c: c["name"].lower()  # noqa: E731
+        _sort_reverse = False
 
     # Show create button if user's role grants client.create permission
     user_role = _get_user_highest_role(request.user)
@@ -359,23 +372,85 @@ def client_list(request):
     can_bulk_transfer = PERMISSIONS.get(user_role, {}).get("client.transfer", DENY) != DENY
     show_bulk = can_bulk_status or can_bulk_transfer
 
-    context = {
-        "page": page,
-        "accessible_programs": accessible_programs,
-        "status_filter": status_filter,
-        "program_filter": program_filter,
-        "editable_filter": editable_filter,
-        "has_plan_edit_programs": bool(plan_edit_program_ids),
-        "search_query": request.GET.get("q", ""),
-        "sort_by": sort_by,
-        "can_create": can_create,
-        "show_bulk": show_bulk,
-        "can_bulk_status": can_bulk_status,
-        "can_bulk_transfer": can_bulk_transfer,
-    }
+    # Build context — split into sections when user has mixed roles
+    if has_mixed_roles:
+        # Split participants: caseload (staff programs) vs oversight (PM programs).
+        # A participant in BOTH a staff and PM program goes to caseload only.
+        caseload_data = []
+        oversight_data = []
+        for item in client_data:
+            enrolled_ids = {p.pk for p in item["programs"]}
+            if enrolled_ids & staff_program_ids:
+                caseload_data.append(item)
+            else:
+                oversight_data.append(item)
 
-    # HTMX request — return only the table partial
+        # Sort each section independently
+        caseload_data.sort(key=_sort_fn, reverse=_sort_reverse)
+        oversight_data.sort(key=_sort_fn, reverse=_sort_reverse)
+
+        # Caseload: show all (typically small). Oversight: paginate at 25.
+        oversight_paginator = Paginator(oversight_data, 25)
+        oversight_page = oversight_paginator.get_page(request.GET.get("page"))
+
+        # Role subtitle: "Staff in X · Manager for Y"
+        staff_label = ", ".join(
+            p.translated_name for p in sorted(staff_programs, key=lambda p: p.name)
+        )
+        pm_label = ", ".join(
+            p.translated_name for p in sorted(pm_programs, key=lambda p: p.name)
+        )
+
+        context = {
+            "has_mixed_roles": True,
+            "caseload_data": caseload_data,
+            "caseload_count": len(caseload_data),
+            "oversight_page": oversight_page,
+            "oversight_count": len(oversight_data),
+            "staff_program_label": staff_label,
+            "pm_program_label": pm_label,
+            "role_subtitle": _("Staff in %(staff)s \u00b7 Manager for %(pm)s") % {
+                "staff": staff_label, "pm": pm_label,
+            },
+            "page": None,
+            "accessible_programs": accessible_programs,
+            "status_filter": status_filter,
+            "program_filter": program_filter,
+            "editable_filter": editable_filter,
+            "has_plan_edit_programs": bool(plan_edit_program_ids),
+            "search_query": request.GET.get("q", ""),
+            "sort_by": sort_by,
+            "can_create": can_create,
+            "show_bulk": show_bulk,
+            "can_bulk_status": can_bulk_status,
+            "can_bulk_transfer": can_bulk_transfer,
+        }
+    else:
+        # Single-role user: keep existing flat list with pagination
+        client_data.sort(key=_sort_fn, reverse=_sort_reverse)
+        paginator = Paginator(client_data, 25)
+        page = paginator.get_page(request.GET.get("page"))
+
+        context = {
+            "has_mixed_roles": False,
+            "page": page,
+            "accessible_programs": accessible_programs,
+            "status_filter": status_filter,
+            "program_filter": program_filter,
+            "editable_filter": editable_filter,
+            "has_plan_edit_programs": bool(plan_edit_program_ids),
+            "search_query": request.GET.get("q", ""),
+            "sort_by": sort_by,
+            "can_create": can_create,
+            "show_bulk": show_bulk,
+            "can_bulk_status": can_bulk_status,
+            "can_bulk_transfer": can_bulk_transfer,
+        }
+
+    # HTMX request — return only the appropriate partial
     if request.headers.get("HX-Request"):
+        if has_mixed_roles:
+            return render(request, "clients/_client_list_sections.html", context)
         return render(request, "clients/_client_list_table.html", context)
 
     return render(request, "clients/list.html", context)

--- a/apps/clients/views.py
+++ b/apps/clients/views.py
@@ -253,11 +253,10 @@ def client_list(request):
 
     clients = _get_accessible_clients(request.user, active_program_ids=search_active_ids)
     accessible_programs = _get_accessible_programs(request.user, active_program_ids=active_ids)
-    user_program_ids = _get_user_program_ids(request.user, active_program_ids=active_ids)
-
-    # Single query for user's program roles — used for both plan-edit check
-    # and role-based grouping.  Respects CONF9 active program context so the
-    # section split collapses when the user narrows to one program.
+    # Single query for user's program roles — used for plan-edit check,
+    # role-based grouping, and user_program_ids.  Respects CONF9 active
+    # program context so the section split collapses when the user narrows
+    # to one program.
     _role_filter = {"user": request.user, "status": "active"}
     if active_ids:
         _role_filter["program_id__in"] = active_ids
@@ -265,6 +264,7 @@ def client_list(request):
         UserProgramRole.objects.filter(**_role_filter)
         .select_related("program")
     )
+    user_program_ids = {upr.program_id for upr in _user_roles}
 
     # Derive plan-edit programs from the role query (replaces separate query).
     _plan_edit_deny_roles = {
@@ -394,8 +394,7 @@ def client_list(request):
         caseload_data = []
         oversight_data = []
         for item in client_data:
-            enrolled_ids = {p.pk for p in item["programs"]}
-            if enrolled_ids & staff_program_ids:
+            if any(p.pk in staff_program_ids for p in item["programs"]):
                 caseload_data.append(item)
             else:
                 oversight_data.append(item)

--- a/apps/clients/views.py
+++ b/apps/clients/views.py
@@ -255,30 +255,29 @@ def client_list(request):
     accessible_programs = _get_accessible_programs(request.user, active_program_ids=active_ids)
     user_program_ids = _get_user_program_ids(request.user, active_program_ids=active_ids)
 
-    # Compute program IDs where user can edit plans.
-    # Uses PERMISSIONS.keys() so any future roles are automatically included.
-    plan_edit_program_ids = set(
-        UserProgramRole.objects.filter(user=request.user, status="active")
-        .exclude(role__in=[
-            r for r in PERMISSIONS.keys()
-            if can_access(r, "plan.edit") == DENY
-        ])
-        .values_list("program_id", flat=True)
+    # Single query for user's program roles — used for both plan-edit check
+    # and role-based grouping.  Respects CONF9 active program context so the
+    # section split collapses when the user narrows to one program.
+    _role_filter = {"user": request.user, "status": "active"}
+    if active_ids:
+        _role_filter["program_id__in"] = active_ids
+    _user_roles = list(
+        UserProgramRole.objects.filter(**_role_filter)
+        .select_related("program")
     )
 
-    # Compute role-to-program mappings for grouped display.
-    # When a user has both staff and PM roles, we split the list into
-    # "Your caseload" (staff programs) and "Programs you manage" (PM programs).
-    _user_role_qs = UserProgramRole.objects.filter(
-        user=request.user, status="active"
-    ).select_related("program")
-    staff_programs = []
-    pm_programs = []
-    for upr in _user_role_qs:
-        if upr.role == "staff":
-            staff_programs.append(upr.program)
-        elif upr.role == "program_manager":
-            pm_programs.append(upr.program)
+    # Derive plan-edit programs from the role query (replaces separate query).
+    _plan_edit_deny_roles = {
+        r for r in PERMISSIONS.keys() if can_access(r, "plan.edit") == DENY
+    }
+    plan_edit_program_ids = {
+        upr.program_id for upr in _user_roles
+        if upr.role not in _plan_edit_deny_roles
+    }
+
+    # Role-to-program mappings for grouped display.
+    staff_programs = [upr.program for upr in _user_roles if upr.role == "staff"]
+    pm_programs = [upr.program for upr in _user_roles if upr.role == "program_manager"]
     staff_program_ids = {p.pk for p in staff_programs}
     has_mixed_roles = bool(staff_program_ids) and bool(pm_programs)
 
@@ -372,7 +371,23 @@ def client_list(request):
     can_bulk_transfer = PERMISSIONS.get(user_role, {}).get("client.transfer", DENY) != DENY
     show_bulk = can_bulk_status or can_bulk_transfer
 
-    # Build context — split into sections when user has mixed roles
+    # Base context shared by both single and split views
+    context = {
+        "has_mixed_roles": has_mixed_roles,
+        "accessible_programs": accessible_programs,
+        "status_filter": status_filter,
+        "program_filter": program_filter,
+        "editable_filter": editable_filter,
+        "has_plan_edit_programs": bool(plan_edit_program_ids),
+        "search_query": request.GET.get("q", ""),
+        "sort_by": sort_by,
+        "can_create": can_create,
+        "show_bulk": show_bulk,
+        "can_bulk_status": can_bulk_status,
+        "can_bulk_transfer": can_bulk_transfer,
+    }
+
+    # Build section-specific context
     if has_mixed_roles:
         # Split participants: caseload (staff programs) vs oversight (PM programs).
         # A participant in BOTH a staff and PM program goes to caseload only.
@@ -400,9 +415,7 @@ def client_list(request):
         pm_label = ", ".join(
             p.translated_name for p in sorted(pm_programs, key=lambda p: p.name)
         )
-
-        context = {
-            "has_mixed_roles": True,
+        context.update({
             "caseload_data": caseload_data,
             "caseload_count": len(caseload_data),
             "oversight_page": oversight_page,
@@ -413,39 +426,12 @@ def client_list(request):
                 "staff": staff_label, "pm": pm_label,
             },
             "page": None,
-            "accessible_programs": accessible_programs,
-            "status_filter": status_filter,
-            "program_filter": program_filter,
-            "editable_filter": editable_filter,
-            "has_plan_edit_programs": bool(plan_edit_program_ids),
-            "search_query": request.GET.get("q", ""),
-            "sort_by": sort_by,
-            "can_create": can_create,
-            "show_bulk": show_bulk,
-            "can_bulk_status": can_bulk_status,
-            "can_bulk_transfer": can_bulk_transfer,
-        }
+        })
     else:
         # Single-role user: keep existing flat list with pagination
         client_data.sort(key=_sort_fn, reverse=_sort_reverse)
         paginator = Paginator(client_data, 25)
-        page = paginator.get_page(request.GET.get("page"))
-
-        context = {
-            "has_mixed_roles": False,
-            "page": page,
-            "accessible_programs": accessible_programs,
-            "status_filter": status_filter,
-            "program_filter": program_filter,
-            "editable_filter": editable_filter,
-            "has_plan_edit_programs": bool(plan_edit_program_ids),
-            "search_query": request.GET.get("q", ""),
-            "sort_by": sort_by,
-            "can_create": can_create,
-            "show_bulk": show_bulk,
-            "can_bulk_status": can_bulk_status,
-            "can_bulk_transfer": can_bulk_transfer,
-        }
+        context["page"] = paginator.get_page(request.GET.get("page"))
 
     # HTMX request — return only the appropriate partial
     if request.headers.get("HX-Request"):

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -19327,3 +19327,38 @@ msgstr "Score"
 msgid "To:"
 msgstr "À :"
 
+#: templates/clients/_client_list_sections.html (role-based grouped view)
+msgid "Your caseload"
+msgstr "Votre charge de travail"
+
+msgid "Programs you manage"
+msgstr "Programmes que vous gérez"
+
+#, python-format
+msgid ""
+"Your caseload — %(programs)s (%(count)s)"
+msgstr ""
+"Votre charge de travail — %(programs)s (%(count)s)"
+
+#, python-format
+msgid ""
+"Programs you manage — %(programs)s (%(count)s)"
+msgstr ""
+"Programmes que vous gérez — %(programs)s (%(count)s)"
+
+#, python-format
+msgid "Staff in %(staff)s \u00b7 Manager for %(pm)s"
+msgstr "Personnel pour %(staff)s \u00b7 Gestionnaire pour %(pm)s"
+
+msgid "No participants in your caseload match the current filters."
+msgstr "Aucun participant de votre charge de travail ne correspond aux filtres sélectionnés."
+
+msgid "No participants in managed programs match the current filters."
+msgstr "Aucun participant des programmes que vous gérez ne correspond aux filtres sélectionnés."
+
+msgid "Select all in caseload"
+msgstr "Tout sélectionner dans la charge de travail"
+
+msgid "Select all in managed programs"
+msgstr "Tout sélectionner dans les programmes gérés"
+

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -19336,15 +19336,15 @@ msgstr "Programmes que vous gérez"
 
 #, python-format
 msgid ""
-"Your caseload — %(programs)s (%(count)s)"
+"Your caseload — %(programs)s (%(total)s)"
 msgstr ""
-"Votre charge de travail — %(programs)s (%(count)s)"
+"Votre charge de travail — %(programs)s (%(total)s)"
 
 #, python-format
 msgid ""
-"Programs you manage — %(programs)s (%(count)s)"
+"Programs you manage — %(programs)s (%(total)s)"
 msgstr ""
-"Programmes que vous gérez — %(programs)s (%(count)s)"
+"Programmes que vous gérez — %(programs)s (%(total)s)"
 
 #, python-format
 msgid "Staff in %(staff)s \u00b7 Manager for %(pm)s"

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -714,6 +714,23 @@ output.form-output {
 .client-table:has(.bulk-col) td:nth-child(2) a { text-decoration: none; }
 .client-table:has(.bulk-col) td:nth-child(2) a:hover { text-decoration: underline; }
 
+/* ---- Client list section headings (mixed-role grouped view) ---- */
+.client-list-section {
+    margin-bottom: 2rem;
+}
+.client-list-section .section-heading {
+    font-size: 1.1rem;
+    font-weight: 600;
+    margin-top: 1.5rem;
+    margin-bottom: 0.5rem;
+    padding-bottom: 0.35rem;
+    border-bottom: 1px solid var(--kn-border-light, #e0e0e0);
+    color: var(--color, inherit);
+}
+.client-list-section:first-child .section-heading {
+    margin-top: 0;
+}
+
 /* ---- Organization header ---- */
 .org-header {
     display: flex;

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -1548,11 +1548,17 @@ document.body.addEventListener("htmx:afterSettle", function (event) {
     }
 
     function setupCheckboxes() {
-        var selectAll = document.getElementById("bulk-select-all");
-        if (selectAll) {
+        // Support multiple select-all checkboxes (one per table section).
+        // Each scopes to its own <table> so checking "select all" in one
+        // section doesn't affect the other.
+        var selectAlls = document.querySelectorAll(".bulk-select-all");
+        selectAlls.forEach(function (selectAll) {
             selectAll.addEventListener("change", function () {
                 var checked = selectAll.checked;
-                var rowCbs = document.querySelectorAll(".bulk-select-row");
+                var table = selectAll.closest("table");
+                var rowCbs = table
+                    ? table.querySelectorAll(".bulk-select-row")
+                    : document.querySelectorAll(".bulk-select-row");
                 rowCbs.forEach(function (cb) {
                     cb.checked = checked;
                     if (checked) {
@@ -1563,7 +1569,7 @@ document.body.addEventListener("htmx:afterSettle", function (event) {
                 });
                 updateBar();
             });
-        }
+        });
 
         // Delegate click events for row checkboxes
         document.addEventListener("change", function (e) {
@@ -1572,8 +1578,11 @@ document.body.addEventListener("htmx:afterSettle", function (event) {
                 selectedIds.add(e.target.value);
             } else {
                 selectedIds.delete(e.target.value);
-                // Uncheck select-all if any row is unchecked
-                var sa = document.getElementById("bulk-select-all");
+                // Uncheck select-all in the same table section
+                var table = e.target.closest("table");
+                var sa = table
+                    ? table.querySelector(".bulk-select-all")
+                    : document.querySelector(".bulk-select-all");
                 if (sa) sa.checked = false;
             }
             updateBar();
@@ -1623,15 +1632,21 @@ document.body.addEventListener("htmx:afterSettle", function (event) {
                     cb.checked = true;
                 }
             });
-            // Update select-all state
-            var sa = target.querySelector("#bulk-select-all");
-            if (sa && rowCbs.length > 0) {
-                var allChecked = true;
-                rowCbs.forEach(function (cb) {
-                    if (!cb.checked) allChecked = false;
-                });
-                sa.checked = allChecked;
-            }
+            // Update select-all state for each table section
+            var selectAlls = target.querySelectorAll(".bulk-select-all");
+            selectAlls.forEach(function (sa) {
+                var table = sa.closest("table");
+                var tableCbs = table
+                    ? table.querySelectorAll(".bulk-select-row")
+                    : rowCbs;
+                if (tableCbs.length > 0) {
+                    var allChecked = true;
+                    tableCbs.forEach(function (cb) {
+                        if (!cb.checked) allChecked = false;
+                    });
+                    sa.checked = allChecked;
+                }
+            });
             updateBar();
         }
     });

--- a/templates/clients/_client_list_sections.html
+++ b/templates/clients/_client_list_sections.html
@@ -11,21 +11,7 @@
     {% if caseload_data %}
     <figure class="client-table-wrap" data-total-clients="{{ caseload_count }}">
     <table role="grid" class="client-table" aria-label="{% trans 'Your caseload' %}">
-        <thead>
-            <tr>
-                {% if show_bulk %}
-                <th scope="col" class="bulk-col">
-                    <label class="visually-hidden" for="bulk-select-caseload">{% trans "Select all" %}</label>
-                    <input type="checkbox" id="bulk-select-caseload" aria-label="{% trans 'Select all in caseload' %}">
-                </th>
-                {% endif %}
-                <th scope="col">{% trans "Name" %}</th>
-                <th scope="col">{% trans "Record ID" %}</th>
-                <th scope="col">{% trans "Status" %}</th>
-                <th scope="col">{{ term.program_plural|default:"Programs" }}</th>
-                <th scope="col">{% trans "Last Contact" %}</th>
-            </tr>
-        </thead>
+        {% include "clients/_client_thead.html" with bulk_select_id="bulk-select-caseload" %}
         <tbody>
             {% for item in caseload_data %}
             {% include "clients/_client_row.html" %}
@@ -46,21 +32,7 @@
     {% if oversight_page.object_list %}
     <figure class="client-table-wrap" data-total-clients="{{ oversight_count }}">
     <table role="grid" class="client-table" aria-label="{% trans 'Programs you manage' %}">
-        <thead>
-            <tr>
-                {% if show_bulk %}
-                <th scope="col" class="bulk-col">
-                    <label class="visually-hidden" for="bulk-select-oversight">{% trans "Select all" %}</label>
-                    <input type="checkbox" id="bulk-select-oversight" aria-label="{% trans 'Select all in managed programs' %}">
-                </th>
-                {% endif %}
-                <th scope="col">{% trans "Name" %}</th>
-                <th scope="col">{% trans "Record ID" %}</th>
-                <th scope="col">{% trans "Status" %}</th>
-                <th scope="col">{{ term.program_plural|default:"Programs" }}</th>
-                <th scope="col">{% trans "Last Contact" %}</th>
-            </tr>
-        </thead>
+        {% include "clients/_client_thead.html" with bulk_select_id="bulk-select-oversight" %}
         <tbody>
             {% for item in oversight_page %}
             {% include "clients/_client_row.html" %}

--- a/templates/clients/_client_list_sections.html
+++ b/templates/clients/_client_list_sections.html
@@ -44,16 +44,16 @@
     {% if oversight_page.has_other_pages %}
     <nav class="pagination" aria-label="{% trans 'Pagination' %}">
         {% if oversight_page.has_previous %}
-        <a href="?page={{ oversight_page.previous_page_number }}{% if sort_by %}&sort={{ sort_by }}{% endif %}{% if status_filter %}&status={{ status_filter }}{% endif %}{% if program_filter %}&program={{ program_filter }}{% endif %}"
-           hx-get="{% url 'clients:client_list' %}?page={{ oversight_page.previous_page_number }}{% if sort_by %}&sort={{ sort_by }}{% endif %}{% if status_filter %}&status={{ status_filter }}{% endif %}{% if program_filter %}&program={{ program_filter }}{% endif %}"
+        <a href="?page={{ oversight_page.previous_page_number }}{% if sort_by %}&sort={{ sort_by }}{% endif %}{% if status_filter %}&status={{ status_filter }}{% endif %}{% if program_filter %}&program={{ program_filter }}{% endif %}{% if editable_filter %}&editable={{ editable_filter }}{% endif %}{% if search_query %}&q={{ search_query }}{% endif %}"
+           hx-get="{% url 'clients:client_list' %}?page={{ oversight_page.previous_page_number }}{% if sort_by %}&sort={{ sort_by }}{% endif %}{% if status_filter %}&status={{ status_filter }}{% endif %}{% if program_filter %}&program={{ program_filter }}{% endif %}{% if editable_filter %}&editable={{ editable_filter }}{% endif %}{% if search_query %}&q={{ search_query }}{% endif %}"
            hx-target="#client-list-container"
            hx-indicator="#loading-bar"
            hx-push-url="true">{% trans "Previous" %}</a>
         {% endif %}
         {% blocktrans with current=oversight_page.number total=oversight_page.paginator.num_pages %}Page {{ current }} of {{ total }}{% endblocktrans %}
         {% if oversight_page.has_next %}
-        <a href="?page={{ oversight_page.next_page_number }}{% if sort_by %}&sort={{ sort_by }}{% endif %}{% if status_filter %}&status={{ status_filter }}{% endif %}{% if program_filter %}&program={{ program_filter }}{% endif %}"
-           hx-get="{% url 'clients:client_list' %}?page={{ oversight_page.next_page_number }}{% if sort_by %}&sort={{ sort_by }}{% endif %}{% if status_filter %}&status={{ status_filter }}{% endif %}{% if program_filter %}&program={{ program_filter }}{% endif %}"
+        <a href="?page={{ oversight_page.next_page_number }}{% if sort_by %}&sort={{ sort_by }}{% endif %}{% if status_filter %}&status={{ status_filter }}{% endif %}{% if program_filter %}&program={{ program_filter }}{% endif %}{% if editable_filter %}&editable={{ editable_filter }}{% endif %}{% if search_query %}&q={{ search_query }}{% endif %}"
+           hx-get="{% url 'clients:client_list' %}?page={{ oversight_page.next_page_number }}{% if sort_by %}&sort={{ sort_by }}{% endif %}{% if status_filter %}&status={{ status_filter }}{% endif %}{% if program_filter %}&program={{ program_filter }}{% endif %}{% if editable_filter %}&editable={{ editable_filter }}{% endif %}{% if search_query %}&q={{ search_query }}{% endif %}"
            hx-target="#client-list-container"
            hx-indicator="#loading-bar"
            hx-push-url="true">{% trans "Next" %}</a>

--- a/templates/clients/_client_list_sections.html
+++ b/templates/clients/_client_list_sections.html
@@ -1,0 +1,95 @@
+{% load i18n %}
+{# Two-section participant list for users with mixed roles (staff + PM). #}
+{# Section 1: caseload (staff programs) — shown in full, no pagination. #}
+{# Section 2: oversight (PM programs) — paginated at 25. #}
+
+{# ── Section 1: Your caseload ── #}
+<section aria-labelledby="caseload-heading" class="client-list-section">
+    <h2 id="caseload-heading" class="section-heading">
+        {% blocktrans with programs=staff_program_label count=caseload_count %}Your caseload — {{ programs }} ({{ count }}){% endblocktrans %}
+    </h2>
+    {% if caseload_data %}
+    <figure class="client-table-wrap" data-total-clients="{{ caseload_count }}">
+    <table role="grid" class="client-table" aria-label="{% trans 'Your caseload' %}">
+        <thead>
+            <tr>
+                {% if show_bulk %}
+                <th scope="col" class="bulk-col">
+                    <label class="visually-hidden" for="bulk-select-caseload">{% trans "Select all" %}</label>
+                    <input type="checkbox" id="bulk-select-caseload" aria-label="{% trans 'Select all in caseload' %}">
+                </th>
+                {% endif %}
+                <th scope="col">{% trans "Name" %}</th>
+                <th scope="col">{% trans "Record ID" %}</th>
+                <th scope="col">{% trans "Status" %}</th>
+                <th scope="col">{{ term.program_plural|default:"Programs" }}</th>
+                <th scope="col">{% trans "Last Contact" %}</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for item in caseload_data %}
+            {% include "clients/_client_row.html" %}
+            {% endfor %}
+        </tbody>
+    </table>
+    </figure>
+    {% else %}
+    <p class="empty-message"><em>{% trans "No participants in your caseload match the current filters." %}</em></p>
+    {% endif %}
+</section>
+
+{# ── Section 2: Programs you manage ── #}
+<section aria-labelledby="oversight-heading" class="client-list-section">
+    <h2 id="oversight-heading" class="section-heading">
+        {% blocktrans with programs=pm_program_label count=oversight_count %}Programs you manage — {{ programs }} ({{ count }}){% endblocktrans %}
+    </h2>
+    {% if oversight_page.object_list %}
+    <figure class="client-table-wrap" data-total-clients="{{ oversight_count }}">
+    <table role="grid" class="client-table" aria-label="{% trans 'Programs you manage' %}">
+        <thead>
+            <tr>
+                {% if show_bulk %}
+                <th scope="col" class="bulk-col">
+                    <label class="visually-hidden" for="bulk-select-oversight">{% trans "Select all" %}</label>
+                    <input type="checkbox" id="bulk-select-oversight" aria-label="{% trans 'Select all in managed programs' %}">
+                </th>
+                {% endif %}
+                <th scope="col">{% trans "Name" %}</th>
+                <th scope="col">{% trans "Record ID" %}</th>
+                <th scope="col">{% trans "Status" %}</th>
+                <th scope="col">{{ term.program_plural|default:"Programs" }}</th>
+                <th scope="col">{% trans "Last Contact" %}</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for item in oversight_page %}
+            {% include "clients/_client_row.html" %}
+            {% endfor %}
+        </tbody>
+    </table>
+    </figure>
+
+    {% if oversight_page.has_other_pages %}
+    <nav class="pagination" aria-label="{% trans 'Pagination' %}">
+        {% if oversight_page.has_previous %}
+        <a href="?page={{ oversight_page.previous_page_number }}{% if sort_by %}&sort={{ sort_by }}{% endif %}{% if status_filter %}&status={{ status_filter }}{% endif %}{% if program_filter %}&program={{ program_filter }}{% endif %}"
+           hx-get="{% url 'clients:client_list' %}?page={{ oversight_page.previous_page_number }}{% if sort_by %}&sort={{ sort_by }}{% endif %}{% if status_filter %}&status={{ status_filter }}{% endif %}{% if program_filter %}&program={{ program_filter }}{% endif %}"
+           hx-target="#client-list-container"
+           hx-indicator="#loading-bar"
+           hx-push-url="true">{% trans "Previous" %}</a>
+        {% endif %}
+        {% blocktrans with current=oversight_page.number total=oversight_page.paginator.num_pages %}Page {{ current }} of {{ total }}{% endblocktrans %}
+        {% if oversight_page.has_next %}
+        <a href="?page={{ oversight_page.next_page_number }}{% if sort_by %}&sort={{ sort_by }}{% endif %}{% if status_filter %}&status={{ status_filter }}{% endif %}{% if program_filter %}&program={{ program_filter }}{% endif %}"
+           hx-get="{% url 'clients:client_list' %}?page={{ oversight_page.next_page_number }}{% if sort_by %}&sort={{ sort_by }}{% endif %}{% if status_filter %}&status={{ status_filter }}{% endif %}{% if program_filter %}&program={{ program_filter }}{% endif %}"
+           hx-target="#client-list-container"
+           hx-indicator="#loading-bar"
+           hx-push-url="true">{% trans "Next" %}</a>
+        {% endif %}
+    </nav>
+    {% endif %}
+
+    {% else %}
+    <p class="empty-message"><em>{% trans "No participants in managed programs match the current filters." %}</em></p>
+    {% endif %}
+</section>

--- a/templates/clients/_client_list_sections.html
+++ b/templates/clients/_client_list_sections.html
@@ -6,7 +6,7 @@
 {# ── Section 1: Your caseload ── #}
 <section aria-labelledby="caseload-heading" class="client-list-section">
     <h2 id="caseload-heading" class="section-heading">
-        {% blocktrans with programs=staff_program_label count=caseload_count %}Your caseload — {{ programs }} ({{ count }}){% endblocktrans %}
+        {% blocktrans with programs=staff_program_label total=caseload_count %}Your caseload — {{ programs }} ({{ total }}){% endblocktrans %}
     </h2>
     {% if caseload_data %}
     <figure class="client-table-wrap" data-total-clients="{{ caseload_count }}">
@@ -41,7 +41,7 @@
 {# ── Section 2: Programs you manage ── #}
 <section aria-labelledby="oversight-heading" class="client-list-section">
     <h2 id="oversight-heading" class="section-heading">
-        {% blocktrans with programs=pm_program_label count=oversight_count %}Programs you manage — {{ programs }} ({{ count }}){% endblocktrans %}
+        {% blocktrans with programs=pm_program_label total=oversight_count %}Programs you manage — {{ programs }} ({{ total }}){% endblocktrans %}
     </h2>
     {% if oversight_page.object_list %}
     <figure class="client-table-wrap" data-total-clients="{{ oversight_count }}">

--- a/templates/clients/_client_list_table.html
+++ b/templates/clients/_client_list_table.html
@@ -2,41 +2,7 @@
 {% if page.object_list %}
 <figure class="client-table-wrap" data-total-clients="{{ page.paginator.count }}">
 <table role="grid" class="client-table" aria-label="{% blocktrans with clients=term.client_plural|default:'Participants' %}{{ clients }} list{% endblocktrans %}">
-    <thead>
-        <tr>
-            {% if show_bulk %}
-            <th scope="col" class="bulk-col">
-                <label class="visually-hidden" for="bulk-select-all">{% trans "Select all" %}</label>
-                <input type="checkbox" id="bulk-select-all" aria-label="{% trans 'Select all visible rows' %}">
-            </th>
-            {% endif %}
-            <th scope="col">
-                {% if sort_by == "name" or not sort_by %}
-                    <strong>{% trans "Name" %}</strong>
-                {% else %}
-                    <a href="?sort=name{% if status_filter %}&status={{ status_filter }}{% endif %}{% if program_filter %}&program={{ program_filter }}{% endif %}{% if search_query %}&q={{ search_query }}{% endif %}{% if editable_filter %}&editable={{ editable_filter }}{% endif %}"
-                       hx-get="{% url 'clients:client_list' %}?sort=name{% if status_filter %}&status={{ status_filter }}{% endif %}{% if program_filter %}&program={{ program_filter }}{% endif %}{% if search_query %}&q={{ search_query }}{% endif %}{% if editable_filter %}&editable={{ editable_filter }}{% endif %}"
-                       hx-target="#client-list-container"
-                       hx-indicator="#loading-bar"
-                       hx-push-url="true">{% trans "Name" %}</a>
-                {% endif %}
-            </th>
-            <th scope="col">{% trans "Record ID" %}</th>
-            <th scope="col">{% trans "Status" %}</th>
-            <th scope="col">{{ term.program_plural|default:"Programs" }}</th>
-            <th scope="col">
-                {% if sort_by == "last_contact" %}
-                    <strong>{% trans "Last Contact" %}</strong>
-                {% else %}
-                    <a href="?sort=last_contact{% if status_filter %}&status={{ status_filter }}{% endif %}{% if program_filter %}&program={{ program_filter }}{% endif %}{% if search_query %}&q={{ search_query }}{% endif %}{% if editable_filter %}&editable={{ editable_filter }}{% endif %}"
-                       hx-get="{% url 'clients:client_list' %}?sort=last_contact{% if status_filter %}&status={{ status_filter }}{% endif %}{% if program_filter %}&program={{ program_filter }}{% endif %}{% if search_query %}&q={{ search_query }}{% endif %}{% if editable_filter %}&editable={{ editable_filter }}{% endif %}"
-                       hx-target="#client-list-container"
-                       hx-indicator="#loading-bar"
-                       hx-push-url="true">{% trans "Last Contact" %}</a>
-                {% endif %}
-            </th>
-        </tr>
-    </thead>
+    {% include "clients/_client_thead.html" %}
     <tbody>
         {% for item in page %}
         {% include "clients/_client_row.html" %}

--- a/templates/clients/_client_list_table.html
+++ b/templates/clients/_client_list_table.html
@@ -39,42 +39,7 @@
     </thead>
     <tbody>
         {% for item in page %}
-        <tr>
-            {% if show_bulk %}
-            <td class="bulk-col">
-                <label class="visually-hidden" for="bulk-cb-{{ item.client.pk }}">{% blocktrans with name=item.name %}Select {{ name }}{% endblocktrans %}</label>
-                <input type="checkbox"
-                       class="bulk-select-row"
-                       id="bulk-cb-{{ item.client.pk }}"
-                       value="{{ item.client.pk }}"
-                       aria-label="{% blocktrans with name=item.name %}Select {{ name }}{% endblocktrans %}">
-            </td>
-            {% endif %}
-            <td><a href="{% url 'clients:client_detail' client_id=item.client.pk %}">{{ item.name }}</a>{% if item.can_edit_plan %} <span class="badge badge-edit-plan" title="{% trans 'You can edit plans for this participant' %}" aria-hidden="true">&#9998;</span><span class="sr-only">{% trans "Editable plan" %}</span>{% endif %}</td>
-            <td data-label="{% trans 'ID' %}">{{ item.client.record_id|default:"&mdash;" }}</td>
-            <td data-label="{% trans 'Status' %}">
-                {% if item.client.status == "active" %}
-                    <span class="badge badge-success"><span aria-hidden="true">&#x25CF;</span> {% trans "Active" %}</span>
-                {% elif item.client.status == "inactive" %}
-                    <span class="badge badge-warning"><span aria-hidden="true">&#x25CB;</span> {% trans "Inactive" %}</span>
-                {% else %}
-                    <span class="badge badge-neutral"><span aria-hidden="true">&#x2014;</span> {% trans "Discharged" %}</span>
-                {% endif %}
-            </td>
-            <td data-label="{{ term.program_plural|default:'Programs' }}">
-                {% for prog in item.programs %}
-                <span class="program-dot" style="background-color: {{ prog.colour_hex }}" aria-hidden="true"></span>{{ prog.translated_name }}{% if not forloop.last %}, {% endif %}
-                {% endfor %}
-            </td>
-            <td data-label="{% trans 'Last Contact' %}">
-                {% if item.last_contact %}
-                    {{ item.last_contact|date:"M j" }}
-                    <br><small style="color: var(--muted-color);">{{ item.last_contact|timesince }} {% trans "ago" %}</small>
-                {% else %}
-                    <span style="color: var(--muted-color);">{% trans "Never" %}</span>
-                {% endif %}
-            </td>
-        </tr>
+        {% include "clients/_client_row.html" %}
         {% endfor %}
     </tbody>
 </table>

--- a/templates/clients/_client_row.html
+++ b/templates/clients/_client_row.html
@@ -1,0 +1,36 @@
+{% load i18n %}<tr>
+    {% if show_bulk %}
+    <td class="bulk-col">
+        <label class="visually-hidden" for="bulk-cb-{{ item.client.pk }}">{% blocktrans with name=item.name %}Select {{ name }}{% endblocktrans %}</label>
+        <input type="checkbox"
+               class="bulk-select-row"
+               id="bulk-cb-{{ item.client.pk }}"
+               value="{{ item.client.pk }}"
+               aria-label="{% blocktrans with name=item.name %}Select {{ name }}{% endblocktrans %}">
+    </td>
+    {% endif %}
+    <td><a href="{% url 'clients:client_detail' client_id=item.client.pk %}">{{ item.name }}</a>{% if item.can_edit_plan %} <span class="badge badge-edit-plan" title="{% trans 'You can edit plans for this participant' %}" aria-hidden="true">&#9998;</span><span class="sr-only">{% trans "Editable plan" %}</span>{% endif %}</td>
+    <td data-label="{% trans 'ID' %}">{{ item.client.record_id|default:"&mdash;" }}</td>
+    <td data-label="{% trans 'Status' %}">
+        {% if item.client.status == "active" %}
+            <span class="badge badge-success"><span aria-hidden="true">&#x25CF;</span> {% trans "Active" %}</span>
+        {% elif item.client.status == "inactive" %}
+            <span class="badge badge-warning"><span aria-hidden="true">&#x25CB;</span> {% trans "Inactive" %}</span>
+        {% else %}
+            <span class="badge badge-neutral"><span aria-hidden="true">&#x2014;</span> {% trans "Discharged" %}</span>
+        {% endif %}
+    </td>
+    <td data-label="{{ term.program_plural|default:'Programs' }}">
+        {% for prog in item.programs %}
+        <span class="program-dot" style="background-color: {{ prog.colour_hex }}" aria-hidden="true"></span>{{ prog.translated_name }}{% if not forloop.last %}, {% endif %}
+        {% endfor %}
+    </td>
+    <td data-label="{% trans 'Last Contact' %}">
+        {% if item.last_contact %}
+            {{ item.last_contact|date:"M j" }}
+            <br><small style="color: var(--muted-color);">{{ item.last_contact|timesince }} {% trans "ago" %}</small>
+        {% else %}
+            <span style="color: var(--muted-color);">{% trans "Never" %}</span>
+        {% endif %}
+    </td>
+</tr>

--- a/templates/clients/_client_thead.html
+++ b/templates/clients/_client_thead.html
@@ -1,0 +1,35 @@
+{% load i18n %}<thead>
+    <tr>
+        {% if show_bulk %}
+        <th scope="col" class="bulk-col">
+            <label class="visually-hidden" for="{{ bulk_select_id|default:'bulk-select-all' }}">{% trans "Select all" %}</label>
+            <input type="checkbox" id="{{ bulk_select_id|default:'bulk-select-all' }}" class="bulk-select-all" aria-label="{% trans 'Select all visible rows' %}">
+        </th>
+        {% endif %}
+        <th scope="col">
+            {% if sort_by == "name" or not sort_by %}
+                <strong>{% trans "Name" %}</strong>
+            {% else %}
+                <a href="?sort=name{% if status_filter %}&status={{ status_filter }}{% endif %}{% if program_filter %}&program={{ program_filter }}{% endif %}{% if search_query %}&q={{ search_query }}{% endif %}{% if editable_filter %}&editable={{ editable_filter }}{% endif %}"
+                   hx-get="{% url 'clients:client_list' %}?sort=name{% if status_filter %}&status={{ status_filter }}{% endif %}{% if program_filter %}&program={{ program_filter }}{% endif %}{% if search_query %}&q={{ search_query }}{% endif %}{% if editable_filter %}&editable={{ editable_filter }}{% endif %}"
+                   hx-target="#client-list-container"
+                   hx-indicator="#loading-bar"
+                   hx-push-url="true">{% trans "Name" %}</a>
+            {% endif %}
+        </th>
+        <th scope="col">{% trans "Record ID" %}</th>
+        <th scope="col">{% trans "Status" %}</th>
+        <th scope="col">{{ term.program_plural|default:"Programs" }}</th>
+        <th scope="col">
+            {% if sort_by == "last_contact" %}
+                <strong>{% trans "Last Contact" %}</strong>
+            {% else %}
+                <a href="?sort=last_contact{% if status_filter %}&status={{ status_filter }}{% endif %}{% if program_filter %}&program={{ program_filter }}{% endif %}{% if search_query %}&q={{ search_query }}{% endif %}{% if editable_filter %}&editable={{ editable_filter }}{% endif %}"
+                   hx-get="{% url 'clients:client_list' %}?sort=last_contact{% if status_filter %}&status={{ status_filter }}{% endif %}{% if program_filter %}&program={{ program_filter }}{% endif %}{% if search_query %}&q={{ search_query }}{% endif %}{% if editable_filter %}&editable={{ editable_filter }}{% endif %}"
+                   hx-target="#client-list-container"
+                   hx-indicator="#loading-bar"
+                   hx-push-url="true">{% trans "Last Contact" %}</a>
+            {% endif %}
+        </th>
+    </tr>
+</thead>

--- a/templates/clients/list.html
+++ b/templates/clients/list.html
@@ -7,7 +7,11 @@
 <div class="page-header page-header--with-action">
     <div>
         <h1>{{ term.client_plural|default:"Participants" }}</h1>
+        {% if role_subtitle %}
+        <p>{{ role_subtitle }}</p>
+        {% else %}
         <p>{% blocktrans with client=term.client|default:"participant" %}All {{ client }} files you have access to.{% endblocktrans %}</p>
+        {% endif %}
     </div>
     {% if can_create %}
     <a href="{% url 'clients:client_create' %}" role="button" class="page-header__action">{% blocktrans with client=term.client|default:"Participant" %}New {{ client }}{% endblocktrans %}</a>
@@ -66,7 +70,7 @@
             </select>
         </div>
         {% endif %}
-        {% if has_plan_edit_programs %}
+        {% if has_plan_edit_programs and not has_mixed_roles %}
         <div class="filter-field">
             <label class="filter-checkbox">
                 <input type="checkbox"
@@ -92,7 +96,11 @@
 
 <!-- Client list container (updated via HTMX) -->
 <div id="client-list-container" aria-live="polite">
+    {% if has_mixed_roles %}
+    {% include "clients/_client_list_sections.html" %}
+    {% else %}
     {% include "clients/_client_list_table.html" %}
+    {% endif %}
 </div>
 
 {% if show_bulk %}

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -1784,3 +1784,114 @@ class BulkOperationsTest(TestCase):
         resp = self.client.get("/participants/?q=Unique")
         self.assertEqual(resp.status_code, 200)
         self.assertContains(resp, "Unique")
+
+
+@override_settings(FIELD_ENCRYPTION_KEY=TEST_KEY)
+class RoleBasedGroupingTest(TestCase):
+    """Tests for the mixed-role participant list grouping (caseload vs oversight)."""
+
+    databases = {"default", "audit"}
+
+    def setUp(self):
+        enc_module._fernet = None
+        self.client = Client()
+        self.prog_kitchen = Program.objects.create(name="Community Kitchen", colour_hex="#10B981")
+        self.prog_housing = Program.objects.create(name="Housing Stability", colour_hex="#F59E0B")
+
+        # Morgan: staff in Kitchen, PM in Housing — dual role
+        self.morgan = User.objects.create_user(username="morgan", password="testpass123")
+        UserProgramRole.objects.create(user=self.morgan, program=self.prog_kitchen, role="staff")
+        UserProgramRole.objects.create(user=self.morgan, program=self.prog_housing, role="program_manager")
+
+        # Single-role staff user
+        self.single_staff = User.objects.create_user(username="single_staff", password="testpass123")
+        UserProgramRole.objects.create(user=self.single_staff, program=self.prog_kitchen, role="staff")
+
+        # Single-role PM user
+        self.single_pm = User.objects.create_user(username="single_pm", password="testpass123")
+        UserProgramRole.objects.create(user=self.single_pm, program=self.prog_housing, role="program_manager")
+
+    def _create_client(self, first, last, programs):
+        from apps.clients.models import ClientFile, ClientProgramEnrolment
+        cf = ClientFile()
+        cf.first_name = first
+        cf.last_name = last
+        cf.status = "active"
+        cf.save()
+        for p in programs:
+            ClientProgramEnrolment.objects.create(client_file=cf, program=p)
+        return cf
+
+    def test_staff_only_user_sees_flat_list(self):
+        """Single-role staff user gets no section split."""
+        self._create_client("Alice", "A", [self.prog_kitchen])
+        self.client.login(username="single_staff", password="testpass123")
+        resp = self.client.get("/participants/")
+        self.assertEqual(resp.status_code, 200)
+        self.assertNotContains(resp, "Your caseload")
+        self.assertNotContains(resp, "Programs you manage")
+        self.assertContains(resp, "Alice")
+
+    def test_pm_only_user_sees_flat_list(self):
+        """Single-role PM user gets no section split."""
+        self._create_client("Bob", "B", [self.prog_housing])
+        self.client.login(username="single_pm", password="testpass123")
+        resp = self.client.get("/participants/")
+        self.assertEqual(resp.status_code, 200)
+        self.assertNotContains(resp, "Your caseload")
+        self.assertNotContains(resp, "Programs you manage")
+        self.assertContains(resp, "Bob")
+
+    def test_mixed_role_user_sees_two_sections(self):
+        """Dual-role user sees caseload and oversight sections."""
+        self._create_client("Caseload", "Client", [self.prog_kitchen])
+        self._create_client("Oversight", "Client", [self.prog_housing])
+        self.client.login(username="morgan", password="testpass123")
+        resp = self.client.get("/participants/")
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, "Your caseload")
+        self.assertContains(resp, "Programs you manage")
+        self.assertContains(resp, "Caseload")
+        self.assertContains(resp, "Oversight")
+
+    def test_participant_in_both_programs_goes_to_caseload(self):
+        """A participant in both a staff and PM program appears in caseload only."""
+        self._create_client("Both", "Programs", [self.prog_kitchen, self.prog_housing])
+        self._create_client("Only", "Housing", [self.prog_housing])
+        self.client.login(username="morgan", password="testpass123")
+        resp = self.client.get("/participants/")
+        content = resp.content.decode()
+        # "Both Programs" should be in caseload section (before oversight heading)
+        caseload_pos = content.find("caseload-heading")
+        oversight_pos = content.find("oversight-heading")
+        both_pos = content.find("Both")
+        self.assertGreater(both_pos, caseload_pos)
+        self.assertLess(both_pos, oversight_pos)
+
+    def test_htmx_returns_sections_for_mixed_role(self):
+        """HTMX request returns sections template for mixed-role user."""
+        self._create_client("Test", "Client", [self.prog_kitchen])
+        self.client.login(username="morgan", password="testpass123")
+        resp = self.client.get("/participants/", HTTP_HX_REQUEST="true")
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, "caseload-heading")
+        self.assertContains(resp, "oversight-heading")
+
+    def test_htmx_returns_flat_table_for_single_role(self):
+        """HTMX request returns flat table for single-role user."""
+        self._create_client("Test", "Client", [self.prog_kitchen])
+        self.client.login(username="single_staff", password="testpass123")
+        resp = self.client.get("/participants/", HTTP_HX_REQUEST="true")
+        self.assertEqual(resp.status_code, 200)
+        self.assertNotContains(resp, "caseload-heading")
+
+    def test_role_subtitle_shows_program_names(self):
+        """Mixed-role user sees role subtitle with program names."""
+        self._create_client("Test", "Client", [self.prog_kitchen])
+        self.client.login(username="morgan", password="testpass123")
+        resp = self.client.get("/participants/")
+        self.assertContains(resp, "Community Kitchen")
+        self.assertContains(resp, "Housing Stability")
+        # Subtitle contains role labels
+        self.assertContains(resp, "Staff in")
+        self.assertContains(resp, "Manager for")


### PR DESCRIPTION
## Summary

- When a user has both Staff and Program Manager roles across different programs, the participant list now splits into two sections: **"Your caseload"** (participants in staff programs) and **"Programs you manage"** (participants in PM-only programs)
- Adds a contextual subtitle showing the user's role per program (e.g. "Staff in Community Kitchen · Manager for Housing Stability")
- Hides the "Can edit plans" checkbox when the section structure makes it redundant
- Single-role users see the existing flat list — no visual change

## Context

Morgan Manager is Staff in Community Kitchen and Program Manager in Housing Stability. Previously the participant list showed a flat list with a tiny pencil icon for "can edit plans" — insufficient for training, orientation, and demo use. An expert panel recommended structural sections over icons/filters for self-describing UX.

## Changes

- **View** (`apps/clients/views.py`): Queries user's role-to-program mapping, splits `client_data` into caseload and oversight lists, section-aware pagination (caseload shows all, oversight paginates at 25)
- **Templates**: New `_client_list_sections.html` renders two `<section>` elements with `<h2>` headings and counts. Extracted `_client_row.html` as a shared row partial (DRY).
- **CSS**: Section heading styles
- **Translations**: French strings for all new UI text

## Test plan

- [ ] Deploy to dev VPS and verify with Morgan Manager demo account
- [ ] Confirm single-role users (e.g. staff-only) see unchanged flat list
- [ ] Confirm dual-role users see two sections with correct participants in each
- [ ] Confirm search works across both sections
- [ ] Confirm filters (status, program) apply to both sections
- [ ] Confirm pagination only appears on oversight section
- [ ] Confirm subtitle shows correct role-program mapping
- [ ] Screen reader test: sections navigable by heading

🤖 Generated with [Claude Code](https://claude.com/claude-code)