### PR TITLE
refactor: extract role string constants

### DIFF
--- a/apps/admin_settings/demo_engine.py
+++ b/apps/admin_settings/demo_engine.py
@@ -43,6 +43,12 @@ from apps.plans.models import (
     PlanTargetRevision,
     PlanTemplate,
 )
+from apps.auth_app.constants import (
+    ROLE_EXECUTIVE,
+    ROLE_PROGRAM_MANAGER,
+    ROLE_RECEPTIONIST,
+    ROLE_STAFF,
+)
 from apps.programs.models import Program, UserProgramRole
 
 User = get_user_model()
@@ -574,14 +580,14 @@ class DemoDataEngine:
         for prog in programs:
             UserProgramRole.objects.get_or_create(
                 user=front_desk, program=prog,
-                defaults={"role": "receptionist"},
+                defaults={"role": ROLE_RECEPTIONIST},
             )
 
         # Executive: executive on all programs
         for prog in programs:
             UserProgramRole.objects.get_or_create(
                 user=executive, program=prog,
-                defaults={"role": "executive"},
+                defaults={"role": ROLE_EXECUTIVE},
             )
 
         # Distribute workers and manager across programs
@@ -590,26 +596,26 @@ class DemoDataEngine:
             for worker in (worker1, worker2):
                 UserProgramRole.objects.get_or_create(
                     user=worker, program=programs[0],
-                    defaults={"role": "staff"},
+                    defaults={"role": ROLE_STAFF},
                 )
             UserProgramRole.objects.get_or_create(
                 user=manager, program=programs[0],
-                defaults={"role": "program_manager"},
+                defaults={"role": ROLE_PROGRAM_MANAGER},
             )
         elif len(programs) == 2:
             # Two programs: split workers
             UserProgramRole.objects.get_or_create(
                 user=worker1, program=programs[0],
-                defaults={"role": "staff"},
+                defaults={"role": ROLE_STAFF},
             )
             UserProgramRole.objects.get_or_create(
                 user=worker2, program=programs[1],
-                defaults={"role": "staff"},
+                defaults={"role": ROLE_STAFF},
             )
             for prog in programs:
                 UserProgramRole.objects.get_or_create(
                     user=manager, program=prog,
-                    defaults={"role": "program_manager"},
+                    defaults={"role": ROLE_PROGRAM_MANAGER},
                 )
         else:
             # 3+ programs: split workers, manager on first half
@@ -617,25 +623,25 @@ class DemoDataEngine:
             for prog in programs[:mid]:
                 UserProgramRole.objects.get_or_create(
                     user=worker1, program=prog,
-                    defaults={"role": "staff"},
+                    defaults={"role": ROLE_STAFF},
                 )
             for prog in programs[mid:]:
                 UserProgramRole.objects.get_or_create(
                     user=worker2, program=prog,
-                    defaults={"role": "staff"},
+                    defaults={"role": ROLE_STAFF},
                 )
             # Worker1 also gets program_manager on first program
             role = UserProgramRole.objects.filter(
                 user=worker1, program=programs[0],
             ).first()
             if role:
-                role.role = "program_manager"
+                role.role = ROLE_PROGRAM_MANAGER
                 role.save(update_fields=["role"])
             # Manager on first half of programs
             for prog in programs[:mid + 1]:
                 UserProgramRole.objects.get_or_create(
                     user=manager, program=prog,
-                    defaults={"role": "program_manager"},
+                    defaults={"role": ROLE_PROGRAM_MANAGER},
                 )
 
         self.log(f"  Created {len(user_specs)} demo users with roles across {len(programs)} programs.")

--- a/apps/admin_settings/management/commands/seed.py
+++ b/apps/admin_settings/management/commands/seed.py
@@ -10,6 +10,13 @@ from pathlib import Path
 from django.conf import settings
 from django.core.management.base import BaseCommand
 
+from apps.auth_app.constants import (
+    ROLE_EXECUTIVE,
+    ROLE_PROGRAM_MANAGER,
+    ROLE_RECEPTIONIST,
+    ROLE_STAFF,
+)
+
 
 class Command(BaseCommand):
     help = "Seed database with metric library, default terminology, and feature toggles."
@@ -466,26 +473,26 @@ class Command(BaseCommand):
         for prog in all_programs:
             UserProgramRole.objects.get_or_create(
                 user=front_desk, program=prog,
-                defaults={"role": "receptionist"},
+                defaults={"role": ROLE_RECEPTIONIST},
             )
 
         # Casey (worker-1): program_manager for Employment, staff for Housing + Kitchen
         # Mixed roles demonstrate how the same person sees different things per program
         UserProgramRole.objects.get_or_create(
             user=worker1, program=employment,
-            defaults={"role": "program_manager"},
+            defaults={"role": ROLE_PROGRAM_MANAGER},
         )
         for prog in (housing, kitchen):
             UserProgramRole.objects.get_or_create(
                 user=worker1, program=prog,
-                defaults={"role": "staff"},
+                defaults={"role": ROLE_STAFF},
             )
 
         # Noor (worker-2): group programs + shared Kitchen
         for prog in (youth, newcomer, kitchen):
             UserProgramRole.objects.get_or_create(
                 user=worker2, program=prog,
-                defaults={"role": "staff"},
+                defaults={"role": ROLE_STAFF},
             )
 
         # Manager: program_manager on Employment, Housing, Kitchen (not all 5)
@@ -493,14 +500,14 @@ class Command(BaseCommand):
         for prog in (employment, housing, kitchen):
             UserProgramRole.objects.get_or_create(
                 user=manager, program=prog,
-                defaults={"role": "program_manager"},
+                defaults={"role": ROLE_PROGRAM_MANAGER},
             )
 
         # Executive: executive on all 5 (dashboard only)
         for prog in all_programs:
             UserProgramRole.objects.get_or_create(
                 user=executive, program=prog,
-                defaults={"role": "executive"},
+                defaults={"role": ROLE_EXECUTIVE},
             )
 
         # --- 15 Demo Clients ---

--- a/apps/audit/management/commands/security_audit.py
+++ b/apps/audit/management/commands/security_audit.py
@@ -22,6 +22,8 @@ from django.core.management.base import BaseCommand
 from django.db import connections
 from django.utils import timezone
 
+from apps.auth_app.constants import ALL_PROGRAM_ROLES
+
 
 class CheckResult:
     """Result of a single security check."""
@@ -344,7 +346,7 @@ class Command(BaseCommand):
         """RBAC003: All roles are valid values."""
         from apps.programs.models import UserProgramRole
 
-        valid_roles = {"receptionist", "staff", "program_manager", "executive"}
+        valid_roles = ALL_PROGRAM_ROLES
         invalid = UserProgramRole.objects.exclude(role__in=valid_roles)
 
         if invalid.exists():

--- a/apps/audit/views.py
+++ b/apps/audit/views.py
@@ -13,6 +13,7 @@ from django.shortcuts import get_object_or_404, render
 from django.utils import timezone
 from django.utils.translation import gettext as _
 
+from apps.auth_app.constants import ROLE_PROGRAM_MANAGER
 from apps.auth_app.decorators import admin_required, requires_permission
 from apps.programs.access import get_user_program_ids
 from apps.reports.csv_utils import sanitise_csv_row
@@ -179,7 +180,7 @@ def program_audit_log(request, program_id):
         user=request.user,
         program=program,
         status="active",
-        role="program_manager",
+        role=ROLE_PROGRAM_MANAGER,
     ).first()
 
     if not role:

--- a/apps/auth_app/admin_views.py
+++ b/apps/auth_app/admin_views.py
@@ -19,6 +19,7 @@ logger = logging.getLogger(__name__)
 from apps.programs.access import get_user_program_ids
 from apps.programs.models import Program, UserProgramRole
 
+from apps.auth_app.constants import ROLE_EXECUTIVE, ROLE_PROGRAM_MANAGER, ROLE_RECEPTIONIST, ROLE_STAFF
 from .decorators import admin_required, requires_permission
 from .forms import UserCreateForm, UserEditForm, UserProgramRoleForm
 from .models import User
@@ -26,14 +27,14 @@ from .models import User
 # Roles that PMs are NOT allowed to assign (no-elevation constraint).
 # PMs with user.manage: PROGRAM can manage staff in their own program
 # but cannot create PM/executive accounts or elevate front desk to staff.
-_PM_BLOCKED_ROLE_ASSIGNMENTS = {"program_manager", "executive"}
+_PM_BLOCKED_ROLE_ASSIGNMENTS = {ROLE_PROGRAM_MANAGER, ROLE_EXECUTIVE}
 
 
 def _get_pm_program_ids(user):
     """Return set of program IDs where the user is an active PM."""
     return set(
         UserProgramRole.objects.filter(
-            user=user, role="program_manager", status="active",
+            user=user, role=ROLE_PROGRAM_MANAGER, status="active",
         ).values_list("program_id", flat=True)
     )
 
@@ -299,7 +300,7 @@ def user_role_add(request, user_id):
                 existing_role = UserProgramRole.objects.filter(
                     user=edit_user, program=program, status="active",
                 ).values_list("role", flat=True).first()
