### PR TITLE
fix: all-programs report respects HTML export format

### DIFF
--- a/apps/reports/views.py
+++ b/apps/reports/views.py
@@ -1449,7 +1449,44 @@ def funder_report_approve(request):
     safe_fy = sanitise_filename(fiscal_year_label.replace(" ", "_"))
 
     try:
-        if all_programs_mode:
+        if all_programs_mode and export_format == "html":
+            from .pdf_utils import render_html_string
+            total_served = sum(
+                rd.get("total_individuals_served", 0)
+                for _, rd in data_or_sections
+                if isinstance(rd.get("total_individuals_served"), int)
+            )
+            total_new = sum(
+                rd.get("new_clients_this_period", 0)
+                for _, rd in data_or_sections
+                if isinstance(rd.get("new_clients_this_period"), int)
+            )
+            total_contacts = sum(
+                rd.get("total_contacts", 0) for _, rd in data_or_sections
+            )
+            programs_list = [
+                {"name": ap.name, "report_data": rd}
+                for ap, rd in data_or_sections
+            ]
+            html_context = {
+                "organisation_name": str(program_display_name),
+                "fiscal_year_label": fiscal_year_label,
+                "date_from": date_from,
+                "date_to": date_to,
+                "generated_at": timezone.now().strftime("%Y-%m-%d"),
+                "generated_by": request.user.display_name,
+                "agency_notes": agency_notes,
+                "total_served": total_served,
+                "total_new_clients": total_new,
+                "total_contacts": total_contacts,
+                "programs": programs_list,
+            }
+            content = render_html_string(
+                "reports/html_report_all_programs.html", html_context,
+            )
+            filename = f"Reporting_Template_Report_{safe_name}_{safe_fy}.html"
+        elif all_programs_mode:
+            # All-programs CSV (default for CSV and PDF fallback)
             csv_buffer = io.StringIO()
             writer = csv.writer(csv_buffer)
             # Agency notes header

