### PR TITLE
feat: graduated privacy threshold + focused theme analysis

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -52,7 +52,6 @@ _All documentation tasks completed — see Recently Done._
 
 Scope is clear, just needs time. A session can pick these up without special approval.
 
-- [ ] Graduated privacy threshold (N=5 self-hosted, N=15 external) + focused theme analysis — managers type a question, AI searches suggestions for relevant patterns. Includes DRR updates. See [tasks/focused-theme-analysis.md](tasks/focused-theme-analysis.md) — GK approved (AI-FOCUSED-THEME1)
 - [ ] Extract role string constants (ROLE_STAFF, ROLE_PROGRAM_MANAGER, etc.) into auth_app/constants.py — 400+ raw string literals across the codebase use "staff", "program_manager" etc. (REFACTOR1)
 - [ ] Add smoke test for all-programs HTML export path (CHORE-RPT-TEST1)
 
@@ -69,6 +68,8 @@ Not yet clear we should build these, or the design isn't settled. May be too com
 - [ ] Optimize encrypted client search performance beyond ~2000 records — defer until a client approaches that scale (PERF1)
 
 ## Recently Done
+
+- [x] Graduated privacy threshold + focused theme analysis — N=5 self-hosted / N=15 external, Ask a Question UI, AI-powered suggestion search, DRR updates — 2026-03-05 (AI-FOCUSED-THEME1)
 
 ### Session 13 — Report Fixes & Cleanup
 

--- a/apps/notes/forms.py
+++ b/apps/notes/forms.py
@@ -548,6 +548,16 @@ class SuggestionThemeForm(forms.ModelForm):
         return cleaned
 
 