-                if existing_role == "receptionist" and role == "staff":
+                if existing_role == ROLE_RECEPTIONIST and role == ROLE_STAFF:
                     messages.error(
                         request,
                         _("Elevating front desk to staff grants clinical data access. "

--- a/apps/auth_app/constants.py
+++ b/apps/auth_app/constants.py
@@ -1,10 +1,29 @@
 """Shared constants for role-based access control."""
 
+# Role constants - values match database/model choices.
+# Display labels (shown in UI) are defined in UserProgramRole.ROLE_CHOICES.
+#
+#   ROLE_RECEPTIONIST    -> "Front Desk"
+#   ROLE_STAFF           -> "Direct Service"
+#   ROLE_PROGRAM_MANAGER -> "Program Manager"
+#   ROLE_EXECUTIVE       -> "Executive"
+#   ROLE_ADMIN           -> "Administrator"
+
+ROLE_RECEPTIONIST = "receptionist"
+ROLE_STAFF = "staff"
+ROLE_PROGRAM_MANAGER = "program_manager"
+ROLE_EXECUTIVE = "executive"
+ROLE_ADMIN = "admin"
+
+# Convenience sets
+ALL_PROGRAM_ROLES = {ROLE_RECEPTIONIST, ROLE_STAFF, ROLE_PROGRAM_MANAGER, ROLE_EXECUTIVE}
+CLIENT_ACCESS_ROLES = {ROLE_RECEPTIONIST, ROLE_STAFF, ROLE_PROGRAM_MANAGER}
+
 # Higher number = more access.
 # Executive has highest rank but no client data access.
 ROLE_RANK = {
-    "receptionist": 1,
-    "staff": 2,
-    "program_manager": 3,
-    "executive": 4,
+    ROLE_RECEPTIONIST: 1,
+    ROLE_STAFF: 2,
+    ROLE_PROGRAM_MANAGER: 3,
+    ROLE_EXECUTIVE: 4,
 }

--- a/apps/auth_app/invite_views.py
+++ b/apps/auth_app/invite_views.py
@@ -11,6 +11,7 @@ from django.utils.translation import gettext as _
 
 from apps.programs.models import UserProgramRole
 
+from apps.auth_app.constants import ROLE_ADMIN
 from .decorators import admin_required
 from .forms import InviteAcceptForm, InviteCreateForm
 from .models import Invite
@@ -38,7 +39,7 @@ def invite_create(request):
             )
             invite.save()
             # Add program assignments (M2M requires save first)
-            if form.cleaned_data["role"] != "admin":
+            if form.cleaned_data["role"] != ROLE_ADMIN:
                 invite.programs.set(form.cleaned_data["programs"])
             from django.urls import reverse
             invite_url = request.build_absolute_uri(
@@ -72,14 +73,14 @@ def invite_accept(request, code):
                 username=form.cleaned_data["username"],
                 password=form.cleaned_data["password"],
                 display_name=form.cleaned_data["display_name"],
-                is_admin=(invite.role == "admin"),
+                is_admin=(invite.role == ROLE_ADMIN),
             )
             if form.cleaned_data.get("email"):
                 user.email = form.cleaned_data["email"]
                 user.save(update_fields=["_email_encrypted"])
 
             # Assign program roles (non-admin roles)
-            if invite.role != "admin":
+            if invite.role != ROLE_ADMIN:
                 UserProgramRole.objects.bulk_create([
                     UserProgramRole(user=user, program=program, role=invite.role)
                     for program in invite.programs.all()

--- a/apps/auth_app/management/commands/validate_permissions.py
+++ b/apps/auth_app/management/commands/validate_permissions.py
@@ -8,6 +8,15 @@ Usage:
 """
 from django.core.management.base import BaseCommand
 
+from apps.auth_app.constants import (
+    ALL_PROGRAM_ROLES,
+    ROLE_EXECUTIVE,
+    ROLE_PROGRAM_MANAGER,
+    ROLE_RANK,
+    ROLE_RECEPTIONIST,
+    ROLE_STAFF,
+)
+
 from apps.auth_app.permissions import (
     ALLOW,
     DENY,
@@ -24,43 +33,43 @@ from apps.auth_app.permissions import (
 # validation.  Format: username → list of (program_name, role).
 EXPECTED_DEMO_ROLES = {
     "demo-frontdesk": [
-        ("Supported Employment", "receptionist"),
-        ("Housing Stability", "receptionist"),
-        ("Youth Drop-In", "receptionist"),
-        ("Newcomer Connections", "receptionist"),
-        ("Community Kitchen", "receptionist"),
+        ("Supported Employment", ROLE_RECEPTIONIST),
+        ("Housing Stability", ROLE_RECEPTIONIST),
+        ("Youth Drop-In", ROLE_RECEPTIONIST),
+        ("Newcomer Connections", ROLE_RECEPTIONIST),
+        ("Community Kitchen", ROLE_RECEPTIONIST),
     ],
     "demo-worker-1": [
-        ("Supported Employment", "program_manager"),
-        ("Housing Stability", "staff"),
-        ("Community Kitchen", "staff"),
+        ("Supported Employment", ROLE_PROGRAM_MANAGER),
+        ("Housing Stability", ROLE_STAFF),
+        ("Community Kitchen", ROLE_STAFF),
     ],
     "demo-worker-2": [
-        ("Youth Drop-In", "staff"),
-        ("Newcomer Connections", "staff"),
-        ("Community Kitchen", "staff"),
+        ("Youth Drop-In", ROLE_STAFF),
+        ("Newcomer Connections", ROLE_STAFF),
+        ("Community Kitchen", ROLE_STAFF),
     ],
     "demo-manager": [
-        ("Supported Employment", "program_manager"),
-        ("Housing Stability", "program_manager"),
-        ("Community Kitchen", "program_manager"),
+        ("Supported Employment", ROLE_PROGRAM_MANAGER),
+        ("Housing Stability", ROLE_PROGRAM_MANAGER),
+        ("Community Kitchen", ROLE_PROGRAM_MANAGER),
     ],
     "demo-executive": [
-        ("Supported Employment", "executive"),
-        ("Housing Stability", "executive"),
-        ("Youth Drop-In", "executive"),
-        ("Newcomer Connections", "executive"),
-        ("Community Kitchen", "executive"),
+        ("Supported Employment", ROLE_EXECUTIVE),
+        ("Housing Stability", ROLE_EXECUTIVE),
+        ("Youth Drop-In", ROLE_EXECUTIVE),
+        ("Newcomer Connections", ROLE_EXECUTIVE),
+        ("Community Kitchen", ROLE_EXECUTIVE),
     ],
 }
 
 
 # Role display names for output
 ROLE_DISPLAY = {
-    "receptionist": "Front Desk",
-    "staff": "Direct Service",
-    "program_manager": "Program Manager",
-    "executive": "Executive",
+    ROLE_RECEPTIONIST: "Front Desk",
+    ROLE_STAFF: "Direct Service",
+    ROLE_PROGRAM_MANAGER: "Program Manager",
+    ROLE_EXECUTIVE: "Executive",
 }
 
 # Permission level display
@@ -137,7 +146,7 @@ class Command(BaseCommand):
             )
 
             # Print summary counts
-            for role in ["receptionist", "staff", "program_manager", "executive"]:
+            for role in list(ALL_PROGRAM_ROLES):
                 role_perms = PERMISSIONS[role]
                 counts = {}
                 for v in role_perms.values():
@@ -289,7 +298,6 @@ class Command(BaseCommand):
         self.stdout.write("")
         self.stdout.write("  Key restrictions (across all programs):")
         # Use the user's highest role for a summary of denials
-        from apps.auth_app.constants import ROLE_RANK
         all_roles = set(r.role for r in roles)
         highest = max(all_roles, key=lambda r: ROLE_RANK.get(r, 0))
         highest_perms = PERMISSIONS.get(highest, {})

--- a/apps/auth_app/permissions.py
+++ b/apps/auth_app/permissions.py
@@ -9,7 +9,14 @@ Enforcement layers:
 - @admin_required is a SEPARATE system — admin keys here are documentation only
 """
 
-from apps.auth_app.constants import ROLE_RANK
+from apps.auth_app.constants import (
+    ALL_PROGRAM_ROLES,
+    ROLE_EXECUTIVE,
+    ROLE_PROGRAM_MANAGER,
+    ROLE_RANK,
+    ROLE_RECEPTIONIST,
+    ROLE_STAFF,
+)
 
 # Permission levels
 DENY = "deny"          # Never allowed
@@ -21,7 +28,7 @@ PER_FIELD = "per_field"  # Check field-level configuration
 # --- Permissions matrix (single source of truth) ---
 
 PERMISSIONS = {
-    "receptionist": {
+    ROLE_RECEPTIONIST: {
         # Tier 1: Operational only — can check people in, see names, safety info only
         "client.view_name": ALLOW,  # Enforced by get_visible_fields() via can_access()
         "client.view_contact": ALLOW,  # Enforced by get_visible_fields() via can_access()
@@ -127,7 +134,7 @@ PERMISSIONS = {
         "circle.edit": DENY,
     },
 
-    "staff": {
+    ROLE_STAFF: {
         # Tier 2: Clinical access — scoped to assigned groups/clients (Phase 2)
         # Phase 1: scoped to program (existing behaviour preserved)
         "client.view_name": ALLOW,
@@ -236,7 +243,7 @@ PERMISSIONS = {
         "circle.edit": PROGRAM,    # Edit circles and manage members in their program
     },
 
-    "program_manager": {
+    ROLE_PROGRAM_MANAGER: {
         # Tier 3: Administrative + aggregate data
         # Phase 1: same as staff (existing behaviour)
         # Phase 3: aggregate-only default with gated individual access
@@ -353,7 +360,7 @@ PERMISSIONS = {
         "circle.edit": ALLOW,     # Edit circles and manage members
     },
 
-    "executive": {
+    ROLE_EXECUTIVE: {
         # Tier 4: Org-wide aggregate only — no individual client data
         "client.view_name": DENY,
         "client.view_contact": DENY,
@@ -505,7 +512,7 @@ def validate_permissions():
         all_keys.update(role_perms.keys())
 
     # Check each role has all keys
-    for role in ["receptionist", "staff", "program_manager", "executive"]:
+    for role in list(ALL_PROGRAM_ROLES):
         if role not in PERMISSIONS:
             errors.append(f"Role '{role}' missing from PERMISSIONS")
             continue

--- a/apps/clients/dashboard_views.py
+++ b/apps/clients/dashboard_views.py
@@ -15,6 +15,7 @@ from django.shortcuts import render
 from django.utils import timezone
 from django.utils.translation import gettext as _
 
+from apps.auth_app.constants import ROLE_EXECUTIVE, ROLE_PROGRAM_MANAGER
 from apps.clients.models import ClientProgramEnrolment
 from apps.notes.models import ProgressNote, SuggestionTheme
 from apps.programs.models import Program, UserProgramRole
@@ -1245,7 +1246,7 @@ def executive_dashboard(request):
     # Only computed for executive/admin roles. Shows pending items only.
     from apps.auth_app.decorators import _get_user_highest_role_any
     user_role = getattr(request, "user_program_role", None) or _get_user_highest_role_any(request.user)
-    is_exec_or_admin = user_role in ("executive", "program_manager") or getattr(request.user, "is_admin", False)
+    is_exec_or_admin = user_role in (ROLE_EXECUTIVE, ROLE_PROGRAM_MANAGER) or getattr(request.user, "is_admin", False)
 
     privacy_banner_items = []
     if is_exec_or_admin:
@@ -1328,7 +1329,7 @@ def _prepare_dashboard_export(request):
     # Role gate: only executives, PMs, and admins may export
     user_role = getattr(request, "user_program_role", None) or _get_user_highest_role_any(request.user)
     is_admin = getattr(request.user, "is_admin", False)
-    if user_role not in ("executive", "program_manager") and not is_admin:
+    if user_role not in (ROLE_EXECUTIVE, ROLE_PROGRAM_MANAGER) and not is_admin:
         return None, HttpResponseForbidden("Access restricted to management roles.")
 
     user_program_ids = list(

--- a/apps/clients/dv_views.py
+++ b/apps/clients/dv_views.py
@@ -18,6 +18,7 @@ from django.utils.translation import gettext as _
 from apps.admin_settings.models import get_access_tier
 from apps.audit.models import AuditLog
 from apps.programs.models import UserProgramRole
+from apps.auth_app.constants import ROLE_EXECUTIVE, ROLE_PROGRAM_MANAGER, ROLE_STAFF
 
 from .models import ClientFile, DvFlagRemovalRequest
 from .views import get_client_queryset
@@ -29,7 +30,7 @@ def _is_staff_or_above(user):
         return True
     return UserProgramRole.objects.filter(
         user=user,
-        role__in=["staff", "program_manager", "executive"],
+        role__in=[ROLE_STAFF, ROLE_PROGRAM_MANAGER, ROLE_EXECUTIVE],
     ).exists()
 
 
@@ -39,7 +40,7 @@ def _is_pm_or_above(user):
         return True
     return UserProgramRole.objects.filter(
         user=user,
-        role__in=["program_manager", "executive"],
+        role__in=[ROLE_PROGRAM_MANAGER, ROLE_EXECUTIVE],
     ).exists()
 
 

--- a/apps/clients/erasure.py
+++ b/apps/clients/erasure.py
@@ -10,6 +10,7 @@ Three tiers of erasure:
 """
 import logging
 
+from apps.auth_app.constants import ROLE_PROGRAM_MANAGER
 from django.db import transaction
 from django.utils import timezone
 from django.utils.translation import gettext as _
@@ -209,7 +210,7 @@ def is_deadlocked(erasure_request):
     for program_id in remaining_program_ids:
         other_pms = UserProgramRole.objects.filter(
             program_id=program_id,
-            role="program_manager",
+            role=ROLE_PROGRAM_MANAGER,
             status="active",
         ).exclude(user=requester)
         if other_pms.exists():

--- a/apps/clients/erasure_views.py
+++ b/apps/clients/erasure_views.py
@@ -12,6 +12,7 @@ from django.utils.translation import gettext as _
 from django.template.exceptions import TemplateDoesNotExist
 
 from apps.auth_app.decorators import requires_permission_global
+from apps.auth_app.constants import ROLE_PROGRAM_MANAGER
 from apps.events.models import Alert
 from apps.programs.models import UserProgramRole
 
@@ -37,7 +38,7 @@ def _user_is_pm_or_admin(user):
     if user.is_admin:
         return True
     return UserProgramRole.objects.filter(
-        user=user, role="program_manager", status="active",
+        user=user, role=ROLE_PROGRAM_MANAGER, status="active",
     ).exists()
 
 
@@ -45,7 +46,7 @@ def _get_user_pm_program_ids(user):
     """Get program IDs where user is an active program manager."""
     return list(
         UserProgramRole.objects.filter(
-            user=user, role="program_manager", status="active",
+            user=user, role=ROLE_PROGRAM_MANAGER, status="active",
         ).values_list("program_id", flat=True)
     )
 
@@ -498,7 +499,7 @@ def _notify_pms_erasure_request(erasure_request, request):
     pm_users = (
         UserProgramRole.objects.filter(
             program_id__in=erasure_request.programs_required,
-            role="program_manager",
+            role=ROLE_PROGRAM_MANAGER,
             status="active",
         )
         .exclude(user=erasure_request.requested_by)

--- a/apps/clients/models.py
+++ b/apps/clients/models.py
@@ -4,6 +4,7 @@ from django.db import models
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
+from apps.auth_app.constants import ROLE_RECEPTIONIST
 from konote.encryption import decrypt_field, encrypt_field, DecryptionError
 
 
@@ -306,7 +307,7 @@ class ClientFile(models.Model):
 
         visible = {}
 
-        if role == 'receptionist':
+        if role == ROLE_RECEPTIONIST:
             # Always-visible fields (identity + status)
             for f in FieldAccessConfig.ALWAYS_VISIBLE:
                 visible[f] = True

--- a/apps/clients/tests/test_last_contact.py
+++ b/apps/clients/tests/test_last_contact.py
@@ -12,6 +12,7 @@ from apps.communications.models import Communication
 from apps.events.models import Event, Meeting
 from apps.notes.models import ProgressNote, ProgressNoteTemplate
 from apps.programs.models import Program, UserProgramRole
+from apps.auth_app.constants import ROLE_STAFF
 
 User = get_user_model()
 
@@ -24,7 +25,7 @@ class LastContactHelperTests(TestCase):
     def setUp(self):
         self.program = Program.objects.create(name="Test")
         self.staff = User.objects.create_user(username="staff", password="pass")
-        UserProgramRole.objects.create(user=self.staff, program=self.program, role="staff", status="active")
+        UserProgramRole.objects.create(user=self.staff, program=self.program, role=ROLE_STAFF, status="active")
 
         self.client1 = ClientFile.objects.create(first_name="Alice", last_name="A")
         self.client2 = ClientFile.objects.create(first_name="Bob", last_name="B")
@@ -132,7 +133,7 @@ class ClientListLastContactTests(TestCase):
     def setUp(self):
         self.program = Program.objects.create(name="Test")
         self.staff = User.objects.create_user(username="staff", password="pass")
-        UserProgramRole.objects.create(user=self.staff, program=self.program, role="staff", status="active")
+        UserProgramRole.objects.create(user=self.staff, program=self.program, role=ROLE_STAFF, status="active")
 
         self.client1 = ClientFile.objects.create(first_name="Alice", last_name="A")
         self.client2 = ClientFile.objects.create(first_name="Bob", last_name="B")

--- a/apps/clients/urls_home.py
+++ b/apps/clients/urls_home.py
@@ -6,7 +6,7 @@ from django.shortcuts import redirect, render
 from django.urls import path
 from django.utils import timezone
 
-from apps.auth_app.constants import ROLE_RANK
+from apps.auth_app.constants import ROLE_EXECUTIVE, ROLE_PROGRAM_MANAGER, ROLE_RANK, ROLE_RECEPTIONIST
 from apps.auth_app.decorators import _get_user_highest_role, _get_user_highest_role_any
 
 
@@ -45,12 +45,12 @@ def home(request):
     # --- Check user role to determine if clinical data should be shown ---
     # BUG-12: Get user's highest role across all programs
     user_role = _get_user_highest_role(request.user)
-    is_receptionist = user_role == "receptionist"
+    is_receptionist = user_role == ROLE_RECEPTIONIST
 
     # DASH-ROLES1: Detect PM and executive using the inclusive helper
     highest_role_any = _get_user_highest_role_any(request.user)
-    is_executive = highest_role_any == "executive"
-    is_pm = highest_role_any == "program_manager" and not is_executive
+    is_executive = highest_role_any == ROLE_EXECUTIVE
+    is_pm = highest_role_any == ROLE_PROGRAM_MANAGER and not is_executive
 
     # CONF9: Use active program context from middleware if available
     active_ids = getattr(request, "active_program_ids", None)

--- a/apps/clients/views.py
+++ b/apps/clients/views.py
@@ -13,6 +13,7 @@ from django.urls import reverse
 from django.utils import timezone
 from django.utils.translation import gettext as _
 
+from apps.auth_app.constants import ROLE_EXECUTIVE, ROLE_PROGRAM_MANAGER, ROLE_RECEPTIONIST, ROLE_STAFF
 from apps.auth_app.decorators import _get_user_highest_role, admin_required, requires_permission
 from apps.auth_app.permissions import DENY, PERMISSIONS, can_access
 from apps.notes.models import ProgressNote
@@ -276,8 +277,8 @@ def client_list(request):
     }
 
     # Role-to-program mappings for grouped display.
-    staff_programs = [upr.program for upr in _user_roles if upr.role == "staff"]
-    pm_programs = [upr.program for upr in _user_roles if upr.role == "program_manager"]
+    staff_programs = [upr.program for upr in _user_roles if upr.role == ROLE_STAFF]
+    pm_programs = [upr.program for upr in _user_roles if upr.role == ROLE_PROGRAM_MANAGER]
     staff_program_ids = {p.pk for p in staff_programs}
     has_mixed_roles = bool(staff_program_ids) and bool(pm_programs)
 
@@ -447,7 +448,7 @@ def _get_create_field_defs(user):
         show_on_create=True,
     ).select_related("group").order_by("group__sort_order", "sort_order")
     user_role = getattr(user, "_program_role", None) or _get_user_highest_role(user)
-    if user_role == "receptionist":
+    if user_role == ROLE_RECEPTIONIST:
         qs = qs.filter(front_desk_access="edit")
     return list(qs)
 
@@ -1098,7 +1099,7 @@ def client_detail(request, client_id):
     request.session["recent_clients"] = recent[:10]
 
     user_role = getattr(request, "user_program_role", None)
-    is_receptionist = user_role == "receptionist"
+    is_receptionist = user_role == ROLE_RECEPTIONIST
 
     # Only show enrolments in programs the user has access to.
     # Prevents leaking confidential program names.
@@ -1133,7 +1134,7 @@ def client_detail(request, client_id):
         client_file=client, status="pending",
     ).exists()
 
-    is_pm_or_admin = user_role in ("program_manager", "executive") or getattr(request.user, "is_admin", False)
+    is_pm_or_admin = user_role in (ROLE_PROGRAM_MANAGER, ROLE_EXECUTIVE) or getattr(request.user, "is_admin", False)
 
     # Circles sidebar (only when feature toggle is on and user is not front desk)
     client_circles = []
@@ -1180,7 +1181,7 @@ def client_detail(request, client_id):
     # Determines which core model fields (e.g. birth_date) the user can see.
     # Custom fields use their own front_desk_access setting instead.
     effective_role = user_role or _get_user_highest_role(request.user)
-    visible_fields = client.get_visible_fields(effective_role) if effective_role else client.get_visible_fields("receptionist")
+    visible_fields = client.get_visible_fields(effective_role) if effective_role else client.get_visible_fields(ROLE_RECEPTIONIST)
 
     # Compute effective sharing state for the note sharing toggle (QA-R7-PRIVACY2).
     # Binary: ON if field is "consent", or "default" with agency toggle on.
@@ -1279,7 +1280,7 @@ def _get_custom_fields_context(client, user_role, hide_empty=False):
     of their front_desk_access setting. Fail closed: if is_dv_safe cannot be
     read, assume True for receptionists.
     """
-    is_receptionist = user_role == "receptionist"
+    is_receptionist = user_role == ROLE_RECEPTIONIST
     # DV-safe: determine whether to hide DV-sensitive fields from front desk
     dv_hide = False
     if is_receptionist:
@@ -1393,7 +1394,7 @@ def client_save_custom_fields(request, client_id):
         return redirect("clients:client_detail", client_id=client.pk)
 
     user_role = getattr(request, "user_program_role", None)
-    is_receptionist = user_role == "receptionist"
+    is_receptionist = user_role == ROLE_RECEPTIONIST
 
     if request.method == "POST":
         groups = CustomFieldGroup.objects.filter(status="active").prefetch_related("fields")
@@ -1482,7 +1483,7 @@ def client_consent_display(request, client_id):
     base_queryset = get_client_queryset(request.user)
     client = get_object_or_404(base_queryset, pk=client_id)
     user_role = getattr(request, "user_program_role", None)
-    is_pm_or_admin = user_role in ("program_manager", "executive") or getattr(request.user, "is_admin", False)
+    is_pm_or_admin = user_role in (ROLE_PROGRAM_MANAGER, ROLE_EXECUTIVE) or getattr(request.user, "is_admin", False)
     return render(request, "clients/_consent_display.html", {
         "client": client,
         "is_pm_or_admin": is_pm_or_admin,
@@ -1524,7 +1525,7 @@ def client_consent_save(request, client_id):
     base_queryset = get_client_queryset(request.user)
     client = get_object_or_404(base_queryset, pk=client_id)
     user_role = getattr(request, "user_program_role", None)
-    is_pm_or_admin = user_role in ("program_manager", "executive") or getattr(request.user, "is_admin", False)
+    is_pm_or_admin = user_role in (ROLE_PROGRAM_MANAGER, ROLE_EXECUTIVE) or getattr(request.user, "is_admin", False)
 
     if request.method == "POST":
         form = ConsentRecordForm(request.POST)
@@ -1614,7 +1615,7 @@ def client_consent_withdraw_form(request, client_id):
     base_queryset = get_client_queryset(request.user)
     client = get_object_or_404(base_queryset, pk=client_id)
     user_role = getattr(request, "user_program_role", None)
-    is_pm_or_admin = user_role in ("program_manager", "executive") or getattr(request.user, "is_admin", False)
+    is_pm_or_admin = user_role in (ROLE_PROGRAM_MANAGER, ROLE_EXECUTIVE) or getattr(request.user, "is_admin", False)
 
     if not client.consent_given_at:
         messages.info(request, _("No active consent to withdraw."))
@@ -1646,7 +1647,7 @@ def client_consent_withdraw(request, client_id):
     base_queryset = get_client_queryset(request.user)
     client = get_object_or_404(base_queryset, pk=client_id)
     user_role = getattr(request, "user_program_role", None)
-    is_pm_or_admin = user_role in ("program_manager", "executive") or getattr(request.user, "is_admin", False)
+    is_pm_or_admin = user_role in (ROLE_PROGRAM_MANAGER, ROLE_EXECUTIVE) or getattr(request.user, "is_admin", False)
 
     if request.method != "POST":
         return redirect("clients:client_detail", client_id=client.pk)

--- a/apps/communications/tests/test_staff_messages.py
+++ b/apps/communications/tests/test_staff_messages.py
@@ -4,6 +4,7 @@ from django.urls import reverse
 from django.contrib.auth import get_user_model
 
 from apps.clients.models import ClientFile, ClientProgramEnrolment
+from apps.auth_app.constants import ROLE_PROGRAM_MANAGER, ROLE_RECEPTIONIST, ROLE_STAFF
 from apps.programs.models import Program, UserProgramRole
 from apps.communications.models import StaffMessage
 
@@ -45,15 +46,15 @@ class StaffMessagePermissionTests(TestCase):
 
         # Receptionist
         self.receptionist = User.objects.create_user(username="recep", password="pass", display_name="Front Desk")
-        UserProgramRole.objects.create(user=self.receptionist, program=self.program, role="receptionist", status="active")
+        UserProgramRole.objects.create(user=self.receptionist, program=self.program, role=ROLE_RECEPTIONIST, status="active")
 
         # Staff
         self.staff = User.objects.create_user(username="staff", password="pass", display_name="Case Worker")
-        UserProgramRole.objects.create(user=self.staff, program=self.program, role="staff", status="active")
+        UserProgramRole.objects.create(user=self.staff, program=self.program, role=ROLE_STAFF, status="active")
 
         # PM
         self.pm = User.objects.create_user(username="pm", password="pass", display_name="Program Manager")
-        UserProgramRole.objects.create(user=self.pm, program=self.program, role="program_manager", status="active")
+        UserProgramRole.objects.create(user=self.pm, program=self.program, role=ROLE_PROGRAM_MANAGER, status="active")
 
         self.test_client = TestClient()
 

--- a/apps/communications/views.py
+++ b/apps/communications/views.py
@@ -14,6 +14,7 @@ from apps.clients.models import ClientFile
 from apps.events.models import Event, Meeting
 from apps.programs.access import get_author_program, get_client_or_403, get_program_from_client
 
+from apps.auth_app.constants import ROLE_PROGRAM_MANAGER, ROLE_STAFF
 from apps.auth_app.decorators import requires_permission, requires_permission_global
 
 from django.db import models as db_models
@@ -331,7 +332,7 @@ def leave_message(request, client_id):
 
     staff_user_ids = UserProgramRole.objects.filter(
         program_id__in=shared_program_ids,
-        role__in=["staff", "program_manager"],
+        role__in=[ROLE_STAFF, ROLE_PROGRAM_MANAGER],
         status="active",
     ).values_list("user_id", flat=True).distinct()
 

--- a/apps/events/forms.py
+++ b/apps/events/forms.py
@@ -2,6 +2,7 @@
 from django import forms
 from django.utils.translation import gettext_lazy as _
 
+from apps.auth_app.constants import ROLE_PROGRAM_MANAGER
 from apps.programs.models import Program, UserProgramRole
 
 from .models import Alert, Event, EventType, SRECategory
@@ -26,7 +27,7 @@ class EventTypeForm(forms.ModelForm):
         if requesting_user and not requesting_user.is_admin:
             pm_program_ids = set(
                 UserProgramRole.objects.filter(
-                    user=requesting_user, role="program_manager", status="active",
+                    user=requesting_user, role=ROLE_PROGRAM_MANAGER, status="active",
                 ).values_list("program_id", flat=True)
             )
             self.fields["owning_program"].queryset = Program.objects.filter(

--- a/apps/events/views.py
+++ b/apps/events/views.py
@@ -24,6 +24,7 @@ from apps.programs.access import (
 )
 from django_ratelimit.decorators import ratelimit
 
+from apps.auth_app.constants import ROLE_EXECUTIVE, ROLE_PROGRAM_MANAGER
 from apps.auth_app.decorators import admin_required, requires_permission, requires_permission_global
 from apps.auth_app.permissions import ALLOW, DENY, can_access
 from apps.programs.models import Program, UserProgramRole
@@ -71,7 +72,7 @@ def _get_pm_program_ids(user):
     """Return set of program IDs where the user is an active PM."""
     return set(
         UserProgramRole.objects.filter(
-            user=user, role="program_manager", status="active",
+            user=user, role=ROLE_PROGRAM_MANAGER, status="active",
         ).values_list("program_id", flat=True)
     )
 
@@ -288,7 +289,7 @@ def _send_sre_notification(event, request):
     if event.author_program_id:
         roles_qs = UserProgramRole.objects.filter(
             program_id=event.author_program_id,
-            role__in=["program_manager", "executive"],
+            role__in=[ROLE_PROGRAM_MANAGER, ROLE_EXECUTIVE],
             status="active",
         ).select_related("user")
         for role_obj in roles_qs:

--- a/apps/field_collection/management/commands/sync_odk.py
+++ b/apps/field_collection/management/commands/sync_odk.py
@@ -18,6 +18,8 @@ from datetime import date, datetime
 from django.core.management.base import BaseCommand, CommandError
 from django.utils import timezone
 
+from apps.auth_app.constants import ROLE_PROGRAM_MANAGER, ROLE_STAFF
+
 logger = logging.getLogger(__name__)
 
 
@@ -194,7 +196,7 @@ class Command(BaseCommand):
         staff_roles = UserProgramRole.objects.filter(
             program=program,
             status="active",
-            role__in=["staff", "program_manager"],
+            role__in=[ROLE_STAFF, ROLE_PROGRAM_MANAGER],
         ).select_related("user")
         self.stdout.write(f"  Staff to sync as app users: {staff_roles.count()}")
 

--- a/apps/notes/admin_views.py
+++ b/apps/notes/admin_views.py
@@ -12,6 +12,7 @@ from django.http import HttpResponseForbidden
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils.translation import gettext as _
 
+from apps.auth_app.constants import ROLE_PROGRAM_MANAGER
 from apps.auth_app.decorators import requires_permission
 from apps.programs.models import UserProgramRole
 
@@ -32,7 +33,7 @@ def _get_pm_program_ids(user):
     """Return set of program IDs where the user is an active PM."""
     return set(
         UserProgramRole.objects.filter(
-            user=user, role="program_manager", status="active",
+            user=user, role=ROLE_PROGRAM_MANAGER, status="active",
         ).values_list("program_id", flat=True)
     )
 

--- a/apps/notes/forms.py
+++ b/apps/notes/forms.py
@@ -4,6 +4,7 @@ from django.db.models import Count
 from django.utils.translation import gettext_lazy as _
 
 from apps.plans.models import SELF_EFFICACY_METRIC_NAME
+from apps.auth_app.constants import ROLE_PROGRAM_MANAGER
 from apps.programs.models import Program, UserProgramRole
 
 from .models import (
@@ -445,7 +446,7 @@ class NoteTemplateForm(forms.ModelForm):
         if requesting_user and not requesting_user.is_admin:
             pm_program_ids = set(
                 UserProgramRole.objects.filter(
-                    user=requesting_user, role="program_manager", status="active",
+                    user=requesting_user, role=ROLE_PROGRAM_MANAGER, status="active",
                 ).values_list("program_id", flat=True)
             )
             self.fields["owning_program"].queryset = Program.objects.filter(

--- a/apps/notes/suggestion_views.py
+++ b/apps/notes/suggestion_views.py
@@ -14,6 +14,8 @@ from django.utils import timezone
 from django.utils.translation import gettext as _
 from django.views.decorators.http import require_POST
 
+from apps.auth_app.constants import ROLE_PROGRAM_MANAGER
+
 from apps.admin_settings.models import FeatureToggle
 from apps.audit.models import AuditLog
 from apps.auth_app.decorators import requires_permission
@@ -35,7 +37,7 @@ def _get_pm_program_ids(user):
     """Return set of program IDs where user is an active program manager."""
     return set(
         UserProgramRole.objects.filter(
-            user=user, role="program_manager", status="active",
+            user=user, role=ROLE_PROGRAM_MANAGER, status="active",
         ).values_list("program_id", flat=True)
     )
 

--- a/apps/notes/tests/test_suggestion_themes.py
+++ b/apps/notes/tests/test_suggestion_themes.py
@@ -12,6 +12,7 @@ from apps.notes.models import (
     THEME_PRIORITY_RANK, ProgressNote, SuggestionLink, SuggestionTheme,
     deduplicate_themes, recalculate_theme_priority,
 )
+from apps.auth_app.constants import ROLE_PROGRAM_MANAGER, ROLE_RECEPTIONIST, ROLE_STAFF
 from apps.programs.models import Program, UserProgramRole
 
 User = get_user_model()
@@ -34,21 +35,21 @@ class SuggestionThemePermissionTests(TestCase):
         self.pm = User.objects.create_user(username="pm", password="pass")
         UserProgramRole.objects.create(
             user=self.pm, program=self.program,
-            role="program_manager", status="active",
+            role=ROLE_PROGRAM_MANAGER, status="active",
         )
 
         # Staff user
         self.staff = User.objects.create_user(username="staff", password="pass")
         UserProgramRole.objects.create(
             user=self.staff, program=self.program,
-            role="staff", status="active",
+            role=ROLE_STAFF, status="active",
         )
 
         # Receptionist user
         self.recep = User.objects.create_user(username="recep", password="pass")
         UserProgramRole.objects.create(
             user=self.recep, program=self.program,
-            role="receptionist", status="active",
+            role=ROLE_RECEPTIONIST, status="active",
         )
 
         # Admin user
@@ -57,7 +58,7 @@ class SuggestionThemePermissionTests(TestCase):
         self.admin.save()
         UserProgramRole.objects.create(
             user=self.admin, program=self.program,
-            role="staff", status="active",
+            role=ROLE_STAFF, status="active",
         )
 
         # Create a theme for testing
@@ -119,7 +120,7 @@ class SuggestionThemePermissionTests(TestCase):
         other_pm = User.objects.create_user(username="other_pm", password="pass")
         UserProgramRole.objects.create(
             user=other_pm, program=other_program,
-            role="program_manager", status="active",
+            role=ROLE_PROGRAM_MANAGER, status="active",
         )
         self.test_client.login(username="other_pm", password="pass")
         response = self.test_client.get(
@@ -158,7 +159,7 @@ class SuggestionThemeLinkingTests(TestCase):
         self.pm = User.objects.create_user(username="pm", password="pass")
         UserProgramRole.objects.create(
             user=self.pm, program=self.program,
-            role="program_manager", status="active",
+            role=ROLE_PROGRAM_MANAGER, status="active",
         )
         self.test_client = TestClient()
         self.test_client.login(username="pm", password="pass")
@@ -246,7 +247,7 @@ class SuggestionThemeLinkingTests(TestCase):
     def test_staff_cannot_link(self):
         staff = User.objects.create_user(username="staff", password="pass")
         UserProgramRole.objects.create(
-            user=staff, program=self.program, role="staff", status="active",
+            user=staff, program=self.program, role=ROLE_STAFF, status="active",
         )
         staff_client = TestClient()
         staff_client.login(username="staff", password="pass")
@@ -273,7 +274,7 @@ class SuggestionThemeStatusTests(TestCase):
         self.pm = User.objects.create_user(username="pm", password="pass")
         UserProgramRole.objects.create(
             user=self.pm, program=self.program,
-            role="program_manager", status="active",
+            role=ROLE_PROGRAM_MANAGER, status="active",
         )
         self.test_client = TestClient()
         self.test_client.login(username="pm", password="pass")

--- a/apps/notes/tests/test_theme_engine.py
+++ b/apps/notes/tests/test_theme_engine.py
@@ -6,6 +6,7 @@ from django.test import TestCase, override_settings
 
 import konote.encryption as enc_module
 from apps.clients.models import ClientFile, ClientProgramEnrolment
+from apps.auth_app.constants import ROLE_STAFF
 from apps.notes.models import (
     ProgressNote, SuggestionLink, SuggestionTheme, recalculate_theme_priority,
 )
@@ -48,7 +49,7 @@ class Tier1AutoLinkTests(TestCase):
         self.user = User.objects.create_user(username="staff", password="pass")
         UserProgramRole.objects.create(
             user=self.user, program=self.program,
-            role="staff", status="active",
+            role=ROLE_STAFF, status="active",
         )
 
         # Create a theme with keywords
@@ -142,7 +143,7 @@ class Tier1PrivacyGateTests(TestCase):
         self.user = User.objects.create_user(username="staff", password="pass")
         UserProgramRole.objects.create(
             user=self.user, program=self.program,
-            role="staff", status="active",
+            role=ROLE_STAFF, status="active",
         )
         self.theme = SuggestionTheme.objects.create(
             program=self.program,

--- a/apps/notes/views.py
+++ b/apps/notes/views.py
@@ -21,6 +21,7 @@ logger = logging.getLogger(__name__)
 
 from django.db.models import Q
 
+from apps.auth_app.constants import ROLE_PROGRAM_MANAGER, ROLE_RANK, ROLE_STAFF
 from apps.auth_app.decorators import program_role_required, requires_permission
 from apps.clients.models import ClientFile
 from apps.plans.models import PlanTarget, PlanTargetMetric
@@ -623,11 +624,10 @@ def template_preview(request, template_id):
 
     Requires at least staff-level role (receptionists cannot preview templates).
     """
-    from apps.auth_app.constants import ROLE_RANK
     from apps.auth_app.decorators import _get_user_highest_role
 
     user_role = _get_user_highest_role(request.user)
-    if ROLE_RANK.get(user_role, 0) < ROLE_RANK.get("staff", 0):
+    if ROLE_RANK.get(user_role, 0) < ROLE_RANK.get(ROLE_STAFF, 0):
         raise PermissionDenied(_("Access restricted to clinical staff."))
 
     template = get_object_or_404(ProgressNoteTemplate, pk=template_id, status="active")
@@ -829,7 +829,7 @@ def note_create(request, client_id):
             # Contextual toast when a suggestion was recorded
             if form.cleaned_data.get("suggestion_priority"):
                 is_pm = UserProgramRole.objects.filter(
-                    user=request.user, role="program_manager", status="active",
+                    user=request.user, role=ROLE_PROGRAM_MANAGER, status="active",
                 ).exists()
                 if is_pm or getattr(request.user, "is_admin", False):
                     messages.info(
@@ -1016,7 +1016,7 @@ def note_cancel(request, note_id):
     user = request.user
     # Permission check — program managers can cancel any note in their programs
     user_role = getattr(request, "user_program_role", None)
-    if user_role != "program_manager":
+    if user_role != ROLE_PROGRAM_MANAGER:
         if note.author_id != user.pk:
             raise PermissionDenied(_("You can only cancel your own notes."))
         age = timezone.now() - note.created_at

--- a/apps/plans/admin_forms.py
+++ b/apps/plans/admin_forms.py
@@ -2,6 +2,7 @@
 from django import forms
 
 from apps.plans.models import PlanTemplate, PlanTemplateSection, PlanTemplateTarget
+from apps.auth_app.constants import ROLE_PROGRAM_MANAGER
 from apps.programs.models import Program, UserProgramRole
 
 
@@ -24,7 +25,7 @@ class PlanTemplateForm(forms.ModelForm):
             # PMs can only assign to their own programs
             pm_program_ids = set(
                 UserProgramRole.objects.filter(
-                    user=requesting_user, role="program_manager", status="active",
+                    user=requesting_user, role=ROLE_PROGRAM_MANAGER, status="active",
                 ).values_list("program_id", flat=True)
             )
             self.fields["owning_program"].queryset = Program.objects.filter(

--- a/apps/plans/admin_views.py
+++ b/apps/plans/admin_views.py
@@ -27,6 +27,7 @@ from apps.plans.models import (
     PlanTemplateSection,
     PlanTemplateTarget,
 )
+from apps.auth_app.constants import ROLE_PROGRAM_MANAGER
 from apps.programs.models import UserProgramRole
 
 
@@ -34,7 +35,7 @@ def _get_pm_program_ids(user):
     """Return set of program IDs where the user is an active PM."""
     return set(
         UserProgramRole.objects.filter(
-            user=user, role="program_manager", status="active",
+            user=user, role=ROLE_PROGRAM_MANAGER, status="active",
         ).values_list("program_id", flat=True)
     )
 

--- a/apps/plans/forms.py
+++ b/apps/plans/forms.py
@@ -4,6 +4,7 @@ import json
 from django import forms
 from django.utils.translation import gettext_lazy as _
 
+from apps.auth_app.constants import ROLE_PROGRAM_MANAGER
 from apps.programs.models import Program
 
 from .models import MetricDefinition, PlanSection, PlanTarget
@@ -177,7 +178,7 @@ class MetricDefinitionForm(forms.ModelForm):
             from apps.programs.models import Program, UserProgramRole
             pm_program_ids = set(
                 UserProgramRole.objects.filter(
-                    user=requesting_user, role="program_manager", status="active",
+                    user=requesting_user, role=ROLE_PROGRAM_MANAGER, status="active",
                 ).values_list("program_id", flat=True)
             )
             self.fields["owning_program"].queryset = Program.objects.filter(

--- a/apps/plans/tests.py
+++ b/apps/plans/tests.py
@@ -7,6 +7,7 @@ from django.urls import reverse
 
 from apps.auth_app.models import User
 from apps.clients.models import ClientFile
+from apps.auth_app.constants import ROLE_PROGRAM_MANAGER, ROLE_STAFF
 from apps.programs.models import Program, UserProgramRole
 
 from .models import (
@@ -43,11 +44,11 @@ class PlanPermissionHelperTest(TestCase):
         )
         # PM role
         UserProgramRole.objects.create(
-            user=self.pm, program=self.program, role="program_manager", status="active"
+            user=self.pm, program=self.program, role=ROLE_PROGRAM_MANAGER, status="active"
         )
         # Staff role
         UserProgramRole.objects.create(
-            user=self.staff, program=self.program, role="staff", status="active"
+            user=self.staff, program=self.program, role=ROLE_STAFF, status="active"
         )
 
     def test_admin_cannot_edit_without_staff_role(self):
@@ -100,10 +101,10 @@ class SectionCreatePermissionTest(TestCase):
             client_file=self.client_file, program=self.program, status="active"
         )
         UserProgramRole.objects.create(
-            user=self.staff, program=self.program, role="staff", status="active"
+            user=self.staff, program=self.program, role=ROLE_STAFF, status="active"
         )
         UserProgramRole.objects.create(
-            user=self.pm, program=self.program, role="program_manager", status="active"
+            user=self.pm, program=self.program, role=ROLE_PROGRAM_MANAGER, status="active"
         )
 
     def test_staff_can_create_section(self):
@@ -143,7 +144,7 @@ class TargetEditRevisionTest(TestCase):
             client_file=self.client_file, program=self.program, status="active"
         )
         UserProgramRole.objects.create(
-            user=self.staff, program=self.program, role="staff", status="active"
+            user=self.staff, program=self.program, role=ROLE_STAFF, status="active"
         )
         self.section = PlanSection.objects.create(
             client_file=self.client_file, name="Section A"

--- a/apps/plans/views.py
+++ b/apps/plans/views.py
@@ -17,6 +17,7 @@ from django.utils.translation import gettext as _
 
 from apps.audit.models import AuditLog
 from apps.auth_app.decorators import admin_required, program_role_required, requires_permission
+from apps.auth_app.constants import ALL_PROGRAM_ROLES, ROLE_PROGRAM_MANAGER
 from apps.auth_app.permissions import DENY, can_access
 from apps.clients.models import ClientFile, ClientProgramEnrolment
 from apps.programs.access import (
@@ -95,7 +96,7 @@ def _can_edit_plan(user, client_file):
         status="active",
     ).exclude(
         role__in=[
-            r for r in ["receptionist", "staff", "program_manager", "executive"]
+            r for r in ALL_PROGRAM_ROLES
             if can_access(r, "plan.edit") == DENY
         ]
     ).exists()
@@ -811,7 +812,7 @@ def _get_pm_program_ids_for_metrics(user):
     """Return set of program IDs where the user is an active PM."""
     return set(
         UserProgramRole.objects.filter(
-            user=user, role="program_manager", status="active",
+            user=user, role=ROLE_PROGRAM_MANAGER, status="active",
         ).values_list("program_id", flat=True)
     )
 

--- a/apps/programs/models.py
+++ b/apps/programs/models.py
@@ -3,6 +3,8 @@ from django.conf import settings
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 
+from apps.auth_app.constants import CLIENT_ACCESS_ROLES, ROLE_EXECUTIVE
+
 
 class Program(models.Model):
     """An organisational unit (e.g., housing, employment, youth services)."""
@@ -113,7 +115,7 @@ class UserProgramRole(models.Model):
         unique_together = ["user", "program"]
 
     # Roles that grant access to individual client records
-    CLIENT_ACCESS_ROLES = {"receptionist", "staff", "program_manager"}
+    CLIENT_ACCESS_ROLES = CLIENT_ACCESS_ROLES
 
     def __str__(self):
         return f"{self.user} → {self.program} ({self.role})"
@@ -135,6 +137,6 @@ class UserProgramRole(models.Model):
             )
         if not roles:
             return False
-        if "executive" in roles:
+        if ROLE_EXECUTIVE in roles:
             return not bool(roles & cls.CLIENT_ACCESS_ROLES)
         return False

--- a/apps/programs/views.py
+++ b/apps/programs/views.py
@@ -23,6 +23,8 @@ from .context import (
 from apps.groups.models import Group
 
 from .forms import CONFIDENTIAL_KEYWORDS, ProgramForm, UserProgramRoleForm, SwitchProgramForm
+from apps.auth_app.constants import ROLE_PROGRAM_MANAGER, ROLE_RECEPTIONIST
+
 from .models import Program, UserProgramRole
 
 logger = logging.getLogger(__name__)
@@ -45,7 +47,7 @@ def program_list(request):
     for program in programs:
         # Get program manager (if any)
         manager_role = UserProgramRole.objects.filter(
-            program=program, role="program_manager", status="active"
+            program=program, role=ROLE_PROGRAM_MANAGER, status="active"
         ).select_related("user").first()
         manager_name = manager_role.user.display_name if manager_role else None
         manager_email = manager_role.user.email if manager_role else None
@@ -135,7 +137,7 @@ def program_detail(request, program_id):
     user_program_role = UserProgramRole.objects.filter(
         user=request.user, program=program, status="active"
     ).values_list("role", flat=True).first()
-    is_receptionist = user_program_role == "receptionist"
+    is_receptionist = user_program_role == ROLE_RECEPTIONIST
 
     # Program health summary for non-front-desk roles (matches Insights RBAC)
     program_summary = None
@@ -174,7 +176,7 @@ def program_detail(request, program_id):
         group_count = groups.count()
 
     # Program Manager name for Front Desk groups summary
-    pm_role = roles.filter(role="program_manager", status="active").first()
+    pm_role = roles.filter(role=ROLE_PROGRAM_MANAGER, status="active").first()
     program_manager_name = pm_role.user.display_name if pm_role else None
 
     return render(request, "programs/detail.html", {

--- a/apps/registration/admin_views.py
+++ b/apps/registration/admin_views.py
@@ -10,6 +10,7 @@ from django.shortcuts import get_object_or_404, redirect, render
 from django.utils import timezone
 from django.utils.translation import gettext as _
 
+from apps.auth_app.constants import ROLE_PROGRAM_MANAGER
 from apps.auth_app.decorators import requires_permission
 from apps.clients.models import ClientFile, CustomFieldDefinition
 from apps.clients.views import get_client_queryset
@@ -24,7 +25,7 @@ def _get_pm_program_ids(user):
     """Return set of program IDs where the user is an active PM."""
     return set(
         UserProgramRole.objects.filter(
-            user=user, role="program_manager", status="active",
+            user=user, role=ROLE_PROGRAM_MANAGER, status="active",
         ).values_list("program_id", flat=True)
     )
 

--- a/apps/registration/forms.py
+++ b/apps/registration/forms.py
@@ -4,6 +4,7 @@ import json
 from django import forms
 from django.utils.translation import gettext_lazy as _
 
+from apps.auth_app.constants import ROLE_PROGRAM_MANAGER
 from apps.clients.models import CustomFieldDefinition, CustomFieldGroup
 from apps.clients.validators import (
     normalize_phone_number, validate_phone_number,
@@ -57,7 +58,7 @@ class RegistrationLinkForm(forms.ModelForm):
         if requesting_user and not requesting_user.is_admin:
             pm_program_ids = set(
                 UserProgramRole.objects.filter(
-                    user=requesting_user, role="program_manager", status="active",
+                    user=requesting_user, role=ROLE_PROGRAM_MANAGER, status="active",
                 ).values_list("program_id", flat=True)
             )
             base_qs = base_qs.filter(pk__in=pm_program_ids)

--- a/apps/reports/insights_views.py
+++ b/apps/reports/insights_views.py
@@ -9,6 +9,7 @@ from django.utils.translation import gettext as _
 
 from django.db.models import Count
 
+from apps.auth_app.constants import ROLE_EXECUTIVE, ROLE_PROGRAM_MANAGER
 from apps.auth_app.decorators import requires_permission
 from apps.programs.access import get_client_or_403
 from apps.programs.models import UserProgramRole
@@ -177,7 +178,7 @@ def program_insights(request):
         UserProgramRole.objects.filter(user=request.user, status="active")
         .values_list("role", flat=True)
     )
-    is_executive_only = user_roles and user_roles <= {"executive"}
+    is_executive_only = user_roles and user_roles <= {ROLE_EXECUTIVE}
 
     form = InsightsFilterForm(request.GET or None, user=request.user)
 
@@ -345,7 +346,7 @@ def program_insights(request):
             "total_theme_count": total_theme_count,
             "can_manage_themes": UserProgramRole.objects.filter(
                 user=request.user, program=program,
-                role="program_manager", status="active",
+                role=ROLE_PROGRAM_MANAGER, status="active",
             ).exists() or request.user.is_superuser,
             "data_tier": data_tier,
             "min_participants": MIN_PARTICIPANTS_FOR_QUOTES,

--- a/apps/reports/tests/test_team_views.py
+++ b/apps/reports/tests/test_team_views.py
@@ -9,6 +9,7 @@ from django.utils import timezone
 from apps.clients.models import ClientFile, ClientProgramEnrolment
 from apps.communications.models import Communication
 from apps.notes.models import ProgressNote, ProgressNoteTemplate
+from apps.auth_app.constants import ROLE_PROGRAM_MANAGER, ROLE_RECEPTIONIST, ROLE_STAFF
 from apps.programs.models import Program, UserProgramRole
 
 User = get_user_model()
@@ -25,21 +26,21 @@ class TeamMeetingViewPermissionTests(TestCase):
 
     def test_pm_can_access(self):
         pm = User.objects.create_user(username="pm", password="pass")
-        UserProgramRole.objects.create(user=pm, program=self.program, role="program_manager", status="active")
+        UserProgramRole.objects.create(user=pm, program=self.program, role=ROLE_PROGRAM_MANAGER, status="active")
         self.test_client.login(username="pm", password="pass")
         response = self.test_client.get(reverse("reports:team_meeting_view"))
         self.assertEqual(response.status_code, 200)
 
     def test_staff_cannot_access(self):
         staff = User.objects.create_user(username="staff", password="pass")
-        UserProgramRole.objects.create(user=staff, program=self.program, role="staff", status="active")
+        UserProgramRole.objects.create(user=staff, program=self.program, role=ROLE_STAFF, status="active")
         self.test_client.login(username="staff", password="pass")
         response = self.test_client.get(reverse("reports:team_meeting_view"))
         self.assertEqual(response.status_code, 403)
 
     def test_receptionist_cannot_access(self):
         recep = User.objects.create_user(username="recep", password="pass")
-        UserProgramRole.objects.create(user=recep, program=self.program, role="receptionist", status="active")
+        UserProgramRole.objects.create(user=recep, program=self.program, role=ROLE_RECEPTIONIST, status="active")
         self.test_client.login(username="recep", password="pass")
         response = self.test_client.get(reverse("reports:team_meeting_view"))
         self.assertEqual(response.status_code, 403)
@@ -48,7 +49,7 @@ class TeamMeetingViewPermissionTests(TestCase):
         admin = User.objects.create_user(username="admin", password="pass")
         admin.is_admin = True
         admin.save()
-        UserProgramRole.objects.create(user=admin, program=self.program, role="staff", status="active")
+        UserProgramRole.objects.create(user=admin, program=self.program, role=ROLE_STAFF, status="active")
         self.test_client.login(username="admin", password="pass")
         response = self.test_client.get(reverse("reports:team_meeting_view"))
         self.assertEqual(response.status_code, 200)
@@ -62,13 +63,13 @@ class TeamMeetingViewContentTests(TestCase):
     def setUp(self):
         self.program = Program.objects.create(name="Youth Services")
         self.pm = User.objects.create_user(username="pm", password="pass", display_name="Program Manager")
-        UserProgramRole.objects.create(user=self.pm, program=self.program, role="program_manager", status="active")
+        UserProgramRole.objects.create(user=self.pm, program=self.program, role=ROLE_PROGRAM_MANAGER, status="active")
 
         self.staff1 = User.objects.create_user(username="staff1", password="pass", display_name="Alice Smith")
-        UserProgramRole.objects.create(user=self.staff1, program=self.program, role="staff", status="active")
+        UserProgramRole.objects.create(user=self.staff1, program=self.program, role=ROLE_STAFF, status="active")
 
         self.staff2 = User.objects.create_user(username="staff2", password="pass", display_name="Bob Jones")
-        UserProgramRole.objects.create(user=self.staff2, program=self.program, role="staff", status="active")
+        UserProgramRole.objects.create(user=self.staff2, program=self.program, role=ROLE_STAFF, status="active")
 
         self.client_file = ClientFile.objects.create(first_name="Test", last_name="Client")
         ClientProgramEnrolment.objects.create(client_file=self.client_file, program=self.program, status="active")
@@ -161,9 +162,9 @@ class TeamMeetingViewContentTests(TestCase):
         """Program filter limits to selected program."""
         other_program = Program.objects.create(name="Other Program")
         other_staff = User.objects.create_user(username="other", password="pass", display_name="Other Staff")
-        UserProgramRole.objects.create(user=other_staff, program=other_program, role="staff", status="active")
+        UserProgramRole.objects.create(user=other_staff, program=other_program, role=ROLE_STAFF, status="active")
         # PM also has access to other program
-        UserProgramRole.objects.create(user=self.pm, program=other_program, role="program_manager", status="active")
+        UserProgramRole.objects.create(user=self.pm, program=other_program, role=ROLE_PROGRAM_MANAGER, status="active")
 
         # Filter to main program only
         response = self.test_client.get(

--- a/apps/reports/utils.py
+++ b/apps/reports/utils.py
@@ -6,6 +6,8 @@ from typing import List, Tuple
 from django.utils.formats import date_format
 from django.utils.translation import gettext_lazy as _
 
+from apps.auth_app.constants import ROLE_EXECUTIVE, ROLE_PROGRAM_MANAGER
+
 
 def is_aggregate_only_user(user):
     """Check if this user should only receive aggregate (non-individual) export data.
@@ -30,7 +32,7 @@ def is_aggregate_only_user(user):
     from apps.programs.models import UserProgramRole
 
     has_pm_role = UserProgramRole.objects.filter(
-        user=user, role="program_manager", status="active"
+        user=user, role=ROLE_PROGRAM_MANAGER, status="active"
     ).exists()
     return not has_pm_role
 
@@ -52,7 +54,7 @@ def can_download_pii_export(user):
     from apps.programs.models import UserProgramRole
 
     return UserProgramRole.objects.filter(
-        user=user, role="program_manager", status="active"
+        user=user, role=ROLE_PROGRAM_MANAGER, status="active"
     ).exists()
 
 
@@ -80,7 +82,7 @@ def can_create_export(user, export_type, program=None):
 
     if export_type in ("metrics", "funder_report", "session_report"):
         qs = UserProgramRole.objects.filter(
-            user=user, role__in=["program_manager", "executive"], status="active"
+            user=user, role__in=[ROLE_PROGRAM_MANAGER, ROLE_EXECUTIVE], status="active"
         )
         if program:
             return qs.filter(program=program).exists()
@@ -105,7 +107,7 @@ def get_manageable_programs(user):
         return Program.objects.filter(status="active")
 
     managed_ids = UserProgramRole.objects.filter(
-        user=user, role__in=["program_manager", "executive"], status="active"
+        user=user, role__in=[ROLE_PROGRAM_MANAGER, ROLE_EXECUTIVE], status="active"
     ).values_list("program_id", flat=True)
     return Program.objects.filter(pk__in=managed_ids, status="active")
 

--- a/apps/reports/views.py
+++ b/apps/reports/views.py
@@ -22,6 +22,7 @@ from django.utils import timezone
 from django.utils.translation import gettext as _
 
 from apps.audit.models import AuditLog
+from apps.auth_app.constants import ROLE_PROGRAM_MANAGER
 from apps.auth_app.decorators import admin_required, requires_permission
 from apps.auth_app.models import User
 from apps.clients.models import ClientFile, ClientProgramEnrolment
@@ -205,7 +206,7 @@ def _save_export_and_create_link(request, content, filename, export_type,
     from apps.programs.models import UserProgramRole
 
     creator_is_pm = UserProgramRole.objects.filter(
-        user=request.user, role="program_manager", status="active"
+        user=request.user, role=ROLE_PROGRAM_MANAGER, status="active"
     ).exists()
     is_elevated = (
         client_count >= 100
@@ -1991,7 +1992,7 @@ def team_meeting_view(request):
     from django.db.models import Count, Max, Q
 
     from apps.auth_app.decorators import _get_user_highest_role
-    from apps.auth_app.constants import ROLE_RANK
+    from apps.auth_app.constants import ROLE_PROGRAM_MANAGER, ROLE_RANK, ROLE_STAFF
     from apps.programs.models import UserProgramRole, Program
     from apps.programs.access import get_user_program_ids
     from apps.notes.models import ProgressNote
@@ -2000,7 +2001,7 @@ def team_meeting_view(request):
 
     # Check PM/admin permission
     role = _get_user_highest_role(request.user)
-    if ROLE_RANK.get(role, 0) < ROLE_RANK.get("program_manager", 99):
+    if ROLE_RANK.get(role, 0) < ROLE_RANK.get(ROLE_PROGRAM_MANAGER, 99):
         if not getattr(request.user, "is_admin", False):
             return HttpResponseForbidden(_("This view is for program managers only."))
 
@@ -2033,7 +2034,7 @@ def team_meeting_view(request):
     # Get staff members in filtered programs (exclude demo users)
     staff_roles = UserProgramRole.objects.filter(
         program_id__in=filter_program_ids,
-        role__in=["staff", "program_manager"],
+        role__in=[ROLE_STAFF, ROLE_PROGRAM_MANAGER],
         status="active",
         user__is_demo=False,
     ).select_related("user", "program").order_by("user__display_name")

--- a/konote/context_processors.py
+++ b/konote/context_processors.py
@@ -1,5 +1,12 @@
 """Template context processors for terminology, features, and settings."""
 from django.core.cache import cache
+
+from apps.auth_app.constants import (
+    ROLE_EXECUTIVE,
+    ROLE_PROGRAM_MANAGER,
+    ROLE_RECEPTIONIST,
+    ROLE_RANK,
+)
 from django.utils.translation import get_language
 
 
@@ -121,7 +128,6 @@ def user_roles(request):
             "user_permissions": {},
         }
 
-    from apps.auth_app.constants import ROLE_RANK
     from apps.auth_app.permissions import DENY, PERMISSIONS
     from apps.programs.models import UserProgramRole
 
@@ -133,12 +139,12 @@ def user_roles(request):
     # Export access: admins, program managers, and executives can create reports
     has_export_access = (
         request.user.is_admin
-        or "program_manager" in roles
-        or "executive" in roles
+        or ROLE_PROGRAM_MANAGER in roles
+        or ROLE_EXECUTIVE in roles
     )
 
     # Front desk only: user has program roles but all of them are front desk
-    is_receptionist_only = has_roles and roles == {"receptionist"}
+    is_receptionist_only = has_roles and roles == {ROLE_RECEPTIONIST}
 
     # Build user_permissions dict using the user's highest role.
     # Keys use underscores so templates can access e.g. user_permissions.note_view
@@ -203,7 +209,7 @@ def pending_erasures(request):
     from apps.programs.models import UserProgramRole
 
     is_pm = UserProgramRole.objects.filter(
-        user=request.user, role="program_manager", status="active",
+        user=request.user, role=ROLE_PROGRAM_MANAGER, status="active",
     ).exists()
 
     if not request.user.is_admin and not is_pm:
@@ -221,7 +227,7 @@ def pending_erasures(request):
             # Filters in Python — works on all DB backends (SQLite + PostgreSQL)
             pm_program_ids = list(
                 UserProgramRole.objects.filter(
-                    user=request.user, role="program_manager", status="active",
+                    user=request.user, role=ROLE_PROGRAM_MANAGER, status="active",
                 ).values_list("program_id", flat=True)
             )
             pids_set = set(pm_program_ids)
@@ -466,8 +472,7 @@ def active_program_context(request):
         # For "all standard", show the user's highest role across standard programs
         from apps.programs.context import get_user_program_tiers
         tiers = get_user_program_tiers(request.user)
-        from apps.auth_app.constants import ROLE_RANK
-
+    
         best = None
         for prog in tiers["standard"]:
             if best is None or ROLE_RANK.get(prog["role"], 0) > ROLE_RANK.get(

--- a/tests/integration/test_page_capture.py
+++ b/tests/integration/test_page_capture.py
@@ -40,6 +40,12 @@ from tests.utils.page_capture import (
     write_axe_report,
     write_manifest,
 )
+from apps.auth_app.constants import (
+    ROLE_EXECUTIVE,
+    ROLE_PROGRAM_MANAGER,
+    ROLE_RECEPTIONIST,
+    ROLE_STAFF,
+)
 
 
 @pytest.mark.skipif(
@@ -71,7 +77,7 @@ class TestPageCapture(BrowserTestBase):
                 display_name="Casey New",
             )
             UserProgramRole.objects.create(
-                user=u, program=self.program_a, role="staff",
+                user=u, program=self.program_a, role=ROLE_STAFF,
             )
 
         # DS2: Jean-Luc (French-speaking staff)
@@ -81,7 +87,7 @@ class TestPageCapture(BrowserTestBase):
                 display_name="Jean-Luc Bergeron",
             )
             UserProgramRole.objects.create(
-                user=u, program=self.program_a, role="staff",
+                user=u, program=self.program_a, role=ROLE_STAFF,
             )
 
         # DS3: Amara (accessibility / keyboard-only staff)
@@ -93,7 +99,7 @@ class TestPageCapture(BrowserTestBase):
                                           # stale cookie from setting lang="fr"
             )
             UserProgramRole.objects.create(
-                user=u, program=self.program_a, role="staff",
+                user=u, program=self.program_a, role=ROLE_STAFF,
             )
 
         # R2: Omar (tech-savvy part-time receptionist)
@@ -103,7 +109,7 @@ class TestPageCapture(BrowserTestBase):
                 display_name="Omar Hussain",
             )
             UserProgramRole.objects.create(
-                user=u, program=self.program_b, role="receptionist",
+                user=u, program=self.program_b, role=ROLE_RECEPTIONIST,
             )
 
         # R2-FR: Amelie (French receptionist)
@@ -113,7 +119,7 @@ class TestPageCapture(BrowserTestBase):
                 display_name="Amelie Tremblay",
             )
             UserProgramRole.objects.create(
-                user=u, program=self.program_a, role="receptionist",
+                user=u, program=self.program_a, role=ROLE_RECEPTIONIST,
             )
 
         # DS1c: Casey with ADHD (cognitive accessibility)
@@ -123,7 +129,7 @@ class TestPageCapture(BrowserTestBase):
                 display_name="Casey Parker",
             )
             UserProgramRole.objects.create(
-                user=u, program=self.program_a, role="staff",
+                user=u, program=self.program_a, role=ROLE_STAFF,
             )
 
         # DS4: Riley Chen (voice navigation / Dragon user)
@@ -133,7 +139,7 @@ class TestPageCapture(BrowserTestBase):
                 display_name="Riley Chen",
             )
             UserProgramRole.objects.create(
-                user=u, program=self.program_a, role="staff",
+                user=u, program=self.program_a, role=ROLE_STAFF,
             )
 
         # PM1: Morgan Tremblay (program manager, cross-program)
@@ -145,13 +151,13 @@ class TestPageCapture(BrowserTestBase):
                 display_name="Morgan Tremblay",
             )
             UserProgramRole.objects.create(
-                user=mgr, program=self.program_a, role="program_manager",
+                user=mgr, program=self.program_a, role=ROLE_PROGRAM_MANAGER,
             )
         if not UserProgramRole.objects.filter(
             user=mgr, program=self.program_b,
         ).exists():
             UserProgramRole.objects.create(
-                user=mgr, program=self.program_b, role="program_manager",
+                user=mgr, program=self.program_b, role=ROLE_PROGRAM_MANAGER,
             )
 
         # E2: Kwame Asante (second executive/admin)
@@ -163,10 +169,10 @@ class TestPageCapture(BrowserTestBase):
             u.is_admin = True
             u.save()
             UserProgramRole.objects.create(
-                user=u, program=self.program_a, role="executive",
+                user=u, program=self.program_a, role=ROLE_EXECUTIVE,
             )
             UserProgramRole.objects.create(
-                user=u, program=self.program_b, role="executive",
+                user=u, program=self.program_b, role=ROLE_EXECUTIVE,
             )
 
     # ------------------------------------------------------------------

--- a/tests/scenario_eval/scenario_runner.py
+++ b/tests/scenario_eval/scenario_runner.py
@@ -20,6 +20,12 @@ from .llm_evaluator import evaluate_step, format_persona_for_prompt
 from .objective_scorer import compute_objective_scores, count_user_actions
 from .score_models import ScenarioResult, StepEvaluation
 from .state_capture import capture_step_state, capture_to_evaluation_context
+from apps.auth_app.constants import (
+    ROLE_EXECUTIVE,
+    ROLE_PROGRAM_MANAGER,
+    ROLE_RECEPTIONIST,
+    ROLE_STAFF,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -201,7 +207,7 @@ class ScenarioRunner(BrowserTestBase):
                 preferred_language="en",
             )
             UserProgramRole.objects.create(
-                user=staff_new, program=self.program_a, role="staff",
+                user=staff_new, program=self.program_a, role=ROLE_STAFF,
             )
 
         # DS2: Jean-Luc (French-speaking staff)
@@ -212,7 +218,7 @@ class ScenarioRunner(BrowserTestBase):
                 preferred_language="fr",
             )
             UserProgramRole.objects.create(
-                user=staff_fr, program=self.program_a, role="staff",
+                user=staff_fr, program=self.program_a, role=ROLE_STAFF,
             )
 
         # DS3: Amara (accessibility / keyboard-only staff)
@@ -224,7 +230,7 @@ class ScenarioRunner(BrowserTestBase):
                                           # stale cookie from setting lang="fr"
             )
             UserProgramRole.objects.create(
-                user=staff_a11y, program=self.program_a, role="staff",
+                user=staff_a11y, program=self.program_a, role=ROLE_STAFF,
             )
 
         # R2: Omar (tech-savvy part-time receptionist)
@@ -235,7 +241,7 @@ class ScenarioRunner(BrowserTestBase):
                 preferred_language="en",
             )
             UserProgramRole.objects.create(
-                user=frontdesk2, program=self.program_b, role="receptionist",
+                user=frontdesk2, program=self.program_b, role=ROLE_RECEPTIONIST,
             )
 
         # DS1c: Casey with ADHD (cognitive accessibility profile)
@@ -246,7 +252,7 @@ class ScenarioRunner(BrowserTestBase):
                 preferred_language="en",
             )
             UserProgramRole.objects.create(
-                user=staff_adhd, program=self.program_a, role="staff",
+                user=staff_adhd, program=self.program_a, role=ROLE_STAFF,
             )
 
         # DS4: Riley Chen (voice navigation / Dragon user)
@@ -257,7 +263,7 @@ class ScenarioRunner(BrowserTestBase):
                 preferred_language="en",
             )
             UserProgramRole.objects.create(
-                user=staff_voice, program=self.program_a, role="staff",
+                user=staff_voice, program=self.program_a, role=ROLE_STAFF,
             )
 
         # PM1: Morgan Tremblay (program manager, cross-program)
@@ -272,7 +278,7 @@ class ScenarioRunner(BrowserTestBase):
             )
             UserProgramRole.objects.create(
                 user=manager_user, program=self.program_a,
-                role="program_manager",
+                role=ROLE_PROGRAM_MANAGER,
             )
         # BUG-24: Ensure explicit language even if base class created this user
         if not manager_user.preferred_language:
@@ -283,7 +289,7 @@ class ScenarioRunner(BrowserTestBase):
         ).exists():
             UserProgramRole.objects.create(
                 user=manager_user, program=self.program_b,
-                role="program_manager",
+                role=ROLE_PROGRAM_MANAGER,
             )
 
         # PM2-FR: Sophie Tremblay (French-speaking program manager)
@@ -295,11 +301,11 @@ class ScenarioRunner(BrowserTestBase):
             )
             UserProgramRole.objects.create(
                 user=manager_fr, program=self.program_a,
-                role="program_manager",
+                role=ROLE_PROGRAM_MANAGER,
             )
             UserProgramRole.objects.create(
                 user=manager_fr, program=self.program_b,
-                role="program_manager",
+                role=ROLE_PROGRAM_MANAGER,
             )
 
         # E2: Kwame Asante (second executive)
@@ -312,10 +318,10 @@ class ScenarioRunner(BrowserTestBase):
             executive2.is_admin = True
             executive2.save()
             UserProgramRole.objects.create(
-                user=executive2, program=self.program_a, role="executive",
+                user=executive2, program=self.program_a, role=ROLE_EXECUTIVE,
             )
             UserProgramRole.objects.create(
-                user=executive2, program=self.program_b, role="executive",
+                user=executive2, program=self.program_b, role=ROLE_EXECUTIVE,
             )
 
         # R2-FR: Amélie Tremblay (French-speaking receptionist)
@@ -327,7 +333,7 @@ class ScenarioRunner(BrowserTestBase):
             )
             UserProgramRole.objects.create(
                 user=frontdesk_fr, program=self.program_a,
-                role="receptionist",
+                role=ROLE_RECEPTIONIST,
             )
 
         # Extra clients needed by specific scenarios.
@@ -953,7 +959,7 @@ class ScenarioRunner(BrowserTestBase):
         # 5. Verify data is accessible (client list or executive dashboard)
         persona_role = (persona_data.get("test_user", {}).get("role", "")
                         or persona_data.get("role", "")).lower()
-        if persona_role == "executive":
+        if persona_role == ROLE_EXECUTIVE:
             # Executives see aggregate stats, not individual client rows
             self.page.goto(self.live_url("/participants/executive/"))
             self._wait_for_idle()

--- a/tests/test_a11y_ci.py
+++ b/tests/test_a11y_ci.py
@@ -12,6 +12,7 @@ import json
 import os
 import shutil
 import tempfile
+from apps.auth_app.constants import ROLE_PROGRAM_MANAGER
 
 os.environ["DJANGO_ALLOW_ASYNC_UNSAFE"] = "true"
 
@@ -119,7 +120,7 @@ class AxeA11ySmokeTest(StaticLiveServerTestCase):
             name="Test Program", colour_hex="#10B981",
         )
         UserProgramRole.objects.create(
-            user=self.user, program=self.program, role="program_manager",
+            user=self.user, program=self.program, role=ROLE_PROGRAM_MANAGER,
         )
 
     def _login(self):

--- a/tests/test_access_grants.py
+++ b/tests/test_access_grants.py
@@ -9,6 +9,7 @@ from apps.admin_settings.models import InstanceSetting
 from apps.auth_app.models import AccessGrant, AccessGrantReason, User
 from apps.programs.models import Program, UserProgramRole
 import konote.encryption as enc_module
+from apps.auth_app.constants import ROLE_PROGRAM_MANAGER, ROLE_STAFF
 
 TEST_KEY = Fernet.generate_key().decode()
 
@@ -131,7 +132,7 @@ class GatedDecoratorTest(TestCase):
         )
         self.program = Program.objects.create(name="Test Program")
         UserProgramRole.objects.create(
-            user=self.pm, program=self.program, role="program_manager",
+            user=self.pm, program=self.program, role=ROLE_PROGRAM_MANAGER,
         )
         self.reason = _create_reason()
 
@@ -286,7 +287,7 @@ class GatedDecoratorTest(TestCase):
             username="staff_user", password="testpass123",
         )
         UserProgramRole.objects.create(
-            user=staff, program=self.program, role="staff",
+            user=staff, program=self.program, role=ROLE_STAFF,
         )
         self.http_client.login(username="staff_user", password="testpass123")
 
@@ -317,7 +318,7 @@ class AccessGrantFormTest(TestCase):
         )
         self.program = Program.objects.create(name="Test Program")
         UserProgramRole.objects.create(
-            user=self.pm, program=self.program, role="program_manager",
+            user=self.pm, program=self.program, role=ROLE_PROGRAM_MANAGER,
         )
         self.reason = _create_reason()
         _setup_tier3()
@@ -412,7 +413,7 @@ class AccessGrantListViewTest(TestCase):
         )
         self.program = Program.objects.create(name="Test Program")
         UserProgramRole.objects.create(
-            user=self.pm, program=self.program, role="program_manager",
+            user=self.pm, program=self.program, role=ROLE_PROGRAM_MANAGER,
         )
         self.reason = _create_reason()
 
@@ -515,7 +516,7 @@ class AccessGrantAdminViewTest(TestCase):
     def test_non_admin_cannot_access_admin_views(self):
         """Non-admin users get 403 on admin grant views."""
         UserProgramRole.objects.create(
-            user=self.pm, program=self.program, role="program_manager",
+            user=self.pm, program=self.program, role=ROLE_PROGRAM_MANAGER,
         )
         self.http_client.login(username="pm", password="testpass123")
         resp = self.http_client.get("/admin/settings/access-grants/")

--- a/tests/test_ai_endpoints.py
+++ b/tests/test_ai_endpoints.py
@@ -10,6 +10,7 @@ from apps.clients.models import ClientFile, ClientProgramEnrolment
 from apps.plans.models import MetricDefinition, PlanSection, PlanTarget, PlanTargetMetric
 from apps.programs.models import Program, UserProgramRole
 import konote.encryption as enc_module
+from apps.auth_app.constants import ROLE_STAFF
 
 
 TEST_KEY = Fernet.generate_key().decode()
@@ -30,7 +31,7 @@ class AIEndpointBaseTest(TestCase):
         )
         self.program = Program.objects.create(name="Housing")
         UserProgramRole.objects.create(
-            user=self.user, program=self.program, role="staff", status="active"
+            user=self.user, program=self.program, role=ROLE_STAFF, status="active"
         )
 
         # Enable the AI feature toggle

