### PR TITLE
fix: HTML report rendering and Funder Report rename

### DIFF
--- a/apps/reports/migrations/0018_rename_funder_to_standard_report.py
+++ b/apps/reports/migrations/0018_rename_funder_to_standard_report.py
@@ -1,0 +1,38 @@
+"""Rename export_type 'funder_report' to 'standard_report' in SecureExportLink,
+and report_type 'funder_report' to 'standard_report' in ReportDeadline."""
+from django.db import migrations
+
+
+def rename_funder_to_standard(apps, schema_editor):
+    SecureExportLink = apps.get_model("reports", "SecureExportLink")
+    SecureExportLink.objects.filter(export_type="funder_report").update(
+        export_type="standard_report"
+    )
+    ReportDeadline = apps.get_model("reports", "ReportDeadline")
+    ReportDeadline.objects.filter(report_type="funder_report").update(
+        report_type="standard_report"
+    )
+
+
+def rename_standard_to_funder(apps, schema_editor):
+    SecureExportLink = apps.get_model("reports", "SecureExportLink")
+    SecureExportLink.objects.filter(export_type="standard_report").update(
+        export_type="funder_report"
+    )
+    ReportDeadline = apps.get_model("reports", "ReportDeadline")
+    ReportDeadline.objects.filter(report_type="standard_report").update(
+        report_type="funder_report"
+    )
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("reports", "0017_reporttemplate_include_all_metrics"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            rename_funder_to_standard,
+            rename_standard_to_funder,
+        ),
+    ]

--- a/apps/reports/models.py
+++ b/apps/reports/models.py
@@ -450,7 +450,7 @@ class SecureExportLink(models.Model):
     EXPORT_TYPE_CHOICES = [
         ("client_data", _("Participant Data")),
         ("metrics", _("Metric Report")),
-        ("funder_report", _("Funder Report")),
+        ("standard_report", _("Standard Report")),
         ("individual_client", _("Individual Client Export")),
     ]
 
@@ -711,7 +711,7 @@ class ReportSchedule(models.Model):
 
     REPORT_TYPE_CHOICES = [
         ("oversight", _("Safety Oversight Report")),
-        ("funder_report", _("Funder Report")),
+        ("standard_report", _("Standard Report")),
     ]
 
     name = models.CharField(max_length=255)

