### PR TITLE
Add export_type validation and HTML rendering regression test

### DIFF
--- a/apps/reports/models.py
+++ b/apps/reports/models.py
@@ -524,6 +524,19 @@ class SecureExportLink(models.Model):
     )
     approved_at = models.DateTimeField(null=True, blank=True)
 
+    def clean(self):
+        valid_types = {choice[0] for choice in self.EXPORT_TYPE_CHOICES}
+        if self.export_type and self.export_type not in valid_types:
+            from django.core.exceptions import ValidationError
+            raise ValidationError(
+                {"export_type": f"Unknown export type '{self.export_type}'. "
+                 f"Valid choices: {', '.join(sorted(valid_types))}"}
+            )
+
+    def save(self, *args, **kwargs):
+        self.clean()
+        super().save(*args, **kwargs)
+
     def is_valid(self):
         """Check if link is still usable (no I/O — checks DB state only)."""
         if self.revoked:

--- a/tests/test_export_permissions.py
+++ b/tests/test_export_permissions.py
@@ -1083,3 +1083,143 @@ class ClientAnalysisPermissionTest(TestCase):
         self.http_client.login(username="frontdesk", password="testpass123")
         resp = self.http_client.get(self._analysis_url())
         self.assertEqual(resp.status_code, 403)
