### PR TITLE
fix: clarify alert dismiss button on PM dashboard

### DIFF
--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -14559,6 +14559,15 @@ msgstr "%(count)d objectif(s) mis à jour"
 msgid "Dismiss for today"
 msgstr "Masquer pour aujourd'hui"
 
+msgid "Hide"
+msgstr "Masquer"
+
+msgid "Hide until tomorrow"
+msgstr "Masquer jusqu'à demain"
+
+msgid "Hiding an alert removes it from your view until tomorrow. It does not resolve the alert."
+msgstr "Masquer une alerte la retire de votre affichage jusqu'à demain. Cela ne résout pas l'alerte."
+
 msgid "Heads up:"
 msgstr "Attention :"
 

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -14568,6 +14568,9 @@ msgstr "Masquer jusqu'à demain"
 msgid "Hiding an alert removes it from your view until tomorrow. It does not resolve the alert."
 msgstr "Masquer une alerte la retire de votre affichage jusqu'à demain. Cela ne résout pas l'alerte."
 
+msgid "Hiding an item removes it from your view until tomorrow. It does not resolve it."
+msgstr "Masquer un élément le retire de votre affichage jusqu'à demain. Cela ne le résout pas."
+
 msgid "Heads up:"
 msgstr "Attention :"
 

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -954,7 +954,10 @@ output.form-output {
     font-style: italic;
 }
 .hide-today-btn {
-    all: unset;
+    border: none;
+    background: none;
+    padding: 0;
+    font: inherit;
     font-size: 0.75rem;
     color: var(--kn-text-muted);
     cursor: pointer;

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -947,6 +947,25 @@ output.form-output {
     padding-left: var(--kn-space-sm);
     margin-left: calc(-1 * var(--kn-space-sm));
 }
+.priority-hint {
+    font-size: 0.75rem;
+    color: var(--kn-text-muted);
+    margin: 0 0 var(--kn-space-xs) 0;
+    font-style: italic;
+}
+.hide-today-btn {
+    all: unset;
+    font-size: 0.75rem;
+    color: var(--kn-text-muted);
+    cursor: pointer;
+    white-space: nowrap;
+    text-decoration: underline;
+    text-decoration-style: dotted;
+}
+.hide-today-btn:hover,
+.hide-today-btn:focus-visible {
+    color: var(--kn-link-colour);
+}
 .empty-message {
     color: var(--kn-text-muted);
     font-size: 0.875rem;

--- a/templates/clients/home.html
+++ b/templates/clients/home.html
@@ -203,10 +203,10 @@
             <span class="badge badge-warning">{{ alert_count|add:needs_attention_count|add:follow_up_count }}</span>
             {% endif %}
         </header>
+        <p class="priority-hint">{% trans "Hiding an item removes it from your view until tomorrow. It does not resolve it." %}</p>
         {% if active_alerts %}
         <div class="priority-section">
             <h2 class="priority-label"><span class="stat-icon" aria-hidden="true">&#9888;</span> {% trans "Alerts" %}</h2>
-            <p class="priority-hint">{% trans "Hiding an alert removes it from your view until tomorrow. It does not resolve the alert." %}</p>
             <ul class="card-list">
                 {% for alert in active_alerts %}
                 <li class="priority-item priority-alert dismissable-item" data-dismiss-key="alert-{{ alert.pk }}">

--- a/templates/clients/home.html
+++ b/templates/clients/home.html
@@ -206,6 +206,7 @@
         {% if active_alerts %}
         <div class="priority-section">
             <h2 class="priority-label"><span class="stat-icon" aria-hidden="true">&#9888;</span> {% trans "Alerts" %}</h2>
+            <p class="priority-hint">{% trans "Hiding an alert removes it from your view until tomorrow. It does not resolve the alert." %}</p>
             <ul class="card-list">
                 {% for alert in active_alerts %}
                 <li class="priority-item priority-alert dismissable-item" data-dismiss-key="alert-{{ alert.pk }}">
@@ -214,7 +215,7 @@
                     </a>
                     <span class="priority-detail">{{ alert.content|truncatechars:40 }}</span>
                     <small class="secondary">{{ alert.created_at|date:"M j" }}</small>
-                    <button type="button" class="dismiss-btn outline secondary" aria-label="{% trans 'Dismiss' %}" title="{% trans 'Dismiss for today' %}">&times;</button>
+                    <button type="button" class="dismiss-btn hide-today-btn" aria-label="{% trans 'Hide until tomorrow' %}" title="{% trans 'Hide until tomorrow' %}">{% trans "Hide" %}</button>
                 </li>
                 {% endfor %}
             </ul>
@@ -231,7 +232,7 @@
                     </a>
                     <span class="priority-detail">{{ note.notes_text|truncatechars:40 }}</span>
                     <small class="secondary">{{ note.follow_up_date|date:"M j" }}</small>
-                    <button type="button" class="dismiss-btn outline secondary" aria-label="{% trans 'Dismiss' %}" title="{% trans 'Dismiss for today' %}">&times;</button>
+                    <button type="button" class="dismiss-btn hide-today-btn" aria-label="{% trans 'Hide until tomorrow' %}" title="{% trans 'Hide until tomorrow' %}">{% trans "Hide" %}</button>
                 </li>
                 {% endfor %}
             </ul>
@@ -245,7 +246,7 @@
                 <li class="priority-item dismissable-item" data-dismiss-key="attention-{{ item.client.pk }}">
                     <a href="{% url 'clients:client_detail' client_id=item.client.pk %}">{{ item.name }}</a>
                     <span class="priority-detail secondary">{% trans "30+ days without notes" %}</span>
-                    <button type="button" class="dismiss-btn outline secondary" aria-label="{% trans 'Dismiss' %}" title="{% trans 'Dismiss for today' %}">&times;</button>
+                    <button type="button" class="dismiss-btn hide-today-btn" aria-label="{% trans 'Hide until tomorrow' %}" title="{% trans 'Hide until tomorrow' %}">{% trans "Hide" %}</button>
                 </li>
                 {% endfor %}
             </ul>


### PR DESCRIPTION
## Summary
- Replaced the ambiguous `×` button on dashboard alerts with a visible "Hide" text link
- Added a hint below the Alerts heading: "Hiding an alert removes it from your view until tomorrow. It does not resolve the alert."
- Styled the "Hide" button as a subtle dotted-underline link so it doesn't compete visually with the alert content
- Added French translations for all new strings

## Test plan
- [ ] View the PM dashboard with active alerts — confirm "Hide" text appears instead of ×
- [ ] Hover over "Hide" — tooltip reads "Hide until tomorrow"
- [ ] Click "Hide" — alert disappears; refresh page — still hidden
- [ ] Wait until next day (or clear localStorage) — alert reappears
- [ ] Switch to French — confirm translated strings appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)