### PR TITLE
fix: handle missing ReportDeadline in migration 0018

### DIFF
--- a/apps/reports/migrations/0018_rename_funder_to_standard_report.py
+++ b/apps/reports/migrations/0018_rename_funder_to_standard_report.py
@@ -8,10 +8,13 @@ def rename_funder_to_standard(apps, schema_editor):
     SecureExportLink.objects.filter(export_type="funder_report").update(
         export_type="standard_report"
     )
-    ReportDeadline = apps.get_model("reports", "ReportDeadline")
-    ReportDeadline.objects.filter(report_type="funder_report").update(
-        report_type="standard_report"
-    )
+    try:
+        ReportDeadline = apps.get_model("reports", "ReportDeadline")
+        ReportDeadline.objects.filter(report_type="funder_report").update(
+            report_type="standard_report"
+        )
+    except LookupError:
+        pass  # ReportDeadline not yet created in this migration chain
 
 
 def rename_standard_to_funder(apps, schema_editor):
@@ -19,10 +22,13 @@ def rename_standard_to_funder(apps, schema_editor):
     SecureExportLink.objects.filter(export_type="standard_report").update(
         export_type="funder_report"
     )
-    ReportDeadline = apps.get_model("reports", "ReportDeadline")
-    ReportDeadline.objects.filter(report_type="standard_report").update(
-        report_type="funder_report"
-    )
+    try:
+        ReportDeadline = apps.get_model("reports", "ReportDeadline")
+        ReportDeadline.objects.filter(report_type="standard_report").update(
+            report_type="funder_report"
+        )
+    except LookupError:
+        pass  # ReportDeadline not yet created in this migration chain
 
 
 class Migration(migrations.Migration):


### PR DESCRIPTION
## Summary
Migration 0018 references `ReportDeadline` model which doesn't exist yet in the current migration chain, causing container startup to fail. Wraps the lookup in `try/except LookupError`.

## Test plan
- [ ] Container starts successfully on dev VPS
- [ ] Migration applies without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)