### PR TITLE
🎨 Palette: Unified Copy to Clipboard UX

### DIFF
--- a/static/js/app.js
+++ b/static/js/app.js
@@ -188,6 +188,61 @@ document.body.addEventListener("htmx:configRequest", function (event) {
     });
 })();
 
+// --- Unified "Copy to Clipboard" utility ---
+// Attaches a click handler to any element with the class "copy-btn"
+(function () {
+    document.addEventListener("click", function (e) {
+        var btn = e.target.closest(".copy-btn");
+        if (!btn) return;
+        e.preventDefault();
+
+        var textToCopy = "";
+
+        // 1. Direct text via data attribute
+        if (btn.hasAttribute("data-clipboard-text")) {
+            textToCopy = btn.getAttribute("data-clipboard-text");
+        }
+        // 2. Read from a target element (input value or text content)
+        else if (btn.hasAttribute("data-clipboard-target")) {
+            var targetSelector = btn.getAttribute("data-clipboard-target");
+            // If it doesn't start with # or ., assume it's an ID
+            if (!targetSelector.startsWith("#") && !targetSelector.startsWith(".")) {
+                targetSelector = "#" + targetSelector;
+            }
+            var targetEl = document.querySelector(targetSelector);
+            if (targetEl) {
+                textToCopy = targetEl.tagName === "INPUT" || targetEl.tagName === "TEXTAREA"
+                    ? targetEl.value
+                    : targetEl.textContent;
+            }
+        }
+
+        if (!textToCopy) return;
+
+        // Perform the copy
+        navigator.clipboard.writeText(textToCopy).then(function () {
+            // Visual feedback
+            var originalText = btn.innerHTML;
+            // Use translation if available, fallback to "Copied!"
+            btn.textContent = t("copied", "Copied!");
+
+            // Temporary success styling
+            var originalColor = btn.style.color;
+            var originalBorder = btn.style.borderColor;
+            btn.style.color = "var(--kn-success-fg, #10B981)";
+            btn.style.borderColor = "var(--kn-success-fg, #10B981)";
+
+            setTimeout(function () {
+                btn.innerHTML = originalText;
+                btn.style.color = originalColor;
+                btn.style.borderColor = originalBorder;
+            }, 2000);
+        }).catch(function (err) {
+            console.error("Failed to copy: ", err);
+        });
+    });
+})();
+
 // --- Screen reader announcer for HTMX form success (IMPROVE-9) ---
 // When an HTMX POST succeeds, announce "Saved" to screen readers via #sr-announcer
 (function () {

--- a/templates/auth_app/invite_list.html
+++ b/templates/auth_app/invite_list.html
@@ -47,9 +47,12 @@
             </td>
             <td>
                 {% if invite.is_valid %}
-                <input type="text" readonly value="{{ request.scheme }}://{{ request.get_host }}/auth/join/{{ invite.code }}/"
-                       style="font-size: 0.8em; padding: 0.25em;" aria-label="{% trans 'Invite link' %}"
-                       onclick="this.select()">
+                <div style="display: flex; gap: 0.5rem; align-items: center;">
+                    <input type="text" id="invite-link-{{ invite.pk }}" readonly value="{{ request.scheme }}://{{ request.get_host }}/auth/join/{{ invite.code }}/"
+                           style="font-size: 0.8em; padding: 0.25em; margin-bottom: 0;" aria-label="{% trans 'Invite link' %}"
+                           onclick="this.select()">
+                    <button type="button" class="outline secondary copy-btn" data-clipboard-target="#invite-link-{{ invite.pk }}" aria-label="{% trans 'Copy invite link' %}" style="padding: 0.25em 0.5em; font-size: 0.8em; margin-bottom: 0;">{% trans "Copy" %}</button>
+                </div>
                 {% else %}
                     —
                 {% endif %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -377,6 +377,7 @@
         resultsLoaded: "{% trans 'Results loaded.' %}",
         selected: "{% trans 'selected' %}",
         "on this page": "{% trans 'on this page' %}",
+        copied: "{% trans 'Copied!' %}",
         confirm_this_value: "{% trans 'Confirm this value' %}",
         click_again_to_confirm: "{% trans 'Click again to confirm' %}",
         value_confirmed: "{% trans 'Value confirmed.' %}",

--- a/templates/registration/admin/link_embed.html
+++ b/templates/registration/admin/link_embed.html
@@ -35,7 +35,8 @@
         <div style="position: relative;">
             <pre style="padding: 1rem; background: var(--pico-secondary-background); border-radius: 0.25rem; overflow-x: auto; white-space: pre-wrap; word-wrap: break-word;"><code id="embed-code">{{ embed_code }}</code></pre>
             <button type="button"
-                    onclick="copyToClipboard('embed-code')"
+                    class="copy-btn"
+                    data-clipboard-target="#embed-code"
                     style="position: absolute; top: 0.5rem; right: 0.5rem;">
                 {% trans "Copy" %}
             </button>
@@ -55,7 +56,8 @@
                    readonly
                    style="padding-right: 5rem;">
             <button type="button"
-                    onclick="copyToClipboard('direct-url')"
+                    class="copy-btn"
+                    data-clipboard-target="#direct-url"
                     style="position: absolute; top: 0.25rem; right: 0.25rem;">
                 {% trans "Copy" %}
             </button>
@@ -107,32 +109,4 @@
     </footer>
 </article>
 
-<script>
-function copyToClipboard(elementId) {
-    const element = document.getElementById(elementId);
-    const text = element.tagName === 'INPUT' ? element.value : element.textContent;
-
-    navigator.clipboard.writeText(text).then(function() {
-        // Show brief feedback
-        const button = event.target;
-        const originalText = button.textContent;
-        button.textContent = '{% trans "Copied!" %}';
-        setTimeout(function() {
-            button.textContent = originalText;
-        }, 2000);
-    }).catch(function(err) {
-        // Fallback for older browsers
-        if (element.tagName === 'INPUT') {
-            element.select();
-        } else {
-            const range = document.createRange();
-            range.selectNode(element);
-            window.getSelection().removeAllRanges();
-            window.getSelection().addRange(range);
-        }
-        document.execCommand('copy');
-        window.getSelection().removeAllRanges();
-    });
-}
-</script>
 {% endblock %}

--- a/templates/registration/admin/link_form.html
+++ b/templates/registration/admin/link_form.html
@@ -14,7 +14,7 @@
     <p>
         <strong>{% trans "Registration URL:" %}</strong><br>
         <code id="registration-url">{{ request.scheme }}://{{ request.get_host }}{{ link.get_absolute_url }}</code>
-        <button type="button" class="outline secondary" style="margin-left: 0.5rem; padding: 0.25rem 0.5rem;" onclick="copyToClipboard()">{% trans "Copy" %}</button>
+        <button type="button" class="outline secondary copy-btn" data-clipboard-target="#registration-url" style="margin-left: 0.5rem; padding: 0.25rem 0.5rem;">{% trans "Copy" %}</button>
     </p>
 </article>
 {% endif %}
@@ -100,16 +100,4 @@
     </div>
 </form>
 
-{% if editing and link %}
-<script>
-function copyToClipboard() {
-    const url = document.getElementById('registration-url').textContent;
-    navigator.clipboard.writeText(url).then(function() {
-        alert('Link copied to clipboard!');
-    }, function() {
-        prompt('Copy this link:', url);
-    });
-}
-</script>
-{% endif %}
 {% endblock %}

--- a/templates/registration/admin/link_list.html
+++ b/templates/registration/admin/link_list.html
@@ -69,7 +69,7 @@
                         <li><a href="{% url 'registration:registration_link_edit' pk=link.pk %}">{% trans "Edit" %}</a></li>
                         <li><a href="{{ link.get_absolute_url }}" target="_blank">{% trans "View Form" %}</a></li>
                         <li><a href="{% url 'registration:registration_link_embed' pk=link.pk %}"><strong>{% trans "Get Embed Code" %}</strong></a></li>
-                        <li><a href="#" onclick="copyToClipboard('{{ request.scheme }}://{{ request.get_host }}{{ link.get_absolute_url }}'); return false;">{% trans "Copy Direct Link" %}</a></li>
+                        <li><a href="#" class="copy-btn" data-clipboard-text="{{ request.scheme }}://{{ request.get_host }}{{ link.get_absolute_url }}">{% trans "Copy Direct Link" %}</a></li>
                         <li><a href="{% url 'registration:submission_list' %}?link={{ link.pk }}">{% trans "View Submissions" %}</a></li>
                         <li><a href="{% url 'registration:registration_link_delete' pk=link.pk %}" class="secondary">{% trans "Delete" %}</a></li>
                     </ul>
@@ -89,13 +89,4 @@
 
 <a href="{% url 'admin_settings:dashboard' %}" role="button" class="outline">{% trans "Back to Settings" %}</a>
 
-<script>
-function copyToClipboard(text) {
-    navigator.clipboard.writeText(text).then(function() {
-        alert('{% trans "Link copied to clipboard!" %}');
-    }, function() {
-        prompt('{% trans "Copy this link:" %}', text);
-    });
-}
-</script>
 {% endblock %}

--- a/templates/surveys/admin/survey_links.html
+++ b/templates/surveys/admin/survey_links.html
@@ -62,7 +62,7 @@
                                aria-label="{% trans 'Survey link URL' %}"
                                style="margin-bottom:0">
                         <button type="button" class="outline secondary copy-btn"
-                                data-url="{{ request.scheme }}://{{ request.get_host }}/s/{{ link.token }}/"
+                                data-clipboard-text="{{ request.scheme }}://{{ request.get_host }}/s/{{ link.token }}/"
                                 style="margin-bottom:0; white-space:nowrap">{% trans "Copy" %}</button>
                     </div>
                 {% else %}
@@ -118,22 +118,6 @@
     </form>
 </article>
 
-<div id="copy-status" role="status" aria-live="polite"></div>
-
 <p><a href="{% url 'survey_manage:survey_detail' survey_id=survey.pk %}">&#8592; {% trans "Back to survey" %}</a></p>
 
-<script>
-document.addEventListener('DOMContentLoaded', function() {
-    document.querySelectorAll('.copy-btn').forEach(function(btn) {
-        btn.addEventListener('click', function() {
-            var url = this.dataset.url;
-            navigator.clipboard.writeText(url).then(function() {
-                var status = document.getElementById('copy-status');
-                status.textContent = '{% trans "Copied!" %}';
-                setTimeout(function() { status.textContent = ''; }, 2000);
-            });
-        });
-    });
-});
-</script>
 {% endblock %}


### PR DESCRIPTION
💡 What: Unified "Copy to Clipboard" functionality across the app with immediate local feedback, replacing scattered inline scripts that often relied on intrusive `alert()` or `prompt()`. Added a new "Copy" button to the Invite links page where one was missing.

🎯 Why: To reduce friction and provide consistent, accessible interactions when copying URLs. The old behavior required either manual selection (Ctrl+C) or triggered browser alerts which are annoying.

♿ Accessibility: The new "Copy" buttons include clear text and don't rely on alerts that interrupt screen reader flow. It instead provides inline text feedback ("Copied!") which updates the DOM.

---
*PR created automatically by Jules for task [7633786664188913977](https://jules.google.com/task/7633786664188913977) started by @pboachie*