### PR TITLE
chore: pass OPENROUTER_MODEL env var through docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,7 @@ services:
       - EMAIL_HOST_USER=${EMAIL_HOST_USER:-}
       - EMAIL_HOST_PASSWORD=${EMAIL_HOST_PASSWORD:-}
       - OPENROUTER_API_KEY=${OPENROUTER_API_KEY:-}
+      - OPENROUTER_MODEL=${OPENROUTER_MODEL:-anthropic/claude-sonnet-4-20250514}
     ports:
       - "127.0.0.1:8000:8000"
     healthcheck:


### PR DESCRIPTION
## Summary
- Adds `OPENROUTER_MODEL` env var pass-through in docker-compose.yml so the AI model can be configured per environment
- Defaults to `anthropic/claude-sonnet-4-20250514` if not set

## Context
The dev VPS has been configured with `qwen/qwen3.5-35b-a3b` (matching the planned self-hosted LLM). Without this compose change, the model setting from `.env` was being ignored.

## Test plan
- [x] Verified on dev VPS: container sees correct model setting

Generated with [Claude Code](https://claude.com/claude-code)