+
+
+# ═════════════════════════════════════════════════════════════════════
+# 14. HTML report rendering regression test
+# ═════════════════════════════════════════════════════════════════════
+
+
+@override_settings(FIELD_ENCRYPTION_KEY=TEST_KEY)
+class HtmlReportRenderingTest(TestCase):
+    """Regression test: HTML format must use html_outcome_report.html, not the PDF template.
+
+    Previously, requesting HTML format returned the WeasyPrint PDF template
+    (pdf_funder_report.html) which rendered as unstyled HTML with @page CSS.
+    This test ensures the correct browser-friendly template is used.
+    """
+
+    databases = {"default", "audit"}
+
+    def setUp(self):
+        enc_module._fernet = None
+        self.export_dir = tempfile.mkdtemp(prefix="konote_test_exports_")
+        self.http_client = Client()
+
+        from apps.clients.models import ClientFile, ClientProgramEnrolment
+        from apps.notes.models import MetricValue, ProgressNote, ProgressNoteTarget
+        from apps.plans.models import MetricDefinition, PlanSection, PlanTarget, PlanTargetMetric
+
+        self.admin = User.objects.create_user(
+            username="admin", password="testpass123", is_admin=True, display_name="Admin"
+        )
+        self.program = Program.objects.create(name="Test Program")
+        UserProgramRole.objects.create(
+            user=self.admin, program=self.program, role=ROLE_PROGRAM_MANAGER
+        )
+
+        self.client_file = ClientFile.objects.create(record_id="REC-HTML-001")
+        self.client_file.first_name = "Test"
+        self.client_file.last_name = "Client"
+        self.client_file.save()
+        ClientProgramEnrolment.objects.create(
+            client_file=self.client_file, program=self.program
+        )
+
+        self.metric_def = MetricDefinition.objects.create(
+            name="HTML Test Metric", is_enabled=True
+        )
+
+        section = PlanSection.objects.create(
+            client_file=self.client_file, name="Test Section", program=self.program,
+        )
+        target = PlanTarget.objects.create(
+            plan_section=section, client_file=self.client_file,
+        )
+        target.name = "Test target"
+        target.description = "Test"
+        target.save()
+        PlanTargetMetric.objects.create(plan_target=target, metric_def=self.metric_def)
+
+        note = ProgressNote.objects.create(
+            client_file=self.client_file, note_type="quick", author=self.admin,
+        )
+        note_target = ProgressNoteTarget.objects.create(
+            progress_note=note, plan_target=target,
+        )
+        MetricValue.objects.create(
+            progress_note_target=note_target, metric_def=self.metric_def, value="7",
+        )
+
+    def tearDown(self):
+        shutil.rmtree(self.export_dir, ignore_errors=True)
+
+    @override_settings()
+    def test_html_export_uses_styled_template(self):
+        """HTML export must contain styled HTML (not WeasyPrint @page CSS)."""
+        settings.SECURE_EXPORT_DIR = self.export_dir
+        self.http_client.login(username="admin", password="testpass123")
+        resp = self.http_client.post("/reports/export/", {
+            "program": self.program.pk,
+            "date_from": "2020-01-01",
+            "date_to": "2030-12-31",
+            "metrics": [self.metric_def.pk],
+            "format": "html",
+            "recipient": "Self — for my own records",
+            "recipient_reason": "Testing HTML rendering",
+        })
+        self.assertEqual(resp.status_code, 200)
+
+        # The response should contain the secure link page, find the file
+        link = SecureExportLink.objects.order_by("-created_at").first()
+        self.assertIsNotNone(link)
+        with open(link.file_path, "r", encoding="utf-8") as f:
+            content = f.read()
+
+        # Must have styled HTML elements from html_outcome_report.html
+        self.assertIn("stat-box", content, "HTML export missing stat-box class — wrong template used")
+        self.assertIn("report-header-bar", content, "HTML export missing report-header-bar — wrong template used")
+        # Must NOT have WeasyPrint-specific CSS
+        self.assertNotIn("@page", content, "HTML export contains @page CSS — PDF template was used")
+
+
+# ═════════════════════════════════════════════════════════════════════
+# 15. SecureExportLink.export_type validation test
+# ═════════════════════════════════════════════════════════════════════
+
+
+@override_settings(FIELD_ENCRYPTION_KEY=TEST_KEY)
+class ExportTypeValidationTest(TestCase):
+    """Verify SecureExportLink rejects unknown export_type values on save."""
+
+    def setUp(self):
+        enc_module._fernet = None
+        self.export_dir = tempfile.mkdtemp(prefix="konote_test_exports_")
+        self.user = User.objects.create_user(
+            username="admin", password="testpass123", is_admin=True, display_name="Admin"
+        )
+
+    def tearDown(self):
+        shutil.rmtree(self.export_dir, ignore_errors=True)
+
+    def test_valid_export_type_accepted(self):
+        """Known export types should save without error."""
+        from django.core.exceptions import ValidationError
+        for type_code, _ in SecureExportLink.EXPORT_TYPE_CHOICES:
+            try:
+                _create_link(self.user, self.export_dir, export_type=type_code)
+            except ValidationError:
+                self.fail(f"Valid export_type '{type_code}' raised ValidationError")
+
+    def test_unknown_export_type_rejected(self):
+        """Unknown export_type (e.g. old 'funder_report') must raise ValidationError."""
+        from django.core.exceptions import ValidationError
+        with self.assertRaises(ValidationError) as cm:
+            _create_link(self.user, self.export_dir, export_type="funder_report")
+        self.assertIn("export_type", cm.exception.message_dict)
+
+    def test_bogus_export_type_rejected(self):
+        """Completely invalid export_type must raise ValidationError."""
+        from django.core.exceptions import ValidationError
+        with self.assertRaises(ValidationError):
+            _create_link(self.user, self.export_dir, export_type="nonexistent_type")


### PR DESCRIPTION
## Summary
- **SecureExportLink.clean()** now validates `export_type` against `EXPORT_TYPE_CHOICES` on every save, rejecting unknown values with a `ValidationError`
- **HTML rendering regression test** verifies that HTML exports use `html_outcome_report.html` (with styled stat-boxes) instead of the WeasyPrint PDF template
- **Export type validation test** confirms old enum values like `funder_report` are properly rejected

Follow-up from review session on PRs #345 and #346.

## Test plan
- [ ] Run `pytest tests/test_export_permissions.py` — new tests in sections 14 and 15 should pass
- [ ] Verify existing tests still pass (clean/save validation doesn't break existing flows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)