### PR TITLE
refactor: client list cleanup from simplify review

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -78,6 +78,7 @@ _All documentation tasks completed — see Recently Done._
 Scope is clear, just needs time. A session can pick these up without special approval.
 
 - [ ] Graduated privacy threshold (N=5 self-hosted, N=15 external) + focused theme analysis — managers type a question, AI searches suggestions for relevant patterns. Includes DRR updates. See [tasks/focused-theme-analysis.md](tasks/focused-theme-analysis.md) — GK approved (AI-FOCUSED-THEME1)
+- [ ] Extract role string constants (ROLE_STAFF, ROLE_PROGRAM_MANAGER, etc.) into auth_app/constants.py — 400+ raw string literals across the codebase use "staff", "program_manager" etc. (REFACTOR1)
 
 ## Parking Lot: Needs Review
 

--- a/apps/clients/views.py
+++ b/apps/clients/views.py
@@ -416,9 +416,7 @@ def client_list(request):
         )
         context.update({
             "caseload_data": caseload_data,
-            "caseload_count": len(caseload_data),
             "oversight_page": oversight_page,
-            "oversight_count": len(oversight_data),
             "staff_program_label": staff_label,
             "pm_program_label": pm_label,
             "role_subtitle": _("Staff in %(staff)s \u00b7 Manager for %(pm)s") % {

--- a/templates/clients/_client_list_sections.html
+++ b/templates/clients/_client_list_sections.html
@@ -6,10 +6,10 @@
 {# ── Section 1: Your caseload ── #}
 <section aria-labelledby="caseload-heading" class="client-list-section">
     <h2 id="caseload-heading" class="section-heading">
-        {% blocktrans with programs=staff_program_label total=caseload_count %}Your caseload — {{ programs }} ({{ total }}){% endblocktrans %}
+        {% blocktrans with programs=staff_program_label total=caseload_data|length %}Your caseload — {{ programs }} ({{ total }}){% endblocktrans %}
     </h2>
     {% if caseload_data %}
-    <figure class="client-table-wrap" data-total-clients="{{ caseload_count }}">
+    <figure class="client-table-wrap" data-total-clients="{{ caseload_data|length }}">
     <table role="grid" class="client-table" aria-label="{% trans 'Your caseload' %}">
         {% include "clients/_client_thead.html" with bulk_select_id="bulk-select-caseload" %}
         <tbody>
@@ -27,10 +27,10 @@
 {# ── Section 2: Programs you manage ── #}
 <section aria-labelledby="oversight-heading" class="client-list-section">
     <h2 id="oversight-heading" class="section-heading">
-        {% blocktrans with programs=pm_program_label total=oversight_count %}Programs you manage — {{ programs }} ({{ total }}){% endblocktrans %}
+        {% blocktrans with programs=pm_program_label total=oversight_page.paginator.count %}Programs you manage — {{ programs }} ({{ total }}){% endblocktrans %}
     </h2>
     {% if oversight_page.object_list %}
-    <figure class="client-table-wrap" data-total-clients="{{ oversight_count }}">
+    <figure class="client-table-wrap" data-total-clients="{{ oversight_page.paginator.count }}">
     <table role="grid" class="client-table" aria-label="{% trans 'Programs you manage' %}">
         {% include "clients/_client_thead.html" with bulk_select_id="bulk-select-oversight" %}
         <tbody>

--- a/templates/clients/_client_list_sections.html
+++ b/templates/clients/_client_list_sections.html
@@ -41,25 +41,7 @@
     </table>
     </figure>
 
-    {% if oversight_page.has_other_pages %}
-    <nav class="pagination" aria-label="{% trans 'Pagination' %}">
-        {% if oversight_page.has_previous %}
-        <a href="?page={{ oversight_page.previous_page_number }}{% if sort_by %}&sort={{ sort_by }}{% endif %}{% if status_filter %}&status={{ status_filter }}{% endif %}{% if program_filter %}&program={{ program_filter }}{% endif %}{% if editable_filter %}&editable={{ editable_filter }}{% endif %}{% if search_query %}&q={{ search_query }}{% endif %}"
-           hx-get="{% url 'clients:client_list' %}?page={{ oversight_page.previous_page_number }}{% if sort_by %}&sort={{ sort_by }}{% endif %}{% if status_filter %}&status={{ status_filter }}{% endif %}{% if program_filter %}&program={{ program_filter }}{% endif %}{% if editable_filter %}&editable={{ editable_filter }}{% endif %}{% if search_query %}&q={{ search_query }}{% endif %}"
-           hx-target="#client-list-container"
-           hx-indicator="#loading-bar"
-           hx-push-url="true">{% trans "Previous" %}</a>
-        {% endif %}
-        {% blocktrans with current=oversight_page.number total=oversight_page.paginator.num_pages %}Page {{ current }} of {{ total }}{% endblocktrans %}
-        {% if oversight_page.has_next %}
-        <a href="?page={{ oversight_page.next_page_number }}{% if sort_by %}&sort={{ sort_by }}{% endif %}{% if status_filter %}&status={{ status_filter }}{% endif %}{% if program_filter %}&program={{ program_filter }}{% endif %}{% if editable_filter %}&editable={{ editable_filter }}{% endif %}{% if search_query %}&q={{ search_query }}{% endif %}"
-           hx-get="{% url 'clients:client_list' %}?page={{ oversight_page.next_page_number }}{% if sort_by %}&sort={{ sort_by }}{% endif %}{% if status_filter %}&status={{ status_filter }}{% endif %}{% if program_filter %}&program={{ program_filter }}{% endif %}{% if editable_filter %}&editable={{ editable_filter }}{% endif %}{% if search_query %}&q={{ search_query }}{% endif %}"
-           hx-target="#client-list-container"
-           hx-indicator="#loading-bar"
-           hx-push-url="true">{% trans "Next" %}</a>
-        {% endif %}
-    </nav>
-    {% endif %}
+    {% include "clients/_client_pagination.html" with page=oversight_page %}
 
     {% else %}
     <p class="empty-message"><em>{% trans "No participants in managed programs match the current filters." %}</em></p>

--- a/templates/clients/_client_list_table.html
+++ b/templates/clients/_client_list_table.html
@@ -11,25 +11,7 @@
 </table>
 </figure>
 
-{% if page.has_other_pages %}
-<nav class="pagination" aria-label="{% trans 'Pagination' %}">
-    {% if page.has_previous %}
-    <a href="?page={{ page.previous_page_number }}{% if sort_by %}&sort={{ sort_by }}{% endif %}{% if status_filter %}&status={{ status_filter }}{% endif %}{% if program_filter %}&program={{ program_filter }}{% endif %}{% if editable_filter %}&editable={{ editable_filter }}{% endif %}"
-       hx-get="{% url 'clients:client_list' %}?page={{ page.previous_page_number }}{% if sort_by %}&sort={{ sort_by }}{% endif %}{% if status_filter %}&status={{ status_filter }}{% endif %}{% if program_filter %}&program={{ program_filter }}{% endif %}{% if editable_filter %}&editable={{ editable_filter }}{% endif %}"
-       hx-target="#client-list-container"
-       hx-indicator="#loading-bar"
-       hx-push-url="true">{% trans "Previous" %}</a>
-    {% endif %}
-    {% blocktrans with current=page.number total=page.paginator.num_pages %}Page {{ current }} of {{ total }}{% endblocktrans %}
-    {% if page.has_next %}
-    <a href="?page={{ page.next_page_number }}{% if sort_by %}&sort={{ sort_by }}{% endif %}{% if status_filter %}&status={{ status_filter }}{% endif %}{% if program_filter %}&program={{ program_filter }}{% endif %}{% if editable_filter %}&editable={{ editable_filter }}{% endif %}"
-       hx-get="{% url 'clients:client_list' %}?page={{ page.next_page_number }}{% if sort_by %}&sort={{ sort_by }}{% endif %}{% if status_filter %}&status={{ status_filter }}{% endif %}{% if program_filter %}&program={{ program_filter }}{% endif %}{% if editable_filter %}&editable={{ editable_filter }}{% endif %}"
-       hx-target="#client-list-container"
-       hx-indicator="#loading-bar"
-       hx-push-url="true">{% trans "Next" %}</a>
-    {% endif %}
-</nav>
-{% endif %}
+{% include "clients/_client_pagination.html" %}
 
 {% else %}
 <div class="empty-state">

--- a/templates/clients/_client_pagination.html
+++ b/templates/clients/_client_pagination.html
@@ -1,0 +1,22 @@
+{% load i18n %}
+{# Shared pagination nav for client list templates. #}
+{# Include with: {% include "clients/_client_pagination.html" with page=your_page_obj %} #}
+{% if page.has_other_pages %}
+<nav class="pagination" aria-label="{% trans 'Pagination' %}">
+    {% if page.has_previous %}
+    <a href="?page={{ page.previous_page_number }}{% if sort_by %}&sort={{ sort_by }}{% endif %}{% if status_filter %}&status={{ status_filter }}{% endif %}{% if program_filter %}&program={{ program_filter }}{% endif %}{% if editable_filter %}&editable={{ editable_filter }}{% endif %}{% if search_query %}&q={{ search_query }}{% endif %}"
+       hx-get="{% url 'clients:client_list' %}?page={{ page.previous_page_number }}{% if sort_by %}&sort={{ sort_by }}{% endif %}{% if status_filter %}&status={{ status_filter }}{% endif %}{% if program_filter %}&program={{ program_filter }}{% endif %}{% if editable_filter %}&editable={{ editable_filter }}{% endif %}{% if search_query %}&q={{ search_query }}{% endif %}"
+       hx-target="#client-list-container"
+       hx-indicator="#loading-bar"
+       hx-push-url="true">{% trans "Previous" %}</a>
+    {% endif %}
+    {% blocktrans with current=page.number total=page.paginator.num_pages %}Page {{ current }} of {{ total }}{% endblocktrans %}
+    {% if page.has_next %}
+    <a href="?page={{ page.next_page_number }}{% if sort_by %}&sort={{ sort_by }}{% endif %}{% if status_filter %}&status={{ status_filter }}{% endif %}{% if program_filter %}&program={{ program_filter }}{% endif %}{% if editable_filter %}&editable={{ editable_filter }}{% endif %}{% if search_query %}&q={{ search_query }}{% endif %}"
+       hx-get="{% url 'clients:client_list' %}?page={{ page.next_page_number }}{% if sort_by %}&sort={{ sort_by }}{% endif %}{% if status_filter %}&status={{ status_filter }}{% endif %}{% if program_filter %}&program={{ program_filter }}{% endif %}{% if editable_filter %}&editable={{ editable_filter }}{% endif %}{% if search_query %}&q={{ search_query }}{% endif %}"
+       hx-target="#client-list-container"
+       hx-indicator="#loading-bar"
+       hx-push-url="true">{% trans "Next" %}</a>
+    {% endif %}
+</nav>
+{% endif %}


### PR DESCRIPTION
## Summary

Follow-up cleanup from the `/simplify` review of PR #333 (role-based participant list grouping).

- **Extract shared pagination partial** — `_client_pagination.html` replaces duplicated pagination nav blocks in `_client_list_table.html` and `_client_list_sections.html`. Also fixes a bug where the flat table pagination was missing `search_query` params (filters dropped on page change).
- **Remove redundant count context vars** — `caseload_count` and `oversight_count` replaced with `caseload_data|length` and `oversight_page.paginator.count` in templates.
- **Add role constants refactoring to parking lot** — 400+ raw string literals flagged for future cleanup (REFACTOR1 in TODO.md).

## Test plan

- [ ] Verify flat participant list pagination preserves search query across pages
- [ ] Verify oversight section pagination preserves all filters
- [ ] Verify section headings show correct counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)