### PR TITLE
fix: clean up role constants import ordering

### DIFF
--- a/apps/auth_app/management/commands/validate_permissions.py
+++ b/apps/auth_app/management/commands/validate_permissions.py
@@ -146,7 +146,7 @@ class Command(BaseCommand):
             )
 
             # Print summary counts
-            for role in list(ALL_PROGRAM_ROLES):
+            for role in sorted(ALL_PROGRAM_ROLES, key=ROLE_RANK.get):
                 role_perms = PERMISSIONS[role]
                 counts = {}
                 for v in role_perms.values():

--- a/apps/auth_app/permissions.py
+++ b/apps/auth_app/permissions.py
@@ -512,7 +512,7 @@ def validate_permissions():
         all_keys.update(role_perms.keys())
 
     # Check each role has all keys
-    for role in list(ALL_PROGRAM_ROLES):
+    for role in sorted(ALL_PROGRAM_ROLES, key=ROLE_RANK.get):
         if role not in PERMISSIONS:
             errors.append(f"Role '{role}' missing from PERMISSIONS")
             continue

--- a/apps/clients/erasure.py
+++ b/apps/clients/erasure.py
@@ -10,10 +10,11 @@ Three tiers of erasure:
 """
 import logging
 
-from apps.auth_app.constants import ROLE_PROGRAM_MANAGER
 from django.db import transaction
 from django.utils import timezone
 from django.utils.translation import gettext as _
+
+from apps.auth_app.constants import ROLE_PROGRAM_MANAGER
 
 logger = logging.getLogger(__name__)
 

--- a/apps/programs/views.py
+++ b/apps/programs/views.py
@@ -11,8 +11,10 @@ from django.shortcuts import get_object_or_404, redirect, render
 from django.utils import timezone
 from django.utils.translation import gettext as _
 
+from apps.auth_app.constants import ROLE_PROGRAM_MANAGER, ROLE_RECEPTIONIST
 from apps.auth_app.decorators import admin_required
 from apps.auth_app.models import User
+from apps.groups.models import Group
 
 from .context import (
     get_switcher_options,
@@ -20,11 +22,7 @@ from .context import (
     needs_program_selector,
     set_active_program,
 )
-from apps.groups.models import Group
-
 from .forms import CONFIDENTIAL_KEYWORDS, ProgramForm, UserProgramRoleForm, SwitchProgramForm
-from apps.auth_app.constants import ROLE_PROGRAM_MANAGER, ROLE_RECEPTIONIST
-
 from .models import Program, UserProgramRole
 
 logger = logging.getLogger(__name__)

--- a/apps/reports/views.py
+++ b/apps/reports/views.py
@@ -22,7 +22,7 @@ from django.utils import timezone
 from django.utils.translation import gettext as _
 
 from apps.audit.models import AuditLog
-from apps.auth_app.constants import ROLE_PROGRAM_MANAGER
+from apps.auth_app.constants import ROLE_PROGRAM_MANAGER, ROLE_RANK, ROLE_STAFF
 from apps.auth_app.decorators import admin_required, requires_permission
 from apps.auth_app.models import User
 from apps.clients.models import ClientFile, ClientProgramEnrolment
@@ -1992,7 +1992,6 @@ def team_meeting_view(request):
     from django.db.models import Count, Max, Q
 
     from apps.auth_app.decorators import _get_user_highest_role
-    from apps.auth_app.constants import ROLE_PROGRAM_MANAGER, ROLE_RANK, ROLE_STAFF
     from apps.programs.models import UserProgramRole, Program
     from apps.programs.access import get_user_program_ids
     from apps.notes.models import ProgressNote

--- a/konote/context_processors.py
+++ b/konote/context_processors.py
@@ -1,5 +1,6 @@
 """Template context processors for terminology, features, and settings."""
 from django.core.cache import cache
+from django.utils.translation import get_language
 
 from apps.auth_app.constants import (
     ROLE_EXECUTIVE,
@@ -7,7 +8,6 @@ from apps.auth_app.constants import (
     ROLE_RECEPTIONIST,
     ROLE_RANK,
 )
-from django.utils.translation import get_language
 
 
 def nav_active(request):

--- a/tests/test_permissions_enforcement.py
+++ b/tests/test_permissions_enforcement.py
@@ -39,7 +39,7 @@ from apps.events.models import Alert, Event, Meeting
 from apps.groups.models import Group
 from apps.notes.models import ProgressNote
 from apps.programs.models import Program, UserProgramRole
-from apps.auth_app.constants import ALL_PROGRAM_ROLES, ROLE_PROGRAM_MANAGER, ROLE_STAFF
+from apps.auth_app.constants import ALL_PROGRAM_ROLES, ROLE_PROGRAM_MANAGER, ROLE_RANK, ROLE_STAFF
 import konote.encryption as enc_module
 
 TEST_KEY = Fernet.generate_key().decode()
@@ -161,7 +161,7 @@ PERMISSION_URL_MAP = {
     "circle.edit": {"url": "/circles/{circle_id}/edit/"},
 }
 
-ALL_ROLES = list(ALL_PROGRAM_ROLES)
+ALL_ROLES = sorted(ALL_PROGRAM_ROLES, key=ROLE_RANK.get)
 
 
 @override_settings(FIELD_ENCRYPTION_KEY=TEST_KEY)


### PR DESCRIPTION
## Summary
Follow-up to PR #344 (role constants refactor). Fixes issues found during code review:

- Fix PEP 8 import ordering in 3 files (Django imports before local app imports)
- Remove redundant inner import in reports/views.py
- Replace `list(ALL_PROGRAM_ROLES)` with `sorted(ALL_PROGRAM_ROLES, key=ROLE_RANK.get)` for deterministic iteration order

## Test plan
- [ ] Syntax checks pass (verified locally)
- [ ] No behaviour changes — only import order and iteration determinism

🤖 Generated with [Claude Code](https://claude.com/claude-code)