### PR TITLE
feat: AI processing notice on admin Features page

### DIFF
--- a/apps/admin_settings/views.py
+++ b/apps/admin_settings/views.py
@@ -462,8 +462,15 @@ def features(request):
             "is_enabled": current_flags.get(key, default_state),
         })
 
+    # AI processing info for admin awareness
+    from django.conf import settings as django_settings
+    ai_key_set = bool(getattr(django_settings, "OPENROUTER_API_KEY", ""))
+    ai_model = getattr(django_settings, "OPENROUTER_MODEL", "")
+
     return render(request, "admin_settings/features.html", {
         "feature_rows": feature_rows,
+        "ai_key_set": ai_key_set,
+        "ai_model": ai_model,
     })
 
 

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -19601,3 +19601,20 @@ msgstr "Aucune suggestion trouvée pour ce programme."
 #: apps/notes/suggestion_views.py
 msgid "AI analysis could not be completed. Please try again."
 msgstr "L’analyse par IA n’a pu être complétée. Veuillez réessayer."
+
+#: templates/admin_settings/features.html
+msgid "AI Processing"
+msgstr "Traitement IA"
+
+#: templates/admin_settings/features.html
+msgid "AI requests are sent to <strong>OpenRouter</strong> (external API) using model: <code>%(model)s</code>."
+msgstr "Les demandes d’IA sont envoyées à <strong>OpenRouter</strong> (API externe) en utilisant le modèle : <code>%(model)s</code>."
+
+#: templates/admin_settings/features.html
+msgid "Data sent depends on which AI features are enabled below. Tools-only AI sends program metadata only (no personal information). Participant-data AI sends de-identified quotes."
+msgstr "Les données envoyées dépendent des fonctionnalités IA activées ci-dessous. L’IA outils uniquement envoie seulement les métadonnées du programme (aucune information personnelle). L’IA données des participants envoie des citations dé-identifiées."
+
+#: templates/admin_settings/features.html
+msgid "No AI API key is configured. AI features are unavailable even if enabled below."
+msgstr "Aucune clé API IA n’est configurée. Les fonctionnalités IA ne sont pas disponibles même si elles sont activées ci-dessous."
+

--- a/templates/admin_settings/features.html
+++ b/templates/admin_settings/features.html
@@ -13,6 +13,25 @@
 
 {% include "admin_settings/_page_help.html" with content=_('Feature toggles turn modules on or off for your whole organisation. Disabling a feature hides it from all users but preserves existing data. Some features depend on others — the confirmation dialog will show you the impact before you commit.') %}
 
+{# -- AI Processing Notice -- #}
+{% if ai_key_set %}
+<article style="background: var(--pico-card-background-color); border-left: 4px solid var(--pico-primary); padding: 1rem 1.25rem; margin-bottom: 1.5rem;">
+    <strong style="font-size: 1.1em;">{% trans "AI Processing" %}</strong>
+    <p style="margin: 0.5rem 0 0;">
+        {% blocktrans with model=ai_model %}AI requests are sent to <strong>OpenRouter</strong> (external API) using model: <code>{{ model }}</code>.{% endblocktrans %}
+        <br>
+        <small class="secondary">{% trans "Data sent depends on which AI features are enabled below. Tools-only AI sends program metadata only (no personal information). Participant-data AI sends de-identified quotes." %}</small>
+    </p>
+</article>
+{% else %}
+<article style="background: var(--pico-card-background-color); border-left: 4px solid var(--pico-del-color); padding: 1rem 1.25rem; margin-bottom: 1.5rem;">
+    <strong style="font-size: 1.1em;">{% trans "AI Processing" %}</strong>
+    <p style="margin: 0.5rem 0 0;">
+        {% trans "No AI API key is configured. AI features are unavailable even if enabled below." %}
+    </p>
+</article>
+{% endif %}
+
 <figure>
 <table role="grid" aria-label="{% trans 'Feature toggles' %}">
     <thead>


### PR DESCRIPTION
## Summary
- Adds a prominent banner on the admin Features page showing where AI requests are processed
- When API key is configured: shows "OpenRouter" + model name (e.g., `qwen/qwen3.5-35b-a3b`)
- When no API key: red banner warning that AI features are unavailable
- French translations included

## Why
Admins need to know at a glance which external service is processing their data. This is especially important for agencies subject to data residency requirements.

## Test plan
- [ ] Visit Admin > Features — banner should show OpenRouter + model name
- [ ] Remove API key — banner should show red "not configured" warning

Generated with [Claude Code](https://claude.com/claude-code)