--- a/tests/test_alert_recommendation.py
+++ b/tests/test_alert_recommendation.py
@@ -17,6 +17,12 @@ from apps.clients.models import ClientFile, ClientProgramEnrolment
 from apps.events.models import Alert, AlertCancellationRecommendation
 from apps.programs.models import Program, UserProgramRole
 import konote.encryption as enc_module
+from apps.auth_app.constants import (
+    ROLE_EXECUTIVE,
+    ROLE_PROGRAM_MANAGER,
+    ROLE_RECEPTIONIST,
+    ROLE_STAFF,
+)
 
 TEST_KEY = Fernet.generate_key().decode()
 
@@ -37,7 +43,7 @@ class AlertRecommendationWorkflowTest(TestCase):
             username="staff1", password="testpass123", display_name="Staff One",
         )
         UserProgramRole.objects.create(
-            user=self.staff_user, program=self.program, role="staff", status="active",
+            user=self.staff_user, program=self.program, role=ROLE_STAFF, status="active",
         )
 
         # PM user — can cancel directly, can review recommendations
@@ -45,7 +51,7 @@ class AlertRecommendationWorkflowTest(TestCase):
             username="pm1", password="testpass123", display_name="PM One",
         )
         UserProgramRole.objects.create(
-            user=self.pm_user, program=self.program, role="program_manager", status="active",
+            user=self.pm_user, program=self.program, role=ROLE_PROGRAM_MANAGER, status="active",
         )
 
         # Receptionist — should be denied everything
@@ -53,7 +59,7 @@ class AlertRecommendationWorkflowTest(TestCase):
             username="recep1", password="testpass123", display_name="Receptionist",
         )
         UserProgramRole.objects.create(
-            user=self.receptionist, program=self.program, role="receptionist", status="active",
+            user=self.receptionist, program=self.program, role=ROLE_RECEPTIONIST, status="active",
         )
 
         # Executive — should be denied everything
@@ -61,7 +67,7 @@ class AlertRecommendationWorkflowTest(TestCase):
             username="exec1", password="testpass123", display_name="Exec One",
         )
         UserProgramRole.objects.create(
-            user=self.executive, program=self.program, role="executive", status="active",
+            user=self.executive, program=self.program, role=ROLE_EXECUTIVE, status="active",
         )
 
         # Client enrolled in the program

--- a/tests/test_audit_views.py
+++ b/tests/test_audit_views.py
@@ -8,6 +8,7 @@ from apps.auth_app.models import User
 from apps.clients.models import ClientFile, ClientProgramEnrolment
 from apps.programs.models import Program, UserProgramRole
 import konote.encryption as enc_module
+from apps.auth_app.constants import ROLE_EXECUTIVE, ROLE_PROGRAM_MANAGER, ROLE_STAFF
 
 TEST_KEY = Fernet.generate_key().decode()
 
@@ -310,15 +311,15 @@ class ProgramAuditLogTests(TestCase):
         # Assign roles
         UserProgramRole.objects.create(
             user=self.manager, program=self.program,
-            role="program_manager", status="active",
+            role=ROLE_PROGRAM_MANAGER, status="active",
         )
         UserProgramRole.objects.create(
             user=self.executive, program=self.program,
-            role="executive", status="active",
+            role=ROLE_EXECUTIVE, status="active",
         )
         UserProgramRole.objects.create(
             user=self.caseworker, program=self.program,
-            role="staff", status="active",
+            role=ROLE_STAFF, status="active",
         )
 
         # Create a client enrolled in the program
@@ -372,7 +373,7 @@ class ProgramAuditLogTests(TestCase):
         )
         UserProgramRole.objects.create(
             user=removed_user, program=self.program,
-            role="program_manager", status="removed",
+            role=ROLE_PROGRAM_MANAGER, status="removed",
         )
         self.client.login(username="removed", password="testpass123")
         resp = self.client.get(self._url())
@@ -584,7 +585,7 @@ class ComplianceSummaryPermissionTests(TestCase):
         self.program = Program.objects.create(name="Test Program", status="active")
         UserProgramRole.objects.create(
             user=self.executive, program=self.program,
-            role="executive", status="active",
+            role=ROLE_EXECUTIVE, status="active",
         )
 
         # Staff — should be denied
@@ -593,7 +594,7 @@ class ComplianceSummaryPermissionTests(TestCase):
         )
         UserProgramRole.objects.create(
             user=self.staff, program=self.program,
-            role="staff", status="active",
+            role=ROLE_STAFF, status="active",
         )
 
         # Program manager — should be denied (uses audit.view for their program)
@@ -602,7 +603,7 @@ class ComplianceSummaryPermissionTests(TestCase):
         )
         UserProgramRole.objects.create(
             user=self.pm, program=self.program,
-            role="program_manager", status="active",
+            role=ROLE_PROGRAM_MANAGER, status="active",
         )
 
         # Seed one audit entry so the view has data to aggregate

--- a/tests/test_auth_views.py
+++ b/tests/test_auth_views.py
@@ -8,6 +8,12 @@ from django.utils import timezone
 from apps.auth_app.models import Invite, User
 from apps.programs.models import Program, UserProgramRole
 import konote.encryption as enc_module
+from apps.auth_app.constants import (
+    ROLE_ADMIN,
+    ROLE_EXECUTIVE,
+    ROLE_PROGRAM_MANAGER,
+    ROLE_STAFF,
+)
 
 
 TEST_KEY = Fernet.generate_key().decode()
@@ -160,7 +166,7 @@ class InviteAcceptViewTest(TestCase):
         )
         self.program = Program.objects.create(name="Test Program")
         self.invite = Invite.objects.create(
-            role="staff",
+            role=ROLE_STAFF,
             created_by=self.admin,
             expires_at=timezone.now() + timedelta(days=7),
         )
@@ -186,7 +192,7 @@ class InviteAcceptViewTest(TestCase):
         self.assertEqual(user.display_name, "New User")
         self.assertFalse(user.is_admin)
         role = UserProgramRole.objects.get(user=user)
-        self.assertEqual(role.role, "staff")
+        self.assertEqual(role.role, ROLE_STAFF)
         self.assertEqual(role.program, self.program)
         # Verify invite is marked as used
         self.invite.refresh_from_db()
@@ -236,7 +242,7 @@ class InviteAcceptViewTest(TestCase):
 
     def test_admin_invite_creates_admin_user(self):
         admin_invite = Invite.objects.create(
-            role="admin",
+            role=ROLE_ADMIN,
             created_by=self.admin,
             expires_at=timezone.now() + timedelta(days=7),
         )
@@ -273,8 +279,8 @@ class AdminRoutePermissionTest(TestCase):
             username="pm", password="pass", display_name="Program Manager"
         )
         self.program = Program.objects.create(name="Test")
-        UserProgramRole.objects.create(user=self.staff, program=self.program, role="staff")
-        UserProgramRole.objects.create(user=self.pm, program=self.program, role="program_manager")
+        UserProgramRole.objects.create(user=self.staff, program=self.program, role=ROLE_STAFF)
+        UserProgramRole.objects.create(user=self.pm, program=self.program, role=ROLE_PROGRAM_MANAGER)
 
     def tearDown(self):
         enc_module._fernet = None
@@ -688,13 +694,13 @@ class ExecutiveLoginRedirectTest(TestCase):
         })
 
     def test_executive_only_redirects_to_executive_dashboard(self):
-        self._create_user("exec_user", ["executive"])
+        self._create_user("exec_user", [ROLE_EXECUTIVE])
         resp = self._login("exec_user")
         self.assertEqual(resp.status_code, 302)
         self.assertEqual(resp.url, "/participants/executive/")
 
     def test_staff_redirects_to_home(self):
-        self._create_user("staff_user", ["staff"])
+        self._create_user("staff_user", [ROLE_STAFF])
         resp = self._login("staff_user")
         self.assertEqual(resp.status_code, 302)
         self.assertEqual(resp.url, "/")
@@ -706,10 +712,10 @@ class ExecutiveLoginRedirectTest(TestCase):
         )
         prog2 = Program.objects.create(name="Program 2")
         UserProgramRole.objects.create(
-            user=user, program=self.program, role="executive", status="active"
+            user=user, program=self.program, role=ROLE_EXECUTIVE, status="active"
         )
         UserProgramRole.objects.create(
-            user=user, program=prog2, role="staff", status="active"
+            user=user, program=prog2, role=ROLE_STAFF, status="active"
         )
         resp = self._login("dual_user")
         self.assertEqual(resp.status_code, 302)

--- a/tests/test_canadian_localisation.py
+++ b/tests/test_canadian_localisation.py
@@ -24,6 +24,7 @@ from apps.clients.validators import (
 )
 from apps.programs.models import Program, UserProgramRole
 import konote.encryption as enc_module
+from apps.auth_app.constants import ROLE_PROGRAM_MANAGER
 
 TEST_KEY = Fernet.generate_key().decode()
 
@@ -275,7 +276,7 @@ class CustomFieldNormalisationIntegrationTest(TestCase):
         )
         self.program = Program.objects.create(name="Test Program", colour_hex="#10B981")
         UserProgramRole.objects.create(
-            user=self.admin, program=self.program, role="program_manager"
+            user=self.admin, program=self.program, role=ROLE_PROGRAM_MANAGER
         )
         self.group = CustomFieldGroup.objects.create(title="Contact Information")
         self.postal_field = CustomFieldDefinition.objects.create(

--- a/tests/test_cids.py
+++ b/tests/test_cids.py
@@ -18,6 +18,7 @@ from apps.plans.models import MetricDefinition, PlanTarget, PlanSection, PlanTar
 from apps.plans.achievement import compute_achievement_status, update_achievement_status
 from apps.programs.models import Program, UserProgramRole
 import konote.encryption as enc_module
+from apps.auth_app.constants import ROLE_PROGRAM_MANAGER, ROLE_STAFF
 
 TEST_KEY = Fernet.generate_key().decode()
 
@@ -860,7 +861,7 @@ class DischargeViewTest(TestCase):
         self.program = Program.objects.create(name="Test Program")
         from apps.programs.models import UserProgramRole
         UserProgramRole.objects.create(
-            user=self.user, program=self.program, role="program_manager",
+            user=self.user, program=self.program, role=ROLE_PROGRAM_MANAGER,
         )
         self.client_file = ClientFile.objects.create()
         self.client_file.first_name = "Test"
@@ -919,7 +920,7 @@ class OnHoldResumeViewTest(TestCase):
         self.program = Program.objects.create(name="Test Program")
         from apps.programs.models import UserProgramRole
         UserProgramRole.objects.create(
-            user=self.user, program=self.program, role="program_manager",
+            user=self.user, program=self.program, role=ROLE_PROGRAM_MANAGER,
         )
         self.client_file = ClientFile.objects.create()
         self.client_file.first_name = "Test"
@@ -1289,7 +1290,7 @@ class AuthorRoleAutoFillTest(TestCase):
         self.user = User.objects.create_user(username="staff", password="test123")
         self.program = Program.objects.create(name="Test Program")
         UserProgramRole.objects.create(
-            user=self.user, program=self.program, role="staff",
+            user=self.user, program=self.program, role=ROLE_STAFF,
         )
         self.client_file = ClientFile.objects.create()
         self.client_file.first_name = "Test"
@@ -1305,13 +1306,13 @@ class AuthorRoleAutoFillTest(TestCase):
         )
         note.notes_text = "Test"
         note.save()
-        self.assertEqual(note.author_role, "staff")
+        self.assertEqual(note.author_role, ROLE_STAFF)
 
     def test_correct_role_lookup(self):
         """Uses the role from the specific program, not just any role."""
         other_program = Program.objects.create(name="Other Program")
         UserProgramRole.objects.create(
-            user=self.user, program=other_program, role="program_manager",
+            user=self.user, program=other_program, role=ROLE_PROGRAM_MANAGER,
         )
         note = ProgressNote(
             client_file=self.client_file,
@@ -1321,7 +1322,7 @@ class AuthorRoleAutoFillTest(TestCase):
         )
         note.notes_text = "Test"
         note.save()
-        self.assertEqual(note.author_role, "program_manager")
+        self.assertEqual(note.author_role, ROLE_PROGRAM_MANAGER)
 
     def test_missing_role_handled_gracefully(self):
         """No UserProgramRole → author_role stays blank."""

--- a/tests/test_circles.py
+++ b/tests/test_circles.py
@@ -19,6 +19,12 @@ from apps.clients.models import ClientAccessBlock, ClientFile, ClientProgramEnro
 from apps.notes.models import ProgressNote
 from apps.programs.models import Program, UserProgramRole
 import konote.encryption as enc_module
+from apps.auth_app.constants import (
+    ROLE_EXECUTIVE,
+    ROLE_PROGRAM_MANAGER,
+    ROLE_RECEPTIONIST,
+    ROLE_STAFF,
+)
 
 TEST_KEY = Fernet.generate_key().decode()
 
@@ -184,7 +190,7 @@ class CircleViewPermissionTest(TestCase):
         FeatureToggle.objects.update_or_create(
             feature_key="circles", defaults={"is_enabled": False},
         )
-        staff = self._make_user("staff1", "staff")
+        staff = self._make_user("staff1", ROLE_STAFF)
         self.http.login(username="staff1", password="testpass123")
         resp = self.http.get("/circles/")
         self.assertEqual(resp.status_code, 404)
@@ -192,7 +198,7 @@ class CircleViewPermissionTest(TestCase):
     def test_feature_toggle_on_staff_can_list(self):
         """Staff with circle.view can access the list."""
         _enable_circles()
-        staff = self._make_user("staff1", "staff")
+        staff = self._make_user("staff1", ROLE_STAFF)
         self.http.login(username="staff1", password="testpass123")
         resp = self.http.get("/circles/")
         self.assertEqual(resp.status_code, 200)
@@ -200,7 +206,7 @@ class CircleViewPermissionTest(TestCase):
     def test_receptionist_denied(self):
         """Receptionists should be denied access (circle.view = DENY)."""
         _enable_circles()
-        receptionist = self._make_user("rec1", "receptionist")
+        receptionist = self._make_user("rec1", ROLE_RECEPTIONIST)
         self.http.login(username="rec1", password="testpass123")
         resp = self.http.get("/circles/")
         self.assertEqual(resp.status_code, 403)
@@ -208,7 +214,7 @@ class CircleViewPermissionTest(TestCase):
     def test_executive_denied(self):
         """Executives should be denied access (circle.view = DENY)."""
         _enable_circles()
-        executive = self._make_user("exec1", "executive")
+        executive = self._make_user("exec1", ROLE_EXECUTIVE)
         self.http.login(username="exec1", password="testpass123")
         resp = self.http.get("/circles/")
         self.assertEqual(resp.status_code, 403)
@@ -216,7 +222,7 @@ class CircleViewPermissionTest(TestCase):
     def test_program_manager_can_access(self):
         """Program managers should have full access."""
         _enable_circles()
-        pm = self._make_user("pm1", "program_manager")
+        pm = self._make_user("pm1", ROLE_PROGRAM_MANAGER)
         self.http.login(username="pm1", password="testpass123")
         resp = self.http.get("/circles/")
         self.assertEqual(resp.status_code, 200)
@@ -235,7 +241,7 @@ class CircleCRUDTest(TestCase):
             username="staff1", password="testpass123",
         )
         UserProgramRole.objects.create(
-            user=self.staff, program=self.program, role="staff",
+            user=self.staff, program=self.program, role=ROLE_STAFF,
         )
         # Create a client enrolled in the program
         self.client_file = ClientFile(is_demo=False)
@@ -361,7 +367,7 @@ class CirclePrivacyTest(TestCase):
             username="staff1", password="testpass123",
         )
         UserProgramRole.objects.create(
-            user=self.staff, program=self.program1, role="staff",
+            user=self.staff, program=self.program1, role=ROLE_STAFF,
         )
         # Client A in program1 (accessible)
         self.client_a = ClientFile(is_demo=False)
@@ -500,7 +506,7 @@ class CircleIntakeTest(TestCase):
             username="staff1", password="testpass123",
         )
         UserProgramRole.objects.create(
-            user=self.staff, program=self.program, role="staff",
+            user=self.staff, program=self.program, role=ROLE_STAFF,
         )
         # Pre-existing circle
         self.circle = Circle(is_demo=False, created_by=self.staff)
@@ -594,7 +600,7 @@ class CircleNoteFormTest(TestCase):
             username="staff1", password="testpass123",
         )
         UserProgramRole.objects.create(
-            user=self.staff, program=self.program, role="staff",
+            user=self.staff, program=self.program, role=ROLE_STAFF,
         )
         self.client_file = ClientFile(is_demo=False)
         self.client_file.first_name = "Jane"

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -3,6 +3,12 @@ from django.test import TestCase, Client, override_settings
 from django.utils import timezone
 from cryptography.fernet import Fernet
 
