### PR TITLE
fix: audit log format bug and missed test rename

### DIFF
--- a/apps/reports/pdf_views.py
+++ b/apps/reports/pdf_views.py
@@ -226,7 +226,7 @@ def generate_outcome_report_pdf(
         "date_to": str(date_to),
         "total_clients": len(unique_clients),
         "total_data_points": len(rows),
-        "format": "pdf",
+        "format": output_format,
     }
     if grouping_type != "none":
         audit_metadata["grouped_by"] = grouping_label

--- a/templates/reports/_report_styles.html
+++ b/templates/reports/_report_styles.html
@@ -1,5 +1,5 @@
-{# Shared CSS for standalone HTML report exports (included by both
-   html_report.html and html_report_all_programs.html). #}
+{# Shared CSS for standalone HTML report exports (included by
+   html_report.html, html_report_all_programs.html, and html_outcome_report.html). #}
 * { box-sizing: border-box; }
 body {
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;

--- a/tests/test_export_permissions.py
+++ b/tests/test_export_permissions.py
@@ -116,7 +116,7 @@ class CanCreateExportHelperTest(TestCase):
         self.assertTrue(can_create_export(self.admin, "metrics"))
 
     def test_admin_can_create_funder_report(self):
-        self.assertTrue(can_create_export(self.admin, "funder_report"))
+        self.assertTrue(can_create_export(self.admin, "standard_report"))
 
     def test_admin_can_export_any_program(self):
         self.assertTrue(can_create_export(self.admin, "metrics", program=self.program_a))
@@ -128,7 +128,7 @@ class CanCreateExportHelperTest(TestCase):
         self.assertTrue(can_create_export(self.pm_user, "metrics"))
 
     def test_pm_can_create_funder_report(self):
-        self.assertTrue(can_create_export(self.pm_user, "funder_report"))
+        self.assertTrue(can_create_export(self.pm_user, "standard_report"))
 
     def test_pm_can_export_own_program(self):
         self.assertTrue(can_create_export(self.pm_user, "metrics", program=self.program_a))
@@ -140,7 +140,7 @@ class CanCreateExportHelperTest(TestCase):
 
     def test_staff_cannot_create_any_export(self):
         self.assertFalse(can_create_export(self.staff_user, "metrics"))
-        self.assertFalse(can_create_export(self.staff_user, "funder_report"))
+        self.assertFalse(can_create_export(self.staff_user, "standard_report"))
 
     # ── Executive ────────────────────────────────────────────────
 
@@ -148,7 +148,7 @@ class CanCreateExportHelperTest(TestCase):
         self.assertTrue(can_create_export(self.exec_user, "metrics"))
 
     def test_executive_can_create_funder_report(self):
-        self.assertTrue(can_create_export(self.exec_user, "funder_report"))
+        self.assertTrue(can_create_export(self.exec_user, "standard_report"))
 
     def test_executive_can_export_own_program(self):
         self.assertTrue(can_create_export(self.exec_user, "metrics", program=self.program_a))


### PR DESCRIPTION
## Summary
Follow-up from `/simplify` review of PR #345:

- **Bug fix**: `pdf_views.py` audit log hardcoded `"format": "pdf"` even for HTML exports — now uses `output_format` variable
- **Bug fix**: `test_export_permissions.py` still used `"funder_report"` in 4 test methods after the rename to `"standard_report"` — PM and executive tests were silently testing the wrong code path
- **Comment fix**: `_report_styles.html` comment now lists all 3 templates that include the shared styles

## Test plan
- [ ] `pytest tests/test_export_permissions.py` — PM and executive standard_report tests should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)