--- a/apps/reports/pdf_views.py
+++ b/apps/reports/pdf_views.py
@@ -239,7 +239,7 @@ def generate_outcome_report_pdf(
     if output_format == "html":
         from .pdf_utils import render_html
         html_filename = filename.replace(".pdf", ".html")
-        return render_html("reports/pdf_funder_report.html", context, html_filename)
+        return render_html("reports/html_outcome_report.html", context, html_filename)
     return render_pdf("reports/pdf_funder_report.html", context, filename)
 
 

--- a/apps/reports/utils.py
+++ b/apps/reports/utils.py
@@ -66,7 +66,7 @@ def can_create_export(user, export_type, program=None):
 
     Args:
         user: The User instance.
-        export_type: One of "metrics", "funder_report".
+        export_type: One of "metrics", "standard_report".
         program: Optional Program instance — when provided, checks whether
                  the user manages that specific program.
 
@@ -78,7 +78,7 @@ def can_create_export(user, export_type, program=None):
     if user.is_admin:
         return True
 
-    if export_type in ("metrics", "funder_report", "session_report"):
+    if export_type in ("metrics", "standard_report", "session_report"):
         qs = UserProgramRole.objects.filter(
             user=user, role__in=["program_manager", "executive"], status="active"
         )

--- a/apps/reports/views.py
+++ b/apps/reports/views.py
@@ -172,7 +172,7 @@ def _save_export_and_create_link(request, content, filename, export_type,
         request: The HTTP request (for user info).
         content: File content — str for CSV, bytes for PDF.
         filename: Display filename for downloads (e.g., "export_2026-02-05.csv").
-        export_type: One of "metrics", "funder_report".
+        export_type: One of "metrics", "standard_report".
         client_count: Number of clients in the export.
         includes_notes: Whether clinical note content is included.
         recipient: Who is receiving the data (from ExportRecipientMixin).
@@ -1222,10 +1222,10 @@ def funder_report_form(request):
     all_programs_mode = form.is_all_programs
 
     if all_programs_mode:
-        if not can_create_export(request.user, "funder_report"):
+        if not can_create_export(request.user, "standard_report"):
             return HttpResponseForbidden("You do not have permission to export data.")
     else:
-        if not can_create_export(request.user, "funder_report", program=program):
+        if not can_create_export(request.user, "standard_report", program=program):
             return HttpResponseForbidden("You do not have permission to export data for this program.")
 
     date_from = form.cleaned_data["date_from"]
@@ -1532,7 +1532,7 @@ def funder_report_approve(request):
         request=request,
         content=content,
         filename=filename,
-        export_type="funder_report",
+        export_type="standard_report",
         client_count=raw_client_count,
         includes_notes=False,
         recipient=recipient,
@@ -1563,7 +1563,7 @@ def funder_report_approve(request):
         user_id=request.user.pk,
         user_display=request.user.display_name,
         action="report_approved",
-        resource_type="funder_report",
+        resource_type="standard_report",
         ip_address=_get_client_ip(request),
         is_demo_context=getattr(request.user, "is_demo", False),
         metadata={
@@ -1668,7 +1668,7 @@ def generate_report_form(request):
         from django.contrib import messages as msg
         msg.warning(
             request,
-            _("This report template covers multiple programs but currently "
+            _("This report covers multiple programs but currently "
               "only includes data from %(program)s. Multi-program reports "
               "are coming soon.")
             % {"program": template_programs[0].name},
@@ -1701,7 +1701,7 @@ def generate_report_form(request):
         request=request,
         content=content,
         filename=filename,
-        export_type="funder_report",
+        export_type="standard_report",
         client_count=client_count,
         includes_notes=False,
         recipient=recipient,

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -3949,8 +3949,8 @@ msgstr "Données du participant"
 msgid "Metric Report"
 msgstr "Rapport de mesures"
 
-msgid "Funder Report"
-msgstr "Rapport pour bailleur de fonds"
+msgid "Standard Report"
+msgstr "Rapport standard"
 
 msgid "%(name)s added."
 msgstr "%(name)s ajouté(e)."
@@ -5583,6 +5583,13 @@ msgid "Your PDF report is ready to download."
 msgstr "Votre rapport PDF est prêt à télécharger."
 
 msgid ""
+"Your HTML report is ready to download. You can open it in any web browser or"
+" share it directly."
+msgstr ""
+"Votre rapport HTML est prêt à télécharger. Vous pouvez l'ouvrir dans "
+"n'importe quel navigateur web ou le partager directement."
+
+msgid ""
 "Your CSV file is ready to download. You can open it in Excel or Google "
 "Sheets."
 msgstr ""
@@ -5591,6 +5598,9 @@ msgstr ""
 
 msgid "Download PDF Report"
 msgstr "Télécharger le rapport PDF"
+
+msgid "Download HTML Report"
+msgstr "Télécharger le rapport HTML"
 
 msgid "Download CSV File"
 msgstr "Télécharger le fichier CSV"
@@ -17803,6 +17813,9 @@ msgstr "Votre rapport CSV est prêt à télécharger."
 
 msgid "Your PDF report is ready for download."
 msgstr "Votre rapport PDF est prêt à télécharger."
+
+msgid "Your HTML report is ready for download."
+msgstr "Votre rapport HTML est prêt à télécharger."
 
 msgid ""
 "e.g., Q1 debt figures include a large legal settlement for one participant. "

--- a/templates/reports/export_link_created.html
+++ b/templates/reports/export_link_created.html
@@ -34,6 +34,8 @@
     <p style="margin-bottom: 0;">
         {% if is_pdf %}
         {% trans "Your PDF report is ready to download." %}
+        {% elif is_html %}
+        {% trans "Your HTML report is ready to download. You can open it in any web browser or share it directly." %}
         {% else %}
         {% trans "Your CSV file is ready to download. You can open it in Excel or Google Sheets." %}
         {% endif %}
@@ -44,6 +46,8 @@
 <a href="{{ download_path }}" role="button" id="download-btn" style="display: inline-flex; align-items: center; gap: 0.5rem; font-size: 1.1rem; padding: 0.75rem 2rem; margin-bottom: 0.5rem;">
     {% if is_pdf %}
     <span aria-hidden="true">&#x1F4C4;</span> {% trans "Download PDF Report" %}
+    {% elif is_html %}
+    <span aria-hidden="true">&#x1F4C4;</span> {% trans "Download HTML Report" %}
     {% else %}
     <span aria-hidden="true">&#x1F4CA;</span> {% trans "Download CSV File" %}
     {% endif %}

--- a/templates/reports/funder_report_approved.html
+++ b/templates/reports/funder_report_approved.html
@@ -7,7 +7,7 @@
 <nav aria-label="{% trans 'Breadcrumb' %}">
     <ul>
         <li><a href="{% url 'home' %}">{% trans "Home" %}</a></li>
-        <li><a href="{% url 'reports:funder_report' %}">{% trans "Funder Report" %}</a></li>
+        <li><a href="{% url 'reports:funder_report' %}">{% trans "Standard Report" %}</a></li>
         <li aria-current="page">{% trans "Approved" %}</li>
     </ul>
 </nav>
@@ -44,6 +44,8 @@
     <p>
         {% if is_pdf %}
         {% trans "Your PDF report is ready for download." %}
+        {% elif is_html %}
+        {% trans "Your HTML report is ready for download." %}
         {% else %}
         {% trans "Your CSV report is ready for download." %}
         {% endif %}

--- a/templates/reports/funder_report_form.html
+++ b/templates/reports/funder_report_form.html
@@ -69,7 +69,7 @@
         {% endif %}
     </label>
 
-    {# Funder reporting template #}
+    {# Reporting template #}
     {% if form.report_template %}
     <label for="{{ form.report_template.id_for_label }}">
         {{ form.report_template.label }}

--- a/templates/reports/funder_report_preview.html
+++ b/templates/reports/funder_report_preview.html
@@ -7,7 +7,7 @@
 <nav aria-label="{% trans 'Breadcrumb' %}">
     <ul>
         <li><a href="{% url 'home' %}">{% trans "Home" %}</a></li>
-        <li><a href="{% url 'reports:funder_report' %}">{% trans "Funder Report" %}</a></li>
+        <li><a href="{% url 'reports:funder_report' %}">{% trans "Standard Report" %}</a></li>
         <li aria-current="page">{% trans "Preview" %}</li>
     </ul>
 </nav>

--- a/templates/reports/html_outcome_report.html
+++ b/templates/reports/html_outcome_report.html
@@ -1,0 +1,237 @@
+{% load i18n %}{% get_current_language as LANGUAGE_CODE %}<!DOCTYPE html>
+<html lang="{{ LANGUAGE_CODE }}">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{% blocktrans with name=program_display_name|default:program.translated_name %}Program Outcome Report — {{ name }}{% endblocktrans %}</title>
+    <style>
+        {% include "reports/_report_styles.html" %}
+
+        @media print {
+            body { padding: 0; max-width: none; }
+            .no-print { display: none; }
+            details > summary { display: none; }
+            details > *:not(summary) { display: block !important; }
+        }
+    </style>
+</head>
+<body>
+<!-- Report Header -->
+<div class="pdf-header">
+    <h1>{% trans "Program Outcome Report" %}</h1>
+    <div class="subtitle">{{ program_display_name|default:program.translated_name }}</div>
+    <dl class="meta-grid">
+        <dt>{% trans "Program" %}</dt>
+        <dd>{{ program_display_name|default:program.translated_name }}</dd>
+        <dt>{% trans "Date Range" %}</dt>
+        <dd>{% blocktrans with dfrom=date_from dto=date_to %}{{ dfrom }} to {{ dto }}{% endblocktrans %}</dd>
+        <dt>{% trans "Metrics" %}</dt>
+        <dd>{% for m in metrics %}{{ m.name }}{% if not forloop.last %}, {% endif %}{% endfor %}</dd>
+        {% if grouping_label %}
+        <dt>{% trans "Grouped By" %}</dt>
+        <dd>{{ grouping_label }}</dd>
+        {% endif %}
+        <dt>{% trans "Generated" %}</dt>
+        <dd>{% blocktrans with date=generated_at|date:"Y-m-d" author=generated_by %}{{ date }} by {{ author }}{% endblocktrans %}</dd>
+    </dl>
+</div>
+
+<!-- Summary Stats -->
+<div class="report-header-bar">{% trans "Summary" %}</div>
+<div class="stat-grid">
+    <div class="stat-box">
+        <div class="value">{{ total_clients }}</div>
+        <div class="label">{% trans "Participants" %}</div>
+    </div>
+    <div class="stat-box">
+        <div class="value">{{ total_data_points }}</div>
+        <div class="label">{% trans "Data Points" %}</div>
+    </div>
+</div>
+
+{% if achievement_summary %}
+<!-- Achievement Rate Summary -->
+<div class="report-header-bar">{% trans "Outcome Achievement Rates" %}</div>
+<div class="summary-grid">
+    <div class="summary-card">
+        <div class="number">{{ achievement_summary.overall_rate }}%</div>
+        <div class="achievement-bar" role="progressbar" aria-valuenow="{{ achievement_summary.overall_rate }}" aria-valuemin="0" aria-valuemax="100" aria-label="{% trans 'Overall achievement rate' %}">
+            <div class="achievement-bar-fill" style="width: {{ achievement_summary.overall_rate }}%;"></div>
+        </div>
+        <div class="label">{% trans "Overall Achievement Rate" %}</div>
+    </div>
+    <div class="summary-card">
+        <div class="number">{{ achievement_summary.clients_met_any_target }} / {{ achievement_summary.total_clients }}</div>
+        <div class="label">{% trans "Participants Met Target" %}</div>
+    </div>
+</div>
+
+{% if achievement_summary.by_metric %}
+<details open>
+<summary class="report-header-bar">{% trans "Achievement by Metric" %}</summary>
+<table>
+    <thead>
+        <tr>
+            <th scope="col">{% trans "Metric" %}</th>
+            <th scope="col">{% trans "Target Value" %}</th>
+            <th scope="col">{% trans "Clients with Data" %}</th>
+            <th scope="col">{% trans "Clients Met Target" %}</th>
+            <th scope="col">{% trans "Achievement Rate" %}</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for metric in achievement_summary.by_metric %}
+        <tr>
+            <td>{{ metric.metric_name }}</td>
+            <td>{% if metric.has_target %}{{ metric.target_value }}{% else %}<em>{% trans "No target defined" %}</em>{% endif %}</td>
+            <td>{{ metric.total_clients }}</td>
+            <td>{% if metric.has_target %}{{ metric.clients_met_target }}{% else %}—{% endif %}</td>
+            <td>
+                {% if metric.has_target %}
+                {{ metric.achievement_rate }}%
+                <div class="achievement-bar" role="progressbar" aria-valuenow="{{ metric.achievement_rate }}" aria-valuemin="0" aria-valuemax="100">
+                    <div class="achievement-bar-fill" style="width: {{ metric.achievement_rate }}%;"></div>
+                </div>
+                {% else %}—{% endif %}
+            </td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+</details>
+{% endif %}
+{% endif %}
+
+{% if is_aggregate %}
+{# ── Aggregate summary — NO individual client data ── #}
+<details open>
+<summary class="report-header-bar">{% trans "Metric Summary" %}</summary>
+<table>
+    <thead>
+        <tr>
+            <th scope="col">{% trans "Metric Name" %}</th>
+            <th scope="col">{% trans "Participants Measured" %}</th>
+            <th scope="col">{% trans "Data Points" %}</th>
+            <th scope="col">{% trans "Average" %}</th>
+            <th scope="col">{% trans "Min" %}</th>
+            <th scope="col">{% trans "Max" %}</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for row in aggregate_rows %}
+        <tr>
+            <td>{{ row.metric_name }}</td>
+            <td>{{ row.clients_measured }}</td>
+            <td>{{ row.data_points }}</td>
+            <td>{{ row.avg }}</td>
+            <td>{{ row.min }}</td>
+            <td>{{ row.max }}</td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+</details>
+
+{% if demographic_aggregate_rows %}
+<details open>
+<summary class="report-header-bar">{% trans "Breakdown by" %} {{ grouping_label }}</summary>
+<table>
+    <thead>
+        <tr>
+            <th scope="col">{{ grouping_label }}</th>
+            <th scope="col">{% trans "Metric Name" %}</th>
+            <th scope="col">{% trans "Participants Measured" %}</th>
+            <th scope="col">{% trans "Average" %}</th>
+            <th scope="col">{% trans "Min" %}</th>
+            <th scope="col">{% trans "Max" %}</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for row in demographic_aggregate_rows %}
+        <tr>
+            <td>{{ row.demographic_group }}</td>
+            <td>{{ row.metric_name }}</td>
+            <td>{{ row.clients_measured }}</td>
+            <td>{{ row.avg }}</td>
+            <td>{{ row.min }}</td>
+            <td>{{ row.max }}</td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+</details>
+{% endif %}
+
+{% else %}
+{# ── Individual data (admin, PM) ── #}
+
+{% if grouped_rows %}
+{% for group_name, group_rows in grouped_rows.items %}
+<details open>
+<summary class="report-header-bar">{{ grouping_label }}: {{ group_name }}</summary>
+<p style="font-size: 0.85rem; color: #718096;">{% blocktrans count counter=group_rows|length %}{{ counter }} data point{% plural %}{{ counter }} data points{% endblocktrans %}</p>
+<table>
+    <thead>
+        <tr>
+            <th scope="col">{% trans "Client Record ID" %}</th>
+            <th scope="col">{% trans "Metric Name" %}</th>
+            <th scope="col">{% trans "Value" %}</th>
+            <th scope="col">{% trans "Date" %}</th>
+            <th scope="col">{% trans "Author" %}</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for row in group_rows %}
+        <tr>
+            <td>{{ row.record_id }}</td>
+            <td>{{ row.metric_name }}</td>
+            <td>{{ row.value }}</td>
+            <td>{{ row.date }}</td>
+            <td>{{ row.author }}</td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+</details>
+{% endfor %}
+
+{% else %}
+<details open>
+<summary class="report-header-bar">{% trans "Metric Data" %}</summary>
+<table>
+    <thead>
+        <tr>
+            <th scope="col">{% trans "Client Record ID" %}</th>
+            <th scope="col">{% trans "Metric Name" %}</th>
+            <th scope="col">{% trans "Value" %}</th>
+            <th scope="col">{% trans "Date" %}</th>
+            <th scope="col">{% trans "Author" %}</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for row in rows %}
+        <tr>
+            <td>{{ row.record_id }}</td>
+            <td>{{ row.metric_name }}</td>
+            <td>{{ row.value }}</td>
+            <td>{{ row.date }}</td>
+            <td>{{ row.author }}</td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+</details>
+{% endif %}
+
+{% endif %}
+
+<div class="footer-note">
+    {% trans "This report was generated using KoNote's Program Outcome Report." %}
+    {% blocktrans with dfrom=date_from dto=date_to %}Data reflects outcomes recorded between {{ dfrom }} and {{ dto }}.{% endblocktrans %}
+</div>
+
+<div class="generated-by">
+    {% trans "Generated by KoNote" %}
+</div>
+</body>
+</html>

--- a/tests/test_export_summary.py
+++ b/tests/test_export_summary.py
@@ -159,7 +159,7 @@ class SendExportSummaryTests(TestCase):
         _create_export(self.staff, export_type="client_data")
         _create_export(self.staff, export_type="client_data", is_elevated=True)
         _create_export(self.staff, export_type="metrics", download_count=3)
-        _create_export(self.staff, export_type="funder_report", revoked=True)
+        _create_export(self.staff, export_type="standard_report", revoked=True)
         out = StringIO()
         call_command("send_export_summary", "--dry-run", stdout=out)
         output = out.getvalue()

--- a/tests/test_secure_export.py
+++ b/tests/test_secure_export.py
@@ -177,9 +177,9 @@ class SecureExportLinkModelTest(TestCase):
 
     def test_str_representation(self):
         """__str__ should include export type and status."""
-        link = _create_link(self.admin, self.export_dir, export_type="funder_report")
+        link = _create_link(self.admin, self.export_dir, export_type="standard_report")
         result = str(link)
-        self.assertIn("funder_report", result)
+        self.assertIn("standard_report", result)
         self.assertIn("Active", result)
 
 


### PR DESCRIPTION
## Summary
- **HTML report now uses designed template** — the standard report HTML export was rendering the WeasyPrint PDF template (`pdf_funder_report.html`), producing a plain unstyled HTML page. Now uses a new `html_outcome_report.html` with the shared report styles (stat boxes, achievement bars, collapsible sections, brand colours).
- **Confirmation page handles HTML format** — both `export_link_created.html` and `funder_report_approved.html` now show "Download HTML Report" with correct messaging when HTML format is selected, instead of falling through to "Download CSV File".
- **"Funder Report" renamed to "Standard Report"** — updated model `EXPORT_TYPE_CHOICES`, `REPORT_TYPE_CHOICES`, breadcrumbs, and the multi-program warning message. Data migration renames existing DB rows. Internal identifiers (URL names, function names, permission strings) left unchanged.
- French translations updated for all new strings.

## Test plan
- [ ] Generate a Standard Report in HTML format — verify the downloaded file has styled layout (stat boxes, tables, achievement bars), not plain unstyled HTML
- [ ] Verify confirmation page says "Download HTML Report" (not "Download CSV File") when HTML is selected
- [ ] Verify confirmation page still says "Download PDF Report" for PDF and "Download CSV File" for CSV
- [ ] Check subtitle on confirmation page shows "Standard Report" (not "Funder Report")
- [ ] Run `pytest tests/test_secure_export.py tests/test_export_summary.py` to verify test updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)