--- a/templates/reports/html_report_all_programs.html
+++ b/templates/reports/html_report_all_programs.html
@@ -1,0 +1,496 @@
+{% load i18n %}{% get_current_language as LANGUAGE_CODE %}<!DOCTYPE html>
+<html lang="{{ LANGUAGE_CODE }}">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{% trans "All Programs — Organisation Summary" %}</title>
+    <style>
+        * { box-sizing: border-box; }
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+            font-size: 14px;
+            line-height: 1.6;
+            color: #1a202c;
+            margin: 0;
+            padding: 2rem;
+            max-width: 900px;
+            margin-left: auto;
+            margin-right: auto;
+            background-color: #ffffff;
+        }
+
+        @media print {
+            body { padding: 0; max-width: none; }
+            .no-print { display: none; }
+            details > summary { display: none; }
+            details > *:not(summary) { display: block !important; }
+            .program-section { page-break-before: always; }
+            .program-section:first-of-type { page-break-before: auto; }
+        }
+
+        .sr-only {
+            position: absolute; width: 1px; height: 1px;
+            padding: 0; margin: -1px; overflow: hidden;
+            clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0;
+        }
+
+        /* Report header */
+        .pdf-header {
+            border-bottom: 3px solid #3176aa;
+            padding-bottom: 0.6rem;
+            margin-bottom: 1rem;
+        }
+        .pdf-header h1 {
+            font-size: 1.5rem;
+            margin: 0 0 0.25rem 0;
+            color: #3176aa;
+        }
+        .pdf-header .subtitle {
+            font-size: 1.1rem;
+            color: #4a5568;
+            margin-bottom: 0.5rem;
+        }
+        .pdf-header .meta-grid {
+            display: grid;
+            grid-template-columns: auto 1fr;
+            gap: 0.1rem 0.8rem;
+            font-size: 0.85rem;
+            color: #718096;
+        }
+        .pdf-header .meta-grid dt {
+            font-weight: 600;
+            color: #4a5568;
+        }
+        .pdf-header .meta-grid dd { margin: 0; }
+
+        /* Table of contents */
+        .report-toc {
+            margin: 1rem 0;
+            padding: 0.6rem 1rem;
+            background-color: #f7f8fa;
+            border-radius: 4px;
+            font-size: 0.85rem;
+        }
+        .report-toc h2 {
+            font-size: 0.9rem;
+            margin: 0 0 0.3rem 0;
+            border: none;
+            color: #4a5568;
+        }
+        .report-toc ol {
+            margin: 0;
+            padding-left: 1.5rem;
+        }
+        .report-toc li { margin-bottom: 0.15rem; }
+        .report-toc a {
+            color: #3176aa;
+            text-decoration: none;
+        }
+        .report-toc a:hover { text-decoration: underline; }
+
+        /* Collapsible section headers */
+        details { margin-top: 1.5rem; }
+        summary.report-header-bar {
+            list-style: none;
+            cursor: pointer;
+            user-select: none;
+        }
+        summary.report-header-bar::-webkit-details-marker { display: none; }
+        summary.report-header-bar::marker { display: none; }
+        summary.report-header-bar::after {
+            content: " \25BE";
+            float: right;
+            transition: transform 0.2s;
+        }
+        details:not([open]) > summary.report-header-bar::after {
+            transform: rotate(-90deg);
+            display: inline-block;
+        }
+
+        .report-header-bar {
+            background-color: #3176aa;
+            color: #ffffff;
+            padding: 0.4rem 0.8rem;
+            margin-top: 1.5rem;
+            font-size: 14px;
+            font-weight: 600;
+            border-radius: 4px 4px 0 0;
+        }
+
+        h2 {
+            font-size: 1.3rem;
+            color: #3176aa;
+            border-bottom: 2px solid #3176aa;
+            padding-bottom: 0.3rem;
+            margin-top: 1.5rem;
+        }
+        h3 {
+            font-size: 1.1rem;
+            color: #1a202c;
+            margin-top: 1rem;
+        }
+
+        /* Stat boxes */
+        .stat-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+            gap: 0.8rem;
+            margin: 0.8rem 0;
+        }
+        .stat-box {
+            border: 1px solid #d1d5db;
+            border-radius: 6px;
+            padding: 1rem;
+            text-align: center;
+        }
+        .stat-box .value {
+            font-size: 1.8rem;
+            font-weight: 700;
+            color: #3176aa;
+        }
+        .stat-box .label {
+            font-size: 0.8rem;
+            color: #718096;
+            margin-top: 0.2rem;
+        }
+
+        /* Tables */
+        table {
+            width: 100%;
+            border-collapse: collapse;
+            margin: 0.8rem 0;
+            font-size: 0.9rem;
+        }
+        thead th {
+            background-color: #3176aa;
+            color: #ffffff;
+            padding: 8px 12px;
+            text-align: left;
+            font-weight: 600;
+        }
+        tbody td {
+            padding: 6px 12px;
+            border-bottom: 1px solid #e5e7eb;
+        }
+        tbody tr:nth-child(even) { background-color: #f7f8fa; }
+
+        /* Outcome cards */
+        .outcome-card {
+            border: 2px solid #3176aa;
+            border-radius: 6px;
+            padding: 1rem;
+            margin: 0.5rem 0;
+        }
+        .outcome-card h4 {
+            margin: 0 0 0.3rem 0;
+            color: #3176aa;
+        }
+        .outcome-card .rate {
+            font-size: 2rem;
+            font-weight: 700;
+            color: #3176aa;
+        }
+        .outcome-card .details {
+            font-size: 0.85rem;
+            color: #4a5568;
+            margin-top: 0.3rem;
+        }
+
+        /* Achievement progress bar */
+        .achievement-bar {
+            background-color: #e5e7eb;
+            height: 10px;
+            border-radius: 5px;
+            margin-top: 0.4rem;
+            overflow: hidden;
+        }
+        .achievement-bar-fill {
+            background-color: #3176aa;
+            height: 100%;
+            border-radius: 5px;
+            transition: width 0.3s;
+        }
+        td .achievement-bar {
+            height: 6px;
+            margin-top: 2px;
+            min-width: 60px;
+        }
+
+        /* Demographic rows and bars */
+        .demo-row {
+            display: grid;
+            grid-template-columns: 1fr 80px 80px;
+            padding: 6px 12px;
+            border-bottom: 1px solid #e5e7eb;
+        }
+        .demo-row.header {
+            background-color: #f7f8fa;
+            font-weight: 600;
+        }
+        .demo-bar {
+            background-color: #e5e7eb;
+            height: 8px;
+            border-radius: 4px;
+            margin-top: 4px;
+            overflow: hidden;
+        }
+        .demo-bar-fill {
+            background-color: #3176aa;
+            height: 100%;
+            border-radius: 4px;
+        }
+
+        /* Summary cards */
+        .summary-grid {
+            display: grid;
+            grid-template-columns: 1fr 1fr;
+            gap: 0.8rem;
+            margin: 0.8rem 0;
+        }
+        .summary-card {
+            border: 1px solid #d1d5db;
+            border-radius: 6px;
+            padding: 1rem;
+            text-align: center;
+        }
+        .summary-card .number {
+            font-size: 1.5rem;
+            font-weight: 700;
+            color: #3176aa;
+        }
+        .summary-card .label {
+            font-size: 0.8rem;
+            color: #718096;
+        }
+
+        /* Program section dividers */
+        .program-section {
+            margin-top: 2rem;
+            border-top: 3px solid #3176aa;
+            padding-top: 1rem;
+        }
+        .program-section:first-of-type {
+            border-top: none;
+            margin-top: 1rem;
+        }
+        .program-section-title {
+            font-size: 1.2rem;
+            font-weight: 700;
+            color: #3176aa;
+            margin-bottom: 0.5rem;
+        }
+
+        /* Footer */
+        .footer-note {
+            font-size: 0.85rem;
+            color: #718096;
+            font-style: italic;
+            margin-top: 2rem;
+            padding-top: 0.5rem;
+            border-top: 1px solid #e5e7eb;
+        }
+        .generated-by {
+            font-size: 0.8rem;
+            color: #a0aec0;
+            margin-top: 1rem;
+            text-align: right;
+        }
+    </style>
+</head>
+<body>
+<!-- Report Header -->
+<div class="pdf-header">
+    <h1>{% trans "All Programs — Organisation Summary" %}</h1>
+    <div class="subtitle">{{ organisation_name }}</div>
+    <dl class="meta-grid">
+        <dt>{% trans "Organisation" %}</dt>
+        <dd>{{ organisation_name }}</dd>
+        <dt>{% trans "Fiscal Year" %}</dt>
+        <dd>{{ fiscal_year_label }}</dd>
+        <dt>{% trans "Period" %}</dt>
+        <dd>{{ date_from }} {% trans "to" %} {{ date_to }}</dd>
+        <dt>{% trans "Generated" %}</dt>
+        <dd>{{ generated_at }} {% trans "by" %} {{ generated_by }}</dd>
+        <dt>{% trans "Programs Included" %}</dt>
+        <dd>{{ programs|length }}</dd>
+    </dl>
+</div>
+
+{% if agency_notes %}
+<div class="report-header-bar">{% trans "Agency Notes" %}</div>
+<div style="padding: 0.8rem 1rem; background-color: #f7f8fa; border: 1px solid #d1d5db; border-top: none; border-radius: 0 0 4px 4px;">
+    <p>{{ agency_notes }}</p>
+</div>
+{% endif %}
+
+<!-- Organisation-wide summary -->
+<div class="report-header-bar">{% trans "Organisation Summary" %}</div>
+<div class="stat-grid">
+    <div class="stat-box">
+        <div class="value">{{ total_served }}</div>
+        <div class="label">{% trans "Total Individuals Served" %}</div>
+    </div>
+    <div class="stat-box">
+        <div class="value">{{ total_new_clients }}</div>
+        <div class="label">{% trans "New Participants This Period" %}</div>
+    </div>
+    <div class="stat-box">
+        <div class="value">{{ total_contacts }}</div>
+        <div class="label">{% trans "Total Service Contacts" %}</div>
+    </div>
+    <div class="stat-box">
+        <div class="value">{{ programs|length }}</div>
+        <div class="label">{% trans "Programs" %}</div>
+    </div>
+</div>
+
+<!-- Table of contents -->
+{% if programs|length >= 3 %}
+<nav class="report-toc no-print" aria-label="{% trans 'Programs in this report' %}">
+    <h2>{% trans "Programs" %}</h2>
+    <ol>
+    {% for prog in programs %}
+        <li><a href="#program-{{ forloop.counter }}">{{ prog.name }}</a></li>
+    {% endfor %}
+    </ol>
+</nav>
+{% endif %}
+
+<!-- Per-program sections -->
+{% for prog in programs %}
+<div class="program-section" id="program-{{ forloop.counter }}">
+    <div class="program-section-title">{{ prog.name }}</div>
+
+    <div class="stat-grid">
+        <div class="stat-box">
+            <div class="value">{{ prog.report_data.total_individuals_served|default:"0" }}</div>
+            <div class="label">{% trans "Total Individuals Served" %}</div>
+        </div>
+        <div class="stat-box">
+            <div class="value">{{ prog.report_data.new_clients_this_period|default:"0" }}</div>
+            <div class="label">{% trans "New Participants This Period" %}</div>
+        </div>
+        <div class="stat-box">
+            <div class="value">{{ prog.report_data.total_contacts|default:"0" }}</div>
+            <div class="label">{% trans "Total Service Contacts" %}</div>
+        </div>
+    </div>
+
+    {% if prog.report_data.age_demographics %}
+    <details open>
+    <summary class="report-header-bar">{% trans "Age Demographics" %} &mdash; {{ prog.report_data.age_demographics_total }} {% trans "participants" %}</summary>
+    <div style="margin: 0.8rem 0;">
+        <div class="demo-row header">
+            <div>{% trans "Age Group" %}</div>
+            <div style="text-align: right;">{% trans "Count" %}</div>
+            <div style="text-align: right;">{% trans "Percentage" %}</div>
+        </div>
+        {% for age_group, count in prog.report_data.age_demographics.items %}
+        <div class="demo-row">
+            <div>
+                {{ age_group }}
+                {% if prog.report_data.age_demographics_total > 0 %}
+                <div class="demo-bar" role="progressbar" aria-valuenow="{% widthratio count prog.report_data.age_demographics_total 100 %}" aria-valuemin="0" aria-valuemax="100" aria-label="{{ age_group }}">
+                    <div class="demo-bar-fill" style="width: {% widthratio count prog.report_data.age_demographics_total 100 %}%;"></div>
+                </div>
+                {% endif %}
+            </div>
+            <div style="text-align: right;">{{ count }}</div>
+            <div style="text-align: right;">
+                {% if prog.report_data.age_demographics_total > 0 %}
+                {% widthratio count prog.report_data.age_demographics_total 100 %}%
+                {% else %}
+                {% trans "N/A" %}
+                {% endif %}
+            </div>
+        </div>
+        {% endfor %}
+        <div class="demo-row header">
+            <div>{% trans "Total" %}</div>
+            <div style="text-align: right;">{{ prog.report_data.age_demographics_total }}</div>
+            <div style="text-align: right;">100%</div>
+        </div>
+    </div>
+    </details>
+    {% endif %}
+
+    {% if prog.report_data.primary_outcome %}
+    <details open>
+    <summary class="report-header-bar">{% trans "Outcome Indicators" %}</summary>
+    <h4 style="margin-top: 0.5rem;">{% trans "Primary Outcome" %}</h4>
+    <div class="outcome-card">
+        <h4>{{ prog.report_data.primary_outcome.name }}</h4>
+        <div class="rate">{{ prog.report_data.primary_outcome.achievement_rate }}%</div>
+        <div class="achievement-bar" role="progressbar" aria-valuenow="{{ prog.report_data.primary_outcome.achievement_rate }}" aria-valuemin="0" aria-valuemax="100" aria-label="{{ prog.report_data.primary_outcome.name }}">
+            <div class="achievement-bar-fill" style="width: {{ prog.report_data.primary_outcome.achievement_rate }}%;"></div>
+        </div>
+        <div class="details">
+            <strong>{% trans "Target:" %}</strong> {{ prog.report_data.primary_outcome.target_value }}<br>
+            <strong>{% trans "Clients Measured:" %}</strong> {{ prog.report_data.primary_outcome.clients_measured }}<br>
+            <strong>{% trans "Clients Achieving Target:" %}</strong> {% blocktrans with achieved=prog.report_data.primary_outcome.clients_achieved measured=prog.report_data.primary_outcome.clients_measured %}{{ achieved }} of {{ measured }}{% endblocktrans %}
+        </div>
+    </div>
+
+    {% if prog.report_data.secondary_outcomes %}
+    <h4>{% trans "Secondary Outcomes" %}</h4>
+    <table>
+        <thead>
+            <tr>
+                <th scope="col">{% trans "Indicator Name" %}</th>
+                <th scope="col">{% trans "Target" %}</th>
+                <th scope="col">{% trans "Measured" %}</th>
+                <th scope="col">{% trans "Achieved" %}</th>
+                <th scope="col">{% trans "Rate" %}</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for outcome in prog.report_data.secondary_outcomes %}
+            <tr>
+                <td>{{ outcome.name }}</td>
+                <td>{{ outcome.target_value }}</td>
+                <td>{{ outcome.clients_measured }}</td>
+                <td>{{ outcome.clients_achieved }}</td>
+                <td>
+                    {{ outcome.achievement_rate }}%
+                    <div class="achievement-bar" role="progressbar" aria-valuenow="{{ outcome.achievement_rate }}" aria-valuemin="0" aria-valuemax="100">
+                        <div class="achievement-bar-fill" style="width: {{ outcome.achievement_rate }}%;"></div>
+                    </div>
+                </td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    {% endif %}
+    </details>
+    {% endif %}
+
+    {% if prog.report_data.achievement_summary.total_clients > 0 %}
+    <div class="report-header-bar">{% trans "Program Summary" %}</div>
+    <div class="summary-grid">
+        <div class="summary-card">
+            <div class="number">{{ prog.report_data.achievement_summary.overall_rate }}%</div>
+            <div class="achievement-bar" role="progressbar" aria-valuenow="{{ prog.report_data.achievement_summary.overall_rate }}" aria-valuemin="0" aria-valuemax="100" aria-label="{% trans 'Overall achievement rate' %}">
+                <div class="achievement-bar-fill" style="width: {{ prog.report_data.achievement_summary.overall_rate }}%;"></div>
+            </div>
+            <div class="label">{% trans "Overall Achievement Rate" %}</div>
+        </div>
+        <div class="summary-card">
+            <div class="number">{{ prog.report_data.achievement_summary.clients_met_any_target }} / {{ prog.report_data.achievement_summary.total_clients }}</div>
+            <div class="label">{% trans "Participants Met at Least One Target" %}</div>
+        </div>
+    </div>
+    {% endif %}
+</div>
+{% endfor %}
+
+<div class="footer-note">
+    {% trans "This report was generated using KoNote's All Programs Organisation Summary." %}
+    {% blocktrans with fy=fiscal_year_label %}Data reflects client outcomes recorded during the {{ fy }} reporting period.{% endblocktrans %}
+    {% blocktrans with count=programs|length %}Includes data from {{ count }} program(s).{% endblocktrans %}
+</div>
+
+<div class="generated-by">
+    {% trans "Generated by KoNote" %}
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- **Bug:** Selecting HTML format for "Organization — All Programs Quarterly Summary" produced a plain CSV dump instead of the styled interactive HTML report
- **Cause:** The `all_programs_mode` branch in `funder_report_approve` (line 1452) unconditionally generated CSV, ignoring the `export_format` parameter. The `elif` chain for PDF/HTML was unreachable.
- **Fix:** Restructured the if/elif chain so `all_programs_mode + html` renders through a new `html_report_all_programs.html` template with the same interactive styling as single-program reports (stat boxes, progress bars, collapsible demographics, outcome cards)

## Test plan

- [ ] Select "Organization — All Programs Quarterly Summary" with HTML format and verify styled output
- [ ] Verify single-program HTML export still works unchanged
- [ ] Verify all-programs CSV export still works unchanged
- [ ] Verify single-program PDF export still works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)