+from apps.auth_app.constants import (
+    ROLE_EXECUTIVE,
+    ROLE_PROGRAM_MANAGER,
+    ROLE_RECEPTIONIST,
+    ROLE_STAFF,
+)
 from apps.auth_app.models import User
 from apps.programs.models import Program, UserProgramRole
 from apps.clients.models import (
@@ -29,12 +35,12 @@ class ClientViewsTest(TestCase):
         self.receptionist = User.objects.create_user(username="receptionist", password="testpass123", is_admin=False)
         self.prog_a = Program.objects.create(name="Program A", colour_hex="#10B981")
         self.prog_b = Program.objects.create(name="Program B", colour_hex="#3B82F6")
-        UserProgramRole.objects.create(user=self.staff, program=self.prog_a, role="staff")
-        UserProgramRole.objects.create(user=self.pm, program=self.prog_a, role="program_manager")
-        UserProgramRole.objects.create(user=self.receptionist, program=self.prog_a, role="receptionist")
+        UserProgramRole.objects.create(user=self.staff, program=self.prog_a, role=ROLE_STAFF)
+        UserProgramRole.objects.create(user=self.pm, program=self.prog_a, role=ROLE_PROGRAM_MANAGER)
+        UserProgramRole.objects.create(user=self.receptionist, program=self.prog_a, role=ROLE_RECEPTIONIST)
         # Give admin access to both programs so they can see all clients
-        UserProgramRole.objects.create(user=self.admin, program=self.prog_a, role="program_manager")
-        UserProgramRole.objects.create(user=self.admin, program=self.prog_b, role="program_manager")
+        UserProgramRole.objects.create(user=self.admin, program=self.prog_a, role=ROLE_PROGRAM_MANAGER)
+        UserProgramRole.objects.create(user=self.admin, program=self.prog_b, role=ROLE_PROGRAM_MANAGER)
 
     def _create_client(self, first="Jane", last="Doe", programs=None):
         cf = ClientFile()
@@ -219,7 +225,7 @@ class ClientViewsTest(TestCase):
     def test_staff_can_transfer_client(self):
         """Staff have client.transfer PROGRAM — can add a program."""
         # Give staff access to both programs
-        UserProgramRole.objects.create(user=self.staff, program=self.prog_b, role="staff")
+        UserProgramRole.objects.create(user=self.staff, program=self.prog_b, role=ROLE_STAFF)
         cf = self._create_client("Jane", "Doe", [self.prog_a])
         self.client.login(username="staff", password="testpass123")
         resp = self.client.post(f"/participants/{cf.pk}/transfer/", {
@@ -235,7 +241,7 @@ class ClientViewsTest(TestCase):
 
     def test_staff_transfer_removes_program(self):
         """Staff can unenrol a client from a program via transfer."""
-        UserProgramRole.objects.create(user=self.staff, program=self.prog_b, role="staff")
+        UserProgramRole.objects.create(user=self.staff, program=self.prog_b, role=ROLE_STAFF)
         cf = self._create_client("Jane", "Doe", [self.prog_a, self.prog_b])
         self.client.login(username="staff", password="testpass123")
         resp = self.client.post(f"/participants/{cf.pk}/transfer/", {
@@ -257,7 +263,7 @@ class ClientViewsTest(TestCase):
     def test_transfer_creates_audit_log(self):
         """Transfer creates an audit log entry with program change details."""
         from apps.audit.models import AuditLog
-        UserProgramRole.objects.create(user=self.staff, program=self.prog_b, role="staff")
+        UserProgramRole.objects.create(user=self.staff, program=self.prog_b, role=ROLE_STAFF)
         cf = self._create_client("Jane", "Doe", [self.prog_a])
         self.client.login(username="staff", password="testpass123")
         self.client.post(f"/participants/{cf.pk}/transfer/", {
@@ -293,7 +299,7 @@ class ClientViewsTest(TestCase):
 
     def test_edit_no_longer_changes_programs(self):
         """Edit form POST does not affect program enrolments (use transfer instead)."""
-        UserProgramRole.objects.create(user=self.staff, program=self.prog_b, role="staff")
+        UserProgramRole.objects.create(user=self.staff, program=self.prog_b, role=ROLE_STAFF)
         cf = self._create_client("Jane", "Doe", [self.prog_a])
         self.client.login(username="staff", password="testpass123")
         # POST to edit — programs field is no longer on the edit form
@@ -316,7 +322,7 @@ class ClientViewsTest(TestCase):
 
     def test_pm_can_transfer_client(self):
         """PMs have client.transfer PROGRAM — can transfer clients."""
-        UserProgramRole.objects.create(user=self.pm, program=self.prog_b, role="program_manager")
+        UserProgramRole.objects.create(user=self.pm, program=self.prog_b, role=ROLE_PROGRAM_MANAGER)
         cf = self._create_client("Jane", "Doe", [self.prog_a])
         self.client.login(username="pm", password="testpass123")
         resp = self.client.post(f"/participants/{cf.pk}/transfer/", {
@@ -421,7 +427,7 @@ class ClientViewsTest(TestCase):
 
     def test_filter_by_program(self):
         """Filter clients by program enrolment."""
-        UserProgramRole.objects.create(user=self.staff, program=self.prog_b, role="staff")
+        UserProgramRole.objects.create(user=self.staff, program=self.prog_b, role=ROLE_STAFF)
         alice = self._create_client("Alice", "Alpha", [self.prog_a])
         bob = self._create_client("Bob", "Beta", [self.prog_b])
 
@@ -441,7 +447,7 @@ class ClientViewsTest(TestCase):
 
     def test_filter_combined_status_and_program(self):
         """Filter clients by both status and program."""
-        UserProgramRole.objects.create(user=self.staff, program=self.prog_b, role="staff")
+        UserProgramRole.objects.create(user=self.staff, program=self.prog_b, role=ROLE_STAFF)
         alice_active = self._create_client("Alice", "Active", [self.prog_a])
         alice_discharged = self._create_client("Alice", "Discharged", [self.prog_a])
         alice_discharged.status = "discharged"
@@ -493,7 +499,7 @@ class ClientViewsTest(TestCase):
 
     def test_search_filter_by_program(self):
         """Filter search results by program."""
-        UserProgramRole.objects.create(user=self.staff, program=self.prog_b, role="staff")
+        UserProgramRole.objects.create(user=self.staff, program=self.prog_b, role=ROLE_STAFF)
         alice = self._create_client("Alice", "Test", [self.prog_a])
         bob = self._create_client("Bob", "Test", [self.prog_b])
 
@@ -549,7 +555,7 @@ class ClientViewsTest(TestCase):
 
     def test_search_combined_filters(self):
         """Multiple filters should work together."""
-        UserProgramRole.objects.create(user=self.staff, program=self.prog_b, role="staff")
+        UserProgramRole.objects.create(user=self.staff, program=self.prog_b, role=ROLE_STAFF)
         alice_active = self._create_client("Alice", "Active", [self.prog_a])
         alice_discharged = self._create_client("Alice", "Discharged", [self.prog_a])
         alice_discharged.status = "discharged"
@@ -576,7 +582,7 @@ class CustomFieldTest(TestCase):
         self.admin = User.objects.create_user(username="admin", password="testpass123", is_admin=True)
         # Admin needs a program role to access client data
         self.program = Program.objects.create(name="Test Program", colour_hex="#10B981")
-        UserProgramRole.objects.create(user=self.admin, program=self.program, role="program_manager")
+        UserProgramRole.objects.create(user=self.admin, program=self.program, role=ROLE_PROGRAM_MANAGER)
 
     def test_custom_field_admin_requires_admin(self):
         staff = User.objects.create_user(username="staff", password="testpass123", is_admin=False)
@@ -645,8 +651,8 @@ class ShowOnCreateFieldTest(TestCase):
         self.admin = User.objects.create_user(username="admin", password="testpass123", is_admin=True)
         self.receptionist = User.objects.create_user(username="recep", password="testpass123", is_admin=False)
         self.prog = Program.objects.create(name="Test Program", colour_hex="#10B981")
-        UserProgramRole.objects.create(user=self.admin, program=self.prog, role="program_manager")
-        UserProgramRole.objects.create(user=self.receptionist, program=self.prog, role="receptionist")
+        UserProgramRole.objects.create(user=self.admin, program=self.prog, role=ROLE_PROGRAM_MANAGER)
+        UserProgramRole.objects.create(user=self.receptionist, program=self.prog, role=ROLE_RECEPTIONIST)
         self.group = CustomFieldGroup.objects.create(title="Identity", sort_order=10)
         self.pronouns = CustomFieldDefinition.objects.create(
             group=self.group, name="Pronouns", input_type="select_other",
@@ -745,7 +751,7 @@ class SelectOtherFieldTest(TestCase):
         self.client = Client()
         self.admin = User.objects.create_user(username="admin", password="testpass123", is_admin=True)
         self.program = Program.objects.create(name="Test Program", colour_hex="#10B981")
-        UserProgramRole.objects.create(user=self.admin, program=self.program, role="program_manager")
+        UserProgramRole.objects.create(user=self.admin, program=self.program, role=ROLE_PROGRAM_MANAGER)
         self.group = CustomFieldGroup.objects.create(title="Contact Information")
         self.pronouns_field = CustomFieldDefinition.objects.create(
             group=self.group, name="Pronouns", input_type="select_other",
@@ -836,7 +842,7 @@ class SelectOtherFieldTest(TestCase):
     def test_front_desk_can_view_but_not_edit(self):
         """Front desk staff (receptionist) can see pronouns but not edit them."""
         receptionist = User.objects.create_user(username="frontdesk", password="testpass123")
-        UserProgramRole.objects.create(user=receptionist, program=self.program, role="receptionist")
+        UserProgramRole.objects.create(user=receptionist, program=self.program, role=ROLE_RECEPTIONIST)
         # Save a value first
         cdv = ClientDetailValue.objects.create(client_file=self.cf, field_def=self.pronouns_field)
         cdv.set_value("They/them")
@@ -862,7 +868,7 @@ class MultiSelectFieldTest(TestCase):
         self.client = Client()
         self.admin = User.objects.create_user(username="admin", password="testpass123", is_admin=True)
         self.program = Program.objects.create(name="Test Program", colour_hex="#10B981")
-        UserProgramRole.objects.create(user=self.admin, program=self.program, role="program_manager")
+        UserProgramRole.objects.create(user=self.admin, program=self.program, role=ROLE_PROGRAM_MANAGER)
         self.group = CustomFieldGroup.objects.create(title="Demographics")
         self.racial_field = CustomFieldDefinition.objects.create(
             group=self.group, name="Racial Identity", input_type="multi_select",
@@ -955,8 +961,8 @@ class ConsentRecordingTest(TestCase):
         self.staff = User.objects.create_user(username="staff", password="testpass123", is_admin=False)
         self.receptionist = User.objects.create_user(username="receptionist", password="testpass123", is_admin=False)
         self.program = Program.objects.create(name="Test Program", colour_hex="#10B981")
-        UserProgramRole.objects.create(user=self.staff, program=self.program, role="staff")
-        UserProgramRole.objects.create(user=self.receptionist, program=self.program, role="receptionist")
+        UserProgramRole.objects.create(user=self.staff, program=self.program, role=ROLE_STAFF)
+        UserProgramRole.objects.create(user=self.receptionist, program=self.program, role=ROLE_RECEPTIONIST)
 
         self.cf = ClientFile()
         self.cf.first_name = "Jane"
@@ -1027,9 +1033,9 @@ class ConsentWithdrawalTest(TestCase):
         self.pm = User.objects.create_user(username="pm", password="testpass123", is_admin=False)
         self.receptionist = User.objects.create_user(username="receptionist", password="testpass123", is_admin=False)
         self.program = Program.objects.create(name="Test Program", colour_hex="#10B981")
-        UserProgramRole.objects.create(user=self.staff, program=self.program, role="staff")
-        UserProgramRole.objects.create(user=self.pm, program=self.program, role="program_manager")
-        UserProgramRole.objects.create(user=self.receptionist, program=self.program, role="receptionist")
+        UserProgramRole.objects.create(user=self.staff, program=self.program, role=ROLE_STAFF)
+        UserProgramRole.objects.create(user=self.pm, program=self.program, role=ROLE_PROGRAM_MANAGER)
+        UserProgramRole.objects.create(user=self.receptionist, program=self.program, role=ROLE_RECEPTIONIST)
 
         self.cf = ClientFile()
         self.cf.first_name = "Jane"
@@ -1198,7 +1204,7 @@ class ExecutiveDashboardExportTest(TestCase):
             username="exec", password="pass", is_admin=False,
         )
         UserProgramRole.objects.create(
-            user=self.executive, program=self.prog, role="executive",
+            user=self.executive, program=self.prog, role=ROLE_EXECUTIVE,
         )
 
         # PM user
@@ -1206,7 +1212,7 @@ class ExecutiveDashboardExportTest(TestCase):
             username="pm", password="pass", is_admin=False,
         )
         UserProgramRole.objects.create(
-            user=self.pm, program=self.prog, role="program_manager",
+            user=self.pm, program=self.prog, role=ROLE_PROGRAM_MANAGER,
         )
 
         # Frontline staff (should be blocked)
@@ -1214,7 +1220,7 @@ class ExecutiveDashboardExportTest(TestCase):
             username="staff", password="pass", is_admin=False,
         )
         UserProgramRole.objects.create(
-            user=self.staff, program=self.prog, role="staff",
+            user=self.staff, program=self.prog, role=ROLE_STAFF,
         )
 
         # Admin user
@@ -1222,7 +1228,7 @@ class ExecutiveDashboardExportTest(TestCase):
             username="admin", password="pass", is_admin=True,
         )
         UserProgramRole.objects.create(
-            user=self.admin, program=self.prog, role="program_manager",
+            user=self.admin, program=self.prog, role=ROLE_PROGRAM_MANAGER,
         )
 
         # Create some clients
@@ -1315,7 +1321,7 @@ class ExecutiveDashboardPdfExportTest(TestCase):
             username="exec", password="pass", is_admin=False,
         )
         UserProgramRole.objects.create(
-            user=self.executive, program=self.prog, role="executive",
+            user=self.executive, program=self.prog, role=ROLE_EXECUTIVE,
         )
 
         # PM user
@@ -1323,7 +1329,7 @@ class ExecutiveDashboardPdfExportTest(TestCase):
             username="pm", password="pass", is_admin=False,
         )
         UserProgramRole.objects.create(
-            user=self.pm, program=self.prog, role="program_manager",
+            user=self.pm, program=self.prog, role=ROLE_PROGRAM_MANAGER,
         )
 
         # Frontline staff (should be blocked)
@@ -1331,7 +1337,7 @@ class ExecutiveDashboardPdfExportTest(TestCase):
             username="staff", password="pass", is_admin=False,
         )
         UserProgramRole.objects.create(
-            user=self.staff, program=self.prog, role="staff",
+            user=self.staff, program=self.prog, role=ROLE_STAFF,
         )
 
         # Admin user
@@ -1339,7 +1345,7 @@ class ExecutiveDashboardPdfExportTest(TestCase):
             username="admin", password="pass", is_admin=True,
         )
         UserProgramRole.objects.create(
-            user=self.admin, program=self.prog, role="program_manager",
+            user=self.admin, program=self.prog, role=ROLE_PROGRAM_MANAGER,
         )
 
         # Create some clients
@@ -1522,7 +1528,7 @@ class FormDataPreservationTest(TestCase):
             username="admin", password="testpass123", is_admin=True,
         )
         self.program = Program.objects.create(name="Test Program", colour_hex="#10B981")
-        UserProgramRole.objects.create(user=self.admin, program=self.program, role="program_manager")
+        UserProgramRole.objects.create(user=self.admin, program=self.program, role=ROLE_PROGRAM_MANAGER)
 
     def test_form_data_preserved_on_validation_error(self):
         """When a required field is missing, entered data should be in the response."""
@@ -1561,9 +1567,9 @@ class BulkOperationsTest(TestCase):
         self.prog_a = Program.objects.create(name="Program A", colour_hex="#10B981")
         self.prog_b = Program.objects.create(name="Program B", colour_hex="#3B82F6")
         self.prog_c = Program.objects.create(name="Program C", colour_hex="#EF4444")
-        UserProgramRole.objects.create(user=self.pm, program=self.prog_a, role="program_manager")
-        UserProgramRole.objects.create(user=self.pm, program=self.prog_b, role="program_manager")
-        UserProgramRole.objects.create(user=self.receptionist, program=self.prog_a, role="receptionist")
+        UserProgramRole.objects.create(user=self.pm, program=self.prog_a, role=ROLE_PROGRAM_MANAGER)
+        UserProgramRole.objects.create(user=self.pm, program=self.prog_b, role=ROLE_PROGRAM_MANAGER)
+        UserProgramRole.objects.create(user=self.receptionist, program=self.prog_a, role=ROLE_RECEPTIONIST)
 
     def _create_client(self, first="Jane", last="Doe", programs=None, status="active"):
         cf = ClientFile()
@@ -1772,9 +1778,9 @@ class BulkOperationsTest(TestCase):
         user_b = User.objects.create_user(
             username="staff_b", password="testpass123", is_admin=False
         )
-        UserProgramRole.objects.create(user=user_b, program=self.prog_b, role="staff")
+        UserProgramRole.objects.create(user=user_b, program=self.prog_b, role=ROLE_STAFF)
         # Also give user_b access to Program A (different role)
-        UserProgramRole.objects.create(user=user_b, program=self.prog_a, role="staff")
+        UserProgramRole.objects.create(user=user_b, program=self.prog_a, role=ROLE_STAFF)
 
         # Create a client enrolled in Program A only
         self._create_client("Unique", "Testname", [self.prog_a])
@@ -1800,16 +1806,16 @@ class RoleBasedGroupingTest(TestCase):
 
         # Morgan: staff in Kitchen, PM in Housing — dual role
         self.morgan = User.objects.create_user(username="morgan", password="testpass123")
-        UserProgramRole.objects.create(user=self.morgan, program=self.prog_kitchen, role="staff")
-        UserProgramRole.objects.create(user=self.morgan, program=self.prog_housing, role="program_manager")
+        UserProgramRole.objects.create(user=self.morgan, program=self.prog_kitchen, role=ROLE_STAFF)
+        UserProgramRole.objects.create(user=self.morgan, program=self.prog_housing, role=ROLE_PROGRAM_MANAGER)
 
         # Single-role staff user
         self.single_staff = User.objects.create_user(username="single_staff", password="testpass123")
-        UserProgramRole.objects.create(user=self.single_staff, program=self.prog_kitchen, role="staff")
+        UserProgramRole.objects.create(user=self.single_staff, program=self.prog_kitchen, role=ROLE_STAFF)
 
         # Single-role PM user
         self.single_pm = User.objects.create_user(username="single_pm", password="testpass123")
-        UserProgramRole.objects.create(user=self.single_pm, program=self.prog_housing, role="program_manager")
+        UserProgramRole.objects.create(user=self.single_pm, program=self.prog_housing, role=ROLE_PROGRAM_MANAGER)
 
     def _create_client(self, first, last, programs):
         from apps.clients.models import ClientFile, ClientProgramEnrolment

--- a/tests/test_communications.py
+++ b/tests/test_communications.py
@@ -18,6 +18,7 @@ from apps.communications.forms import CommunicationLogForm, QuickLogForm
 from apps.communications.models import Communication
 from apps.programs.models import Program, UserProgramRole
 import konote.encryption as enc_module
+from apps.auth_app.constants import ROLE_RECEPTIONIST, ROLE_STAFF
 
 TEST_KEY = Fernet.generate_key().decode()
 
@@ -139,7 +140,7 @@ class QuickLogViewTest(TestCase):
         )
         UserProgramRole.objects.create(
             user=self.staff, program=self.program,
-            role="staff", status="active",
+            role=ROLE_STAFF, status="active",
         )
         self.client_file = ClientFile()
         self.client_file.first_name = "Test"
@@ -188,7 +189,7 @@ class CommunicationLogViewTest(TestCase):
         )
         UserProgramRole.objects.create(
             user=self.staff, program=self.program,
-            role="staff", status="active",
+            role=ROLE_STAFF, status="active",
         )
         self.client_file = ClientFile()
         self.client_file.first_name = "Test"
@@ -230,7 +231,7 @@ class LogCommunicationServiceTest(TestCase):
         )
         UserProgramRole.objects.create(
             user=self.staff, program=self.program,
-            role="staff", status="active",
+            role=ROLE_STAFF, status="active",
         )
         self.client_file = ClientFile()
         self.client_file.first_name = "Test"
@@ -316,7 +317,7 @@ class CommunicationPermissionTest(TestCase):
         )
         UserProgramRole.objects.create(
             user=self.receptionist, program=self.program,
-            role="receptionist", status="active",
+            role=ROLE_RECEPTIONIST, status="active",
         )
         # Staff — should be ALLOWED communication.log
         self.staff = User.objects.create_user(
@@ -325,7 +326,7 @@ class CommunicationPermissionTest(TestCase):
         )
         UserProgramRole.objects.create(
             user=self.staff, program=self.program,
-            role="staff", status="active",
+            role=ROLE_STAFF, status="active",
         )
         self.client_file = ClientFile()
         self.client_file.first_name = "Test"
@@ -388,7 +389,7 @@ class ComposeEmailViewTest(TestCase):
         )
         UserProgramRole.objects.create(
             user=self.staff, program=self.program,
-            role="staff", status="active",
+            role=ROLE_STAFF, status="active",
         )
         self.client_file = ClientFile()
         self.client_file.first_name = "Test"
@@ -530,7 +531,7 @@ class ComposeEmailViewTest(TestCase):
         )
         UserProgramRole.objects.create(
             user=receptionist, program=self.program,
-            role="receptionist", status="active",
+            role=ROLE_RECEPTIONIST, status="active",
         )
         self.client.login(username="test_receptionist", password="testpass123")
         url = f"/communications/participant/{self.client_file.pk}/compose-email/"
@@ -637,7 +638,7 @@ class LeaveMessageViewTest(TestCase):
             username="test_staff_lm", password="testpass123", display_name="Test Staff",
         )
         UserProgramRole.objects.create(
-            user=self.staff, program=self.program, role="staff", status="active",
+            user=self.staff, program=self.program, role=ROLE_STAFF, status="active",
         )
         self.client_file = ClientFile()
         self.client_file.first_name = "Test"
@@ -688,7 +689,7 @@ class MyMessagesViewTest(TestCase):
             username="test_staff_mm", password="testpass123", display_name="Test Staff",
         )
         UserProgramRole.objects.create(
-            user=self.staff, program=self.program, role="staff", status="active",
+            user=self.staff, program=self.program, role=ROLE_STAFF, status="active",
         )
         self.sender = User.objects.create_user(
             username="test_sender", password="testpass123", display_name="Sender",

--- a/tests/test_confidential_isolation.py
+++ b/tests/test_confidential_isolation.py
@@ -17,6 +17,7 @@ from apps.programs.models import Program, UserProgramRole
 from apps.reports.suppression import suppress_small_cell
 
 import konote.encryption as enc_module
+from apps.auth_app.constants import ROLE_PROGRAM_MANAGER, ROLE_STAFF
 
 TEST_KEY = Fernet.generate_key().decode()
 
@@ -53,13 +54,13 @@ class ConfidentialIsolationTest(TestCase):
 
         # Roles
         UserProgramRole.objects.create(
-            user=self.standard_staff, program=self.standard_prog, role="staff",
+            user=self.standard_staff, program=self.standard_prog, role=ROLE_STAFF,
         )
         UserProgramRole.objects.create(
-            user=self.confidential_staff, program=self.confidential_prog, role="staff",
+            user=self.confidential_staff, program=self.confidential_prog, role=ROLE_STAFF,
         )
         UserProgramRole.objects.create(
-            user=self.admin, program=self.standard_prog, role="program_manager",
+            user=self.admin, program=self.standard_prog, role=ROLE_PROGRAM_MANAGER,
         )
 
         # Client in standard program only
@@ -231,7 +232,7 @@ class DuplicateMatchingTest(TestCase):
         )
 
         UserProgramRole.objects.create(
-            user=self.staff, program=self.standard_prog, role="staff",
+            user=self.staff, program=self.standard_prog, role=ROLE_STAFF,
         )
 
         # Existing client in standard program with phone and DOB
@@ -304,7 +305,7 @@ class DuplicateMatchingTest(TestCase):
             username="demo_staff", password="testpass123", is_demo=True,
         )
         UserProgramRole.objects.create(
-            user=demo_staff, program=self.standard_prog, role="staff",
+            user=demo_staff, program=self.standard_prog, role=ROLE_STAFF,
         )
         self.http.login(username="demo_staff", password="testpass123")
         resp = self.http.get(
@@ -433,7 +434,7 @@ class DuplicateMatchingTest(TestCase):
             username="demo_staff2", password="testpass123", is_demo=True,
         )
         UserProgramRole.objects.create(
-            user=demo_staff, program=self.standard_prog, role="staff",
+            user=demo_staff, program=self.standard_prog, role=ROLE_STAFF,
         )
         self.http.login(username="demo_staff2", password="testpass123")
         resp = self.http.get(
@@ -475,7 +476,7 @@ class RegistrationLinkConfidentialTest(TestCase):
         )
 
         UserProgramRole.objects.create(
-            user=self.admin, program=self.standard_prog, role="program_manager",
+            user=self.admin, program=self.standard_prog, role=ROLE_PROGRAM_MANAGER,
         )
 
     def test_confidential_program_excluded_from_registration_form(self):
@@ -508,10 +509,10 @@ class GroupAccessTest(TestCase):
         )
 
         UserProgramRole.objects.create(
-            user=self.staff_a, program=self.prog_a, role="staff",
+            user=self.staff_a, program=self.prog_a, role=ROLE_STAFF,
         )
         UserProgramRole.objects.create(
-            user=self.staff_b, program=self.prog_b, role="staff",
+            user=self.staff_b, program=self.prog_b, role=ROLE_STAFF,
         )
 
         # Create groups
@@ -557,7 +558,7 @@ class PhoneFieldTest(TestCase):
         )
         self.prog = Program.objects.create(name="Sports", colour_hex="#10B981")
         UserProgramRole.objects.create(
-            user=self.staff, program=self.prog, role="staff",
+            user=self.staff, program=self.prog, role=ROLE_STAFF,
         )
 
     def test_phone_saved_and_retrieved_encrypted(self):
@@ -643,11 +644,11 @@ class DjangoAdminConfidentialTest(TestCase):
         # Roles
         UserProgramRole.objects.create(
             user=self.admin_standard, program=self.standard_prog,
-            role="program_manager",
+            role=ROLE_PROGRAM_MANAGER,
         )
         UserProgramRole.objects.create(
             user=self.admin_confidential, program=self.confidential_prog,
-            role="program_manager",
+            role=ROLE_PROGRAM_MANAGER,
         )
 
         # Clients
@@ -798,10 +799,10 @@ class AuditConfidentialTaggingTest(TestCase):
         )
 
         UserProgramRole.objects.create(
-            user=self.staff, program=self.standard_prog, role="staff",
+            user=self.staff, program=self.standard_prog, role=ROLE_STAFF,
         )
         UserProgramRole.objects.create(
-            user=self.staff, program=self.conf_prog, role="staff",
+            user=self.staff, program=self.conf_prog, role=ROLE_STAFF,
         )
 
         self.standard_client = ClientFile()
@@ -848,7 +849,7 @@ class AuditConfidentialTaggingTest(TestCase):
             username="outsider", password="testpass123",
         )
         UserProgramRole.objects.create(
-            user=outsider, program=self.standard_prog, role="staff",
+            user=outsider, program=self.standard_prog, role=ROLE_STAFF,
         )
         self.http.login(username="outsider", password="testpass123")
         resp = self.http.get(f"/participants/{self.conf_client.pk}/")
@@ -866,7 +867,7 @@ class AuditConfidentialTaggingTest(TestCase):
             username="pm_audit", password="testpass123",
         )
         UserProgramRole.objects.create(
-            user=pm, program=self.conf_prog, role="program_manager",
+            user=pm, program=self.conf_prog, role=ROLE_PROGRAM_MANAGER,
         )
         self.http.login(username="pm_audit", password="testpass123")
         resp = self.http.get(f"/audit/program/{self.conf_prog.pk}/")