+class FocusedAnalysisForm(forms.Form):
+    """Validate the question for focused theme analysis."""
+    question = forms.CharField(
+        max_length=500,
+        strip=True,
+        label=_("Question"),
+    )
+    program_id = forms.IntegerField()
+
+
 class SuggestionThemeStatusForm(forms.ModelForm):
     """Inline status update for a suggestion theme.
 

--- a/apps/notes/suggestion_urls.py
+++ b/apps/notes/suggestion_urls.py
@@ -12,4 +12,5 @@ urlpatterns = [
     path("<int:pk>/edit/", suggestion_views.theme_form, name="theme_edit"),
     path("<int:pk>/unlinked/", suggestion_views.unlinked_partial, name="unlinked_partial"),
     path("<int:pk>/status/", suggestion_views.theme_status_update, name="status_update"),
+    path("themes/focused-analysis/", suggestion_views.focused_analysis_view, name="focused_analysis"),
 ]

--- a/apps/notes/suggestion_views.py
+++ b/apps/notes/suggestion_views.py
@@ -209,6 +209,12 @@ def theme_detail(request, pk):
             "date": note.effective_date,
         })
 
+    # Determine if verbatim text should be suppressed (5–14 participant programs)
+    from apps.notes.theme_engine import get_participant_count
+    from apps.reports.insights import MIN_PARTICIPANTS_FOR_QUOTES
+    participant_count = get_participant_count(theme.program)
+    suppress_verbatim = participant_count < MIN_PARTICIPANTS_FOR_QUOTES
+
     breadcrumbs = [
         {"url": reverse("suggestion_themes:theme_list"), "label": _("Suggestion Themes")},
         {"url": "", "label": theme.name},
@@ -222,6 +228,8 @@ def theme_detail(request, pk):
         "is_filtered": is_filtered,
         "date_from": date_from,
         "date_to": date_to,
+        "suppress_verbatim": suppress_verbatim,
+        "participant_count": participant_count,
     })
 
 

--- a/apps/notes/suggestion_views.py
+++ b/apps/notes/suggestion_views.py
@@ -1,24 +1,32 @@
 """Views for suggestion theme management (UX-INSIGHT6 Phase 1)."""
+import logging
+
+from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
+from django.core.cache import cache
 from django.db.models import Count, DateTimeField
 from django.db.models.functions import Coalesce
-from django.http import HttpResponseForbidden
+from django.http import HttpResponseBadRequest, HttpResponseForbidden
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.translation import gettext as _
+from django.views.decorators.http import require_POST
 
+from apps.admin_settings.models import FeatureToggle
 from apps.audit.models import AuditLog
 from apps.auth_app.decorators import requires_permission
 from apps.programs.access import get_accessible_programs
+from apps.programs.models import Program, UserProgramRole
 from apps.utils.dates import parse_date_safely
-from apps.programs.models import UserProgramRole
 
-from .forms import SuggestionThemeForm
+from .forms import FocusedAnalysisForm, SuggestionThemeForm
 from .models import (
     ProgressNote, SuggestionLink, SuggestionTheme, recalculate_theme_priority,
 )
+
+logger = logging.getLogger(__name__)
 
 
 # ── Helpers ──────────────────────────────────────────────────────────
@@ -126,8 +134,17 @@ def theme_form(request, pk=None):
             )
             return redirect("suggestion_themes:theme_detail", pk=obj.pk)
     else:
+        initial = {}
+        if not editing:
+            # Support prefill from focused analysis "Create Theme from This"
+            if request.GET.get("prefill_name"):
+                initial["name"] = request.GET["prefill_name"][:200]
+            if request.GET.get("prefill_description"):
+                initial["description"] = request.GET["prefill_description"][:500]
+            if request.GET.get("prefill_program"):
+                initial["program"] = request.GET["prefill_program"]
         form = SuggestionThemeForm(
-            instance=theme, requesting_user=request.user,
+            instance=theme, requesting_user=request.user, initial=initial,
         )
 
     breadcrumbs = [
@@ -432,4 +449,118 @@ def theme_status_update(request, pk):
     return render(request, "reports/_theme_row.html", {
         "theme": theme,
         "can_manage_themes": True,
+    })
+
+
+# ── Focused Theme Analysis (AI-FOCUSED-THEME1) ──────────────────────
+
+FOCUSED_ANALYSIS_RATE_KEY = "focused_analysis:{user_id}"
+FOCUSED_ANALYSIS_RATE_LIMIT = 10  # per hour
+FOCUSED_ANALYSIS_RATE_WINDOW = 3600  # seconds
+
+
+def _check_focused_rate_limit(user_id):
+    """Return True if the user is within the rate limit."""
+    key = FOCUSED_ANALYSIS_RATE_KEY.format(user_id=user_id)
+    count = cache.get(key, 0)
+    return count < FOCUSED_ANALYSIS_RATE_LIMIT
+
+
+def _increment_focused_rate_limit(user_id):
+    key = FOCUSED_ANALYSIS_RATE_KEY.format(user_id=user_id)
+    count = cache.get(key, 0)
+    cache.set(key, count + 1, FOCUSED_ANALYSIS_RATE_WINDOW)
+
+
+@login_required
+@require_POST
+@requires_permission("suggestion_theme.view", allow_admin=True)
+def focused_analysis_view(request):
+    """HTMX POST: Run focused theme analysis on a program's suggestions."""
+    # Check feature toggle
+    flags = FeatureToggle.get_all_flags()
+    if not flags.get("ai_assist_participant_data", False):
+        return HttpResponseForbidden(_("AI participant data features are not enabled."))
+
+    form = FocusedAnalysisForm(request.POST)
+    if not form.is_valid():
+        return render(request, "notes/suggestions/_focused_results.html", {
+            "error": _("Please enter a question (max 500 characters)."),
+        })
+
+    question = form.cleaned_data["question"]
+    program_id = form.cleaned_data["program_id"]
+
+    # Verify program access
+    program = get_object_or_404(Program, pk=program_id)
+    accessible_ids = set(
+        get_accessible_programs(request.user).values_list("pk", flat=True)
+    )
+    if program.pk not in accessible_ids:
+        return HttpResponseForbidden()
+
+    # Check privacy gate
+    from apps.notes.theme_engine import get_participant_count, _check_privacy_gate
+    if not _check_privacy_gate(program):
+        participant_count = get_participant_count(program)
+        return render(request, "notes/suggestions/_focused_results.html", {
+            "error": _("This program has %(count)d participants. A minimum of 5 is required for AI analysis.") % {"count": participant_count},
+        })
+
+    # Rate limit
+    if not _check_focused_rate_limit(request.user.pk):
+        return render(request, "notes/suggestions/_focused_results.html", {
+            "error": _("Rate limit reached (10 per hour). Please try again later."),
+        })
+
+    # Collect suggestions (PII-scrubbed) using the same pipeline as insights
+    from apps.reports.insights import collect_quotes
+    suggestions = collect_quotes(
+        program=program,
+        include_dates=False,
+    )
+    # Filter to only suggestion-source items
+    suggestion_items = [q for q in suggestions if q.get("source") == "suggestion"]
+    if not suggestion_items:
+        # Fall back to all quotes if no dedicated suggestions exist
+        suggestion_items = suggestions
+
+    if not suggestion_items:
+        return render(request, "notes/suggestions/_focused_results.html", {
+            "error": _("No suggestions found for this program."),
+        })
+
+    # Call AI
+    from konote.ai import generate_focused_analysis
+    result = generate_focused_analysis(question, suggestion_items, program.name)
+
+    _increment_focused_rate_limit(request.user.pk)
+
+    # Audit log
+    AuditLog.objects.using("audit").create(
+        event_timestamp=timezone.now(),
+        user_id=request.user.pk,
+        user_display=str(request.user),
+        ip_address=request.META.get("REMOTE_ADDR", ""),
+        action="focused_analysis",
+        resource_type="suggestion_theme",
+        resource_id=0,
+        program_id=program.pk,
+        old_values={},
+        new_values={
+            "question": question,
+            "participant_count": get_participant_count(program),
+        },
+        is_demo_context=getattr(request.user, "is_demo", False),
+    )
+
+    if result is None:
+        return render(request, "notes/suggestions/_focused_results.html", {
+            "error": _("AI analysis could not be completed. Please try again."),
+        })
+
+    return render(request, "notes/suggestions/_focused_results.html", {
+        "result": result,
+        "question": question,
+        "program": program,
     })

--- a/apps/notes/theme_engine.py
+++ b/apps/notes/theme_engine.py
@@ -41,15 +41,24 @@ def _extract_content_words(text):
 def _check_privacy_gate(program):
     """Return True if theme operations are allowed for this program.
 
-    Mirrors the privacy gate in collect_quotes() — programs with fewer
-    than 15 enrolled participants don't get auto-themes to prevent
-    re-identification risk.
+    Graduated threshold:
+    - Self-hosted LLM (INSIGHTS_API_BASE set): N >= 5
+    - External provider (OpenRouter): N >= 15
     """
     if getattr(settings, "DEMO_MODE", False):
         return True
 
     from apps.clients.models import ClientProgramEnrolment
