### PR TITLE
chore: session 13 review follow-ups

### DIFF
--- a/apps/reports/views.py
+++ b/apps/reports/views.py
@@ -1460,8 +1460,8 @@ def funder_report_approve(request):
                 "reports/html_report_all_programs.html", html_context,
             )
             filename = f"Reporting_Template_Report_{safe_name}_{safe_fy}.html"
-        elif all_programs_mode:
-            # All-programs CSV (covers CSV, PDF, and any other format)
+        elif all_programs_mode and export_format == "csv":
+            # All-programs CSV
             csv_buffer = io.StringIO()
             writer = csv.writer(csv_buffer)
             # Agency notes header
@@ -1487,6 +1487,9 @@ def funder_report_approve(request):
                 writer.writerow([])
             filename = f"Reporting_Template_Report_{safe_name}_{safe_fy}.csv"
             content = csv_buffer.getvalue()
+        elif all_programs_mode:
+            # Unsupported format for all-programs (form should block this)
+            raise ValueError(f"Unsupported export format for All Programs: {export_format}")
         elif export_format == "pdf":
             from .pdf_views import generate_funder_report_pdf
             report_data = data_or_sections

--- a/templates/reports/html_report_all_programs.html
+++ b/templates/reports/html_report_all_programs.html
@@ -31,6 +31,9 @@
             font-weight: 700;
             color: #3176aa;
             margin-bottom: 0.5rem;
+            margin-top: 0;
+            border-bottom: none;
+            padding-bottom: 0;
         }
     </style>
 </head>
@@ -96,7 +99,7 @@
 <!-- Per-program sections -->
 {% for prog in programs %}
 <div class="program-section" id="program-{{ forloop.counter }}">
-    <div class="program-section-title">{{ prog.name }}</div>
+    <h2 class="program-section-title">{{ prog.name }}</h2>
 
     <div class="stat-grid">
         <div class="stat-box">

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -1926,6 +1926,53 @@ class FunderReportViewTests(TestCase):
         self.assertEqual(resp["Location"], "/reports/funder-report/")
 
 
+
+class AggregateAllProgramsTotalsTest(TestCase):
+    """Tests for aggregate_all_programs_totals() utility."""
+
+    def test_sums_integer_values(self):
+        from apps.reports.utils import aggregate_all_programs_totals
+        from unittest.mock import Mock
+        p1 = Mock(name='Program A')
+        p1.name = 'Program A'
+        p2 = Mock(name='Program B')
+        p2.name = 'Program B'
+        data = [
+            (p1, {'total_individuals_served': 10, 'new_clients_this_period': 3, 'total_contacts': 20}),
+            (p2, {'total_individuals_served': 5, 'new_clients_this_period': 2, 'total_contacts': 8}),
+        ]
+        result = aggregate_all_programs_totals(data)
+        self.assertEqual(result['total_served'], 15)
+        self.assertEqual(result['total_new_clients'], 5)
+        self.assertEqual(result['total_contacts'], 28)
+        self.assertEqual(len(result['programs']), 2)
+        self.assertEqual(result['programs'][0]['name'], 'Program A')
+
+    def test_skips_suppressed_string_values(self):
+        from apps.reports.utils import aggregate_all_programs_totals
+        from unittest.mock import Mock
+        p1 = Mock(name='Program A')
+        p1.name = 'Program A'
+        p2 = Mock(name='Program B')
+        p2.name = 'Program B'
+        data = [
+            (p1, {'total_individuals_served': '< 5', 'new_clients_this_period': 3, 'total_contacts': 10}),
+            (p2, {'total_individuals_served': 7, 'new_clients_this_period': '< 5', 'total_contacts': 5}),
+        ]
+        result = aggregate_all_programs_totals(data)
+        self.assertEqual(result['total_served'], 7)  # skips suppressed '< 5'
+        self.assertEqual(result['total_new_clients'], 3)  # skips suppressed '< 5'
+        self.assertEqual(result['total_contacts'], 15)
+
+    def test_empty_input(self):
+        from apps.reports.utils import aggregate_all_programs_totals
+        result = aggregate_all_programs_totals([])
+        self.assertEqual(result['total_served'], 0)
+        self.assertEqual(result['total_new_clients'], 0)
+        self.assertEqual(result['total_contacts'], 0)
+        self.assertEqual(result['programs'], [])
+
+
 # =============================================================================
 # Template-driven report generation (DRR: reporting-architecture.md)
 # =============================================================================


### PR DESCRIPTION
## Summary
- Add 3 unit tests for `aggregate_all_programs_totals()` (integers, suppressed strings, empty input)
- Reject unsupported export formats for all-programs mode with explicit ValueError instead of silent CSV fallback
- Use semantic `<h2>` for program section titles in all-programs HTML report (improves screen reader heading navigation)
- Translation `.mo` compilation pending next deploy (VPS dev container lacks gettext tools)

## Test plan
- [ ] Verify new unit tests pass: `pytest tests/test_reports.py::AggregateAllProgramsTotalsTest -v`
- [ ] Verify existing all-programs HTML test still passes: `pytest tests/test_reports.py::FunderReportViewTests::test_funder_report_all_programs_html_export -v`

🤖 Generated with [Claude Code](https://claude.com/claude-code)