--- a/tests/test_cross_program_security.py
+++ b/tests/test_cross_program_security.py
@@ -1,5 +1,6 @@
 """Tests for cross-program permission leakage — users must not access data
 from programs they aren't assigned to by manipulating URL IDs.
+from apps.auth_app.constants import ROLE_STAFF
 
 Covers group views (membership_remove, milestone_create/edit, outcome_create)
 and plans views (target_history).
@@ -42,7 +43,7 @@ class CrossProgramSecurityTest(TestCase):
             username="casey", password="testpass123", display_name="Casey Worker",
         )
         UserProgramRole.objects.create(
-            user=cls.staff, program=cls.program_a, role="staff",
+            user=cls.staff, program=cls.program_a, role=ROLE_STAFF,
         )
 
         # Group in Program A (accessible)
@@ -159,10 +160,10 @@ class CrossProgramConsentTest(TestCase):
             username="multi", password="testpass123", display_name="Multi Worker",
         )
         UserProgramRole.objects.create(
-            user=cls.multi_staff, program=cls.program_a, role="staff",
+            user=cls.multi_staff, program=cls.program_a, role=ROLE_STAFF,
         )
         UserProgramRole.objects.create(
-            user=cls.multi_staff, program=cls.program_b, role="staff",
+            user=cls.multi_staff, program=cls.program_b, role=ROLE_STAFF,
         )
 
         # Client enrolled in both programs
@@ -270,7 +271,7 @@ class CrossProgramConsentTest(TestCase):
             username="single", password="testpass123", display_name="Single Worker",
         )
         UserProgramRole.objects.create(
-            user=single_staff, program=self.program_a, role="staff",
+            user=single_staff, program=self.program_a, role=ROLE_STAFF,
         )
         self._set_agency_sharing(False)
         self.shared_client.cross_program_sharing = "default"
@@ -388,7 +389,7 @@ class CrossProgramConsentTest(TestCase):
         )
         program_c = Program.objects.create(name="Program C", status="active")
         UserProgramRole.objects.create(
-            user=no_shared, program=program_c, role="staff",
+            user=no_shared, program=program_c, role=ROLE_STAFF,
         )
 
         notes_qs = ProgressNote.objects.filter(client_file=self.shared_client)
@@ -462,7 +463,7 @@ class SearchConsentTest(TestCase):
             username="searcher", password="testpass123", display_name="Search Worker",
         )
         UserProgramRole.objects.create(
-            user=cls.staff_a, program=cls.program_a, role="staff",
+            user=cls.staff_a, program=cls.program_a, role=ROLE_STAFF,
         )
 
         # Multi-program staff — access to both programs
@@ -470,10 +471,10 @@ class SearchConsentTest(TestCase):
             username="multisearch", password="testpass123", display_name="Multi Search",
         )
         UserProgramRole.objects.create(
-            user=cls.multi_staff, program=cls.program_a, role="staff",
+            user=cls.multi_staff, program=cls.program_a, role=ROLE_STAFF,
         )
         UserProgramRole.objects.create(
-            user=cls.multi_staff, program=cls.program_b, role="staff",
+            user=cls.multi_staff, program=cls.program_b, role=ROLE_STAFF,
         )
 
         # Client enrolled in both programs
@@ -590,10 +591,10 @@ class QualitativeSummaryConsentTest(TestCase):
             username="qualuser", password="testpass123", display_name="Qual Worker",
         )
         UserProgramRole.objects.create(
-            user=cls.multi_staff, program=cls.program_a, role="staff",
+            user=cls.multi_staff, program=cls.program_a, role=ROLE_STAFF,
         )
         UserProgramRole.objects.create(
-            user=cls.multi_staff, program=cls.program_b, role="staff",
+            user=cls.multi_staff, program=cls.program_b, role=ROLE_STAFF,
         )
 
         # Client enrolled in both programs

--- a/tests/test_dashboard_suggestions.py
+++ b/tests/test_dashboard_suggestions.py
@@ -12,6 +12,7 @@ from apps.clients.dashboard_views import _batch_suggestion_counts, _batch_top_th
 from apps.clients.models import ClientFile, ClientProgramEnrolment
 from apps.notes.models import ProgressNote, SuggestionLink, SuggestionTheme
 from apps.programs.models import Program, UserProgramRole
+from apps.auth_app.constants import ROLE_EXECUTIVE, ROLE_PROGRAM_MANAGER
 
 User = get_user_model()
 
@@ -240,7 +241,7 @@ class ExecutiveDashboardSuggestionViewTest(TestCase):
         self.program = Program.objects.create(name="Housing", status="active")
         self.user = User.objects.create_user(username="exec", password="testpass123")
         UserProgramRole.objects.create(
-            user=self.user, program=self.program, role="executive", status="active",
+            user=self.user, program=self.program, role=ROLE_EXECUTIVE, status="active",
         )
 
         self.client_file = ClientFile.objects.create(record_id="EXEC-001")
@@ -359,7 +360,7 @@ class ThemeDetailDateFilteringTest(TestCase):
         self.user = User.objects.create_user(username="pm", password="testpass123")
         UserProgramRole.objects.create(
             user=self.user, program=self.program,
-            role="program_manager", status="active",
+            role=ROLE_PROGRAM_MANAGER, status="active",
         )
         self.theme = SuggestionTheme.objects.create(
             program=self.program,

--- a/tests/test_data_access.py
+++ b/tests/test_data_access.py
@@ -8,6 +8,7 @@ from apps.auth_app.models import User
 from apps.clients.models import ClientFile, ClientProgramEnrolment, DataAccessRequest
 from apps.programs.models import Program, UserProgramRole
 import konote.encryption as enc_module
+from apps.auth_app.constants import ROLE_STAFF
 
 
 TEST_KEY = Fernet.generate_key().decode()
@@ -32,7 +33,7 @@ class DataAccessAuthorizationTest(TestCase):
             username="staffuser", password="testpass123", display_name="Staff"
         )
         UserProgramRole.objects.create(
-            user=self.staff, program=self.prog_a, role="staff"
+            user=self.staff, program=self.prog_a, role=ROLE_STAFF
         )
 
         # Client enrolled in Program B only (not accessible to staff)
@@ -111,7 +112,7 @@ class DataAccessCompletePostOnlyTest(TestCase):
             username="staffuser", password="testpass123", display_name="Staff"
         )
         UserProgramRole.objects.create(
-            user=self.staff, program=self.prog, role="staff"
+            user=self.staff, program=self.prog, role=ROLE_STAFF
         )
         self.client_file = ClientFile()
         self.client_file.first_name = "Test"

--- a/tests/test_demo_data_separation.py
+++ b/tests/test_demo_data_separation.py
@@ -12,6 +12,7 @@ from apps.auth_app.models import User
 from apps.programs.models import Program, UserProgramRole
 from apps.clients.models import ClientFile, ClientProgramEnrolment
 import konote.encryption as enc_module
+from apps.auth_app.constants import ROLE_STAFF
 
 TEST_KEY = Fernet.generate_key().decode()
 
@@ -79,7 +80,7 @@ class DemoDataVisibilityTest(TestCase):
         self.real_staff = User.objects.create_user(
             username="real-staff", password="testpass123", is_admin=False, is_demo=False
         )
-        UserProgramRole.objects.create(user=self.real_staff, program=self.prog, role="staff")
+        UserProgramRole.objects.create(user=self.real_staff, program=self.prog, role=ROLE_STAFF)
 
         # Create demo users
         self.demo_admin = User.objects.create_user(
@@ -88,7 +89,7 @@ class DemoDataVisibilityTest(TestCase):
         self.demo_staff = User.objects.create_user(
             username="demo-staff", password="testpass123", is_admin=False, is_demo=True
         )
-        UserProgramRole.objects.create(user=self.demo_staff, program=self.prog, role="staff")
+        UserProgramRole.objects.create(user=self.demo_staff, program=self.prog, role=ROLE_STAFF)
 
         # Create clients
         self.real_client = self._create_client("Real", "Client", is_demo=False)

--- a/tests/test_document_storage_security.py
+++ b/tests/test_document_storage_security.py
@@ -15,6 +15,7 @@ from apps.admin_settings.models import InstanceSetting
 from apps.auth_app.models import User
 from apps.clients.models import ClientFile
 import konote.encryption as enc_module
+from apps.auth_app.constants import ROLE_PROGRAM_MANAGER
 
 TEST_KEY = Fernet.generate_key().decode()
 
@@ -307,7 +308,7 @@ class DocumentStorageAdminIntegrationTests(TestCase):
 
         program = Program.objects.create(name="Test Prog")
         UserProgramRole.objects.create(
-            user=self.admin, program=program, role="program_manager", status="active"
+            user=self.admin, program=program, role=ROLE_PROGRAM_MANAGER, status="active"
         )
         client_file = ClientFile.objects.create(
             record_id="REC-2024-042", status="active"
@@ -338,7 +339,7 @@ class DocumentStorageAdminIntegrationTests(TestCase):
 
         program = Program.objects.create(name="Test Prog")
         UserProgramRole.objects.create(
-            user=self.admin, program=program, role="program_manager", status="active"
+            user=self.admin, program=program, role=ROLE_PROGRAM_MANAGER, status="active"
         )
         client_file = ClientFile.objects.create(
             record_id="REC-2024-042", status="active"

--- a/tests/test_dv_safe.py
+++ b/tests/test_dv_safe.py
@@ -14,6 +14,11 @@ from django.utils import timezone
 from cryptography.fernet import Fernet
 
 from apps.admin_settings.models import InstanceSetting
+from apps.auth_app.constants import (
+    ROLE_PROGRAM_MANAGER,
+    ROLE_RECEPTIONIST,
+    ROLE_STAFF,
+)
 from apps.auth_app.models import User
 from apps.clients.models import (
     ClientFile,
@@ -66,7 +71,7 @@ def _create_staff_user(username="staff_user"):
     """Create a user with staff role."""
     user = User.objects.create_user(username=username, password="testpass123")
     program = Program.objects.get_or_create(name="Test Program")[0]
-    UserProgramRole.objects.create(user=user, program=program, role="staff")
+    UserProgramRole.objects.create(user=user, program=program, role=ROLE_STAFF)
     return user, program
 
 
@@ -74,7 +79,7 @@ def _create_pm_user(username="pm_user"):
     """Create a user with program_manager role."""
     user = User.objects.create_user(username=username, password="testpass123")
     program = Program.objects.get_or_create(name="Test Program")[0]
-    UserProgramRole.objects.create(user=user, program=program, role="program_manager")
+    UserProgramRole.objects.create(user=user, program=program, role=ROLE_PROGRAM_MANAGER)
     return user, program
 
 
@@ -82,7 +87,7 @@ def _create_receptionist_user(username="reception_user"):
     """Create a user with receptionist role."""
     user = User.objects.create_user(username=username, password="testpass123")
     program = Program.objects.get_or_create(name="Test Program")[0]
-    UserProgramRole.objects.create(user=user, program=program, role="receptionist")
+    UserProgramRole.objects.create(user=user, program=program, role=ROLE_RECEPTIONIST)
     return user, program
 
 
@@ -210,7 +215,7 @@ class DvFieldHidingTest(TestCase):
     def test_receptionist_sees_both_without_dv_flag(self):
         """Without DV flag, receptionist sees all allowed fields."""
         from apps.clients.views import _get_custom_fields_context
-        ctx = _get_custom_fields_context(self.client_file, "receptionist", hide_empty=False)
+        ctx = _get_custom_fields_context(self.client_file, ROLE_RECEPTIONIST, hide_empty=False)
         field_names = [
             f["field_def"].name
             for group_data in ctx["custom_data"]
@@ -225,7 +230,7 @@ class DvFieldHidingTest(TestCase):
         self.client_file.save(update_fields=["is_dv_safe"])
 
         from apps.clients.views import _get_custom_fields_context
-        ctx = _get_custom_fields_context(self.client_file, "receptionist", hide_empty=False)
+        ctx = _get_custom_fields_context(self.client_file, ROLE_RECEPTIONIST, hide_empty=False)
         field_names = [
             f["field_def"].name
             for group_data in ctx["custom_data"]
@@ -240,7 +245,7 @@ class DvFieldHidingTest(TestCase):
         self.client_file.save(update_fields=["is_dv_safe"])
 
         from apps.clients.views import _get_custom_fields_context
-        ctx = _get_custom_fields_context(self.client_file, "staff", hide_empty=False)
+        ctx = _get_custom_fields_context(self.client_file, ROLE_STAFF, hide_empty=False)
         field_names = [
             f["field_def"].name
             for group_data in ctx["custom_data"]

--- a/tests/test_erasure.py
+++ b/tests/test_erasure.py
@@ -32,6 +32,7 @@ from apps.notes.models import ProgressNote
 from apps.plans.models import PlanSection
 from apps.programs.models import Program, UserProgramRole
 from konote import encryption as enc_module
+from apps.auth_app.constants import ROLE_PROGRAM_MANAGER, ROLE_RECEPTIONIST, ROLE_STAFF
 
 
 @override_settings(FIELD_ENCRYPTION_KEY="ly6OqAlMm32VVf08PoPJigrLCIxGd_tW1-kfWhXxXj8=")
@@ -216,9 +217,9 @@ class MultiProgramApprovalTests(TestCase):
         self.prog_a = Program.objects.create(name="Program A", colour_hex="#10B981", status="active")
         self.prog_b = Program.objects.create(name="Program B", colour_hex="#3B82F6", status="active")
 
-        UserProgramRole.objects.create(user=self.staff, program=self.prog_a, role="staff")
-        UserProgramRole.objects.create(user=self.pm_a, program=self.prog_a, role="program_manager")
-        UserProgramRole.objects.create(user=self.pm_b, program=self.prog_b, role="program_manager")
+        UserProgramRole.objects.create(user=self.staff, program=self.prog_a, role=ROLE_STAFF)
+        UserProgramRole.objects.create(user=self.pm_a, program=self.prog_a, role=ROLE_PROGRAM_MANAGER)
+        UserProgramRole.objects.create(user=self.pm_b, program=self.prog_b, role=ROLE_PROGRAM_MANAGER)
 
         self.cf = ClientFile()
         self.cf.first_name = "Test"
@@ -292,8 +293,8 @@ class RejectionTests(TestCase):
         self.prog_a = Program.objects.create(name="Program A", colour_hex="#10B981", status="active")
         self.prog_b = Program.objects.create(name="Program B", colour_hex="#3B82F6", status="active")
 
-        UserProgramRole.objects.create(user=self.pm_a, program=self.prog_a, role="program_manager")
-        UserProgramRole.objects.create(user=self.pm_b, program=self.prog_b, role="program_manager")
+        UserProgramRole.objects.create(user=self.pm_a, program=self.prog_a, role=ROLE_PROGRAM_MANAGER)
+        UserProgramRole.objects.create(user=self.pm_b, program=self.prog_b, role=ROLE_PROGRAM_MANAGER)
 
         self.cf = ClientFile()
         self.cf.first_name = "Test"
@@ -340,7 +341,7 @@ class ExecuteErasureTests(TestCase):
         self.pm = User.objects.create_user(username="pm", password="testpass123")
 
         self.prog = Program.objects.create(name="Program A", colour_hex="#10B981", status="active")
-        UserProgramRole.objects.create(user=self.pm, program=self.prog, role="program_manager")
+        UserProgramRole.objects.create(user=self.pm, program=self.prog, role=ROLE_PROGRAM_MANAGER)
 
         self.cf = ClientFile()
         self.cf.first_name = "Jane"
@@ -453,7 +454,7 @@ class DeadlockTests(TestCase):
         self.admin = User.objects.create_user(username="admin", password="testpass123", is_admin=True)
 
         self.prog = Program.objects.create(name="Program A", colour_hex="#10B981", status="active")
-        UserProgramRole.objects.create(user=self.pm, program=self.prog, role="program_manager")
+        UserProgramRole.objects.create(user=self.pm, program=self.prog, role=ROLE_PROGRAM_MANAGER)
 
         self.cf = ClientFile()
         self.cf.first_name = "Test"
@@ -479,7 +480,7 @@ class DeadlockTests(TestCase):
 
     def test_not_deadlocked_when_other_pm_exists(self):
         other_pm = User.objects.create_user(username="other_pm", password="testpass123")
-        UserProgramRole.objects.create(user=other_pm, program=self.prog, role="program_manager")
+        UserProgramRole.objects.create(user=other_pm, program=self.prog, role=ROLE_PROGRAM_MANAGER)
         self.assertFalse(is_deadlocked(self.er))
 
     def test_admin_can_approve_in_deadlock(self):
@@ -491,7 +492,7 @@ class DeadlockTests(TestCase):
 
     def test_requester_cannot_self_approve_without_deadlock(self):
         other_pm = User.objects.create_user(username="other_pm", password="testpass123")
-        UserProgramRole.objects.create(user=other_pm, program=self.prog, role="program_manager")
+        UserProgramRole.objects.create(user=other_pm, program=self.prog, role=ROLE_PROGRAM_MANAGER)
         with self.assertRaises(ValueError):
             record_approval(self.er, self.pm, self.prog, "127.0.0.1")
 
@@ -511,9 +512,9 @@ class ErasureViewPermissionTests(TestCase):
 
         self.prog = Program.objects.create(name="Program A", colour_hex="#10B981", status="active")
 
-        UserProgramRole.objects.create(user=self.staff, program=self.prog, role="staff")
-        UserProgramRole.objects.create(user=self.pm, program=self.prog, role="program_manager")
-        UserProgramRole.objects.create(user=self.receptionist, program=self.prog, role="receptionist")
+        UserProgramRole.objects.create(user=self.staff, program=self.prog, role=ROLE_STAFF)
+        UserProgramRole.objects.create(user=self.pm, program=self.prog, role=ROLE_PROGRAM_MANAGER)
+        UserProgramRole.objects.create(user=self.receptionist, program=self.prog, role=ROLE_RECEPTIONIST)
 
         self.cf = ClientFile()
         self.cf.first_name = "Test"
@@ -573,8 +574,8 @@ class ErasureViewWorkflowTests(TestCase):
 
         self.prog = Program.objects.create(name="Program A", colour_hex="#10B981", status="active")
 
-        UserProgramRole.objects.create(user=self.staff, program=self.prog, role="staff")
-        UserProgramRole.objects.create(user=self.pm, program=self.prog, role="program_manager")
+        UserProgramRole.objects.create(user=self.staff, program=self.prog, role=ROLE_STAFF)
+        UserProgramRole.objects.create(user=self.pm, program=self.prog, role=ROLE_PROGRAM_MANAGER)
 
         self.cf = ClientFile()
         self.cf.first_name = "Test"
@@ -658,7 +659,7 @@ class ErasureViewWorkflowTests(TestCase):
 
         # Create a second PM so the first PM isn't approving their own request
         pm2 = User.objects.create_user(username="pm2", password="testpass123")
-        UserProgramRole.objects.create(user=pm2, program=self.prog, role="program_manager")
+        UserProgramRole.objects.create(user=pm2, program=self.prog, role=ROLE_PROGRAM_MANAGER)
 
         self.client.login(username="pm", password="testpass123")
         self.client.post(f"/participants/{self.cf.pk}/erase/", {
@@ -687,7 +688,7 @@ class ErasureViewWorkflowTests(TestCase):
     def test_approve_anonymise_via_post(self, mock_notify):
         """Anonymise tier: approval anonymises but keeps client record."""
         pm2 = User.objects.create_user(username="pm2", password="testpass123")
-        UserProgramRole.objects.create(user=pm2, program=self.prog, role="program_manager")
+        UserProgramRole.objects.create(user=pm2, program=self.prog, role=ROLE_PROGRAM_MANAGER)
 
         self.client.login(username="pm", password="testpass123")
         self.client.post(f"/participants/{self.cf.pk}/erase/", {
@@ -809,7 +810,7 @@ class ErasureViewWorkflowTests(TestCase):
     def test_cancel_by_unrelated_staff_forbidden(self):
         other_staff = User.objects.create_user(username="other_staff", password="testpass123")
         other_prog = Program.objects.create(name="Other Prog", colour_hex="#000000", status="active")
-        UserProgramRole.objects.create(user=other_staff, program=other_prog, role="staff")
+        UserProgramRole.objects.create(user=other_staff, program=other_prog, role=ROLE_STAFF)
 
         er = ErasureRequest.objects.create(
             client_file=self.cf,
@@ -844,10 +845,10 @@ class ErasureViewWorkflowTests(TestCase):
 
     def test_requester_cannot_approve_own_request(self):
         # Upgrade staff's existing role to PM for this test
-        UserProgramRole.objects.filter(user=self.staff, program=self.prog).update(role="program_manager")
+        UserProgramRole.objects.filter(user=self.staff, program=self.prog).update(role=ROLE_PROGRAM_MANAGER)
         # Also add another PM so it's not deadlocked
         other_pm = User.objects.create_user(username="other_pm", password="testpass123")
-        UserProgramRole.objects.create(user=other_pm, program=self.prog, role="program_manager")
+        UserProgramRole.objects.create(user=other_pm, program=self.prog, role=ROLE_PROGRAM_MANAGER)
 
         er = ErasureRequest.objects.create(
             client_file=self.cf,
@@ -874,7 +875,7 @@ class ErasureViewWorkflowTests(TestCase):
         """PM not involved in the request's programs cannot download the PDF receipt."""
         other_pm = User.objects.create_user(username="other_pm", password="testpass123")
         other_prog = Program.objects.create(name="Other Prog", colour_hex="#000000", status="active")
-        UserProgramRole.objects.create(user=other_pm, program=other_prog, role="program_manager")
+        UserProgramRole.objects.create(user=other_pm, program=other_prog, role=ROLE_PROGRAM_MANAGER)
 
         er = ErasureRequest.objects.create(
             client_file=self.cf,
@@ -963,8 +964,8 @@ class DemoDataSeparationTests(TestCase):
         self.real_staff = User.objects.create_user(username="real_staff", password="testpass123", is_demo=False)
 
         self.prog = Program.objects.create(name="Program A", colour_hex="#10B981", status="active")
-        UserProgramRole.objects.create(user=self.demo_staff, program=self.prog, role="staff")
-        UserProgramRole.objects.create(user=self.real_staff, program=self.prog, role="staff")
+        UserProgramRole.objects.create(user=self.demo_staff, program=self.prog, role=ROLE_STAFF)
+        UserProgramRole.objects.create(user=self.real_staff, program=self.prog, role=ROLE_STAFF)
 
         self.demo_client = ClientFile(is_demo=True)
         self.demo_client.first_name = "Demo"
@@ -1009,9 +1010,9 @@ class ContextProcessorTests(TestCase):
         self.prog_a = Program.objects.create(name="Program A", colour_hex="#10B981", status="active")
         self.prog_b = Program.objects.create(name="Program B", colour_hex="#3B82F6", status="active")
 
-        UserProgramRole.objects.create(user=self.pm_a, program=self.prog_a, role="program_manager")
-        UserProgramRole.objects.create(user=self.pm_b, program=self.prog_b, role="program_manager")
-        UserProgramRole.objects.create(user=self.staff, program=self.prog_a, role="staff")
+        UserProgramRole.objects.create(user=self.pm_a, program=self.prog_a, role=ROLE_PROGRAM_MANAGER)
+        UserProgramRole.objects.create(user=self.pm_b, program=self.prog_b, role=ROLE_PROGRAM_MANAGER)
+        UserProgramRole.objects.create(user=self.staff, program=self.prog_a, role=ROLE_STAFF)
 
         self.cf = ClientFile()
         self.cf.first_name = "Test"
@@ -1088,7 +1089,7 @@ class StuckRequestTests(TestCase):
         enc_module._fernet = None
         self.staff = User.objects.create_user(username="staff", password="testpass123")
         self.prog = Program.objects.create(name="Program A", colour_hex="#10B981", status="active")
-        UserProgramRole.objects.create(user=self.staff, program=self.prog, role="staff")
+        UserProgramRole.objects.create(user=self.staff, program=self.prog, role=ROLE_STAFF)
 
         self.cf = ClientFile()
         self.cf.first_name = "Test"
@@ -1170,7 +1171,7 @@ class Tier1AnonymiseTests(TestCase):
         self.staff = User.objects.create_user(username="staff", password="testpass123")
         self.pm = User.objects.create_user(username="pm", password="testpass123")
         self.prog = Program.objects.create(name="Program A", colour_hex="#10B981", status="active")
-        UserProgramRole.objects.create(user=self.pm, program=self.prog, role="program_manager")
+        UserProgramRole.objects.create(user=self.pm, program=self.prog, role=ROLE_PROGRAM_MANAGER)
 
         self.cf = ClientFile()
         self.cf.first_name = "Jane"
@@ -1429,7 +1430,7 @@ class EmailNotificationWarningTests(TestCase):
             username="pm", password="testpass123", email="pm@example.com",
         )
         self.prog = Program.objects.create(name="Prog A", colour_hex="#10B981", status="active")
-        UserProgramRole.objects.create(user=self.pm, program=self.prog, role="program_manager", status="active")
+        UserProgramRole.objects.create(user=self.pm, program=self.prog, role=ROLE_PROGRAM_MANAGER, status="active")
 
         self.cf = ClientFile()
         self.cf.first_name = "Test"
@@ -1484,7 +1485,7 @@ class EmailNotificationWarningTests(TestCase):
         self.admin.save()
         UserProgramRole.objects.create(
             user=self.admin, program=self.prog,
-            role="program_manager", status="active",
+            role=ROLE_PROGRAM_MANAGER, status="active",
         )
         resp = self.client.post(
             f"/participants/{self.cf.pk}/erase/",
@@ -1523,8 +1524,8 @@ class SQLFilteredVisibilityTests(TestCase):
         self.prog_a = Program.objects.create(name="Prog A", colour_hex="#10B981", status="active")
         self.prog_b = Program.objects.create(name="Prog B", colour_hex="#3B82F6", status="active")
 
-        UserProgramRole.objects.create(user=self.pm1, program=self.prog_a, role="program_manager", status="active")
-        UserProgramRole.objects.create(user=self.pm2, program=self.prog_b, role="program_manager", status="active")
+        UserProgramRole.objects.create(user=self.pm1, program=self.prog_a, role=ROLE_PROGRAM_MANAGER, status="active")
+        UserProgramRole.objects.create(user=self.pm2, program=self.prog_b, role=ROLE_PROGRAM_MANAGER, status="active")
 
         self.cf = ClientFile()
         self.cf.first_name = "Test"
@@ -1584,7 +1585,7 @@ class PIPEDAAgingTests(TestCase):
         self.prog = Program.objects.create(name="Prog A", colour_hex="#10B981", status="active")
         UserProgramRole.objects.create(
             user=self.admin, program=self.prog,
-            role="program_manager", status="active",
+            role=ROLE_PROGRAM_MANAGER, status="active",
         )
         self.cf = ClientFile()
         self.cf.first_name = "Test"

--- a/tests/test_executive_dashboard.py
+++ b/tests/test_executive_dashboard.py
@@ -16,6 +16,7 @@ from apps.plans.models import MetricDefinition, PlanSection, PlanTarget, PlanTar
 from apps.programs.models import Program, UserProgramRole
 from apps.registration.models import RegistrationLink, RegistrationSubmission
 import konote.encryption as enc_module
+from apps.auth_app.constants import ROLE_EXECUTIVE
 
 TEST_KEY = Fernet.generate_key().decode()
 
@@ -34,10 +35,10 @@ class ExecutiveDashboardViewTest(TestCase):
         self.prog_a = Program.objects.create(name="Program A", colour_hex="#10B981")
         self.prog_b = Program.objects.create(name="Program B", colour_hex="#3B82F6")
         UserProgramRole.objects.create(
-            user=self.exec_user, program=self.prog_a, role="executive"
+            user=self.exec_user, program=self.prog_a, role=ROLE_EXECUTIVE
         )
         UserProgramRole.objects.create(
-            user=self.exec_user, program=self.prog_b, role="executive"
+            user=self.exec_user, program=self.prog_b, role=ROLE_EXECUTIVE
         )
 
     def _create_client(self, status="active", programs=None):
@@ -319,7 +320,7 @@ class ProgramLearningCardTest(TestCase):
             name="Youth Employment", colour_hex="#10B981", status="active",
         )
         UserProgramRole.objects.create(
-            user=self.user, program=self.program, role="executive",
+            user=self.user, program=self.program, role=ROLE_EXECUTIVE,
         )
         self.date_from = date.today() - timedelta(days=90)
         self.date_to = date.today()
@@ -722,7 +723,7 @@ class ExecutiveDashboardMetricInsightsTest(TestCase):
         )
         self.prog = Program.objects.create(name="Insights Program", colour_hex="#10B981")
         UserProgramRole.objects.create(
-            user=self.exec_user, program=self.prog, role="executive"
+            user=self.exec_user, program=self.prog, role=ROLE_EXECUTIVE
         )
 
     def _create_client(self, status="active"):

--- a/tests/test_export_permissions.py
+++ b/tests/test_export_permissions.py
@@ -26,6 +26,12 @@ from apps.programs.models import Program, UserProgramRole
 from apps.reports.models import SecureExportLink
 from apps.reports.utils import can_create_export, can_download_pii_export, get_manageable_programs, is_aggregate_only_user
 import konote.encryption as enc_module
+from apps.auth_app.constants import (
+    ROLE_EXECUTIVE,
+    ROLE_PROGRAM_MANAGER,
+    ROLE_RECEPTIONIST,
+    ROLE_STAFF,
+)
 
 TEST_KEY = Fernet.generate_key().decode()
 
@@ -93,15 +99,15 @@ class CanCreateExportHelperTest(TestCase):
 
         # PM manages program A only
         UserProgramRole.objects.create(
-            user=self.pm_user, program=self.program_a, role="program_manager"
+            user=self.pm_user, program=self.program_a, role=ROLE_PROGRAM_MANAGER
         )
         # Staff in program A
         UserProgramRole.objects.create(
-            user=self.staff_user, program=self.program_a, role="staff"
+            user=self.staff_user, program=self.program_a, role=ROLE_STAFF
         )
         # Executive in program A
         UserProgramRole.objects.create(
-            user=self.exec_user, program=self.program_a, role="executive"
+            user=self.exec_user, program=self.program_a, role=ROLE_EXECUTIVE
         )
 
     # ── Admin ────────────────────────────────────────────────────
@@ -173,7 +179,7 @@ class GetManageableProgramsTest(TestCase):
         self.archived = Program.objects.create(name="Archived", status="archived")
 
         UserProgramRole.objects.create(
-            user=self.pm_user, program=self.program_a, role="program_manager"
+            user=self.pm_user, program=self.program_a, role=ROLE_PROGRAM_MANAGER
         )
 
     def test_admin_sees_all_active_programs(self):
@@ -221,16 +227,16 @@ class MetricsExportPermissionTest(TestCase):
         self.program_a = Program.objects.create(name="Program A")
 
         UserProgramRole.objects.create(
-            user=self.pm_user, program=self.program_a, role="program_manager"
+            user=self.pm_user, program=self.program_a, role=ROLE_PROGRAM_MANAGER
         )
         UserProgramRole.objects.create(
-            user=self.staff_user, program=self.program_a, role="staff"
+            user=self.staff_user, program=self.program_a, role=ROLE_STAFF
         )
         UserProgramRole.objects.create(
-            user=self.exec_user, program=self.program_a, role="executive"
+            user=self.exec_user, program=self.program_a, role=ROLE_EXECUTIVE
         )
         UserProgramRole.objects.create(
-            user=self.receptionist, program=self.program_a, role="receptionist"
+            user=self.receptionist, program=self.program_a, role=ROLE_RECEPTIONIST
         )
 
     def test_admin_can_access_metrics_export(self):
@@ -288,13 +294,13 @@ class FunderReportPermissionTest(TestCase):
         self.program_a = Program.objects.create(name="Program A")
 
         UserProgramRole.objects.create(
-            user=self.pm_user, program=self.program_a, role="program_manager"
+            user=self.pm_user, program=self.program_a, role=ROLE_PROGRAM_MANAGER
         )
         UserProgramRole.objects.create(
-            user=self.staff_user, program=self.program_a, role="staff"
+            user=self.staff_user, program=self.program_a, role=ROLE_STAFF
         )
         UserProgramRole.objects.create(
-            user=self.exec_user, program=self.program_a, role="executive"
+            user=self.exec_user, program=self.program_a, role=ROLE_EXECUTIVE
         )
 
     def test_admin_can_access_funder_report(self):
@@ -349,10 +355,10 @@ class DownloadExportPermissionTest(TestCase):
 
         self.program_a = Program.objects.create(name="Program A")
         UserProgramRole.objects.create(
-            user=self.pm_user, program=self.program_a, role="program_manager"
+            user=self.pm_user, program=self.program_a, role=ROLE_PROGRAM_MANAGER
         )
         UserProgramRole.objects.create(
-            user=self.pm_user2, program=self.program_a, role="program_manager"
+            user=self.pm_user2, program=self.program_a, role=ROLE_PROGRAM_MANAGER
         )
 
     def tearDown(self):
@@ -410,7 +416,7 @@ class DownloadExportPermissionTest(TestCase):
             username="exec_dl", password="testpass123", is_admin=False, display_name="Exec"
         )
         UserProgramRole.objects.create(
-            user=exec_user, program=self.program_a, role="executive"
+            user=exec_user, program=self.program_a, role=ROLE_EXECUTIVE
         )
         settings.SECURE_EXPORT_DIR = self.export_dir
         link = _create_link(exec_user, self.export_dir, contains_pii=True)
@@ -460,7 +466,7 @@ class ManageRevokePermissionTest(TestCase):
 
         self.program_a = Program.objects.create(name="Program A")
         UserProgramRole.objects.create(
-            user=self.pm_user, program=self.program_a, role="program_manager"
+            user=self.pm_user, program=self.program_a, role=ROLE_PROGRAM_MANAGER
         )
 
     def tearDown(self):
@@ -511,13 +517,13 @@ class ExportAccessContextTest(TestCase):
 
         self.program_a = Program.objects.create(name="Program A")
         UserProgramRole.objects.create(
-            user=self.pm_user, program=self.program_a, role="program_manager"
+            user=self.pm_user, program=self.program_a, role=ROLE_PROGRAM_MANAGER
         )
         UserProgramRole.objects.create(
-            user=self.staff_user, program=self.program_a, role="staff"
+            user=self.staff_user, program=self.program_a, role=ROLE_STAFF
         )
         UserProgramRole.objects.create(
-            user=self.exec_user, program=self.program_a, role="executive"
+            user=self.exec_user, program=self.program_a, role=ROLE_EXECUTIVE
         )
 
     def _get_context(self, username):
@@ -571,17 +577,17 @@ class IsAggregateOnlyUserTest(TestCase):
         self.program_b = Program.objects.create(name="Program B")
 
         UserProgramRole.objects.create(
-            user=self.exec_user, program=self.program_a, role="executive"
+            user=self.exec_user, program=self.program_a, role=ROLE_EXECUTIVE
         )
         UserProgramRole.objects.create(
-            user=self.pm_user, program=self.program_a, role="program_manager"
+            user=self.pm_user, program=self.program_a, role=ROLE_PROGRAM_MANAGER
         )
         # Dual user: executive in program A, PM in program B
         UserProgramRole.objects.create(
-            user=self.dual_user, program=self.program_a, role="executive"
+            user=self.dual_user, program=self.program_a, role=ROLE_EXECUTIVE
         )
         UserProgramRole.objects.create(
-            user=self.dual_user, program=self.program_b, role="program_manager"
+            user=self.dual_user, program=self.program_b, role=ROLE_PROGRAM_MANAGER
         )
 
     def test_admin_without_pm_role_is_aggregate_only(self):
@@ -605,7 +611,7 @@ class IsAggregateOnlyUserTest(TestCase):
             username="admin_pm", password="testpass123", is_admin=True, display_name="AdminPM"
         )
         UserProgramRole.objects.create(
-            user=admin_pm, program=self.program_a, role="program_manager"
+            user=admin_pm, program=self.program_a, role=ROLE_PROGRAM_MANAGER
         )
         self.assertFalse(is_aggregate_only_user(admin_pm))
 
@@ -661,10 +667,10 @@ class ExecutiveAggregateExportTest(TestCase):
 
         # Roles
         UserProgramRole.objects.create(
-            user=self.pm_user, program=self.program, role="program_manager"
+            user=self.pm_user, program=self.program, role=ROLE_PROGRAM_MANAGER
         )
         UserProgramRole.objects.create(
-            user=self.exec_user, program=self.program, role="executive"
+            user=self.exec_user, program=self.program, role=ROLE_EXECUTIVE
         )
 
         # Client
@@ -863,22 +869,22 @@ class IndividualClientExportPermissionTest(TestCase):
         self.program_a = Program.objects.create(name="Program A")
 
         UserProgramRole.objects.create(
-            user=self.pm_user, program=self.program_a, role="program_manager"
+            user=self.pm_user, program=self.program_a, role=ROLE_PROGRAM_MANAGER
         )
         UserProgramRole.objects.create(
-            user=self.staff_user, program=self.program_a, role="staff"
+            user=self.staff_user, program=self.program_a, role=ROLE_STAFF
         )
         UserProgramRole.objects.create(
-            user=self.exec_user, program=self.program_a, role="executive"
+            user=self.exec_user, program=self.program_a, role=ROLE_EXECUTIVE
         )
         UserProgramRole.objects.create(
-            user=self.receptionist, program=self.program_a, role="receptionist"
+            user=self.receptionist, program=self.program_a, role=ROLE_RECEPTIONIST
         )
 
         # Admin needs a program role to pass ProgramAccessMiddleware
         # (admins without program roles are blocked from client URLs)
         UserProgramRole.objects.create(
-            user=self.admin, program=self.program_a, role="program_manager"
+            user=self.admin, program=self.program_a, role=ROLE_PROGRAM_MANAGER
         )
 
         # Create a client for the export endpoint
@@ -962,16 +968,16 @@ class ClientProgressPdfPermissionTest(TestCase):
         self.program_a = Program.objects.create(name="Program A")
 
         UserProgramRole.objects.create(
-            user=self.admin, program=self.program_a, role="program_manager"
+            user=self.admin, program=self.program_a, role=ROLE_PROGRAM_MANAGER
         )
         UserProgramRole.objects.create(
-            user=self.pm_user, program=self.program_a, role="program_manager"
+            user=self.pm_user, program=self.program_a, role=ROLE_PROGRAM_MANAGER
         )
         UserProgramRole.objects.create(
-            user=self.staff_user, program=self.program_a, role="staff"
+            user=self.staff_user, program=self.program_a, role=ROLE_STAFF
         )
         UserProgramRole.objects.create(
-            user=self.exec_user, program=self.program_a, role="executive"
+            user=self.exec_user, program=self.program_a, role=ROLE_EXECUTIVE
         )
 
         self.client_file = ClientFile.objects.create()
@@ -1042,16 +1048,16 @@ class ClientAnalysisPermissionTest(TestCase):
         self.program_a = Program.objects.create(name="Program A")
 
         UserProgramRole.objects.create(
-            user=self.pm_user, program=self.program_a, role="program_manager"
+            user=self.pm_user, program=self.program_a, role=ROLE_PROGRAM_MANAGER
         )
         UserProgramRole.objects.create(
-            user=self.staff_user, program=self.program_a, role="staff"
+            user=self.staff_user, program=self.program_a, role=ROLE_STAFF
         )
         UserProgramRole.objects.create(
-            user=self.exec_user, program=self.program_a, role="executive"
+            user=self.exec_user, program=self.program_a, role=ROLE_EXECUTIVE
         )
         UserProgramRole.objects.create(
-            user=self.receptionist, program=self.program_a, role="receptionist"
+            user=self.receptionist, program=self.program_a, role=ROLE_RECEPTIONIST
         )
 
         self.client_file = ClientFile.objects.create()

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -26,6 +26,7 @@ from apps.reports.funder_report import (
     generate_funder_report_data,
 )
 from apps.reports.utils import get_quarter_range, get_quarter_choices