-    from apps.reports.insights import MIN_PARTICIPANTS_FOR_QUOTES
+    from apps.reports.insights import (
+        MIN_PARTICIPANTS_FOR_QUOTES,
+        MIN_PARTICIPANTS_FOR_THEME_PROCESSING,
+    )
+
+    is_self_hosted = bool(getattr(settings, "INSIGHTS_API_BASE", ""))
+    threshold = (
+        MIN_PARTICIPANTS_FOR_THEME_PROCESSING if is_self_hosted
+        else MIN_PARTICIPANTS_FOR_QUOTES
+    )
 
     participant_count = (
         ClientProgramEnrolment.objects.filter(
@@ -59,13 +68,26 @@ def _check_privacy_gate(program):
         .distinct()
         .count()
     )
-    if participant_count < MIN_PARTICIPANTS_FOR_QUOTES:
+    if participant_count < threshold:
         logger.info(
-            "Theme privacy gate: program %s has %d participants (minimum %d)",
-            program.name, participant_count, MIN_PARTICIPANTS_FOR_QUOTES,
+            "Theme privacy gate: program %s has %d participants (minimum %d, self_hosted=%s)",
+            program.name, participant_count, threshold, is_self_hosted,
         )
         return False
     return True
+
+
+def get_participant_count(program):
+    """Return the distinct active participant count for a program."""
+    from apps.clients.models import ClientProgramEnrolment
+    return (
+        ClientProgramEnrolment.objects.filter(
+            program=program, status="active",
+        )
+        .values("client_file_id")
+        .distinct()
+        .count()
+    )
 
 
 # ── Tier 1: Lightweight auto-link on note save ─────────────────────

--- a/apps/reports/insights.py
+++ b/apps/reports/insights.py
@@ -29,6 +29,11 @@ logger = logging.getLogger(__name__)
 # Below this threshold, individual quotes risk re-identification.
 MIN_PARTICIPANTS_FOR_QUOTES = 15
 
+# Minimum participants for AI theme processing (self-hosted LLM only).
+# Between 5–14, AI can analyse suggestions but verbatim text is suppressed.
+# See DRRs: self-hosted-llm-infrastructure.md, ai-feature-toggles.md
+MIN_PARTICIPANTS_FOR_THEME_PROCESSING = 5
+
 
 def get_structured_insights(program=None, client_file=None, date_from=None, date_to=None):
     """Aggregate descriptor and engagement data from plaintext fields via SQL.

--- a/konote/ai.py
+++ b/konote/ai.py
@@ -901,3 +901,114 @@ def suggest_note_structure(target_name, target_description, metric_names):
     except (json.JSONDecodeError, TypeError):
         logger.warning("Could not parse note structure: %s", result[:200])
         return None
+
+
+def generate_focused_analysis(question, suggestions, program_name):
+    """Run a focused theme analysis on suggestions for a manager's question.
+
+    Args:
+        question: str — the manager's question (max 500 chars)
+        suggestions: list of dicts — PII-scrubbed suggestions with text, priority
+        program_name: str
+
+    Returns:
+        dict {relevant_count, total_count, summary, sub_themes, suggestion}
+        or None on failure.
+    """
+    system = (
+        "You are an outcome-tracking assistant for a Canadian nonprofit. "
+        "A program manager has a question about participant suggestions. "
+        "You will receive the question and a list of PII-scrubbed participant "
+        "suggestions. Analyse them and respond.\n\n"
+        "RULES:\n"
+        "- Search the suggestions for content relevant to the question\n"
+        "- Group relevant suggestions into sub-themes if distinct patterns exist\n"
+        "- Provide a synthesised summary — NEVER return verbatim quotes\n"
+        "- Report how many suggestions are relevant out of total\n"
+        "- If nothing relevant is found, say so clearly\n"
+        "- Use Canadian English spelling (colour, centre)\n\n"
+        "Return a JSON object:\n"
+        "{\n"
+        '  "relevant_count": <int>,\n'
+        '  "total_count": <int>,\n'
+        '  "summary": "<synthesised summary paragraph>",\n'
+        '  "sub_themes": [\n'
+        '    {"name": "<short label>", "description": "<1 sentence>", "count": <int>}\n'
+        "  ],\n"
+        '  "suggestion": "<optional: suggest a theme name if pattern is worth tracking>"\n'
+        "}\n\n"
+        "Return ONLY the JSON object, no other text."
+    )
+
+    suggestion_texts = []
+    for s in suggestions:
+        text = s.get("text", "")
+        priority = s.get("priority", "")
+        if priority:
+            suggestion_texts.append(f"[{priority}] {text}")
+        else:
+            suggestion_texts.append(text)
+
+    user_msg = (
+        f"Program: {program_name}\n"
+        f"Question: {question}\n\n"
+        f"Participant suggestions ({len(suggestions)} total, PII-scrubbed):\n"
+        + "\n".join(f"- {t}" for t in suggestion_texts)
+    )
+
+    result = _call_insights_api(system, user_msg, max_tokens=1024)
+    if result is None:
+        return None
+
+    # Strip markdown fences if present
+    text = result.strip()
+    if text.startswith("```"):
+        lines = text.split("\n")
+        lines = [ln for ln in lines if not ln.strip().startswith("```")]
+        text = "\n".join(lines).strip()
+
+    try:
+        parsed = json.loads(text)
+    except (json.JSONDecodeError, TypeError):
+        logger.warning("Could not parse focused analysis response: %s", text[:300])
+        return None
+
+    return _validate_focused_analysis(parsed, len(suggestions))
+
+
+def _validate_focused_analysis(response, total_suggestions):
+    """Validate the focused analysis AI response structure."""
+    if not isinstance(response, dict):
+        logger.warning("Focused analysis response is not a dict")
+        return None
+
+    if not isinstance(response.get("summary"), str) or not response["summary"].strip():
+        logger.warning("Focused analysis response missing summary")
+        return None
+
+    # Ensure counts are reasonable
+    response["total_count"] = total_suggestions
+    rc = response.get("relevant_count", 0)
+    if not isinstance(rc, int) or rc < 0:
+        response["relevant_count"] = 0
+    if response["relevant_count"] > total_suggestions:
+        response["relevant_count"] = total_suggestions
+
+    # Validate sub_themes
+    if isinstance(response.get("sub_themes"), list):
+        valid_themes = []
+        for st in response["sub_themes"]:
+            if isinstance(st, dict) and isinstance(st.get("name"), str):
+                if not isinstance(st.get("description"), str):
+                    st["description"] = ""
+                if not isinstance(st.get("count"), int):
+                    st["count"] = 0
+                valid_themes.append(st)
+        response["sub_themes"] = valid_themes
+    else:
+        response["sub_themes"] = []
+
+    if not isinstance(response.get("suggestion"), str):
+        response["suggestion"] = ""
+
+    return response

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -19512,3 +19512,79 @@ msgstr "Comprend les données de %(count)s programme(s)."
 
 msgid "PDF export is not available for All Programs. Please select CSV or HTML."
 msgstr "L’exportation PDF n’est pas disponible pour Tous les programmes. Veuillez sélectionner CSV ou HTML."
+
+#: templates/notes/suggestions/_linked_list.html
+msgid "Suggestion content is not shown for programs with fewer than 15 participants to protect privacy. Suggestion count and priority are shown below."
+msgstr "Le contenu des suggestions n’est pas affiché pour les programmes de moins de 15 participants afin de protéger la vie privée. Le nombre et la priorité des suggestions sont indiqués ci-dessous."
+
+#: templates/notes/suggestions/_linked_list.html
+msgid "Content not shown for small programs"
+msgstr "Contenu non affiché pour les petits programmes"
+
+#: templates/notes/suggestions/_linked_list.html
+msgid "Remove suggestion"
+msgstr "Retirer la suggestion"
+
+#: templates/notes/suggestions/theme_list.html
+msgid "Ask a Question"
+msgstr "Poser une question"
+
+#: templates/notes/suggestions/theme_list.html
+msgid "Search suggestions for a specific topic"
+msgstr "Rechercher des suggestions sur un sujet précis"
+
+#: templates/notes/suggestions/theme_list.html
+msgid "e.g., Are there any themes about scheduling or opening hours?"
+msgstr "p. ex., Y a-t-il des thèmes liés aux horaires ou aux heures d’ouverture?"
+
+#: templates/notes/suggestions/theme_list.html
+msgid "Analyse"
+msgstr "Analyser"
+
+#: templates/notes/suggestions/theme_list.html
+msgid "Analysing..."
+msgstr "Analyse en cours..."
+
+#: templates/notes/suggestions/_focused_results.html
+msgid "Analysis Results"
+msgstr "Résultats de l’analyse"
+
+#, python-format
+msgid "%(relevant)s of %(total)s suggestions relate to this topic"
+msgstr "%(relevant)s des %(total)s suggestions concernent ce sujet"
+
+#: templates/notes/suggestions/_focused_results.html
+msgid "Sub-themes"
+msgstr "Sous-thèmes"
+
+#: templates/notes/suggestions/_focused_results.html
+msgid "Suggested theme:"
+msgstr "Thème suggéré :"
+
+#: templates/notes/suggestions/_focused_results.html
+msgid "Create Theme from This"
+msgstr "Créer un thème à partir de ceci"
+
+#: apps/notes/suggestion_views.py
+msgid "AI participant data features are not enabled."
+msgstr "Les fonctionnalités IA pour les données des participants ne sont pas activées."
+
+#: apps/notes/suggestion_views.py
+msgid "Please enter a question (max 500 characters)."
+msgstr "Veuillez saisir une question (max. 500 caractères)."
+
+#, python-format
+msgid "This program has %(count)d participants. A minimum of 5 is required for AI analysis."
+msgstr "Ce programme compte %(count)d participants. Un minimum de 5 est requis pour l’analyse par IA."
+
+#: apps/notes/suggestion_views.py
+msgid "Rate limit reached (10 per hour). Please try again later."
+msgstr "Limite atteinte (10 par heure). Veuillez réessayer plus tard."
+
+#: apps/notes/suggestion_views.py
+msgid "No suggestions found for this program."
+msgstr "Aucune suggestion trouvée pour ce programme."
+
+#: apps/notes/suggestion_views.py
+msgid "AI analysis could not be completed. Please try again."
+msgstr "L’analyse par IA n’a pu être complétée. Veuillez réessayer."

--- a/tasks/design-rationale/ai-feature-toggles.md
+++ b/tasks/design-rationale/ai-feature-toggles.md
@@ -233,6 +233,20 @@ The toggle design already supports this — `ai_assist_participant_data` can swi
 6. Update templates referencing `features.ai_assist` to `features.ai_assist_tools_only`
 7. Data migration: if an agency had `ai_assist = True`, set both new toggles to True to preserve their current behaviour
 
+## Graduated Minimum Sample Size (Added 2026-03-05, AI-FOCUSED-THEME1)
+
+The minimum sample size for AI theme processing is now graduated:
+
+| Participant Count | What Happens |
+|---|---|
+| < 5 | No AI theme processing at all |
+| 5–14 | AI theme processing (self-hosted only); verbatim quotes suppressed in theme detail |
+| 15+ | Full display — AI processing + verbatim quotes shown |
+
+The N=5 threshold **only applies when `INSIGHTS_API_BASE` is configured** (self-hosted LLM). Agencies using OpenRouter retain the N=15 threshold. See the [self-hosted LLM DRR](self-hosted-llm-infrastructure.md) for infrastructure details.
+
+**Focused analysis** (top-down question-based search) follows the same graduated model and always returns synthesised content, never verbatim quotes, regardless of program size.
+
 ## GK Review Items
 
 - [ ] Participant-facing transparency wording (portal statement)

--- a/tasks/design-rationale/self-hosted-llm-infrastructure.md
+++ b/tasks/design-rationale/self-hosted-llm-infrastructure.md
@@ -793,3 +793,19 @@ The [OVHcloud DRR](ovhcloud-deployment.md) lists this as an anti-pattern for hig
 - [ ] Confirm VPS-4 sizing is appropriate for expected workload — deferred to deployment, will be confirmed via testing
 - [ ] Review whether survey analysis outputs need the same privacy controls as KoNote insights — deferred to deployment assessment
 - [ ] Choose subdomain on logicaloutcomes.net — use a non-obvious, hard-to-guess subdomain (not `llm.`). Decided during deployment.
+
+---
+
+## Graduated Privacy Threshold (Added 2026-03-05, AI-FOCUSED-THEME1)
+
+The N=5 privacy threshold for AI theme processing **only applies when `INSIGHTS_API_BASE` is configured** (self-hosted LLM). If an agency routes through OpenRouter (no `INSIGHTS_API_BASE`), the N=15 threshold still applies.
+
+| Participant Count | Self-hosted (`INSIGHTS_API_BASE` set) | External (OpenRouter) |
+|---|---|---|
+| < 5 | No AI theme processing | No AI theme processing |
+| 5–14 | AI processing allowed; verbatim text suppressed in UI | No AI theme processing |
+| 15+ | Full processing + verbatim display | Full processing + verbatim display |
+
+**Rationale:** Self-hosted processing keeps de-identified data within Canadian infrastructure, reducing re-identification risk enough to lower the threshold from 15 to 5. The verbatim text suppression for 5–14 provides an additional privacy layer.
+
+**Deployment note:** This threshold difference must be documented in ops deployment instructions. Agencies expecting the N=5 threshold must have `INSIGHTS_API_BASE` configured.

--- a/templates/notes/suggestions/_focused_results.html
+++ b/templates/notes/suggestions/_focused_results.html
@@ -1,0 +1,50 @@
+{% load i18n %}
+{# HTMX partial: focused theme analysis results #}
+
+{% if error %}
+<article class="focused-analysis-error" role="alert">
+    <p>{{ error }}</p>
+</article>
+{% elif result %}
+<article class="focused-analysis-results">
+    <header>
+        <strong>{% trans "Analysis Results" %}</strong>
+        <small class="muted">
+            {% blocktrans with relevant=result.relevant_count total=result.total_count %}{{ relevant }} of {{ total }} suggestions relate to this topic{% endblocktrans %}
+        </small>
+    </header>
+
+    <p>{{ result.summary }}</p>
+
+    {% if result.sub_themes %}
+    <h4>{% trans "Sub-themes" %}</h4>
+    <ul>
+        {% for st in result.sub_themes %}
+        <li>
+            <strong>{{ st.name }}</strong> ({{ st.count }})
+            {% if st.description %}<br><small class="muted">{{ st.description }}</small>{% endif %}
+        </li>
+        {% endfor %}
+    </ul>
+    {% endif %}
+
+    {% if result.suggestion %}
+    <footer style="margin-top:1rem;padding-top:0.75rem;border-top:1px solid var(--pico-muted-border-color);">
+        <p class="muted" style="font-size:0.9rem;">
+            <strong>{% trans "Suggested theme:" %}</strong> {{ result.suggestion }}
+        </p>
+        <form method="get" action="{% url 'suggestion_themes:theme_create' %}">
+            <input type="hidden" name="prefill_name" value="{{ result.suggestion }}">
+            <input type="hidden" name="prefill_description" value="{{ result.summary|truncatewords:50 }}">
+            <input type="hidden" name="prefill_source" value="ai_generated">
+            {% if program %}
+            <input type="hidden" name="prefill_program" value="{{ program.pk }}">
+            {% endif %}
+            <button type="submit" class="secondary" style="font-size:0.9rem;">
+                {% trans "Create Theme from This" %}
+            </button>
+        </form>
+    </footer>
+    {% endif %}
+</article>
+{% endif %}

--- a/templates/notes/suggestions/_linked_list.html
+++ b/templates/notes/suggestions/_linked_list.html
@@ -1,11 +1,21 @@
 {% load i18n %}
 {# Partial: linked suggestion list (rendered inside theme_detail.html) #}
 
+{% if suppress_verbatim %}
+<p class="muted" style="font-size:0.9rem;">
+    {% trans "Suggestion content is not shown for programs with fewer than 15 participants to protect privacy. Suggestion count and priority are shown below." %}
+</p>
+{% endif %}
+
 {% if linked_notes %}
 {% for s in linked_notes %}
 <article class="suggestion-card">
     <blockquote class="insight-quote">
+        {% if suppress_verbatim %}
+        <p class="muted"><em>{% trans "Content not shown for small programs" %}</em></p>
+        {% else %}
         <p>"{{ s.text }}"</p>
+        {% endif %}
         <cite>
             {% if s.priority == "urgent" %}
             <span class="badge badge-danger">{% trans "Urgent" %}</span>
@@ -16,8 +26,10 @@
             {% elif s.priority == "noted" %}
             <span class="badge badge-neutral">{% trans "Noted" %}</span>
             {% endif %}
+            {% if not suppress_verbatim %}
             &middot;
             {{ s.date|date:"M j, Y" }}
+            {% endif %}
             {% if s.linked_by %}
             &middot;
             {% blocktrans with name=s.linked_by %}Linked by {{ name }}{% endblocktrans %}
@@ -30,7 +42,7 @@
         <input type="hidden" name="action" value="unlink">
         <input type="hidden" name="link_id" value="{{ s.link_id }}">
         <button type="submit" class="outline secondary" style="padding:0.25rem 0.5rem;font-size:0.85rem;color:var(--kn-text);"
-                aria-label="{% blocktrans with text=s.text|truncatewords:5 %}Remove suggestion: {{ text }}{% endblocktrans %}">
+                aria-label="{% trans 'Remove suggestion' %}">
             {% trans "Remove" %}
         </button>
     </form>

--- a/templates/notes/suggestions/theme_list.html
+++ b/templates/notes/suggestions/theme_list.html
@@ -42,6 +42,38 @@
 <p><a href="{% url 'suggestion_themes:theme_create' %}" role="button">{% trans "Create Theme" %}</a></p>
 {% endif %}
 
+{# ── Focused Analysis (Ask a Question) ── #}
+{% if features.ai_assist_participant_data and can_manage %}
+<details class="focused-analysis-section" style="margin-bottom:1.5rem;">
+    <summary><strong>{% trans "Ask a Question" %}</strong> — {% trans "Search suggestions for a specific topic" %}</summary>
+    <form hx-post="{% url 'suggestion_themes:focused_analysis' %}"
+          hx-target="#focused-results"
+          hx-indicator="#focused-spinner"
+          style="margin-top:0.75rem;">
+        {% csrf_token %}
+        <div class="grid" style="grid-template-columns:1fr auto auto;">
+            <label for="focused-program">
+                {% trans "Program" %}
+                <select id="focused-program" name="program_id" required>
+                    {% for prog in accessible_programs %}
+                    <option value="{{ prog.pk }}" {% if program_filter == prog.pk|stringformat:"d" %}selected{% endif %}>{{ prog.name }}</option>
+                    {% endfor %}
+                </select>
+            </label>
+        </div>
+        <label for="focused-question">
+            {% trans "Question" %}
+            <input type="text" id="focused-question" name="question"
+                   maxlength="500" required
+                   placeholder="{% trans 'e.g., Are there any themes about scheduling or opening hours?' %}">
+        </label>
+        <button type="submit">{% trans "Analyse" %}</button>
+        <span id="focused-spinner" class="htmx-indicator" aria-busy="true" style="display:none;">{% trans "Analysing..." %}</span>
+    </form>
+    <div id="focused-results"></div>
+</details>
+{% endif %}
+
 {# ── Theme cards ── #}
 {% if themes %}
 <div class="theme-cards">

--- a/tests/test_suggestions.py
+++ b/tests/test_suggestions.py
@@ -1,0 +1,313 @@
+"""Tests for focused theme analysis and graduated privacy threshold."""
+from unittest.mock import patch
+
+from cryptography.fernet import Fernet
+from django.test import TestCase, Client, override_settings
+
+from apps.admin_settings.models import FeatureToggle
+from apps.auth_app.models import User
+from apps.clients.models import ClientFile, ClientProgramEnrolment
+from apps.notes.models import ProgressNote
+from apps.notes.theme_engine import _check_privacy_gate, get_participant_count
+from apps.programs.models import Program, UserProgramRole
+from apps.reports.insights import (
+    MIN_PARTICIPANTS_FOR_QUOTES,
+    MIN_PARTICIPANTS_FOR_THEME_PROCESSING,
+)
+import konote.encryption as enc_module
+
+
+TEST_KEY = Fernet.generate_key().decode()
+FOCUSED_URL = "/manage/suggestions/themes/focused-analysis/"
+
+
+def _create_participants(program, count):
+    """Create N active participant enrolments for a program."""
+    for i in range(count):
+        cf = ClientFile.objects.create()
+        ClientProgramEnrolment.objects.create(
+            client_file=cf, program=program, status="active",
+        )
+
+
+# ── Privacy gate tests ──────────────────────────────────────────────
+
+@override_settings(FIELD_ENCRYPTION_KEY=TEST_KEY)
+class PrivacyGateGraduatedThresholdTest(TestCase):
+    """Test _check_privacy_gate with graduated N=5/15 thresholds."""
+
+    def setUp(self):
+        enc_module._fernet = None
+        self.program = Program.objects.create(name="Test Program")
+
+    def tearDown(self):
+        enc_module._fernet = None
+
+    @override_settings(INSIGHTS_API_BASE="http://localhost:11434/v1")
+    def test_self_hosted_4_participants_denied(self):
+        _create_participants(self.program, 4)
+        self.assertFalse(_check_privacy_gate(self.program))
+
+    @override_settings(INSIGHTS_API_BASE="http://localhost:11434/v1")
+    def test_self_hosted_5_participants_allowed(self):
+        _create_participants(self.program, 5)
+        self.assertTrue(_check_privacy_gate(self.program))
+
+    @override_settings(INSIGHTS_API_BASE="http://localhost:11434/v1")
+    def test_self_hosted_14_participants_allowed(self):
+        _create_participants(self.program, 14)
+        self.assertTrue(_check_privacy_gate(self.program))
+
+    @override_settings(INSIGHTS_API_BASE="")
+    def test_external_14_participants_denied(self):
+        _create_participants(self.program, 14)
+        self.assertFalse(_check_privacy_gate(self.program))
+
+    @override_settings(INSIGHTS_API_BASE="")
+    def test_external_15_participants_allowed(self):
+        _create_participants(self.program, 15)
+        self.assertTrue(_check_privacy_gate(self.program))
+
+    @override_settings(DEMO_MODE=True, INSIGHTS_API_BASE="")
+    def test_demo_mode_bypasses_gate(self):
+        _create_participants(self.program, 2)
+        self.assertTrue(_check_privacy_gate(self.program))
+
+    def test_constants_are_correct(self):
+        self.assertEqual(MIN_PARTICIPANTS_FOR_THEME_PROCESSING, 5)
+        self.assertEqual(MIN_PARTICIPANTS_FOR_QUOTES, 15)
+
+
+# ── Focused analysis view tests ─────────────────────────────────────
+
+@override_settings(
+    FIELD_ENCRYPTION_KEY=TEST_KEY,
+    OPENROUTER_API_KEY="test-key",
+    INSIGHTS_API_BASE="http://localhost:11434/v1",
+)
+class FocusedAnalysisViewTest(TestCase):
+    """Test the focused analysis HTMX endpoint."""
+
+    databases = {"default", "audit"}
+
+    def setUp(self):
+        enc_module._fernet = None
+        self.http = Client()
+
+        self.user = User.objects.create_user(
+            username="pm", password="pass", display_name="PM User"
+        )
+        self.program = Program.objects.create(name="Housing")
+        UserProgramRole.objects.create(
+            user=self.user, program=self.program,
+            role="program_manager", status="active",
+        )
+
+        # Enable feature toggles
+        FeatureToggle.objects.create(
+            feature_key="ai_assist_tools_only", is_enabled=True,
+        )
+        FeatureToggle.objects.create(
+            feature_key="ai_assist_participant_data", is_enabled=True,
+        )
+
+        # Create 10 participants (above N=5 self-hosted threshold)
+        _create_participants(self.program, 10)
+
+        # Create some suggestions
+        for i in range(5):
+            cf = ClientFile.objects.create()
+            ClientProgramEnrolment.objects.create(
+                client_file=cf, program=self.program, status="active",
+            )
+            ProgressNote.objects.create(
+                client_file=cf,
+                author=self.user,
+                author_program=self.program,
+                participant_suggestion=f"I wish there were evening sessions available {i}",
+                suggestion_priority="important",
+            )
+
+    def tearDown(self):
+        enc_module._fernet = None
+
+    def test_unauthenticated_redirected(self):
+        resp = self.http.post(FOCUSED_URL, {
+            "question": "Any themes about hours?",
+            "program_id": self.program.pk,
+        })
+        self.assertEqual(resp.status_code, 302)
+
+    def test_get_not_allowed(self):
+        self.http.login(username="pm", password="pass")
+        resp = self.http.get(FOCUSED_URL)
+        self.assertEqual(resp.status_code, 405)
+
+    def test_feature_toggle_disabled(self):
+        FeatureToggle.objects.filter(
+            feature_key="ai_assist_participant_data",
+        ).update(is_enabled=False)
+        self.http.login(username="pm", password="pass")
+        resp = self.http.post(FOCUSED_URL, {
+            "question": "test",
+            "program_id": self.program.pk,
+        })
+        self.assertEqual(resp.status_code, 403)
+
+    def test_empty_question_returns_error(self):
+        self.http.login(username="pm", password="pass")
+        resp = self.http.post(FOCUSED_URL, {
+            "question": "",
+            "program_id": self.program.pk,
+        })
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, "Please enter a question")
+
+    @override_settings(INSIGHTS_API_BASE="http://localhost:11434/v1")
+    def test_privacy_gate_blocks_small_programs(self):
+        small_program = Program.objects.create(name="Small")
+        UserProgramRole.objects.create(
+            user=self.user, program=small_program,
+            role="program_manager", status="active",
+        )
+        _create_participants(small_program, 3)
+
+        self.http.login(username="pm", password="pass")
+        resp = self.http.post(FOCUSED_URL, {
+            "question": "test",
+            "program_id": small_program.pk,
+        })
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, "minimum of 5")
+
+    @patch("apps.notes.suggestion_views.generate_focused_analysis")
+    def test_happy_path_returns_results(self, mock_ai):
+        mock_ai.return_value = {
+            "relevant_count": 3,
+            "total_count": 5,
+            "summary": "Participants want evening sessions.",
+            "sub_themes": [
+                {"name": "Evening Hours", "description": "Want evening sessions", "count": 3},
+            ],
+            "suggestion": "Schedule Flexibility",
+        }
+        self.http.login(username="pm", password="pass")
+        resp = self.http.post(FOCUSED_URL, {
+            "question": "Any themes about scheduling?",
+            "program_id": self.program.pk,
+        })
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, "Analysis Results")
+        self.assertContains(resp, "evening sessions")
+        self.assertContains(resp, "Schedule Flexibility")
+        self.assertContains(resp, "Create Theme from This")
+
+    @patch("apps.notes.suggestion_views.generate_focused_analysis")
+    def test_ai_failure_returns_error(self, mock_ai):
+        mock_ai.return_value = None
+        self.http.login(username="pm", password="pass")
+        resp = self.http.post(FOCUSED_URL, {
+            "question": "test question",
+            "program_id": self.program.pk,
+        })
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, "could not be completed")
+
+    @patch("apps.notes.suggestion_views.generate_focused_analysis")
+    def test_rate_limit_enforced(self, mock_ai):
+        mock_ai.return_value = {
+            "relevant_count": 0,
+            "total_count": 0,
+            "summary": "Nothing found.",
+            "sub_themes": [],
+            "suggestion": "",
+        }
+        self.http.login(username="pm", password="pass")
+
+        # Exhaust the rate limit
+        from django.core.cache import cache
+        cache.set(f"focused_analysis:{self.user.pk}", 10, 3600)
+
+        resp = self.http.post(FOCUSED_URL, {
+            "question": "test",
+            "program_id": self.program.pk,
+        })
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, "Rate limit")
+
+    @patch("apps.notes.suggestion_views.generate_focused_analysis")
+    def test_audit_log_created(self, mock_ai):
+        mock_ai.return_value = {
+            "relevant_count": 0,
+            "total_count": 0,
+            "summary": "Nothing found.",
+            "sub_themes": [],
+            "suggestion": "",
+        }
+        self.http.login(username="pm", password="pass")
+        self.http.post(FOCUSED_URL, {
+            "question": "opening hours",
+            "program_id": self.program.pk,
+        })
+
+        from apps.audit.models import AuditLog
+        log = AuditLog.objects.using("audit").filter(
+            action="focused_analysis",
+        ).first()
+        self.assertIsNotNone(log)
+        self.assertEqual(log.new_values["question"], "opening hours")
+        self.assertEqual(log.program_id, self.program.pk)
+
+    def test_inaccessible_program_returns_403(self):
+        other_program = Program.objects.create(name="Secret")
+        self.http.login(username="pm", password="pass")
+        resp = self.http.post(FOCUSED_URL, {
+            "question": "test",
+            "program_id": other_program.pk,
+        })
+        self.assertEqual(resp.status_code, 403)
+
+
+# ── AI response validation tests ────────────────────────────────────
+
+class FocusedAnalysisValidationTest(TestCase):
+    """Test _validate_focused_analysis."""
+
+    def test_valid_response(self):
+        from konote.ai import _validate_focused_analysis
+        resp = {
+            "relevant_count": 3,
+            "total_count": 10,
+            "summary": "Participants mentioned scheduling concerns.",
+            "sub_themes": [
+                {"name": "Timing", "description": "About timing", "count": 2},
+            ],
+            "suggestion": "Scheduling",
+        }
+        result = _validate_focused_analysis(resp, 10)
+        self.assertIsNotNone(result)
+        self.assertEqual(result["total_count"], 10)
+        self.assertEqual(result["relevant_count"], 3)
+
+    def test_missing_summary_returns_none(self):
+        from konote.ai import _validate_focused_analysis
+        resp = {"relevant_count": 0, "total_count": 0}
+        result = _validate_focused_analysis(resp, 0)
+        self.assertIsNone(result)
+
+    def test_relevant_count_capped(self):
+        from konote.ai import _validate_focused_analysis
+        resp = {
+            "relevant_count": 999,
+            "total_count": 5,
+            "summary": "Test summary.",
+            "sub_themes": [],
+            "suggestion": "",
+        }
+        result = _validate_focused_analysis(resp, 5)
+        self.assertEqual(result["relevant_count"], 5)
+
+    def test_non_dict_returns_none(self):
+        from konote.ai import _validate_focused_analysis
+        result = _validate_focused_analysis("not a dict", 5)
+        self.assertIsNone(result)


### PR DESCRIPTION
## Summary

- **Part A — Graduated privacy threshold**: Programs with 5–14 participants can now use AI theme processing when self-hosted LLM is configured (`INSIGHTS_API_BASE`). Verbatim text is suppressed in the theme detail view for these smaller programs. External providers (OpenRouter) retain the N=15 threshold.
- **Part B — Focused analysis**: New "Ask a Question" feature on the Suggestion Themes page lets program managers type a question (e.g., "Are there any themes about opening hours?") and the AI searches existing suggestions for relevant patterns, returning a synthesised summary with sub-themes. Includes a "Create Theme from This" button to make findings persistent.
- **DRR updates**: Both self-hosted LLM and AI feature toggles design rationale records updated with the graduated threshold model.
- **Tests**: Privacy gate tests at N=4/5/14/15 with/without self-hosted, focused analysis view tests (permissions, validation, rate limiting, audit, AI mock).
- **French translations**: All new UI strings translated.

## Files changed

| File | Change |
|---|---|
| `apps/reports/insights.py` | Added `MIN_PARTICIPANTS_FOR_THEME_PROCESSING = 5` |
| `apps/notes/theme_engine.py` | Updated `_check_privacy_gate()` graduated threshold + `get_participant_count()` |
| `apps/notes/suggestion_views.py` | Added `focused_analysis_view()`, rate limiting, audit, prefill support |
| `apps/notes/suggestion_urls.py` | Added `themes/focused-analysis/` route |
| `apps/notes/forms.py` | Added `FocusedAnalysisForm` |
| `konote/ai.py` | Added `generate_focused_analysis()` + validation |
| `templates/notes/suggestions/theme_list.html` | "Ask a Question" collapsible section |
| `templates/notes/suggestions/_focused_results.html` | New results partial |
| `templates/notes/suggestions/_linked_list.html` | Verbatim suppression for small programs |
| `tasks/design-rationale/self-hosted-llm-infrastructure.md` | Graduated threshold documentation |
| `tasks/design-rationale/ai-feature-toggles.md` | Graduated threshold documentation |
| `tests/test_suggestions.py` | New test file (15 tests) |
| `locale/fr/LC_MESSAGES/django.po` | French translations |
| `TODO.md` | AI-FOCUSED-THEME1 marked done |

## Test plan

- [ ] Run `pytest tests/test_suggestions.py` — all 15 tests should pass
- [ ] Verify focused analysis UI appears only when `ai_assist_participant_data` is enabled
- [ ] Test with a program that has < 5 participants — should show error
- [ ] Test rate limit by making 10+ requests in quick succession
- [ ] Verify "Create Theme from This" pre-fills the theme creation form
- [ ] Verify verbatim text is hidden on theme detail for programs with 5–14 participants

🤖 Generated with [Claude Code](https://claude.com/claude-code)