### PR TITLE
fix: mobile Actions dropdown + softer goal form errors

### DIFF
--- a/apps/plans/forms.py
+++ b/apps/plans/forms.py
@@ -296,6 +296,7 @@ class GoalForm(forms.Form):
     )
     name = forms.CharField(
         max_length=255,
+        error_messages={"required": _("Please give this goal a short name.")},
         widget=forms.TextInput(attrs={
             "placeholder": _("e.g., Find stable housing"),
             "autocomplete": "off",
@@ -370,11 +371,11 @@ class GoalForm(forms.Form):
         if section_choice == "new" and not new_name:
             self.add_error(
                 "new_section_name",
-                _("Please enter a name for the new section."),
+                _("You chose to create a new section — please give it a name."),
             )
         elif not section_choice:
             raise forms.ValidationError(
-                _("Please select a section or create a new one.")
+                _("Please choose which area of the plan this goal belongs to.")
             )
 
         return cleaned

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -11967,6 +11967,18 @@ msgstr "Veuillez corriger les éléments suivants :"
 msgid "Please select a section or create a new one."
 msgstr "Veuillez sélectionner une section ou en créer une nouvelle."
 
+msgid "Almost there — a few things need your attention:"
+msgstr "Presque terminé — quelques éléments nécessitent votre attention :"
+
+msgid "You chose to create a new section — please give it a name."
+msgstr "Vous avez choisi de créer une nouvelle section — veuillez lui donner un nom."
+
+msgid "Please choose which area of the plan this goal belongs to."
+msgstr "Veuillez choisir à quelle section du plan cet objectif appartient."
+
+msgid "Please give this goal a short name."
+msgstr "Veuillez donner un nom court à cet objectif."
+
 msgid "Prefer to fill in the form yourself? Go to manual form"
 msgstr ""
 "Vous préférez remplir le formulaire vous-même? Aller au formulaire manuel"

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -3461,6 +3461,20 @@ article[aria-label="notification"].fading-out {
         flex-direction: column;
         align-items: flex-start;
     }
+    /* Keep goal-card dropdown menu within viewport on mobile */
+    .goal-card-actions .actions-dropdown {
+        position: static;
+    }
+    .goal-card-actions .actions-dropdown-menu {
+        position: relative;
+        left: auto;
+        right: auto;
+        min-width: 0;
+        width: 100%;
+        box-shadow: none;
+        border: 1px solid var(--kn-border-light);
+        margin-top: var(--kn-space-xs);
+    }
 }
 
 /* ---- Priority items mobile ---- */
@@ -4691,6 +4705,18 @@ article[aria-label="notification"].fading-out {
 }
 .error-summary ul { margin-bottom: 0; }
 .error-summary a { color: var(--kn-danger-fg); text-decoration: underline; }
+
+/* Softer form validation notice (amber instead of red) */
+.form-notice {
+    background: #fef9e7;
+    color: #6c5a1e;
+    border: 1px solid #f0d668;
+    border-radius: var(--pico-border-radius);
+    padding: var(--kn-space-sm) var(--kn-space-md);
+    margin-bottom: var(--kn-space-md);
+}
+.form-notice ul { margin-bottom: 0; }
+.form-notice a { color: #6c5a1e; text-decoration: underline; }
 
 /* Common goal cards — tappable quick-pick tiles */
 .goal-card-grid {

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -3359,6 +3359,8 @@ article[aria-label="notification"].fading-out {
         left: 0;
         right: 0;
         min-width: 0;
+        list-style: none;
+        padding-left: 0;
     }
 }
 
@@ -3474,6 +3476,8 @@ article[aria-label="notification"].fading-out {
         box-shadow: none;
         border: 1px solid var(--kn-border-light);
         margin-top: var(--kn-space-xs);
+        list-style: none;
+        padding-left: 0;
     }
 }
 
@@ -4515,11 +4519,14 @@ article[aria-label="notification"].fading-out {
         padding: 8px 0 !important;
     }
 
-    /* Actions dropdown menu items */
+    /* Actions dropdown menu items — flex-column keeps <small> descriptions
+       on their own line instead of running into the link text */
     .actions-dropdown-menu li a,
     .actions-dropdown-menu li button {
         display: flex !important;
-        align-items: center;
+        flex-direction: column;
+        align-items: flex-start;
+        justify-content: center;
         min-height: 44px !important;
         padding: 8px var(--kn-space-base, 16px) !important;
     }

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -3359,7 +3359,6 @@ article[aria-label="notification"].fading-out {
         left: 0;
         right: 0;
         min-width: 0;
-        list-style: none;
         padding-left: 0;
     }
 }
@@ -3476,7 +3475,6 @@ article[aria-label="notification"].fading-out {
         box-shadow: none;
         border: 1px solid var(--kn-border-light);
         margin-top: var(--kn-space-xs);
-        list-style: none;
         padding-left: 0;
     }
 }
@@ -4715,15 +4713,15 @@ article[aria-label="notification"].fading-out {
 
 /* Softer form validation notice (amber instead of red) */
 .form-notice {
-    background: #fef9e7;
-    color: #6c5a1e;
-    border: 1px solid #f0d668;
+    background: var(--kn-warning-bg);
+    color: var(--kn-warning-fg);
+    border: 1px solid var(--kn-warning-fg);
     border-radius: var(--pico-border-radius);
     padding: var(--kn-space-sm) var(--kn-space-md);
     margin-bottom: var(--kn-space-md);
 }
 .form-notice ul { margin-bottom: 0; }
-.form-notice a { color: #6c5a1e; text-decoration: underline; }
+.form-notice a { color: var(--kn-warning-fg); text-decoration: underline; }
 
 /* Common goal cards — tappable quick-pick tiles */
 .goal-card-grid {

--- a/templates/plans/goal_form.html
+++ b/templates/plans/goal_form.html
@@ -16,15 +16,15 @@
 </details>
 
 {% if form.errors %}
-<div class="error-summary" role="alert" id="error-summary" tabindex="-1">
-    <strong>{% trans "Please fix the following:" %}</strong>
+<div class="form-notice" role="alert" id="error-summary" tabindex="-1">
+    <strong>{% trans "Almost there — a few things need your attention:" %}</strong>
     <ul>
         {% for error in form.non_field_errors %}
         <li>{{ error }}</li>
         {% endfor %}
         {% for field in form %}
             {% if field.errors %}
-            <li><a href="#{{ field.id_for_label }}">{{ field.label }}: {{ field.errors.0 }}</a></li>
+            <li><a href="#{{ field.id_for_label }}">{{ field.errors.0 }}</a></li>
             {% endif %}
         {% endfor %}
     </ul>


### PR DESCRIPTION
## Summary
- **Actions dropdown on mobile**: On narrow screens (≤480px), the goal card Actions dropdown now renders inline instead of overflowing the viewport edge. Uses `position: static` / `position: relative` approach matching the existing client-header fix.
- **Goal form validation messages**: Replaced the alarming red error box with a softer amber notice. Heading changed from "Please fix the following:" to "Almost there — a few things need your attention:". Error messages now explain context without repeating field labels (e.g. "You chose to create a new section — please give it a name."). French translations included.

## Test plan
- [ ] On mobile (or narrow browser), open a participant's Plan tab and tap "Actions" on any goal — menu should display inline below the button, not overflow off-screen
- [ ] On the Add a Goal page, submit with missing goal name — error notice should be amber with friendly wording
- [ ] On the Add a Goal page, select "+ Create new section" but leave the name blank — error should say "You chose to create a new section — please give it a name."

🤖 Generated with [Claude Code](https://claude.com/claude-code)