+from apps.auth_app.constants import ROLE_EXECUTIVE, ROLE_PROGRAM_MANAGER, ROLE_STAFF
 
 
 class FormatNumberTests(SimpleTestCase):
@@ -224,7 +225,7 @@ class StructuredInsightsJSONTest(TestCase):
         )
         self.program = Program.objects.create(name="Housing")
         UserProgramRole.objects.create(
-            user=self.user, program=self.program, role="staff", status="active"
+            user=self.user, program=self.program, role=ROLE_STAFF, status="active"
         )
         self.client_file = ClientFile()
         self.client_file.first_name = "Test"
@@ -277,7 +278,7 @@ class AnalysisChartTimeframeTest(TestCase):
         )
         self.program = Program.objects.create(name="Coaching")
         UserProgramRole.objects.create(
-            user=self.user, program=self.program, role="staff", status="active"
+            user=self.user, program=self.program, role=ROLE_STAFF, status="active"
         )
         self.client_file = ClientFile()
         self.client_file.first_name = "Chart"
@@ -464,7 +465,7 @@ class FunderReportTemplateMetricFilterTest(TestCase):
         )
         self.program = Program.objects.create(name="Coaching")
         UserProgramRole.objects.create(
-            user=self.user, program=self.program, role="executive", status="active"
+            user=self.user, program=self.program, role=ROLE_EXECUTIVE, status="active"
         )
 
         self.client_file = ClientFile()
@@ -790,7 +791,7 @@ class ConsortiumMetricLockingTest(TestCase):
         )
         self.program = Program.objects.create(name="Coaching")
         UserProgramRole.objects.create(
-            user=self.user, program=self.program, role="staff", status="active"
+            user=self.user, program=self.program, role=ROLE_STAFF, status="active"
         )
 
         self.metric_a = MetricDefinition.objects.create(
@@ -881,10 +882,10 @@ class AllProgramsFormChoicesTest(TestCase):
         self.program_a = Program.objects.create(name="Housing")
         self.program_b = Program.objects.create(name="Employment")
         UserProgramRole.objects.create(
-            user=self.user, program=self.program_a, role="program_manager", status="active"
+            user=self.user, program=self.program_a, role=ROLE_PROGRAM_MANAGER, status="active"
         )
         UserProgramRole.objects.create(
-            user=self.user, program=self.program_b, role="program_manager", status="active"
+            user=self.user, program=self.program_b, role=ROLE_PROGRAM_MANAGER, status="active"
         )
 
         # A user with only one program
@@ -892,7 +893,7 @@ class AllProgramsFormChoicesTest(TestCase):
             username="single_pm", password="pass", display_name="Single PM"
         )
         UserProgramRole.objects.create(
-            user=self.single_user, program=self.program_a, role="program_manager", status="active"
+            user=self.single_user, program=self.program_a, role=ROLE_PROGRAM_MANAGER, status="active"
         )
 
     def tearDown(self):
@@ -952,10 +953,10 @@ class AllProgramsCleanProgramTest(TestCase):
         self.program_a = Program.objects.create(name="Housing")
         self.program_b = Program.objects.create(name="Employment")
         UserProgramRole.objects.create(
-            user=self.user, program=self.program_a, role="program_manager", status="active"
+            user=self.user, program=self.program_a, role=ROLE_PROGRAM_MANAGER, status="active"
         )
         UserProgramRole.objects.create(
-            user=self.user, program=self.program_b, role="program_manager", status="active"
+            user=self.user, program=self.program_b, role=ROLE_PROGRAM_MANAGER, status="active"
         )
         # Create metric for form validation to pass
         self.metric = MetricDefinition.objects.create(
@@ -1085,10 +1086,10 @@ class AllProgramsFunderFormCleanTest(TestCase):
         self.program_a = Program.objects.create(name="Housing")
         self.program_b = Program.objects.create(name="Employment")
         UserProgramRole.objects.create(
-            user=self.user, program=self.program_a, role="program_manager", status="active"
+            user=self.user, program=self.program_a, role=ROLE_PROGRAM_MANAGER, status="active"
         )
         UserProgramRole.objects.create(
-            user=self.user, program=self.program_b, role="program_manager", status="active"
+            user=self.user, program=self.program_b, role=ROLE_PROGRAM_MANAGER, status="active"
         )
         # Create a report template linked to program A
         partner = Partner.objects.create(name="Test Funder", partner_type="funder")
@@ -1451,7 +1452,7 @@ class ComplianceBannerIntegrationTests(TestCase):
             username="banner_exec", password="pass", is_admin=False,
         )
         UserProgramRole.objects.create(
-            user=self.executive, program=self.prog, role="executive",
+            user=self.executive, program=self.prog, role=ROLE_EXECUTIVE,
         )
 
         # Create a client enrolled in the program

--- a/tests/test_field_access.py
+++ b/tests/test_field_access.py
@@ -12,6 +12,7 @@ from apps.clients.models import (
     FieldAccessConfig,
 )
 from apps.programs.models import Program, UserProgramRole
+from apps.auth_app.constants import ROLE_PROGRAM_MANAGER, ROLE_RECEPTIONIST, ROLE_STAFF
 import konote.encryption as enc_module
 
 TEST_KEY = Fernet.generate_key().decode()
@@ -90,38 +91,38 @@ class GetVisibleFieldsTest(TestCase):
 
     def test_receptionist_sees_always_visible_fields(self):
         """Receptionist always sees identity fields regardless of config."""
-        visible = self.cf.get_visible_fields("receptionist")
+        visible = self.cf.get_visible_fields(ROLE_RECEPTIONIST)
         for field in FieldAccessConfig.ALWAYS_VISIBLE:
             self.assertTrue(visible.get(field), f"{field} should be visible")
 
     def test_receptionist_sees_phone_by_default(self):
         """Receptionist sees phone (safe default is 'edit')."""
-        visible = self.cf.get_visible_fields("receptionist")
+        visible = self.cf.get_visible_fields(ROLE_RECEPTIONIST)
         self.assertTrue(visible.get("phone"))
         self.assertTrue(visible.get("phone_editable"))
 
     def test_receptionist_birth_date_hidden_by_default(self):
         """Receptionist cannot see birth_date by default (safe default is 'none')."""
-        visible = self.cf.get_visible_fields("receptionist")
+        visible = self.cf.get_visible_fields(ROLE_RECEPTIONIST)
         self.assertFalse(visible.get("birth_date"))
 
     def test_receptionist_sees_birth_date_when_configured(self):
         """Receptionist sees birth_date when config is set to 'view'."""
         FieldAccessConfig.objects.create(field_name="birth_date", front_desk_access="view")
-        visible = self.cf.get_visible_fields("receptionist")
+        visible = self.cf.get_visible_fields(ROLE_RECEPTIONIST)
         self.assertTrue(visible.get("birth_date"))
         self.assertFalse(visible.get("birth_date_editable"))
 
     def test_staff_sees_all_fields(self):
         """Staff role sees all fields as visible and editable."""
-        visible = self.cf.get_visible_fields("staff")
+        visible = self.cf.get_visible_fields(ROLE_STAFF)
         for field in ("first_name", "last_name", "phone", "email"):
             self.assertTrue(visible.get(field), f"{field} should be visible for staff")
             self.assertTrue(visible.get(f"{field}_editable"), f"{field} should be editable for staff")
 
     def test_program_manager_sees_all_fields(self):
         """Program manager sees all fields as visible and editable."""
-        visible = self.cf.get_visible_fields("program_manager")
+        visible = self.cf.get_visible_fields(ROLE_PROGRAM_MANAGER)
         self.assertTrue(visible.get("phone"))
         self.assertTrue(visible.get("email"))
 
@@ -142,8 +143,8 @@ class FieldAccessAdminViewTest(TestCase):
             username="staff", password="testpass123", is_admin=False,
         )
         self.prog = Program.objects.create(name="Test Program", colour_hex="#10B981")
-        UserProgramRole.objects.create(user=self.admin, program=self.prog, role="program_manager")
-        UserProgramRole.objects.create(user=self.staff_user, program=self.prog, role="staff")
+        UserProgramRole.objects.create(user=self.admin, program=self.prog, role=ROLE_PROGRAM_MANAGER)
+        UserProgramRole.objects.create(user=self.staff_user, program=self.prog, role=ROLE_STAFF)
 
         # Set tier to 2 so the page is accessible
         InstanceSetting.objects.create(setting_key="access_tier", setting_value="2")

--- a/tests/test_french_journey.py
+++ b/tests/test_french_journey.py
@@ -24,6 +24,7 @@ from apps.plans.models import (
 )
 from apps.programs.models import Program, UserProgramRole
 import konote.encryption as enc_module
+from apps.auth_app.constants import ROLE_PROGRAM_MANAGER, ROLE_STAFF
 
 
 TEST_KEY = Fernet.generate_key().decode()
@@ -61,8 +62,8 @@ class FrenchJourneyBaseTest(TestCase):
 
         # Program
         self.program = Program.objects.create(name="Programme de soutien", colour_hex="#10B981")
-        UserProgramRole.objects.create(user=self.admin, program=self.program, role="program_manager")
-        UserProgramRole.objects.create(user=self.staff, program=self.program, role="staff")
+        UserProgramRole.objects.create(user=self.admin, program=self.program, role=ROLE_PROGRAM_MANAGER)
+        UserProgramRole.objects.create(user=self.staff, program=self.program, role=ROLE_STAFF)
 
         # Enable features that affect navigation
         FeatureToggle.objects.create(feature_key="programs", is_enabled=True)

--- a/tests/test_goal_builder.py
+++ b/tests/test_goal_builder.py
@@ -21,6 +21,7 @@ from apps.plans.models import (
 )
 from apps.programs.models import Program, UserProgramRole
 import konote.encryption as enc_module
+from apps.auth_app.constants import ROLE_PROGRAM_MANAGER, ROLE_STAFF
 
 
 TEST_KEY = Fernet.generate_key().decode()
@@ -67,7 +68,7 @@ class GoalBuilderBaseTest(TestCase):
         )
         self.program = Program.objects.create(name="Housing Support")
         UserProgramRole.objects.create(
-            user=self.user, program=self.program, role="staff", status="active"
+            user=self.user, program=self.program, role=ROLE_STAFF, status="active"
         )
 
         # Client enrolled in program
@@ -129,7 +130,7 @@ class GoalBuilderStartTest(GoalBuilderBaseTest):
         """Program managers have plan.edit: DENY, so they can't use Goal Builder."""
         pm = User.objects.create_user(username="pm", password="pass", display_name="PM")
         UserProgramRole.objects.create(
-            user=pm, program=self.program, role="program_manager", status="active"
+            user=pm, program=self.program, role=ROLE_PROGRAM_MANAGER, status="active"
         )
         self.http.login(username="pm", password="pass")
         resp = self.http.get(self.start_url)

--- a/tests/test_groups_phase2.py
+++ b/tests/test_groups_phase2.py
@@ -21,6 +21,7 @@ from apps.groups.models import (
 )
 from apps.programs.models import Program, UserProgramRole
 import konote.encryption as enc_module
+from apps.auth_app.constants import ROLE_STAFF
 
 TEST_KEY = Fernet.generate_key().decode()
 
@@ -90,7 +91,7 @@ class AttendanceReportTest(TestCase):
             name="Youth Group", service_model="group",
         )
         UserProgramRole.objects.create(
-            user=self.staff, program=self.program, role="staff", status="active",
+            user=self.staff, program=self.program, role=ROLE_STAFF, status="active",
         )
         self.group = Group.objects.create(
             name="Monday Group", program=self.program, group_type="group",
@@ -173,7 +174,7 @@ class GroupDetailSessionCountsTest(TestCase):
             name="Test Program", service_model="group",
         )
         UserProgramRole.objects.create(
-            user=self.staff, program=self.program, role="staff", status="active",
+            user=self.staff, program=self.program, role=ROLE_STAFF, status="active",
         )
         self.group = Group.objects.create(
             name="Test Group", program=self.program, group_type="group",
@@ -235,7 +236,7 @@ class SessionLogHappyPathTest(TestCase):
             name="Youth Group", service_model="group",
         )
         UserProgramRole.objects.create(
-            user=self.staff, program=self.program, role="staff", status="active",
+            user=self.staff, program=self.program, role=ROLE_STAFF, status="active",
         )
         self.group = Group.objects.create(
             name="Monday Group", program=self.program, group_type="group",
@@ -335,7 +336,7 @@ class SessionLogHappyPathTest(TestCase):
             username="other", password="testpass123", is_admin=False,
         )
         UserProgramRole.objects.create(
-            user=other_user, program=other_program, role="staff", status="active",
+            user=other_user, program=other_program, role=ROLE_STAFF, status="active",
         )
         self.client.login(username="other", password="testpass123")
         data = self._valid_post_data()

--- a/tests/test_home_dashboard.py
+++ b/tests/test_home_dashboard.py
@@ -7,6 +7,12 @@ from apps.clients.models import ClientFile, ClientProgramEnrolment
 from apps.events.models import Alert
 from apps.notes.models import ProgressNote
 from apps.programs.models import Program, UserProgramRole
+from apps.auth_app.constants import (
+    ROLE_EXECUTIVE,
+    ROLE_PROGRAM_MANAGER,
+    ROLE_RECEPTIONIST,
+    ROLE_STAFF,
+)
 
 User = get_user_model()
 
@@ -28,10 +34,10 @@ class HomeDashboardPermissionsTest(TestCase):
 
         # Assign roles
         UserProgramRole.objects.create(
-            user=self.receptionist, program=self.program, role="receptionist"
+            user=self.receptionist, program=self.program, role=ROLE_RECEPTIONIST
         )
         UserProgramRole.objects.create(
-            user=self.staff, program=self.program, role="staff"
+            user=self.staff, program=self.program, role=ROLE_STAFF
         )
 
         # Create a client
@@ -147,7 +153,7 @@ class HomeDashboardRoleBasedTest(TestCase):
             username="pm", password="testpass123", is_demo=False
         )
         UserProgramRole.objects.create(
-            user=self.pm_user, program=self.program_a, role="program_manager"
+            user=self.pm_user, program=self.program_a, role=ROLE_PROGRAM_MANAGER
         )
 
         # Executive user — executive on program A
@@ -155,7 +161,7 @@ class HomeDashboardRoleBasedTest(TestCase):
             username="exec", password="testpass123", is_demo=False
         )
         UserProgramRole.objects.create(
-            user=self.exec_user, program=self.program_a, role="executive"
+            user=self.exec_user, program=self.program_a, role=ROLE_EXECUTIVE
         )
 
         # Executive-only user — executive on program B, no other roles
@@ -163,7 +169,7 @@ class HomeDashboardRoleBasedTest(TestCase):
             username="exec_only", password="testpass123", is_demo=False
         )
         UserProgramRole.objects.create(
-            user=self.exec_only_user, program=self.program_b, role="executive"
+            user=self.exec_only_user, program=self.program_b, role=ROLE_EXECUTIVE
         )
 
         # Staff user
@@ -171,7 +177,7 @@ class HomeDashboardRoleBasedTest(TestCase):
             username="staff2", password="testpass123", is_demo=False
         )
         UserProgramRole.objects.create(
-            user=self.staff_user, program=self.program_a, role="staff"
+            user=self.staff_user, program=self.program_a, role=ROLE_STAFF
         )
 
         # Receptionist user
@@ -179,7 +185,7 @@ class HomeDashboardRoleBasedTest(TestCase):
             username="frontdesk2", password="testpass123", is_demo=False
         )
         UserProgramRole.objects.create(
-            user=self.receptionist_user, program=self.program_a, role="receptionist"
+            user=self.receptionist_user, program=self.program_a, role=ROLE_RECEPTIONIST
         )
 
         # Create a client enrolled in program A

--- a/tests/test_htmx_errors.py
+++ b/tests/test_htmx_errors.py
@@ -10,6 +10,7 @@ from apps.auth_app.models import User
 from apps.programs.models import Program, UserProgramRole
 from apps.clients.models import ClientFile, ClientProgramEnrolment
 import konote.encryption as enc_module
+from apps.auth_app.constants import ROLE_RECEPTIONIST, ROLE_STAFF
 
 
 TEST_KEY = Fernet.generate_key().decode()
@@ -40,9 +41,9 @@ class Error403ResponseTest(TestCase):
         self.program_b = Program.objects.create(name="Program B")
 
         # Assign users to programs
-        UserProgramRole.objects.create(user=self.receptionist, program=self.program_a, role="receptionist")
-        UserProgramRole.objects.create(user=self.staff_user, program=self.program_a, role="staff")
-        UserProgramRole.objects.create(user=self.other_staff, program=self.program_b, role="staff")
+        UserProgramRole.objects.create(user=self.receptionist, program=self.program_a, role=ROLE_RECEPTIONIST)
+        UserProgramRole.objects.create(user=self.staff_user, program=self.program_a, role=ROLE_STAFF)
+        UserProgramRole.objects.create(user=self.other_staff, program=self.program_b, role=ROLE_STAFF)
 
         # Create client in Program A only
         self.client_file = ClientFile.objects.create()
@@ -102,7 +103,7 @@ class FormValidationErrorTest(TestCase):
             username="staff", password="testpass123", display_name="Staff"
         )
         self.program = Program.objects.create(name="Test Program")
-        UserProgramRole.objects.create(user=self.staff_user, program=self.program, role="staff")
+        UserProgramRole.objects.create(user=self.staff_user, program=self.program, role=ROLE_STAFF)
 
         # Create client for testing
         self.client_file = ClientFile.objects.create()
@@ -155,7 +156,7 @@ class HTMXPartialResponseTest(TestCase):
             username="staff", password="testpass123", display_name="Staff"
         )
         self.program = Program.objects.create(name="Test Program")
-        UserProgramRole.objects.create(user=self.staff_user, program=self.program, role="staff")
+        UserProgramRole.objects.create(user=self.staff_user, program=self.program, role=ROLE_STAFF)
 
         self.client_file = ClientFile.objects.create()
         self.client_file.first_name = "Test"
@@ -237,8 +238,8 @@ class CustomFieldEditHTMXTest(TestCase):
         )
 
         self.program = Program.objects.create(name="Test Program")
-        UserProgramRole.objects.create(user=self.staff_user, program=self.program, role="staff")
-        UserProgramRole.objects.create(user=self.receptionist, program=self.program, role="receptionist")
+        UserProgramRole.objects.create(user=self.staff_user, program=self.program, role=ROLE_STAFF)
+        UserProgramRole.objects.create(user=self.receptionist, program=self.program, role=ROLE_RECEPTIONIST)
 
         self.client_file = ClientFile.objects.create()
         self.client_file.first_name = "Test"
@@ -315,7 +316,7 @@ class AdminRouteErrorTest(TestCase):
             username="staff", password="testpass123", display_name="Staff"
         )
         self.program = Program.objects.create(name="Test Program")
-        UserProgramRole.objects.create(user=self.staff_user, program=self.program, role="staff")
+        UserProgramRole.objects.create(user=self.staff_user, program=self.program, role=ROLE_STAFF)
 
     def tearDown(self):
         enc_module._fernet = None

--- a/tests/test_individual_client_export.py
+++ b/tests/test_individual_client_export.py
@@ -24,6 +24,7 @@ from apps.clients.models import ClientFile, ClientProgramEnrolment
 from apps.programs.models import Program, UserProgramRole
 from apps.reports.models import SecureExportLink
 import konote.encryption as enc_module
+from apps.auth_app.constants import ROLE_PROGRAM_MANAGER, ROLE_STAFF
 
 TEST_KEY = Fernet.generate_key().decode()
 
@@ -46,7 +47,7 @@ class IndividualClientExportTestBase(TestCase):
             username="pm_user", password="testpass123", display_name="PM User"
         )
         UserProgramRole.objects.create(
-            user=self.pm_user, program=self.program, role="program_manager"
+            user=self.pm_user, program=self.program, role=ROLE_PROGRAM_MANAGER
         )
 
         # Staff user — does NOT have report.data_extract permission
@@ -54,7 +55,7 @@ class IndividualClientExportTestBase(TestCase):
             username="staff_user", password="testpass123", display_name="Staff User"
         )
         UserProgramRole.objects.create(
-            user=self.staff_user, program=self.program, role="staff"
+            user=self.staff_user, program=self.program, role=ROLE_STAFF
         )
 
         # Client

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -34,6 +34,7 @@ from apps.plans.models import PlanSection, PlanTarget
 from apps.programs.models import Program, UserProgramRole
 
 import konote.encryption as enc_module
+from apps.auth_app.constants import ROLE_PROGRAM_MANAGER, ROLE_STAFF
 
 TEST_KEY = Fernet.generate_key().decode()
 
@@ -54,7 +55,7 @@ class MergeCandidatesTest(TestCase):
             name="Counselling", colour_hex="#EF4444", is_confidential=True,
         )
         UserProgramRole.objects.create(
-            user=self.admin, program=self.prog_a, role="program_manager",
+            user=self.admin, program=self.prog_a, role=ROLE_PROGRAM_MANAGER,
         )
 
     def _make_client(self, first_name, last_name, phone="", birth_date="", program=None):
@@ -208,7 +209,7 @@ class MergeExecutionTest(TestCase):
         )
         self.prog = Program.objects.create(name="Employment", colour_hex="#10B981")
         UserProgramRole.objects.create(
-            user=self.admin, program=self.prog, role="program_manager",
+            user=self.admin, program=self.prog, role=ROLE_PROGRAM_MANAGER,
         )
 
         # Create two clients
@@ -440,10 +441,10 @@ class MergeViewsTest(TestCase):
         )
         self.prog = Program.objects.create(name="Employment", colour_hex="#10B981")
         UserProgramRole.objects.create(
-            user=self.admin, program=self.prog, role="program_manager",
+            user=self.admin, program=self.prog, role=ROLE_PROGRAM_MANAGER,
         )
         UserProgramRole.objects.create(
-            user=self.staff, program=self.prog, role="staff",
+            user=self.staff, program=self.prog, role=ROLE_STAFF,
         )
 
     def test_candidates_list_requires_admin(self):

--- a/tests/test_metric_insights.py
+++ b/tests/test_metric_insights.py
@@ -24,6 +24,7 @@ from apps.reports.metric_insights import (
     get_metric_trends,
     get_two_lenses,
 )
+from apps.auth_app.constants import ROLE_PROGRAM_MANAGER
 
 User = get_user_model()
 TEST_KEY = Fernet.generate_key().decode()
@@ -749,7 +750,7 @@ class ProgramInsightsViewContextTest(TestCase):
         )
         UserProgramRole.objects.create(
             user=self.user, program=self.program,
-            role="program_manager", status="active",
+            role=ROLE_PROGRAM_MANAGER, status="active",
         )
 
         self.metric = MetricDefinition.objects.create(

--- a/tests/test_middleware_behaviour.py
+++ b/tests/test_middleware_behaviour.py
@@ -13,6 +13,7 @@ from apps.auth_app.models import User
 from apps.clients.models import ClientFile, ClientProgramEnrolment
 from apps.programs.models import Program, UserProgramRole
 import konote.encryption as enc_module
+from apps.auth_app.constants import ROLE_STAFF
 
 TEST_KEY = Fernet.generate_key().decode()
 
@@ -30,7 +31,7 @@ def _setup_staff_with_client(test_case):
     )
     program = Program.objects.create(name="Test Program", status="active")
     UserProgramRole.objects.create(
-        user=user, program=program, role="staff", status="active",
+        user=user, program=program, role=ROLE_STAFF, status="active",
     )
     client_file = ClientFile.objects.create(is_demo=False)
     client_file.first_name = "Test"
@@ -100,7 +101,7 @@ class AuditMiddlewareBehaviourTest(TestCase):
         # Give outsider a role in a DIFFERENT program so they are authenticated but cannot access
         other_program = Program.objects.create(name="Other Program", status="active")
         UserProgramRole.objects.create(
-            user=outsider, program=other_program, role="staff", status="active",
+            user=outsider, program=other_program, role=ROLE_STAFF, status="active",
         )
         self.http.login(username="outsider", password="testpass123")
         url = f"/participants/{self.client_file.pk}/"

--- a/tests/test_notes.py
+++ b/tests/test_notes.py
@@ -10,6 +10,7 @@ from apps.clients.models import ClientFile, ClientProgramEnrolment
 from apps.plans.models import MetricDefinition, PlanSection, PlanTarget, PlanTargetMetric
 from apps.notes.models import ProgressNote, ProgressNoteTarget, MetricValue
 import konote.encryption as enc_module
+from apps.auth_app.constants import ROLE_PROGRAM_MANAGER, ROLE_RECEPTIONIST, ROLE_STAFF
 
 TEST_KEY = Fernet.generate_key().decode()
 
@@ -26,8 +27,8 @@ class NoteViewsTest(TestCase):
         self.other_staff = User.objects.create_user(username="other", password="pass", is_admin=False)
 
         self.prog = Program.objects.create(name="Prog A", colour_hex="#10B981")
-        UserProgramRole.objects.create(user=self.staff, program=self.prog, role="staff")
-        UserProgramRole.objects.create(user=self.other_staff, program=self.prog, role="staff")
+        UserProgramRole.objects.create(user=self.staff, program=self.prog, role=ROLE_STAFF)
+        UserProgramRole.objects.create(user=self.other_staff, program=self.prog, role=ROLE_STAFF)
 
         self.client_file = ClientFile()
         self.client_file.first_name = "Jane"
@@ -103,7 +104,7 @@ class NoteViewsTest(TestCase):
 
     def test_admin_with_program_role_can_create_note(self):
         """Admins who also have a program role can create notes."""
-        UserProgramRole.objects.create(user=self.admin, program=self.prog_b, role="program_manager")
+        UserProgramRole.objects.create(user=self.admin, program=self.prog_b, role=ROLE_PROGRAM_MANAGER)
         # Add consent to other_client so note creation is allowed
         self.other_client.consent_given_at = timezone.now()
         self.other_client.consent_type = "written"
@@ -698,7 +699,7 @@ class NoteViewsTest(TestCase):
 
     def test_admin_with_program_role_can_cancel_note(self):
         """Admins who also have a program role can cancel notes in their programs."""
-        UserProgramRole.objects.create(user=self.admin, program=self.prog, role="program_manager")
+        UserProgramRole.objects.create(user=self.admin, program=self.prog, role=ROLE_PROGRAM_MANAGER)
         note = ProgressNote.objects.create(
             client_file=self.client_file, note_type="quick",
             notes_text="Admin cancel", author=self.staff,
@@ -847,8 +848,8 @@ class QualitativeSummaryTest(TestCase):
         self.receptionist = User.objects.create_user(username="recep", password="pass", is_admin=False)
 
         self.prog = Program.objects.create(name="Prog A", colour_hex="#10B981")
-        UserProgramRole.objects.create(user=self.staff, program=self.prog, role="staff")
-        UserProgramRole.objects.create(user=self.receptionist, program=self.prog, role="receptionist")
+        UserProgramRole.objects.create(user=self.staff, program=self.prog, role=ROLE_STAFF)
+        UserProgramRole.objects.create(user=self.receptionist, program=self.prog, role=ROLE_RECEPTIONIST)
 
         self.client_file = ClientFile()
         self.client_file.first_name = "Jane"
@@ -939,8 +940,8 @@ class CheckNoteDateTest(TestCase):
         self.staff = User.objects.create_user(username="staff", password="pass", is_admin=False)
         self.receptionist = User.objects.create_user(username="recep", password="pass", is_admin=False)
         self.prog = Program.objects.create(name="Prog A", colour_hex="#10B981")
-        UserProgramRole.objects.create(user=self.staff, program=self.prog, role="staff")
-        UserProgramRole.objects.create(user=self.receptionist, program=self.prog, role="receptionist")
+        UserProgramRole.objects.create(user=self.staff, program=self.prog, role=ROLE_STAFF)
+        UserProgramRole.objects.create(user=self.receptionist, program=self.prog, role=ROLE_RECEPTIONIST)
 
         self.client_file = ClientFile()
         self.client_file.first_name = "Jane"
@@ -1012,8 +1013,8 @@ class TemplatePreviewTest(TestCase):
         self.staff = User.objects.create_user(username="staff", password="pass", is_admin=False)
         self.receptionist = User.objects.create_user(username="recep", password="pass", is_admin=False)
         self.prog = Program.objects.create(name="Prog A", colour_hex="#10B981")
-        UserProgramRole.objects.create(user=self.staff, program=self.prog, role="staff")
-        UserProgramRole.objects.create(user=self.receptionist, program=self.prog, role="receptionist")
+        UserProgramRole.objects.create(user=self.staff, program=self.prog, role=ROLE_STAFF)
+        UserProgramRole.objects.create(user=self.receptionist, program=self.prog, role=ROLE_RECEPTIONIST)
 
         from apps.notes.models import ProgressNoteTemplate, ProgressNoteTemplateSection
         self.template = ProgressNoteTemplate.objects.create(
@@ -1107,7 +1108,7 @@ class PlausibilityOverrideLogTest(TestCase):
         self.staff = User.objects.create_user(username="staff", password="pass", is_admin=False)
 
         self.prog = Program.objects.create(name="Financial Coaching", colour_hex="#10B981")
-        UserProgramRole.objects.create(user=self.staff, program=self.prog, role="staff")
+        UserProgramRole.objects.create(user=self.staff, program=self.prog, role=ROLE_STAFF)
 
         self.client_file = ClientFile()
         self.client_file.first_name = "Jane"
@@ -1268,7 +1269,7 @@ class PlausibilityTuningDashboardTest(TestCase):
         self.staff = User.objects.create_user(username="staff", password="pass", is_admin=False)
 
         self.prog = Program.objects.create(name="Financial Coaching", colour_hex="#10B981")
-        UserProgramRole.objects.create(user=self.staff, program=self.prog, role="staff")
+        UserProgramRole.objects.create(user=self.staff, program=self.prog, role=ROLE_STAFF)
 
         self.metric_def = MetricDefinition.objects.create(
             name="Total Debt",
@@ -1419,7 +1420,7 @@ class TestMetricCadence(TestCase):
         self.user = User.objects.create_user(username="cadtest", password="pass", is_admin=True)
 
         self.prog = Program.objects.create(name="Cadence Prog", colour_hex="#10B981")
-        UserProgramRole.objects.create(user=self.user, program=self.prog, role="staff")
+        UserProgramRole.objects.create(user=self.user, program=self.prog, role=ROLE_STAFF)
 
         self.client_file = ClientFile()
         self.client_file.first_name = "Test"
@@ -1552,7 +1553,7 @@ class TestAllianceRotation(TestCase):
         enc_module._fernet = None
         self.user = User.objects.create_user(username="allitest", password="pass", is_admin=True)
         self.prog = Program.objects.create(name="Alliance Prog", colour_hex="#10B981")
-        UserProgramRole.objects.create(user=self.user, program=self.prog, role="staff")
+        UserProgramRole.objects.create(user=self.user, program=self.prog, role=ROLE_STAFF)
         self.client_file = ClientFile()
         self.client_file.first_name = "Test"
         self.client_file.last_name = "Client"

--- a/tests/test_permissions_enforcement.py
+++ b/tests/test_permissions_enforcement.py
@@ -39,6 +39,7 @@ from apps.events.models import Alert, Event, Meeting
 from apps.groups.models import Group
 from apps.notes.models import ProgressNote
 from apps.programs.models import Program, UserProgramRole
+from apps.auth_app.constants import ALL_PROGRAM_ROLES, ROLE_PROGRAM_MANAGER, ROLE_STAFF
 import konote.encryption as enc_module
 
 TEST_KEY = Fernet.generate_key().decode()
@@ -160,7 +161,7 @@ PERMISSION_URL_MAP = {
     "circle.edit": {"url": "/circles/{circle_id}/edit/"},
 }
 
-ALL_ROLES = ["receptionist", "staff", "program_manager", "executive"]
+ALL_ROLES = list(ALL_PROGRAM_ROLES)
 
 
 @override_settings(FIELD_ENCRYPTION_KEY=TEST_KEY)
@@ -211,7 +212,7 @@ class PermissionEnforcementTest(TestCase):
         self.alert = Alert.objects.create(
             client_file=self.client_file,
             content="Test safety alert.",
-            author=self.users["staff"],
+            author=self.users[ROLE_STAFF],
             author_program=self.program,
         )
 
@@ -219,7 +220,7 @@ class PermissionEnforcementTest(TestCase):
         self.note = ProgressNote.objects.create(
             client_file=self.client_file,
             note_type="quick",
-            author=self.users["staff"],
+            author=self.users[ROLE_STAFF],
             author_program=self.program,
             notes_text="Test progress note.",
         )
@@ -243,7 +244,7 @@ class PermissionEnforcementTest(TestCase):
         # Circle with the client as a member
         from apps.circles.models import Circle, CircleMembership
         self.circle = Circle.objects.create(
-            created_by=self.users["staff"],
+            created_by=self.users[ROLE_STAFF],
         )
         self.circle.name = "Test Family"
         self.circle.save()
@@ -396,7 +397,7 @@ class AdminPermissionTest(TestCase):
         )
         UserProgramRole.objects.create(
             user=self.admin, program=self.program,
-            role="program_manager", status="active",
+            role=ROLE_PROGRAM_MANAGER, status="active",
         )
 
         # Non-admin users

--- a/tests/test_phase5.py
+++ b/tests/test_phase5.py
@@ -11,6 +11,7 @@ from apps.audit.models import AuditLog
 from apps.plans.models import MetricDefinition, PlanSection, PlanTarget, PlanTargetMetric
 from apps.notes.models import ProgressNote, ProgressNoteTarget, MetricValue
 import konote.encryption as enc_module
+from apps.auth_app.constants import ROLE_PROGRAM_MANAGER, ROLE_STAFF
 
 TEST_KEY = Fernet.generate_key().decode()
 
@@ -76,7 +77,7 @@ class EventCRUDTest(TestCase):
         self.admin = User.objects.create_user(username="admin", password="pass", is_admin=True)
 
         self.prog = Program.objects.create(name="Prog A", colour_hex="#10B981")
-        UserProgramRole.objects.create(user=self.staff, program=self.prog, role="staff")
+        UserProgramRole.objects.create(user=self.staff, program=self.prog, role=ROLE_STAFF)
 
         self.client_file = ClientFile()
         self.client_file.first_name = "Jane"
@@ -235,10 +236,10 @@ class CrossProgramPermissionTest(TestCase):
         self.prog_pm = Program.objects.create(name="Employment", colour_hex="#3B82F6")
         self.prog_staff = Program.objects.create(name="Kitchen", colour_hex="#10B981")
         UserProgramRole.objects.create(
-            user=self.user, program=self.prog_pm, role="program_manager"
+            user=self.user, program=self.prog_pm, role=ROLE_PROGRAM_MANAGER
         )
         UserProgramRole.objects.create(
-            user=self.user, program=self.prog_staff, role="staff"
+            user=self.user, program=self.prog_staff, role=ROLE_STAFF
         )
 
         # Client enrolled in BOTH programs
@@ -316,11 +317,11 @@ class AlertCRUDTest(TestCase):
         self.pm = User.objects.create_user(username="pm", password="pass", is_admin=False)
 
         self.prog = Program.objects.create(name="Prog A", colour_hex="#10B981")
-        UserProgramRole.objects.create(user=self.staff, program=self.prog, role="staff")
-        UserProgramRole.objects.create(user=self.other_staff, program=self.prog, role="staff")
-        UserProgramRole.objects.create(user=self.pm, program=self.prog, role="program_manager")
+        UserProgramRole.objects.create(user=self.staff, program=self.prog, role=ROLE_STAFF)
+        UserProgramRole.objects.create(user=self.other_staff, program=self.prog, role=ROLE_STAFF)
+        UserProgramRole.objects.create(user=self.pm, program=self.prog, role=ROLE_PROGRAM_MANAGER)
         # Admin needs a PM role to cancel alerts (admin alone is not a program role)
-        UserProgramRole.objects.create(user=self.admin, program=self.prog, role="program_manager")
+        UserProgramRole.objects.create(user=self.admin, program=self.prog, role=ROLE_PROGRAM_MANAGER)
 
         self.client_file = ClientFile()
         self.client_file.first_name = "Jane"
@@ -469,7 +470,7 @@ class AnalysisChartTest(TestCase):
         self.http = Client()
         self.staff = User.objects.create_user(username="staff", password="pass", is_admin=False)
         self.prog = Program.objects.create(name="Prog A", colour_hex="#10B981")
-        UserProgramRole.objects.create(user=self.staff, program=self.prog, role="staff")
+        UserProgramRole.objects.create(user=self.staff, program=self.prog, role=ROLE_STAFF)
 
         self.client_file = ClientFile()
         self.client_file.first_name = "Jane"

--- a/tests/test_plan_crud.py
+++ b/tests/test_plan_crud.py
@@ -16,6 +16,7 @@ from apps.plans.models import (
 )
 from apps.programs.models import Program, UserProgramRole
 import konote.encryption as enc_module
+from apps.auth_app.constants import ROLE_PROGRAM_MANAGER, ROLE_STAFF
 
 
 TEST_KEY = Fernet.generate_key().decode()
@@ -51,13 +52,13 @@ class PlanCRUDBaseTest(TestCase):
 
         # Roles
         UserProgramRole.objects.create(
-            user=self.manager, program=self.program, role="program_manager", status="active"
+            user=self.manager, program=self.program, role=ROLE_PROGRAM_MANAGER, status="active"
         )
         UserProgramRole.objects.create(
-            user=self.counsellor, program=self.program, role="staff", status="active"
+            user=self.counsellor, program=self.program, role=ROLE_STAFF, status="active"
         )
         UserProgramRole.objects.create(
-            user=self.other_manager, program=self.other_program, role="program_manager", status="active"
+            user=self.other_manager, program=self.other_program, role=ROLE_PROGRAM_MANAGER, status="active"
         )
 
         # Client enrolled in program

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -20,6 +20,7 @@ from apps.plans.models import (
     PlanTargetMetric,
 )
 from apps.programs.models import Program, UserProgramRole
+from apps.auth_app.constants import ROLE_STAFF
 
 
 TEST_KEY = Fernet.generate_key().decode()
@@ -575,7 +576,7 @@ class TestMetricReview(TestCase):
             username="revtest", password="testpass123", is_admin=True,
         )
         UserProgramRole.objects.create(
-            user=self.user, program=self.program, role="staff", status="active",
+            user=self.user, program=self.program, role=ROLE_STAFF, status="active",
         )
 
         self.client_file = ClientFile()
@@ -999,7 +1000,7 @@ class AssessmentDueBannerViewTest(TestCase):
         )
         self.program = Program.objects.create(name="Banner Program", status="active")
         UserProgramRole.objects.create(
-            user=self.user, program=self.program, role="staff", status="active",
+            user=self.user, program=self.program, role=ROLE_STAFF, status="active",
         )
         self.client_file = ClientFile()
         self.client_file.first_name = "Banner"

