### PR TITLE
feat: collapse sensitive demographic groups by default

### DIFF
--- a/apps/clients/admin.py
+++ b/apps/clients/admin.py
@@ -137,7 +137,7 @@ class ClientAccessBlockAdmin(admin.ModelAdmin):
 
 @admin.register(CustomFieldGroup)
 class CustomFieldGroupAdmin(admin.ModelAdmin):
-    list_display = ("title", "sort_order")
+    list_display = ("title", "sort_order", "collapsed_by_default")
 
 
 @admin.register(CustomFieldDefinition)

--- a/apps/clients/forms.py
+++ b/apps/clients/forms.py
@@ -330,7 +330,7 @@ class ClientTransferForm(forms.Form):
 class CustomFieldGroupForm(forms.ModelForm):
     class Meta:
         model = CustomFieldGroup
-        fields = ["title", "sort_order", "status"]
+        fields = ["title", "sort_order", "collapsed_by_default", "status"]
         labels = {
             "sort_order": _("Display order"),
         }

--- a/apps/clients/migrations/0038_customfieldgroup_collapsed_by_default.py
+++ b/apps/clients/migrations/0038_customfieldgroup_collapsed_by_default.py
@@ -1,0 +1,22 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("clients", "0037_customfielddefinition_show_on_create"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="customfieldgroup",
+            name="collapsed_by_default",
+            field=models.BooleanField(
+                default=False,
+                help_text=(
+                    "When checked, this group is collapsed on the participant info tab. "
+                    "Use for sensitive demographics that aren't needed for daily service delivery."
+                ),
+            ),
+        ),
+    ]

--- a/apps/clients/migrations/0039_set_demographics_collapsed.py
+++ b/apps/clients/migrations/0039_set_demographics_collapsed.py
@@ -1,0 +1,27 @@
+"""Set collapsed_by_default=True for the Demographics group.
+
+Sensitive demographic fields (gender identity, racial identity, etc.)
+should not be displayed by default on the participant info tab.
+"""
+from django.db import migrations
+
+
+def set_demographics_collapsed(apps, schema_editor):
+    CustomFieldGroup = apps.get_model("clients", "CustomFieldGroup")
+    CustomFieldGroup.objects.filter(title="Demographics").update(collapsed_by_default=True)
+
+
+def unset_demographics_collapsed(apps, schema_editor):
+    CustomFieldGroup = apps.get_model("clients", "CustomFieldGroup")
+    CustomFieldGroup.objects.filter(title="Demographics").update(collapsed_by_default=False)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("clients", "0038_customfieldgroup_collapsed_by_default"),
+    ]
+
+    operations = [
+        migrations.RunPython(set_demographics_collapsed, unset_demographics_collapsed),
+    ]

--- a/apps/clients/models.py
+++ b/apps/clients/models.py
@@ -708,6 +708,13 @@ class CustomFieldGroup(models.Model):
 
     title = models.CharField(max_length=255)
     sort_order = models.IntegerField(default=0)
+    collapsed_by_default = models.BooleanField(
+        default=False,
+        help_text=_(
+            "When checked, this group is collapsed on the participant info tab. "
+            "Use for sensitive demographics that aren't needed for daily service delivery."
+        ),
+    )
     status = models.CharField(
         max_length=20, default="active",
         choices=[("active", "Active"), ("archived", "Archived")],

--- a/templates/clients/_custom_fields_display.html
+++ b/templates/clients/_custom_fields_display.html
@@ -18,19 +18,21 @@
 
 {% for group in custom_data %}
 <section aria-labelledby="group-{{ group.group.pk }}">
-    <h3 id="group-{{ group.group.pk }}">{{ group.group.title }}</h3>
-    <dl class="info-grid-compact">
-        {% for item in group.fields %}
-        <div class="info-field{% if not item.is_editable %} view-only{% endif %}">
-            <dt>
-                {{ item.field_def.name }}
-                {% if not item.is_editable %}<small class="secondary">({% trans "view only" %})</small>{% endif %}
-                {% if item.field_def.is_sensitive %}<small class="secondary">({% trans "encrypted" %})</small>{% endif %}
-            </dt>
-            <dd>{{ item.display_value|default:item.value }}</dd>
-        </div>
-        {% endfor %}
-    </dl>
+    <details{% if not group.group.collapsed_by_default %} open{% endif %}>
+        <summary><h3 id="group-{{ group.group.pk }}" style="display: inline; margin: 0;">{{ group.group.title }}</h3></summary>
+        <dl class="info-grid-compact" style="margin-top: var(--kn-space-sm);">
+            {% for item in group.fields %}
+            <div class="info-field{% if not item.is_editable %} view-only{% endif %}">
+                <dt>
+                    {{ item.field_def.name }}
+                    {% if not item.is_editable %}<small class="secondary">({% trans "view only" %})</small>{% endif %}
+                    {% if item.field_def.is_sensitive %}<small class="secondary">({% trans "encrypted" %})</small>{% endif %}
+                </dt>
+                <dd>{{ item.display_value|default:item.value }}</dd>
+            </div>
+            {% endfor %}
+        </dl>
+    </details>
 </section>
 {% endfor %}
 

--- a/templates/clients/custom_fields_admin.html
+++ b/templates/clients/custom_fields_admin.html
@@ -20,6 +20,7 @@
     <header>
         <strong>{{ group.title }}</strong>
         {% if group.status == "archived" %}<span class="badge badge-neutral">{% trans "Archived" %}</span>{% endif %}
+        {% if group.collapsed_by_default %}<span class="badge badge-neutral">{% trans "Collapsed by default" %}</span>{% endif %}
         <span style="float: right;">
             <a href="{% url 'clients:custom_field_group_edit' group_id=group.pk %}">{% trans "Edit Group" %}</a>
         </span>


### PR DESCRIPTION
## Summary

- Adds a `collapsed_by_default` boolean to `CustomFieldGroup` so admins can control which field groups are expanded vs collapsed on the participant Info tab
- Wraps each custom field group in a `<details>` element — groups with `collapsed_by_default=True` render collapsed
- Data migration sets the "Demographics" group to collapsed by default
- Admin UI shows a "Collapsed by default" badge and the setting is exposed in the group edit form

## Why

Displaying sensitive demographic characteristics (gender identity, transgender experience, 2SLGBTQIA+ identity, racial identity, Indigenous identity) every time a staff person opens a participant file is clinically inappropriate. These fields are collected for reporting, not for daily service delivery. Service-relevant fields (preferred language, disability/accommodation needs, contact info) remain visible in their open groups.

Staff can still expand the Demographics section with one click when needed.

## Test plan

- [ ] Verify the Demographics group renders collapsed on a participant's Info tab
- [ ] Verify Contact Information and other groups render open
- [ ] Verify clicking the collapsed Demographics summary expands it
- [ ] Verify the Edit button still works and shows all groups expanded
- [ ] Verify the admin Custom Fields page shows "Collapsed by default" badge
- [ ] Verify editing a group shows the collapsed_by_default checkbox
- [ ] Run migrations on dev VPS

🤖 Generated with [Claude Code](https://claude.com/claude-code)