--- a/tests/test_pm_scoping.py
+++ b/tests/test_pm_scoping.py
@@ -12,6 +12,12 @@ from apps.events.models import EventType
 from apps.plans.models import MetricDefinition, PlanTemplate
 from apps.programs.models import Program, UserProgramRole
 import konote.encryption as enc_module
+from apps.auth_app.constants import (
+    ROLE_EXECUTIVE,
+    ROLE_PROGRAM_MANAGER,
+    ROLE_RECEPTIONIST,
+    ROLE_STAFF,
+)
 
 TEST_KEY = Fernet.generate_key().decode()
 
@@ -40,7 +46,7 @@ class TestPMScopingEnforcement(TestCase):
         )
         UserProgramRole.objects.create(
             user=self.pm_a, program=self.program_a,
-            role="program_manager", status="active",
+            role=ROLE_PROGRAM_MANAGER, status="active",
         )
 
         # Staff user in Program B only
@@ -50,7 +56,7 @@ class TestPMScopingEnforcement(TestCase):
         )
         UserProgramRole.objects.create(
             user=self.staff_b, program=self.program_b,
-            role="staff", status="active",
+            role=ROLE_STAFF, status="active",
         )
 
         # Staff user in Program A (PM can manage this one)
@@ -60,7 +66,7 @@ class TestPMScopingEnforcement(TestCase):
         )
         UserProgramRole.objects.create(
             user=self.staff_a, program=self.program_a,
-            role="staff", status="active",
+            role=ROLE_STAFF, status="active",
         )
 
         # Admin user
@@ -184,14 +190,14 @@ class TestPMScopingEnforcement(TestCase):
         self._login_pm()
         response = self.client.post(
             f"/manage/users/{self.staff_a.pk}/roles/add/",
-            {"program": self.program_a.pk, "role": "program_manager"},
+            {"program": self.program_a.pk, "role": ROLE_PROGRAM_MANAGER},
         )
         # Should get an error message and redirect, not succeed
         self.assertIn(response.status_code, (302, 200))
         # Verify no PM role was actually created
         self.assertFalse(
             UserProgramRole.objects.filter(
-                user=self.staff_a, role="program_manager",
+                user=self.staff_a, role=ROLE_PROGRAM_MANAGER,
             ).exists(),
             "PM should not be able to assign program_manager role",
         )
@@ -201,12 +207,12 @@ class TestPMScopingEnforcement(TestCase):
         self._login_pm()
         response = self.client.post(
             f"/manage/users/{self.staff_a.pk}/roles/add/",
-            {"program": self.program_a.pk, "role": "executive"},
+            {"program": self.program_a.pk, "role": ROLE_EXECUTIVE},
         )
         self.assertIn(response.status_code, (302, 200))
         self.assertFalse(
             UserProgramRole.objects.filter(
-                user=self.staff_a, role="executive",
+                user=self.staff_a, role=ROLE_EXECUTIVE,
             ).exists(),
             "PM should not be able to assign executive role",
         )
@@ -221,7 +227,7 @@ class TestPMScopingEnforcement(TestCase):
         # Give them a receptionist role in Program A so PM can see them
         UserProgramRole.objects.create(
             user=new_user, program=self.program_a,
-            role="receptionist", status="active",
+            role=ROLE_RECEPTIONIST, status="active",
         )
         self._login_pm()
         # Note: user already has receptionist in program_a, so we'd need
@@ -281,7 +287,7 @@ class TestPMScopingEnforcement(TestCase):
         # Give admin a role in Program A so PM can see them
         UserProgramRole.objects.create(
             user=self.admin, program=self.program_a,
-            role="staff", status="active",
+            role=ROLE_STAFF, status="active",
         )
         self._login_pm()
         self.client.post(
@@ -337,7 +343,7 @@ class TestPMScopingEnforcement(TestCase):
         self._login_pm()
         response = self.client.post(
             f"/manage/users/{self.staff_a.pk}/roles/add/",
-            {"program": self.program_b.pk, "role": "staff"},
+            {"program": self.program_b.pk, "role": ROLE_STAFF},
         )
         # Should be blocked — verify no role was created in Program B
         self.assertFalse(

--- a/tests/test_portal_resources.py
+++ b/tests/test_portal_resources.py
@@ -12,6 +12,7 @@ from apps.clients.models import ClientFile, ClientProgramEnrolment
 from apps.portal.models import ClientResourceLink, ParticipantUser, PortalResourceLink
 from apps.programs.models import Program, UserProgramRole
 import konote.encryption as enc_module
+from apps.auth_app.constants import ROLE_PROGRAM_MANAGER
 
 TEST_KEY = Fernet.generate_key().decode()
 
@@ -283,7 +284,7 @@ class StaffClientResourceTests(TestCase):
         # Admin needs a program role to pass @requires_permission("note.create")
         UserProgramRole.objects.create(
             user=self.staff, program=self.program,
-            role="program_manager", status="active",
+            role=ROLE_PROGRAM_MANAGER, status="active",
         )
         self.client_file = ClientFile.objects.create(
             record_id="CLI-001", status="active",

--- a/tests/test_program_filtering.py
+++ b/tests/test_program_filtering.py
@@ -19,6 +19,7 @@ from apps.notes.models import ProgressNote
 from apps.plans.models import PlanSection, PlanTarget
 from apps.programs.models import Program, UserProgramRole
 from konote import encryption as enc_module
+from apps.auth_app.constants import ROLE_STAFF
 
 TEST_KEY = Fernet.generate_key().decode()
 
@@ -45,7 +46,7 @@ class ProgramFilteringTestBase(TestCase):
             username="worker_a", password="pass", display_name="Worker A"
         )
         UserProgramRole.objects.create(
-            user=self.worker_a, program=self.prog_a, role="staff", status="active"
+            user=self.worker_a, program=self.prog_a, role=ROLE_STAFF, status="active"
         )
 
         # Worker in Program B only
@@ -53,7 +54,7 @@ class ProgramFilteringTestBase(TestCase):
             username="worker_b", password="pass", display_name="Worker B"
         )
         UserProgramRole.objects.create(
-            user=self.worker_b, program=self.prog_b, role="staff", status="active"
+            user=self.worker_b, program=self.prog_b, role=ROLE_STAFF, status="active"
         )
 
         # Multi-program worker (both A and B)
@@ -61,10 +62,10 @@ class ProgramFilteringTestBase(TestCase):
             username="worker_ab", password="pass", display_name="Worker AB"
         )
         UserProgramRole.objects.create(
-            user=self.worker_ab, program=self.prog_a, role="staff", status="active"
+            user=self.worker_ab, program=self.prog_a, role=ROLE_STAFF, status="active"
         )
         UserProgramRole.objects.create(
-            user=self.worker_ab, program=self.prog_b, role="staff", status="active"
+            user=self.worker_ab, program=self.prog_b, role=ROLE_STAFF, status="active"
         )
 
         # Client enrolled in both programs

--- a/tests/test_program_role_decorator.py
+++ b/tests/test_program_role_decorator.py
@@ -15,6 +15,7 @@ from apps.auth_app.models import User
 from apps.auth_app.decorators import program_role_required
 from apps.programs.models import Program, UserProgramRole
 from apps.groups.models import Group
+from apps.auth_app.constants import ROLE_PROGRAM_MANAGER, ROLE_RECEPTIONIST, ROLE_STAFF
 
 TEST_KEY = Fernet.generate_key().decode()
 
@@ -43,7 +44,7 @@ class ProgramRoleRequiredDecoratorTest(TestCase):
         UserProgramRole.objects.create(
             user=self.user,
             program=self.program_a,
-            role="receptionist",
+            role=ROLE_RECEPTIONIST,
             status="active",
         )
 
@@ -51,7 +52,7 @@ class ProgramRoleRequiredDecoratorTest(TestCase):
         UserProgramRole.objects.create(
             user=self.user,
             program=self.program_b,
-            role="staff",
+            role=ROLE_STAFF,
             status="active",
         )
 
@@ -72,7 +73,7 @@ class ProgramRoleRequiredDecoratorTest(TestCase):
     def test_allows_access_when_user_has_required_role_in_program(self):
         """User with staff role in Program B can access Program B resource."""
 
-        @program_role_required("staff", lambda req, group_id: get_object_or_404(Group, pk=group_id).program)
+        @program_role_required(ROLE_STAFF, lambda req, group_id: get_object_or_404(Group, pk=group_id).program)
         def test_view(request, group_id):
             return HttpResponse("OK")
 
@@ -86,7 +87,7 @@ class ProgramRoleRequiredDecoratorTest(TestCase):
     def test_denies_access_when_user_lacks_required_role_in_program(self):
         """User with receptionist role in Program A cannot access staff-only resource in Program A."""
 
-        @program_role_required("staff", lambda req, group_id: get_object_or_404(Group, pk=group_id).program)
+        @program_role_required(ROLE_STAFF, lambda req, group_id: get_object_or_404(Group, pk=group_id).program)
         def test_view(request, group_id):
             return HttpResponse("OK")
 
@@ -106,7 +107,7 @@ class ProgramRoleRequiredDecoratorTest(TestCase):
             group_type="activity",
         )
 
-        @program_role_required("staff", lambda req, group_id: get_object_or_404(Group, pk=group_id).program)
+        @program_role_required(ROLE_STAFF, lambda req, group_id: get_object_or_404(Group, pk=group_id).program)
         def test_view(request, group_id):
             return HttpResponse("OK")
 
@@ -125,7 +126,7 @@ class ProgramRoleRequiredDecoratorTest(TestCase):
         This is the security hole that program_role_required fixes.
         """
 
-        @program_role_required("staff", lambda req, group_id: get_object_or_404(Group, pk=group_id).program)
+        @program_role_required(ROLE_STAFF, lambda req, group_id: get_object_or_404(Group, pk=group_id).program)
         def test_view(request, group_id):
             return HttpResponse("OK")
 
@@ -140,7 +141,7 @@ class ProgramRoleRequiredDecoratorTest(TestCase):
     def test_attaches_user_program_role_to_request(self):
         """Decorator attaches the user's role in this program to request object."""
 
-        @program_role_required("staff", lambda req, group_id: get_object_or_404(Group, pk=group_id).program)
+        @program_role_required(ROLE_STAFF, lambda req, group_id: get_object_or_404(Group, pk=group_id).program)
         def test_view(request, group_id):
             return HttpResponse(f"Role: {request.user_program_role}")
 
@@ -157,7 +158,7 @@ class ProgramRoleRequiredDecoratorTest(TestCase):
         def bad_program_getter(request, group_id):
             raise ValueError("Cannot determine program")
 
-        @program_role_required("staff", bad_program_getter)
+        @program_role_required(ROLE_STAFF, bad_program_getter)
         def test_view(request, group_id):
             return HttpResponse("OK")
 
@@ -171,7 +172,7 @@ class ProgramRoleRequiredDecoratorTest(TestCase):
     def test_role_hierarchy_receptionist_less_than_staff(self):
         """Receptionist role is lower rank than staff."""
 
-        @program_role_required("staff", lambda req, group_id: get_object_or_404(Group, pk=group_id).program)
+        @program_role_required(ROLE_STAFF, lambda req, group_id: get_object_or_404(Group, pk=group_id).program)
         def test_view(request, group_id):
             return HttpResponse("OK")
 
@@ -185,7 +186,7 @@ class ProgramRoleRequiredDecoratorTest(TestCase):
     def test_role_hierarchy_staff_meets_staff_requirement(self):
         """Staff role meets staff requirement."""
 
-        @program_role_required("staff", lambda req, group_id: get_object_or_404(Group, pk=group_id).program)
+        @program_role_required(ROLE_STAFF, lambda req, group_id: get_object_or_404(Group, pk=group_id).program)
         def test_view(request, group_id):
             return HttpResponse("OK")
 
@@ -198,9 +199,9 @@ class ProgramRoleRequiredDecoratorTest(TestCase):
 
     def test_role_hierarchy_program_manager_exceeds_staff_requirement(self):
         """Program manager role exceeds staff requirement."""
-        UserProgramRole.objects.filter(user=self.user, program=self.program_a).update(role="program_manager")
+        UserProgramRole.objects.filter(user=self.user, program=self.program_a).update(role=ROLE_PROGRAM_MANAGER)
 
-        @program_role_required("staff", lambda req, group_id: get_object_or_404(Group, pk=group_id).program)
+        @program_role_required(ROLE_STAFF, lambda req, group_id: get_object_or_404(Group, pk=group_id).program)
         def test_view(request, group_id):
             return HttpResponse("OK")
 

--- a/tests/test_program_selector.py
+++ b/tests/test_program_selector.py
@@ -23,6 +23,7 @@ from apps.programs.context import (
 from apps.programs.models import Program, UserProgramRole
 
 import konote.encryption as enc_module
+from apps.auth_app.constants import ROLE_PROGRAM_MANAGER, ROLE_STAFF
 
 TEST_KEY = Fernet.generate_key().decode()
 
@@ -63,28 +64,28 @@ class ProgramContextHelpersTest(TestCase):
 
         # Roles
         UserProgramRole.objects.create(
-            user=self.single_standard_user, program=self.employment, role="staff",
+            user=self.single_standard_user, program=self.employment, role=ROLE_STAFF,
         )
         UserProgramRole.objects.create(
-            user=self.multi_standard_user, program=self.employment, role="staff",
+            user=self.multi_standard_user, program=self.employment, role=ROLE_STAFF,
         )
         UserProgramRole.objects.create(
-            user=self.multi_standard_user, program=self.housing, role="staff",
+            user=self.multi_standard_user, program=self.housing, role=ROLE_STAFF,
         )
         UserProgramRole.objects.create(
-            user=self.single_confidential_user, program=self.counselling, role="staff",
+            user=self.single_confidential_user, program=self.counselling, role=ROLE_STAFF,
         )
         UserProgramRole.objects.create(
-            user=self.mixed_user, program=self.employment, role="staff",
+            user=self.mixed_user, program=self.employment, role=ROLE_STAFF,
         )
         UserProgramRole.objects.create(
-            user=self.mixed_user, program=self.counselling, role="staff",
+            user=self.mixed_user, program=self.counselling, role=ROLE_STAFF,
         )
         UserProgramRole.objects.create(
-            user=self.multi_conf_user, program=self.counselling, role="staff",
+            user=self.multi_conf_user, program=self.counselling, role=ROLE_STAFF,
         )
         UserProgramRole.objects.create(
-            user=self.multi_conf_user, program=self.dv_support, role="program_manager",
+            user=self.multi_conf_user, program=self.dv_support, role=ROLE_PROGRAM_MANAGER,
         )
 
     def tearDown(self):
@@ -163,7 +164,7 @@ class ProgramContextHelpersTest(TestCase):
     def test_all_standard_option(self):
         # Give mixed user a second standard program
         UserProgramRole.objects.create(
-            user=self.mixed_user, program=self.housing, role="staff",
+            user=self.mixed_user, program=self.housing, role=ROLE_STAFF,
         )
         session = {SESSION_KEY: "all_standard"}
         ids = get_active_program_ids(self.mixed_user, session)
@@ -197,7 +198,7 @@ class ProgramContextHelpersTest(TestCase):
 
     def test_switcher_options_all_standard_appears_with_2_plus(self):
         UserProgramRole.objects.create(
-            user=self.mixed_user, program=self.housing, role="staff",
+            user=self.mixed_user, program=self.housing, role=ROLE_STAFF,
         )
         options = get_switcher_options(self.mixed_user)
         values = [o["value"] for o in options]
@@ -233,16 +234,16 @@ class ProgramSwitcherViewTest(TestCase):
         self.housing = Program.objects.create(name="Housing", colour_hex="#3B82F6")
 
         UserProgramRole.objects.create(
-            user=self.mixed_user, program=self.employment, role="staff",
+            user=self.mixed_user, program=self.employment, role=ROLE_STAFF,
         )
         UserProgramRole.objects.create(
-            user=self.mixed_user, program=self.counselling, role="staff",
+            user=self.mixed_user, program=self.counselling, role=ROLE_STAFF,
         )
         UserProgramRole.objects.create(
-            user=self.standard_user, program=self.employment, role="staff",
+            user=self.standard_user, program=self.employment, role=ROLE_STAFF,
         )
         UserProgramRole.objects.create(
-            user=self.standard_user, program=self.housing, role="staff",
+            user=self.standard_user, program=self.housing, role=ROLE_STAFF,
         )
 
     def tearDown(self):
@@ -313,13 +314,13 @@ class ForcedSelectionRedirectTest(TestCase):
         )
 
         UserProgramRole.objects.create(
-            user=self.mixed_user, program=self.employment, role="staff",
+            user=self.mixed_user, program=self.employment, role=ROLE_STAFF,
         )
         UserProgramRole.objects.create(
-            user=self.mixed_user, program=self.counselling, role="staff",
+            user=self.mixed_user, program=self.counselling, role=ROLE_STAFF,
         )
         UserProgramRole.objects.create(
-            user=self.standard_user, program=self.employment, role="staff",
+            user=self.standard_user, program=self.employment, role=ROLE_STAFF,
         )
 
     def tearDown(self):
@@ -399,10 +400,10 @@ class ClientFilteringByActiveProgram(TestCase):
         )
 
         UserProgramRole.objects.create(
-            user=self.mixed_user, program=self.employment, role="staff",
+            user=self.mixed_user, program=self.employment, role=ROLE_STAFF,
         )
         UserProgramRole.objects.create(
-            user=self.mixed_user, program=self.counselling, role="staff",
+            user=self.mixed_user, program=self.counselling, role=ROLE_STAFF,
         )
 
         # Client in standard program
@@ -482,10 +483,10 @@ class RoleRemovedClearsSessionTest(TestCase):
         )
 
         self.std_role = UserProgramRole.objects.create(
-            user=self.user, program=self.employment, role="staff",
+            user=self.user, program=self.employment, role=ROLE_STAFF,
         )
         self.conf_role = UserProgramRole.objects.create(
-            user=self.user, program=self.counselling, role="staff",
+            user=self.user, program=self.counselling, role=ROLE_STAFF,
         )
 
     def tearDown(self):

--- a/tests/test_programs.py
+++ b/tests/test_programs.py
@@ -5,6 +5,7 @@ from cryptography.fernet import Fernet
 from apps.auth_app.models import User
 from apps.programs.models import Program, UserProgramRole
 import konote.encryption as enc_module
+from apps.auth_app.constants import ROLE_PROGRAM_MANAGER, ROLE_STAFF
 
 TEST_KEY = Fernet.generate_key().decode()
 
@@ -34,7 +35,7 @@ class ProgramViewsTest(TestCase):
         """Non-admin users see all programs in the list (access controlled at detail level)."""
         prog1 = Program.objects.create(name="Assigned Program")
         prog2 = Program.objects.create(name="Other Program")
-        UserProgramRole.objects.create(user=self.staff, program=prog1, role="staff", status="active")
+        UserProgramRole.objects.create(user=self.staff, program=prog1, role=ROLE_STAFF, status="active")
         # staff is NOT assigned to prog2
 
         self.client.login(username="staff", password="testpass123")
@@ -91,7 +92,7 @@ class ProgramViewsTest(TestCase):
         prog = Program.objects.create(name="Housing")
         resp = self.client.post(f"/programs/{prog.pk}/roles/add/", {
             "user": self.staff.pk,
-            "role": "staff",
+            "role": ROLE_STAFF,
         })
         self.assertEqual(resp.status_code, 200)
         self.assertTrue(UserProgramRole.objects.filter(user=self.staff, program=prog, status="active").exists())
@@ -99,7 +100,7 @@ class ProgramViewsTest(TestCase):
     def test_admin_can_remove_role(self):
         self.client.login(username="admin", password="testpass123")
         prog = Program.objects.create(name="Housing")
-        role = UserProgramRole.objects.create(user=self.staff, program=prog, role="staff")
+        role = UserProgramRole.objects.create(user=self.staff, program=prog, role=ROLE_STAFF)
         resp = self.client.post(f"/programs/{prog.pk}/roles/{role.pk}/remove/")
         self.assertEqual(resp.status_code, 200)
         role.refresh_from_db()
@@ -108,7 +109,7 @@ class ProgramViewsTest(TestCase):
     def test_nonadmin_can_view_assigned_program_detail(self):
         """Non-admin users can view detail of programs they're assigned to."""
         prog = Program.objects.create(name="Assigned Program")
-        UserProgramRole.objects.create(user=self.staff, program=prog, role="staff", status="active")
+        UserProgramRole.objects.create(user=self.staff, program=prog, role=ROLE_STAFF, status="active")
         self.client.login(username="staff", password="testpass123")
         resp = self.client.get(f"/programs/{prog.pk}/")
         self.assertEqual(resp.status_code, 200)
@@ -127,7 +128,7 @@ class ProgramViewsTest(TestCase):
         """Non-admin users see all programs in the list (not just their assigned ones)."""
         prog1 = Program.objects.create(name="Assigned Program")
         prog2 = Program.objects.create(name="Other Program")
-        UserProgramRole.objects.create(user=self.staff, program=prog1, role="staff", status="active")
+        UserProgramRole.objects.create(user=self.staff, program=prog1, role=ROLE_STAFF, status="active")
         # staff is NOT assigned to prog2
         self.client.login(username="staff", password="testpass123")
         resp = self.client.get("/programs/")
@@ -142,7 +143,7 @@ class ProgramViewsTest(TestCase):
         manager = User.objects.create_user(username="manager", password="testpass123", is_admin=False)
         manager.display_name = "Jane Manager"
         manager.save()
-        UserProgramRole.objects.create(user=manager, program=prog, role="program_manager", status="active")
+        UserProgramRole.objects.create(user=manager, program=prog, role=ROLE_PROGRAM_MANAGER, status="active")
         self.client.login(username="admin", password="testpass123")
         resp = self.client.get("/programs/")
         self.assertEqual(resp.status_code, 200)

--- a/tests/test_rbac.py
+++ b/tests/test_rbac.py
@@ -5,6 +5,7 @@ from cryptography.fernet import Fernet
 from apps.auth_app.models import User
 from apps.programs.models import Program, UserProgramRole
 from apps.clients.models import ClientFile, ClientProgramEnrolment
+from apps.auth_app.constants import ROLE_PROGRAM_MANAGER, ROLE_RECEPTIONIST, ROLE_STAFF
 from konote.middleware.program_access import ProgramAccessMiddleware
 import konote.encryption as enc_module
 
@@ -89,8 +90,8 @@ class ClientAccessTest(TestCase):
         self.program_b = Program.objects.create(name="Program B")
 
         # Assign staff to programs
-        UserProgramRole.objects.create(user=self.staff_a, program=self.program_a, role="staff")
-        UserProgramRole.objects.create(user=self.staff_b, program=self.program_b, role="staff")
+        UserProgramRole.objects.create(user=self.staff_a, program=self.program_a, role=ROLE_STAFF)
+        UserProgramRole.objects.create(user=self.staff_b, program=self.program_b, role=ROLE_STAFF)
 
         # Create a client enrolled in Program A only
         self.client = ClientFile.objects.create()
@@ -129,7 +130,7 @@ class ClientAccessTest(TestCase):
     def test_admin_with_program_role_can_access_client(self):
         """Admins who also have a program role can access client data."""
         UserProgramRole.objects.create(
-            user=self.admin_user, program=self.program_a, role="program_manager"
+            user=self.admin_user, program=self.program_a, role=ROLE_PROGRAM_MANAGER
         )
         request = self.factory.get(f"/participants/{self.client.pk}/")
         request.user = self.admin_user
@@ -180,8 +181,8 @@ class ReceptionistFieldAccessTest(TestCase):
 
         # Create program and assign users
         self.program = Program.objects.create(name="Test Program")
-        UserProgramRole.objects.create(user=self.receptionist, program=self.program, role="receptionist")
-        UserProgramRole.objects.create(user=self.staff_user, program=self.program, role="staff")
+        UserProgramRole.objects.create(user=self.receptionist, program=self.program, role=ROLE_RECEPTIONIST)
+        UserProgramRole.objects.create(user=self.staff_user, program=self.program, role=ROLE_STAFF)
 
         # Create client
         self.client_file = ClientFile.objects.create()
@@ -346,8 +347,8 @@ class ReceptionistNotesAccessTest(TestCase):
 
         # Create program and assign users
         self.program = Program.objects.create(name="Test Program")
-        UserProgramRole.objects.create(user=self.receptionist, program=self.program, role="receptionist")
-        UserProgramRole.objects.create(user=self.staff_user, program=self.program, role="staff")
+        UserProgramRole.objects.create(user=self.receptionist, program=self.program, role=ROLE_RECEPTIONIST)
+        UserProgramRole.objects.create(user=self.staff_user, program=self.program, role=ROLE_STAFF)
 
         # Create client
         self.client_file = ClientFile.objects.create()
@@ -437,9 +438,9 @@ class ReceptionistPlansAccessTest(TestCase):
 
         # Create program and assign users
         self.program = Program.objects.create(name="Test Program")
-        UserProgramRole.objects.create(user=self.receptionist, program=self.program, role="receptionist")
-        UserProgramRole.objects.create(user=self.staff_user, program=self.program, role="staff")
-        UserProgramRole.objects.create(user=self.manager, program=self.program, role="program_manager")
+        UserProgramRole.objects.create(user=self.receptionist, program=self.program, role=ROLE_RECEPTIONIST)
+        UserProgramRole.objects.create(user=self.staff_user, program=self.program, role=ROLE_STAFF)
+        UserProgramRole.objects.create(user=self.manager, program=self.program, role=ROLE_PROGRAM_MANAGER)
 
         # Create client
         self.client_file = ClientFile.objects.create()
@@ -508,8 +509,8 @@ class SensitiveFieldReceptionistAccessTest(TestCase):
 
         # Create program and assign users
         self.program = Program.objects.create(name="Test Program")
-        UserProgramRole.objects.create(user=self.receptionist, program=self.program, role="receptionist")
-        UserProgramRole.objects.create(user=self.staff_user, program=self.program, role="staff")
+        UserProgramRole.objects.create(user=self.receptionist, program=self.program, role=ROLE_RECEPTIONIST)
+        UserProgramRole.objects.create(user=self.staff_user, program=self.program, role=ROLE_STAFF)
 
         # Create client
         self.client_file = ClientFile.objects.create()

--- a/tests/test_report_preview.py
+++ b/tests/test_report_preview.py
@@ -21,6 +21,7 @@ from apps.programs.models import Program, UserProgramRole
 from apps.reports.models import Partner, ReportTemplate
 from apps.reports.preview_views import _querydict_to_pairs
 import konote.encryption as enc_module
+from apps.auth_app.constants import ROLE_EXECUTIVE, ROLE_PROGRAM_MANAGER, ROLE_STAFF
 
 TEST_KEY = Fernet.generate_key().decode()
 
@@ -209,13 +210,13 @@ class TemplateReportPreviewTest(TestCase):
 
         # Roles
         UserProgramRole.objects.create(
-            user=self.pm_user, program=self.program, role="program_manager",
+            user=self.pm_user, program=self.program, role=ROLE_PROGRAM_MANAGER,
         )
         UserProgramRole.objects.create(
-            user=self.exec_user, program=self.program, role="executive",
+            user=self.exec_user, program=self.program, role=ROLE_EXECUTIVE,
         )
         UserProgramRole.objects.create(
-            user=self.staff, program=self.program, role="staff",
+            user=self.staff, program=self.program, role=ROLE_STAFF,
         )
 
         # Create metric data
@@ -413,13 +414,13 @@ class AdhocReportPreviewTest(TestCase):
 
         # Roles
         UserProgramRole.objects.create(
-            user=self.pm_user, program=self.program, role="program_manager",
+            user=self.pm_user, program=self.program, role=ROLE_PROGRAM_MANAGER,
         )
         UserProgramRole.objects.create(
-            user=self.exec_user, program=self.program, role="executive",
+            user=self.exec_user, program=self.program, role=ROLE_EXECUTIVE,
         )
         UserProgramRole.objects.create(
-            user=self.staff_user, program=self.program, role="staff",
+            user=self.staff_user, program=self.program, role=ROLE_STAFF,
         )
 
         # Create metric data

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -51,6 +51,12 @@ from apps.reports.utils import (
 from apps.reports.forms import MetricExportForm
 from apps.reports.models import ReportMetric, SecureExportLink
 import konote.encryption as enc_module
+from apps.auth_app.constants import (
+    ROLE_EXECUTIVE,
+    ROLE_PROGRAM_MANAGER,
+    ROLE_RECEPTIONIST,
+    ROLE_STAFF,
+)
 
 
 def create_test_partner(name="Test Partner", partner_type="funder", **kwargs):
@@ -2149,7 +2155,7 @@ class TemplateExportFormTest(TestCase):
         # Staff user with access to only Youth Services
         staff = User.objects.create_user(username="pm", password="testpass123")
         UserProgramRole.objects.create(
-            user=staff, program=self.program, role="program_manager", status="active",
+            user=staff, program=self.program, role=ROLE_PROGRAM_MANAGER, status="active",
         )
         form = TemplateExportForm(user=staff)
         qs = form.fields["report_template"].queryset
@@ -2291,19 +2297,19 @@ class GenerateReportCustomExportContextTest(TestCase):
         self.assertTrue(resp.context["can_custom_export"])
 
     def test_program_manager_gets_can_custom_export(self):
-        self._make_user("pm", role="program_manager")
+        self._make_user("pm", role=ROLE_PROGRAM_MANAGER)
         self.client_http.login(username="pm", password="testpass123")
         resp = self.client_http.get("/reports/generate/")
         self.assertTrue(resp.context["can_custom_export"])
 
     def test_executive_gets_can_custom_export(self):
-        self._make_user("exec", role="executive")
+        self._make_user("exec", role=ROLE_EXECUTIVE)
         self.client_http.login(username="exec", password="testpass123")
         resp = self.client_http.get("/reports/generate/")
         self.assertTrue(resp.context["can_custom_export"])
 
     def test_staff_does_not_get_can_custom_export(self):
-        self._make_user("staff", role="staff")
+        self._make_user("staff", role=ROLE_STAFF)
         self.client_http.login(username="staff", password="testpass123")
         # Staff with report.funder_report=DENY gets 403, so they
         # cannot even reach the page — verify that.
@@ -2499,10 +2505,10 @@ class DemoRealExportSeparationTests(TestCase):
 
         # Give admin users PM roles so they get individual (not aggregate) export data
         UserProgramRole.objects.create(
-            user=self.demo_admin, program=self.program, role="program_manager"
+            user=self.demo_admin, program=self.program, role=ROLE_PROGRAM_MANAGER
         )
         UserProgramRole.objects.create(
-            user=self.real_admin, program=self.program, role="program_manager"
+            user=self.real_admin, program=self.program, role=ROLE_PROGRAM_MANAGER
         )
 
         # Create DEMO client
@@ -2758,7 +2764,7 @@ class ExportWarningDialogTests(TestCase):
         self.program = Program.objects.create(name="Test Program", status="active")
         # Admin needs PM role to see PII warning (non-aggregate mode)
         UserProgramRole.objects.create(
-            user=self.admin, program=self.program, role="program_manager"
+            user=self.admin, program=self.program, role=ROLE_PROGRAM_MANAGER
         )
         self.metric = MetricDefinition.objects.create(
             name="Test Metric",
@@ -2915,7 +2921,7 @@ class IndividualClientExportViewTests(TestCase):
             username="staff", password="testpass123", display_name="Staff User"
         )
         UserProgramRole.objects.create(
-            user=self.staff_user, program=self.program, role="program_manager"
+            user=self.staff_user, program=self.program, role=ROLE_PROGRAM_MANAGER
         )
 
         # Create receptionist user
@@ -2923,7 +2929,7 @@ class IndividualClientExportViewTests(TestCase):
             username="receptionist", password="testpass123", display_name="Receptionist"
         )
         UserProgramRole.objects.create(
-            user=self.receptionist, program=self.program, role="receptionist"
+            user=self.receptionist, program=self.program, role=ROLE_RECEPTIONIST
         )
 
         # Create a client enrolled in the program
@@ -3115,7 +3121,7 @@ class IndividualClientExportViewTests(TestCase):
             is_demo=True,
         )
         UserProgramRole.objects.create(
-            user=demo_user, program=self.program, role="staff",
+            user=demo_user, program=self.program, role=ROLE_STAFF,
         )
         self.client.login(username="demo", password="testpass123")
         resp = self.client.get(self.export_url)
@@ -3270,7 +3276,7 @@ class CsvInjectionIntegrationTests(TestCase):
             username="csvtest", password="testpass123", display_name="CSV Tester"
         )
         UserProgramRole.objects.create(
-            user=self.staff_user, program=self.program, role="program_manager"
+            user=self.staff_user, program=self.program, role=ROLE_PROGRAM_MANAGER
         )
 
         # Create client with a malicious-looking first name
@@ -3332,7 +3338,7 @@ class FilenameSanitisationIntegrationTests(TestCase):
             username="fntest", password="testpass123", display_name="Filename Tester"
         )
         UserProgramRole.objects.create(
-            user=self.staff_user, program=self.program, role="program_manager"
+            user=self.staff_user, program=self.program, role=ROLE_PROGRAM_MANAGER
         )
 
         # Create client with special characters in record_id

--- a/tests/test_roles_invites.py
+++ b/tests/test_roles_invites.py
@@ -11,6 +11,7 @@ from apps.auth_app.models import Invite, User
 from apps.clients.models import ClientFile, ClientProgramEnrolment
 from apps.programs.models import Program, UserProgramRole
 from konote.middleware.program_access import ProgramAccessMiddleware
+from apps.auth_app.constants import ROLE_PROGRAM_MANAGER, ROLE_RECEPTIONIST, ROLE_STAFF
 import konote.encryption as enc_module
 
 
@@ -37,19 +38,19 @@ class RoleHierarchyTest(TestCase):
             username="receptionist", password="testpass123", display_name="Front Desk"
         )
         UserProgramRole.objects.create(
-            user=self.receptionist, program=self.program, role="receptionist"
+            user=self.receptionist, program=self.program, role=ROLE_RECEPTIONIST
         )
         self.counsellor = User.objects.create_user(
             username="counsellor", password="testpass123", display_name="Direct Service"
         )
         UserProgramRole.objects.create(
-            user=self.counsellor, program=self.program, role="staff"
+            user=self.counsellor, program=self.program, role=ROLE_STAFF
         )
         self.manager = User.objects.create_user(
             username="manager", password="testpass123", display_name="Manager"
         )
         UserProgramRole.objects.create(
-            user=self.manager, program=self.program, role="program_manager"
+            user=self.manager, program=self.program, role=ROLE_PROGRAM_MANAGER
         )
 
         # Create client in program
@@ -70,7 +71,7 @@ class RoleHierarchyTest(TestCase):
         request.session = {}
         response = self.middleware(request)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(request.user_program_role, "receptionist")
+        self.assertEqual(request.user_program_role, ROLE_RECEPTIONIST)
 
     def test_counsellor_gets_staff_role(self):
         request = self.factory.get(f"/participants/{self.client.pk}/")
@@ -78,7 +79,7 @@ class RoleHierarchyTest(TestCase):
         request.session = {}
         response = self.middleware(request)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(request.user_program_role, "staff")
+        self.assertEqual(request.user_program_role, ROLE_STAFF)
 
     def test_manager_gets_program_manager_role(self):
         request = self.factory.get(f"/participants/{self.client.pk}/")
@@ -86,39 +87,39 @@ class RoleHierarchyTest(TestCase):
         request.session = {}
         response = self.middleware(request)
         self.assertEqual(response.status_code, 200)
-        self.assertEqual(request.user_program_role, "program_manager")
+        self.assertEqual(request.user_program_role, ROLE_PROGRAM_MANAGER)
 
     def test_minimum_role_blocks_receptionist_from_staff_view(self):
         """minimum_role('staff') should block front desk staff."""
-        @minimum_role("staff")
+        @minimum_role(ROLE_STAFF)
         def staff_view(request):
             from django.http import HttpResponse
             return HttpResponse("OK")
 
         request = self.factory.get("/test/")
-        request.user_program_role = "receptionist"
+        request.user_program_role = ROLE_RECEPTIONIST
         response = staff_view(request)
         self.assertEqual(response.status_code, 403)
 
     def test_minimum_role_allows_staff(self):
-        @minimum_role("staff")
+        @minimum_role(ROLE_STAFF)
         def staff_view(request):
             from django.http import HttpResponse
             return HttpResponse("OK")
 
         request = self.factory.get("/test/")
-        request.user_program_role = "staff"
+        request.user_program_role = ROLE_STAFF
         response = staff_view(request)
         self.assertEqual(response.status_code, 200)
 
     def test_minimum_role_allows_manager_for_staff_view(self):
-        @minimum_role("staff")
+        @minimum_role(ROLE_STAFF)
         def staff_view(request):
             from django.http import HttpResponse
             return HttpResponse("OK")
 
         request = self.factory.get("/test/")
-        request.user_program_role = "program_manager"
+        request.user_program_role = ROLE_PROGRAM_MANAGER
         response = staff_view(request)
         self.assertEqual(response.status_code, 200)
 
@@ -138,7 +139,7 @@ class InviteModelTest(TestCase):
 
     def test_valid_invite(self):
         invite = Invite.objects.create(
-            role="staff",
+            role=ROLE_STAFF,
             created_by=self.admin,
             expires_at=timezone.now() + timedelta(days=7),
         )
@@ -148,7 +149,7 @@ class InviteModelTest(TestCase):
 
     def test_expired_invite(self):
         invite = Invite.objects.create(
-            role="staff",
+            role=ROLE_STAFF,
             created_by=self.admin,
             expires_at=timezone.now() - timedelta(days=1),
         )
@@ -160,7 +161,7 @@ class InviteModelTest(TestCase):
             username="newuser", password="testpass123", display_name="New User"
         )
         invite = Invite.objects.create(
-            role="staff",
+            role=ROLE_STAFF,
             created_by=self.admin,
             expires_at=timezone.now() + timedelta(days=7),
             used_by=user,

--- a/tests/test_safety_oversight.py
+++ b/tests/test_safety_oversight.py
@@ -28,6 +28,7 @@ from apps.reports.oversight import (
     quarter_dates,
 )
 import konote.encryption as enc_module
+from apps.auth_app.constants import ROLE_EXECUTIVE
 
 TEST_KEY = Fernet.generate_key().decode()
 
@@ -51,7 +52,7 @@ class EnhancedAlertCardTest(TestCase):
         )
         self.prog = Program.objects.create(name="Test Program", colour_hex="#10B981")
         UserProgramRole.objects.create(
-            user=self.exec_user, program=self.prog, role="executive",
+            user=self.exec_user, program=self.prog, role=ROLE_EXECUTIVE,
         )
 
     def _create_client(self, status="active"):

--- a/tests/test_security.py
+++ b/tests/test_security.py
@@ -19,6 +19,7 @@ from apps.auth_app.models import User
 from apps.programs.models import Program, UserProgramRole
 from apps.clients.models import ClientFile, ClientProgramEnrolment
 import konote.encryption as enc_module
+from apps.auth_app.constants import ROLE_STAFF
 
 
 TEST_KEY = Fernet.generate_key().decode()
@@ -186,10 +187,10 @@ class RBACBypassTest(TestCase):
 
         # Assign users to programs
         UserProgramRole.objects.create(
-            user=self.user_a, program=self.program_a, role="staff"
+            user=self.user_a, program=self.program_a, role=ROLE_STAFF
         )
         UserProgramRole.objects.create(
-            user=self.user_b, program=self.program_b, role="staff"
+            user=self.user_b, program=self.program_b, role=ROLE_STAFF
         )
 
         # Create client in Program A only
@@ -276,7 +277,7 @@ class AuditCoverageTest(TestCase):
             username="auditor", password="testpass123", display_name="Auditor"
         )
         UserProgramRole.objects.create(
-            user=self.user, program=self.program, role="staff"
+            user=self.user, program=self.program, role=ROLE_STAFF
         )
 
         # Create a client

--- a/tests/test_send_reminders.py
+++ b/tests/test_send_reminders.py
@@ -25,6 +25,7 @@ from apps.clients.models import ClientFile, ClientProgramEnrolment
 from apps.events.models import Event, EventType, Meeting
 from apps.programs.models import Program, UserProgramRole
 import konote.encryption as enc_module
+from apps.auth_app.constants import ROLE_STAFF
 
 TEST_KEY = Fernet.generate_key().decode()
 
@@ -38,7 +39,7 @@ def _setup_fixtures(tc):
         display_name="Staff User",
     )
     UserProgramRole.objects.create(
-        user=tc.staff, program=tc.program, role="staff", status="active",
+        user=tc.staff, program=tc.program, role=ROLE_STAFF, status="active",
     )
     tc.client_file = ClientFile()
     tc.client_file.first_name = "Reminder"

--- a/tests/test_session_report.py
+++ b/tests/test_session_report.py
@@ -21,6 +21,7 @@ from apps.reports.session_report import generate_session_report
 from apps.reports.session_csv import generate_session_report_csv
 
 import konote.encryption as enc_module
+from apps.auth_app.constants import ROLE_EXECUTIVE, ROLE_PROGRAM_MANAGER, ROLE_STAFF
 
 TEST_KEY = Fernet.generate_key().decode()
 
@@ -114,7 +115,7 @@ class SessionReportAggregationTest(TestCase):
         enc_module._fernet = None
         self.user = User.objects.create_user(username="pm", password="pass")
         self.program = Program.objects.create(name="Coaching Program", colour_hex="#10B981")
-        UserProgramRole.objects.create(user=self.user, program=self.program, role="program_manager")
+        UserProgramRole.objects.create(user=self.user, program=self.program, role=ROLE_PROGRAM_MANAGER)
 
         # Create two clients
         self.client_a = ClientFile()
@@ -412,18 +413,18 @@ class SessionReportPermissionTest(TestCase):
 
         # Program manager (should have access)
         self.pm = User.objects.create_user(username="pm", password="pass")
-        UserProgramRole.objects.create(user=self.pm, program=self.program, role="program_manager")
+        UserProgramRole.objects.create(user=self.pm, program=self.program, role=ROLE_PROGRAM_MANAGER)
 
         # Admin (should have access)
         self.admin = User.objects.create_user(username="admin", password="pass", is_admin=True)
 
         # Executive (aggregate-only, should NOT have access)
         self.exec_user = User.objects.create_user(username="exec", password="pass")
-        UserProgramRole.objects.create(user=self.exec_user, program=self.program, role="executive")
+        UserProgramRole.objects.create(user=self.exec_user, program=self.program, role=ROLE_EXECUTIVE)
 
         # Staff (should NOT have access — no report.program_report permission)
         self.staff = User.objects.create_user(username="staff", password="pass")
-        UserProgramRole.objects.create(user=self.staff, program=self.program, role="staff")
+        UserProgramRole.objects.create(user=self.staff, program=self.program, role=ROLE_STAFF)
 
     def tearDown(self):
         enc_module._fernet = None
@@ -472,8 +473,8 @@ class SessionReportCrossProgramTest(TestCase):
         # Two programs
         self.prog_a = Program.objects.create(name="Program A", colour_hex="#10B981")
         self.prog_b = Program.objects.create(name="Program B", colour_hex="#EF4444")
-        UserProgramRole.objects.create(user=self.user, program=self.prog_a, role="program_manager")
-        UserProgramRole.objects.create(user=self.user, program=self.prog_b, role="program_manager")
+        UserProgramRole.objects.create(user=self.user, program=self.prog_a, role=ROLE_PROGRAM_MANAGER)
+        UserProgramRole.objects.create(user=self.user, program=self.prog_b, role=ROLE_PROGRAM_MANAGER)
 
         # Client enrolled in program A only
         self.client_a = ClientFile()
@@ -540,7 +541,7 @@ class SessionReportAuditLogTest(TestCase):
         self.http = HttpClient()
         self.program = Program.objects.create(name="Test Program", colour_hex="#10B981")
         self.pm = User.objects.create_user(username="pm", password="pass")
-        UserProgramRole.objects.create(user=self.pm, program=self.program, role="program_manager")
+        UserProgramRole.objects.create(user=self.pm, program=self.program, role=ROLE_PROGRAM_MANAGER)
 
         self.client_file = ClientFile()
         self.client_file.first_name = "Jane"

--- a/tests/test_sre.py
+++ b/tests/test_sre.py
@@ -27,6 +27,7 @@ from apps.events.forms import EventForm
 from apps.events.models import Event, EventType, SRECategory
 from apps.programs.models import Program, UserProgramRole
 import konote.encryption as enc_module
+from apps.auth_app.constants import ROLE_EXECUTIVE, ROLE_PROGRAM_MANAGER, ROLE_STAFF
 
 TEST_KEY = Fernet.generate_key().decode()
 
@@ -206,7 +207,7 @@ class SREFlaggingViewTest(TestCase):
             username="sre_staff", password="testpass123", display_name="Staff SRE",
         )
         UserProgramRole.objects.create(
-            user=cls.staff, program=cls.program, role="staff",
+            user=cls.staff, program=cls.program, role=ROLE_STAFF,
         )
         cls.client_file = ClientFile.objects.create(is_demo=False, status="active")
         ClientProgramEnrolment.objects.create(
@@ -289,13 +290,13 @@ class SREUnflagViewTest(TestCase):
             username="sre_pm", password="testpass123", display_name="PM SRE",
         )
         UserProgramRole.objects.create(
-            user=cls.pm, program=cls.program, role="program_manager",
+            user=cls.pm, program=cls.program, role=ROLE_PROGRAM_MANAGER,
         )
         cls.staff = User.objects.create_user(
             username="sre_staff2", password="testpass123", display_name="Staff SRE 2",
         )
         UserProgramRole.objects.create(
-            user=cls.staff, program=cls.program, role="staff",
+            user=cls.staff, program=cls.program, role=ROLE_STAFF,
         )
 
         cls.client_file = ClientFile.objects.create(is_demo=False, status="active")
@@ -372,19 +373,19 @@ class SREReportViewTest(TestCase):
             username="report_exec", password="testpass123", display_name="Exec Report",
         )
         UserProgramRole.objects.create(
-            user=cls.executive, program=cls.program, role="executive",
+            user=cls.executive, program=cls.program, role=ROLE_EXECUTIVE,
         )
         cls.staff = User.objects.create_user(
             username="report_staff", password="testpass123", display_name="Staff Report",
         )
         UserProgramRole.objects.create(
-            user=cls.staff, program=cls.program, role="staff",
+            user=cls.staff, program=cls.program, role=ROLE_STAFF,
         )
         cls.pm = User.objects.create_user(
             username="report_pm", password="testpass123", display_name="PM Report",
         )
         UserProgramRole.objects.create(
-            user=cls.pm, program=cls.program, role="program_manager",
+            user=cls.pm, program=cls.program, role=ROLE_PROGRAM_MANAGER,
         )
 
     def setUp(self):

--- a/tests/test_suggestions.py
+++ b/tests/test_suggestions.py
@@ -15,6 +15,7 @@ from apps.reports.insights import (
     MIN_PARTICIPANTS_FOR_THEME_PROCESSING,
 )
 import konote.encryption as enc_module
+from apps.auth_app.constants import ROLE_PROGRAM_MANAGER
 
 
 TEST_KEY = Fernet.generate_key().decode()
@@ -100,7 +101,7 @@ class FocusedAnalysisViewTest(TestCase):
         self.program = Program.objects.create(name="Housing")
         UserProgramRole.objects.create(
             user=self.user, program=self.program,
-            role="program_manager", status="active",
+            role=ROLE_PROGRAM_MANAGER, status="active",
         )
 
         # Enable feature toggles
@@ -168,7 +169,7 @@ class FocusedAnalysisViewTest(TestCase):
         small_program = Program.objects.create(name="Small")
         UserProgramRole.objects.create(
             user=self.user, program=small_program,
-            role="program_manager", status="active",
+            role=ROLE_PROGRAM_MANAGER, status="active",
         )
         _create_participants(small_program, 3)
 

--- a/tests/test_surveys.py
+++ b/tests/test_surveys.py
@@ -21,6 +21,7 @@ from apps.surveys.models import (
     SurveyLink,
 )
 import konote.encryption as enc_module
+from apps.auth_app.constants import ROLE_STAFF
 
 TEST_KEY = Fernet.generate_key().decode()
 
@@ -1791,7 +1792,7 @@ class StaffDataEntryConditionTests(TestCase):
             client_file=self.client_obj, program=self.program, status="active",
         )
         UserProgramRole.objects.create(
-            user=self.staff, program=self.program, role="staff", status="active",
+            user=self.staff, program=self.program, role=ROLE_STAFF, status="active",
         )
 
         self.survey = Survey.objects.create(

--- a/tests/test_user_roles.py
+++ b/tests/test_user_roles.py
@@ -5,6 +5,7 @@ from cryptography.fernet import Fernet
 from apps.auth_app.models import User
 from apps.programs.models import Program, UserProgramRole
 import konote.encryption as enc_module
+from apps.auth_app.constants import ROLE_PROGRAM_MANAGER, ROLE_STAFF
 
 TEST_KEY = Fernet.generate_key().decode()
 
@@ -41,7 +42,7 @@ class UserRoleManagementTest(TestCase):
 
         # Give staff a role so they can log in
         UserProgramRole.objects.create(
-            user=self.staff, program=self.program_a, role="staff",
+            user=self.staff, program=self.program_a, role=ROLE_STAFF,
         )
 
     def tearDown(self):
@@ -58,13 +59,13 @@ class UserRoleManagementTest(TestCase):
         self.client.login(username="staff", password="testpass123")
         resp = self.client.post(
             f"/manage/users/{self.target.pk}/roles/add/",
-            {"program": self.program_a.pk, "role": "staff"},
+            {"program": self.program_a.pk, "role": ROLE_STAFF},
         )
         self.assertEqual(resp.status_code, 403)
 
     def test_non_admin_cannot_remove_role(self):
         role = UserProgramRole.objects.create(
-            user=self.target, program=self.program_a, role="staff",
+            user=self.target, program=self.program_a, role=ROLE_STAFF,
         )
         self.client.login(username="staff", password="testpass123")
         resp = self.client.post(
@@ -82,7 +83,7 @@ class UserRoleManagementTest(TestCase):
 
     def test_roles_page_shows_existing_roles(self):
         UserProgramRole.objects.create(
-            user=self.target, program=self.program_a, role="staff",
+            user=self.target, program=self.program_a, role=ROLE_STAFF,
         )
         self.client.login(username="admin", password="testpass123")
         resp = self.client.get(f"/manage/users/{self.target.pk}/roles/")
@@ -95,35 +96,35 @@ class UserRoleManagementTest(TestCase):
         self.client.login(username="admin", password="testpass123")
         resp = self.client.post(
             f"/manage/users/{self.target.pk}/roles/add/",
-            {"program": self.program_a.pk, "role": "staff"},
+            {"program": self.program_a.pk, "role": ROLE_STAFF},
         )
         self.assertEqual(resp.status_code, 302)
         self.assertTrue(
             UserProgramRole.objects.filter(
-                user=self.target, program=self.program_a, role="staff", status="active",
+                user=self.target, program=self.program_a, role=ROLE_STAFF, status="active",
             ).exists()
         )
 
     def test_add_role_reactivates_removed_role(self):
         """Adding a role to a program where the user was previously removed reactivates it."""
         role = UserProgramRole.objects.create(
-            user=self.target, program=self.program_a, role="staff", status="removed",
+            user=self.target, program=self.program_a, role=ROLE_STAFF, status="removed",
         )
         self.client.login(username="admin", password="testpass123")
         resp = self.client.post(
             f"/manage/users/{self.target.pk}/roles/add/",
-            {"program": self.program_a.pk, "role": "program_manager"},
+            {"program": self.program_a.pk, "role": ROLE_PROGRAM_MANAGER},
         )
         self.assertEqual(resp.status_code, 302)
         role.refresh_from_db()
         self.assertEqual(role.status, "active")
-        self.assertEqual(role.role, "program_manager")
+        self.assertEqual(role.role, ROLE_PROGRAM_MANAGER)
 
     # --- Remove role ---
 
     def test_admin_can_remove_role(self):
         role = UserProgramRole.objects.create(
-            user=self.target, program=self.program_a, role="staff",
+            user=self.target, program=self.program_a, role=ROLE_STAFF,
         )
         self.client.login(username="admin", password="testpass123")
         resp = self.client.post(
@@ -137,7 +138,7 @@ class UserRoleManagementTest(TestCase):
 
     def test_add_form_excludes_assigned_programs(self):
         UserProgramRole.objects.create(
-            user=self.target, program=self.program_a, role="staff",
+            user=self.target, program=self.program_a, role=ROLE_STAFF,
         )
         self.client.login(username="admin", password="testpass123")
         resp = self.client.get(f"/manage/users/{self.target.pk}/roles/")
@@ -152,7 +153,7 @@ class UserRoleManagementTest(TestCase):
 
     def test_user_list_shows_program_roles(self):
         UserProgramRole.objects.create(
-            user=self.target, program=self.program_a, role="program_manager",
+            user=self.target, program=self.program_a, role=ROLE_PROGRAM_MANAGER,
         )
         self.client.login(username="admin", password="testpass123")
         resp = self.client.get("/manage/users/")

--- a/tests/test_ux_plan_discoverability.py
+++ b/tests/test_ux_plan_discoverability.py
@@ -16,6 +16,7 @@ from apps.clients.models import ClientFile, ClientProgramEnrolment
 from apps.programs.models import Program, UserProgramRole
 from konote.middleware.htmx_vary import HtmxVaryMiddleware
 import konote.encryption as enc_module
+from apps.auth_app.constants import ROLE_PROGRAM_MANAGER, ROLE_STAFF
 
 TEST_KEY = Fernet.generate_key().decode()
 
@@ -52,10 +53,10 @@ class EditableFilterTest(TestCase):
             username="staffuser", password="testpass123", display_name="Staff User"
         )
         UserProgramRole.objects.create(
-            user=self.user, program=self.prog_a, role="staff", status="active"
+            user=self.user, program=self.prog_a, role=ROLE_STAFF, status="active"
         )
         UserProgramRole.objects.create(
-            user=self.user, program=self.prog_b, role="program_manager", status="active"
+            user=self.user, program=self.prog_b, role=ROLE_PROGRAM_MANAGER, status="active"
         )
 
         # editable_client is enrolled in prog_a (staff can edit plans there)
@@ -108,7 +109,7 @@ class EditableFilterTest(TestCase):
             username="pmonly", password="testpass123", display_name="PM Only"
         )
         UserProgramRole.objects.create(
-            user=pm_only, program=self.prog_a, role="program_manager", status="active"
+            user=pm_only, program=self.prog_a, role=ROLE_PROGRAM_MANAGER, status="active"
         )
         self.http.login(username="pmonly", password="testpass123")
         resp = self.http.get("/participants/?editable=1")
@@ -138,7 +139,7 @@ class PlanViewDisabledButtonTest(TestCase):
             username="staff", password="testpass123", display_name="Staff"
         )
         UserProgramRole.objects.create(
-            user=self.staff, program=self.program, role="staff", status="active"
+            user=self.staff, program=self.program, role=ROLE_STAFF, status="active"
         )
 
         # Program manager (plan.edit=DENY — cannot edit)
@@ -146,7 +147,7 @@ class PlanViewDisabledButtonTest(TestCase):
             username="pm", password="testpass123", display_name="PM"
         )
         UserProgramRole.objects.create(
-            user=self.pm, program=self.program, role="program_manager", status="active"
+            user=self.pm, program=self.program, role=ROLE_PROGRAM_MANAGER, status="active"
         )
 
         self.client_file = _make_client_in_program("Jane", "Doe", self.program)

--- a/tests/test_wave3_messaging.py
+++ b/tests/test_wave3_messaging.py
@@ -33,6 +33,7 @@ from apps.communications.services import (
 from apps.events.models import Event, EventType, Meeting
 from apps.programs.models import Program, UserProgramRole
 import konote.encryption as enc_module
+from apps.auth_app.constants import ROLE_STAFF
 
 TEST_KEY = Fernet.generate_key().decode()
 
@@ -48,7 +49,7 @@ def _create_test_fixtures(test_case):
     UserProgramRole.objects.create(
         user=test_case.staff,
         program=test_case.program,
-        role="staff",
+        role=ROLE_STAFF,
         status="active",
     )
     test_case.admin_user = User.objects.create_user(
@@ -60,7 +61,7 @@ def _create_test_fixtures(test_case):
     UserProgramRole.objects.create(
         user=test_case.admin_user,
         program=test_case.program,
-        role="staff",
+        role=ROLE_STAFF,
         status="active",
     )
     test_case.client_file = ClientFile()

--- a/tests/ux_walkthrough/base.py
+++ b/tests/ux_walkthrough/base.py
@@ -7,6 +7,12 @@ import konote.encryption as enc_module
 
 from .checker import Severity, UxChecker
 from .conftest import get_report
+from apps.auth_app.constants import (
+    ROLE_EXECUTIVE,
+    ROLE_PROGRAM_MANAGER,
+    ROLE_RECEPTIONIST,
+    ROLE_STAFF,
+)
 
 TEST_KEY = Fernet.generate_key().decode()
 
@@ -100,37 +106,37 @@ class UxWalkthroughBase(TestCase):
         UserProgramRole.objects.create(
             user=cls.receptionist_user,
             program=cls.program_a,
-            role="receptionist",
+            role=ROLE_RECEPTIONIST,
         )
         UserProgramRole.objects.create(
             user=cls.staff_user,
             program=cls.program_a,
-            role="staff",
+            role=ROLE_STAFF,
         )
         UserProgramRole.objects.create(
             user=cls.manager_user,
             program=cls.program_a,
-            role="program_manager",
+            role=ROLE_PROGRAM_MANAGER,
         )
         UserProgramRole.objects.create(
             user=cls.executive_user,
             program=cls.program_a,
-            role="executive",
+            role=ROLE_EXECUTIVE,
         )
         UserProgramRole.objects.create(
             user=cls.executive_user,
             program=cls.program_b,
-            role="executive",
+            role=ROLE_EXECUTIVE,
         )
         UserProgramRole.objects.create(
             user=cls.admin_pm_user,
             program=cls.program_a,
-            role="program_manager",
+            role=ROLE_PROGRAM_MANAGER,
         )
         UserProgramRole.objects.create(
             user=cls.admin_pm_user,
             program=cls.program_b,
-            role="program_manager",
+            role=ROLE_PROGRAM_MANAGER,
         )
 
         # --- Clients ---

--- a/tests/ux_walkthrough/browser_base.py
+++ b/tests/ux_walkthrough/browser_base.py
@@ -24,6 +24,12 @@ import konote.encryption as enc_module
 
 from .checker import Severity, UxIssue
 from .conftest import get_report
+from apps.auth_app.constants import (
+    ROLE_EXECUTIVE,
+    ROLE_PROGRAM_MANAGER,
+    ROLE_RECEPTIONIST,
+    ROLE_STAFF,
+)
 
 # Lazy import — lets the module load even if Playwright isn't installed
 # (tests skip gracefully via pytest.importorskip in test_browser.py)
@@ -212,22 +218,22 @@ class BrowserTestBase(StaticLiveServerTestCase):
         # Role assignments
         UserProgramRole.objects.create(
             user=self.receptionist_user, program=self.program_a,
-            role="receptionist",
+            role=ROLE_RECEPTIONIST,
         )
         UserProgramRole.objects.create(
-            user=self.staff_user, program=self.program_a, role="staff",
+            user=self.staff_user, program=self.program_a, role=ROLE_STAFF,
         )
         UserProgramRole.objects.create(
             user=self.manager_user, program=self.program_a,
-            role="program_manager",
+            role=ROLE_PROGRAM_MANAGER,
         )
         UserProgramRole.objects.create(
             user=self.executive_user, program=self.program_a,
-            role="executive",
+            role=ROLE_EXECUTIVE,
         )
         UserProgramRole.objects.create(
             user=self.executive_user, program=self.program_b,
-            role="executive",
+            role=ROLE_EXECUTIVE,
         )
 
         # Clients

--- a/tests/ux_walkthrough/test_admin_workflows.py
+++ b/tests/ux_walkthrough/test_admin_workflows.py
@@ -15,6 +15,7 @@ from django.test import override_settings
 
 from .base import TEST_KEY, UxScenarioBase
 from .checker import Severity
+from apps.auth_app.constants import ROLE_STAFF
 
 
 # =====================================================================
@@ -261,7 +262,7 @@ class AdminProgramWorkflow(UxScenarioBase):
         url = f"/programs/{pid}/roles/add/"
         resp = self.client.post(
             url,
-            data={"user": self.staff_user.pk, "role": "staff"},
+            data={"user": self.staff_user.pk, "role": ROLE_STAFF},
             HTTP_HX_REQUEST="true",
         )
         issues = []
@@ -1009,7 +1010,7 @@ class AdminInviteWorkflow(UxScenarioBase):
             role, "Submit new invite",
             "/manage/users/invites/new/",
             data={
-                "role": "staff",
+                "role": ROLE_STAFF,
                 "programs": [self.program_a.pk],
                 "expires_days": "7",
             },
@@ -1248,7 +1249,7 @@ class AdminFullSetupScenario(UxScenarioBase):
 
         resp = self.client.post(
             f"/programs/{program.pk}/roles/add/",
-            data={"user": worker.pk, "role": "staff"},
+            data={"user": worker.pk, "role": ROLE_STAFF},
             HTTP_HX_REQUEST="true",
         )
         url = f"/programs/{program.pk}/roles/add/"


### PR DESCRIPTION
## Summary
- Adds named constants (`ROLE_RECEPTIONIST`, `ROLE_STAFF`, `ROLE_PROGRAM_MANAGER`, `ROLE_EXECUTIVE`, `ROLE_ADMIN`) and convenience sets (`ALL_PROGRAM_ROLES`, `CLIENT_ACCESS_ROLES`) to `apps/auth_app/constants.py`
- Replaces 400+ raw role string literals across 98 files with these constants
- `ROLE_RANK` keys now reference constants instead of raw strings

## What was NOT changed
- `ROLE_CHOICES` tuples in models (Django stores the raw string in DB)
- Migration files
- Templates and `.po` files
- Username strings (`username="staff"`, `login_as("staff")`, etc.)
- `method="staff"` in communications/services.py (different concept — send method, not role)
- `GroupMembership` roles (different concept — group roles, not program roles)

## Test plan
- [ ] All syntax checks pass locally (verified with `py_compile`)
- [ ] Run targeted tests on VPS: `pytest tests/test_permissions_enforcement.py tests/test_clients.py tests/test_reports.py tests/test_exports.py -v`
- [ ] Verify no import errors on container startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)