### PR TITLE
feat: redesign participant Progress Snapshot to per-goal status

### DIFF
--- a/apps/reports/insights_views.py
+++ b/apps/reports/insights_views.py
@@ -1,6 +1,7 @@
 """Views for Outcome Insights — program-level and client-level qualitative analysis."""
 import json
 import logging
+from collections import defaultdict
 
 from django.contrib.auth.decorators import login_required
 from django.http import HttpResponseForbidden
@@ -14,9 +15,10 @@ from apps.auth_app.decorators import requires_permission
 from apps.programs.access import get_client_or_403
 from apps.programs.models import UserProgramRole
 from apps.notes.models import (
-    ProgressNote, SuggestionLink, SuggestionTheme,
+    ProgressNote, ProgressNoteTarget, SuggestionLink, SuggestionTheme,
     THEME_PRIORITY_RANK, deduplicate_themes,
 )
+from apps.plans.models import PlanTarget
 from .insights import get_structured_insights, collect_quotes, MIN_PARTICIPANTS_FOR_QUOTES
 from .insights_forms import InsightsFilterForm
 from .interpretations import (
@@ -421,23 +423,30 @@ def client_insights_partial(request, client_id):
 
     data_tier = _get_data_tier(structured["note_count"], structured["month_count"])
 
-    # Per-goal current status for "How they're doing" section
-    from apps.plans.models import PlanTarget
-    from apps.notes.models import ProgressNoteTarget
-
+    # Per-goal current status for "How they're doing" section (2 queries)
     descriptor_labels = dict(ProgressNoteTarget.PROGRESS_DESCRIPTOR_CHOICES)
-    active_targets = PlanTarget.objects.filter(
-        client_file=client, status="default",
-    ).order_by("plan_section__name", "pk")
+    active_targets = list(
+        PlanTarget.objects.filter(client_file=client, status="default")
+        .order_by("plan_section__name", "pk")
+    )
+
+    # Bulk-fetch all descriptor entries for these targets in one query
+    all_entries = (
+        ProgressNoteTarget.objects
+        .filter(plan_target__in=active_targets, progress_descriptor__gt="")
+        .select_related("progress_note")
+        .order_by("plan_target_id", "-progress_note__created_at")
+    )
+    # Group by target, keep only the 2 most recent per target
+    by_target = defaultdict(list)
+    for entry in all_entries:
+        lst = by_target[entry.plan_target_id]
+        if len(lst) < 2:
+            lst.append(entry)
 
     goal_statuses = []
     for target in active_targets:
-        recent = list(
-            ProgressNoteTarget.objects
-            .filter(plan_target=target, progress_descriptor__gt="")
-            .select_related("progress_note")
-            .order_by("-progress_note__created_at")[:2]
-        )
+        recent = by_target.get(target.pk, [])
         if not recent:
             continue
 
@@ -459,11 +468,11 @@ def client_insights_partial(request, client_id):
             "is_first": previous is None,
         })
 
-    all_same_descriptor = (
-        len(goal_statuses) > 1
-        and len(set(g["descriptor_key"] for g in goal_statuses)) == 1
-    )
-    summary_line = goal_statuses[0]["descriptor_label"] if all_same_descriptor else ""
+    summary_line = ""
+    if len(goal_statuses) > 1:
+        descriptors = set(g["descriptor_key"] for g in goal_statuses)
+        if len(descriptors) == 1:
+            summary_line = goal_statuses[0]["descriptor_label"]
 
     # Client-level: no participant threshold, dates included
     quotes = collect_quotes(
@@ -512,7 +521,6 @@ def client_insights_partial(request, client_id):
         "quotes": other_quotes,
         "suggestions": suggestions,
         "goal_statuses": goal_statuses,
-        "all_same_descriptor": all_same_descriptor,
         "summary_line": summary_line,
         "data_tier": data_tier,
         "chart_data_json": structured["descriptor_trend"],

--- a/apps/reports/insights_views.py
+++ b/apps/reports/insights_views.py
@@ -421,6 +421,50 @@ def client_insights_partial(request, client_id):
 
     data_tier = _get_data_tier(structured["note_count"], structured["month_count"])
 
+    # Per-goal current status for "How they're doing" section
+    from apps.plans.models import PlanTarget
+    from apps.notes.models import ProgressNoteTarget
+
+    descriptor_labels = dict(ProgressNoteTarget.PROGRESS_DESCRIPTOR_CHOICES)
+    active_targets = PlanTarget.objects.filter(
+        client_file=client, status="default",
+    ).order_by("plan_section__name", "pk")
+
+    goal_statuses = []
+    for target in active_targets:
+        recent = list(
+            ProgressNoteTarget.objects
+            .filter(plan_target=target, progress_descriptor__gt="")
+            .select_related("progress_note")
+            .order_by("-progress_note__created_at")[:2]
+        )
+        if not recent:
+            continue
+
+        current = recent[0]
+        previous = recent[1] if len(recent) > 1 else None
+        current_label = str(descriptor_labels.get(current.progress_descriptor, ""))
+        show_previous = (
+            previous
+            and current.progress_descriptor != previous.progress_descriptor
+        )
+
+        goal_statuses.append({
+            "goal_name": target.name,
+            "descriptor_key": current.progress_descriptor,
+            "descriptor_label": current_label,
+            "note_id": current.progress_note_id,
+            "prev_label": str(descriptor_labels.get(previous.progress_descriptor, "")) if show_previous else "",
+            "prev_date": previous.progress_note.effective_date if show_previous else None,
+            "is_first": previous is None,
+        })
+
+    all_same_descriptor = (
+        len(goal_statuses) > 1
+        and len(set(g["descriptor_key"] for g in goal_statuses)) == 1
+    )
+    summary_line = goal_statuses[0]["descriptor_label"] if all_same_descriptor else ""
+
     # Client-level: no participant threshold, dates included
     quotes = collect_quotes(
         client_file=client,
@@ -467,6 +511,9 @@ def client_insights_partial(request, client_id):
         "structured": structured,
         "quotes": other_quotes,
         "suggestions": suggestions,
+        "goal_statuses": goal_statuses,
+        "all_same_descriptor": all_same_descriptor,
+        "summary_line": summary_line,
         "data_tier": data_tier,
         "chart_data_json": structured["descriptor_trend"],
         "ai_enabled": ai_enabled,

--- a/apps/reports/insights_views.py
+++ b/apps/reports/insights_views.py
@@ -425,8 +425,13 @@ def client_insights_partial(request, client_id):
 
     # Per-goal current status for "How they're doing" section (2 queries)
     descriptor_labels = dict(ProgressNoteTarget.PROGRESS_DESCRIPTOR_CHOICES)
+    user_program_ids = set(
+        UserProgramRole.objects.filter(user=request.user, status="active")
+        .values_list("program_id", flat=True)
+    )
     active_targets = list(
         PlanTarget.objects.filter(client_file=client, status="default")
+        .select_related("plan_section")
         .order_by("plan_section__name", "pk")
     )
 
@@ -458,11 +463,17 @@ def client_insights_partial(request, client_id):
             and current.progress_descriptor != previous.progress_descriptor
         )
 
+        # Only link to note if user has access to this goal's program
+        can_link = (
+            target.plan_section.program_id is None
+            or target.plan_section.program_id in user_program_ids
+        )
+
         goal_statuses.append({
             "goal_name": target.name,
             "descriptor_key": current.progress_descriptor,
             "descriptor_label": current_label,
-            "note_id": current.progress_note_id,
+            "note_id": current.progress_note_id if can_link else None,
             "prev_label": str(descriptor_labels.get(previous.progress_descriptor, "")) if show_previous else "",
             "prev_date": previous.progress_note.effective_date if show_previous else None,
             "is_first": previous is None,

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -19719,3 +19719,19 @@ msgstr "Les données envoyées dépendent des fonctionnalités IA activées ci-d
 msgid "No AI API key is configured. AI features are unavailable even if enabled below."
 msgstr "Aucune clé API IA n’est configurée. Les fonctionnalités IA ne sont pas disponibles même si elles sont activées ci-dessous."
 
+#: templates/reports/_insights_client.html
+msgid "How they’re doing"
+msgstr "Comment ça va"
+
+#: templates/reports/_insights_client.html
+msgid "All goals: %(desc)s"
+msgstr "Tous les objectifs : %(desc)s"
+
+#: templates/reports/_insights_client.html
+msgid "was:"
+msgstr "était :"
+
+#: templates/reports/_insights_client.html
+msgid "first assessment"
+msgstr "première évaluation"
+

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -4339,6 +4339,32 @@ article[aria-label="notification"].fading-out {
     border-radius: 0 var(--pico-border-radius) var(--pico-border-radius) 0;
 }
 
+/* ──── Per-goal status (participant analysis) ──── */
+.goal-status-list { margin: 0; padding: 0; }
+.goal-status-row {
+    display: flex;
+    gap: 0.5rem;
+    align-items: baseline;
+    margin-bottom: 0.75rem;
+    border: 0;
+}
+.goal-status-row dt { font-weight: 600; margin: 0; }
+.goal-status-row dd { margin: 0; }
+.goal-was { display: block; font-size: 0.85em; color: var(--kn-text-muted, #888); }
+.descriptor-dot {
+    display: inline-block;
+    width: 0.7em;
+    height: 0.7em;
+    border-radius: 50%;
+    margin-right: 0.3em;
+    vertical-align: middle;
+}
+.descriptor-dot--good_place { background: #27ae60; }
+.descriptor-dot--shifting { background: #3498db; }
+.descriptor-dot--holding { background: #f39c12; }
+.descriptor-dot--harder { background: #e74c3c; }
+.descriptor-summary { font-style: italic; margin-bottom: 0.5rem; }
+
 /* ──── Goal Builder ──── */
 .goal-builder {
     border: 1px solid var(--pico-muted-border-color);

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -4363,6 +4363,12 @@ article[aria-label="notification"].fading-out {
 .descriptor-dot--shifting { background: #3498db; }
 .descriptor-dot--holding { background: #f39c12; }
 .descriptor-dot--harder { background: #e74c3c; }
+@media (prefers-color-scheme: dark) {
+    .descriptor-dot--good_place { background: #2ecc71; }
+    .descriptor-dot--shifting { background: #5dade2; }
+    .descriptor-dot--holding { background: #f5b041; }
+    .descriptor-dot--harder { background: #ec7063; }
+}
 .descriptor-summary { font-style: italic; margin-bottom: 0.5rem; }
 
 /* ──── Goal Builder ──── */

--- a/templates/reports/_insights_client.html
+++ b/templates/reports/_insights_client.html
@@ -6,20 +6,36 @@
 
 {% if structured.note_count == 0 %}
 <p class="empty-state">{% trans "No notes recorded yet for this participant." %}</p>
-{% elif data_tier == "sparse" %}
+{% else %}
 
-{# Sparse: snapshot only #}
-{% if structured.descriptor_distribution %}
-<h3>{% trans "Progress Snapshot" %}</h3>
-<div class="descriptor-pills">
-    {% for label, pct in structured.descriptor_distribution.items %}
-    <span class="pill pill--descriptor">{{ label }}: {{ pct }}%</span>
-    {% endfor %}
+{# Per-goal current status #}
+{% if goal_statuses %}
+<h3>{% trans "How they're doing" %}</h3>
+{% if summary_line %}
+<p class="descriptor-summary">{% blocktrans with desc=summary_line %}All goals: {{ desc }}{% endblocktrans %}</p>
+{% endif %}
+<dl class="goal-status-list">
+{% for goal in goal_statuses %}
+<div class="goal-status-row">
+    <dt>
+        <span class="descriptor-dot descriptor-dot--{{ goal.descriptor_key }}" aria-hidden="true"></span>
+        <a href="{% url 'notes:note_detail' note_id=goal.note_id %}">{{ goal.goal_name }}</a>
+    </dt>
+    <dd>
+        {{ goal.descriptor_label }}
+        {% if goal.prev_label %}
+        <span class="goal-was">{% trans "was:" %} {{ goal.prev_label }}{% if goal.prev_date %} ({{ goal.prev_date }}){% endif %}</span>
+        {% elif goal.is_first %}
+        <span class="goal-was">({% trans "first assessment" %})</span>
+        {% endif %}
+    </dd>
 </div>
+{% endfor %}
+</dl>
 {% endif %}
 
+{% if data_tier == "sparse" %}
 <p class="insights-notice-inline">{% trans "More data needed for trend analysis." %}</p>
-
 {% else %}
 
 {# Trend chart #}
@@ -90,7 +106,9 @@
 {% endfor %}
 {% endif %}
 
-{% endif %}{# end data_tier #}
+{% endif %}{# end data_tier sparse/else #}
+
+{% endif %}{# end note_count #}
 </section>
 
 {# Chart.js for client descriptor trend #}

--- a/templates/reports/_insights_client.html
+++ b/templates/reports/_insights_client.html
@@ -19,7 +19,7 @@
 <div class="goal-status-row">
     <dt>
         <span class="descriptor-dot descriptor-dot--{{ goal.descriptor_key }}" aria-hidden="true"></span>
-        <a href="{% url 'notes:note_detail' note_id=goal.note_id %}">{{ goal.goal_name }}</a>
+        {% if goal.note_id %}<a href="{% url 'notes:note_detail' note_id=goal.note_id %}">{{ goal.goal_name }}</a>{% else %}{{ goal.goal_name }}{% endif %}
     </dt>
     <dd>
         {{ goal.descriptor_label }}

--- a/templates/reports/_insights_client.html
+++ b/templates/reports/_insights_client.html
@@ -24,7 +24,7 @@
     <dd>
         {{ goal.descriptor_label }}
         {% if goal.prev_label %}
-        <span class="goal-was">{% trans "was:" %} {{ goal.prev_label }}{% if goal.prev_date %} ({{ goal.prev_date }}){% endif %}</span>
+        <span class="goal-was">{% trans "was:" %} {{ goal.prev_label }}{% if goal.prev_date %} ({{ goal.prev_date|date:"M j" }}){% endif %}</span>
         {% elif goal.is_first %}
         <span class="goal-was">({% trans "first assessment" %})</span>
         {% endif %}

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -1496,3 +1496,106 @@ class ComplianceBannerIntegrationTests(TestCase):
         resp = self.http.get("/participants/executive/")
         self.assertEqual(resp.status_code, 200)
         self.assertNotContains(resp, "privacy-compliance-banner")
+
+
+@override_settings(FIELD_ENCRYPTION_KEY=TEST_KEY)
+class ClientInsightsPartialTest(TestCase):
+    """Tests for the participant-level insights HTMX partial (goal status view)."""
+
+    databases = {"default", "audit"}
+
+    def setUp(self):
+        import konote.encryption as enc_module
+        enc_module._fernet = None
+
+        from apps.auth_app.models import User
+        from apps.clients.models import ClientFile, ClientProgramEnrolment
+        from apps.notes.models import ProgressNote, ProgressNoteTarget
+        from apps.plans.models import PlanSection, PlanTarget
+        from apps.programs.models import Program, UserProgramRole
+
+        self.http = HttpClient()
+        self.user = User.objects.create_user(
+            username="worker", password="pass", display_name="Worker"
+        )
+        self.program = Program.objects.create(name="Support")
+        UserProgramRole.objects.create(
+            user=self.user, program=self.program, role=ROLE_STAFF, status="active"
+        )
+        self.client_file = ClientFile()
+        self.client_file.first_name = "Goal"
+        self.client_file.last_name = "Status"
+        self.client_file.save()
+        ClientProgramEnrolment.objects.create(
+            client_file=self.client_file, program=self.program, status="active"
+        )
+
+        section = PlanSection.objects.create(
+            client_file=self.client_file, name="Wellbeing", program=self.program,
+        )
+        self.target = PlanTarget.objects.create(
+            plan_section=section, client_file=self.client_file, name="Community",
+        )
+
+        # Create two notes with different descriptors
+        note1 = ProgressNote.objects.create(
+            client_file=self.client_file, author=self.user,
+            backdate=timezone.now() - timedelta(days=30),
+        )
+        ProgressNoteTarget.objects.create(
+            progress_note=note1, plan_target=self.target,
+            progress_descriptor="holding",
+        )
+        note2 = ProgressNote.objects.create(
+            client_file=self.client_file, author=self.user,
+            backdate=timezone.now() - timedelta(days=5),
+        )
+        ProgressNoteTarget.objects.create(
+            progress_note=note2, plan_target=self.target,
+            progress_descriptor="good_place",
+        )
+
+    def tearDown(self):
+        import konote.encryption as enc_module
+        enc_module._fernet = None
+
+    def _url(self):
+        return f"/reports/participant/{self.client_file.pk}/insights/"
+
+    def test_unauthenticated_redirects(self):
+        resp = self.http.get(self._url())
+        self.assertEqual(resp.status_code, 302)
+
+    def test_unauthorised_user_gets_403(self):
+        from apps.auth_app.models import User
+        User.objects.create_user(username="nobody", password="pass", display_name="Nobody")
+        self.http.login(username="nobody", password="pass")
+        resp = self.http.get(self._url())
+        self.assertEqual(resp.status_code, 403)
+
+    def test_happy_path_shows_goal_status(self):
+        self.http.login(username="worker", password="pass")
+        resp = self.http.get(self._url())
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, "How they")
+        self.assertContains(resp, "In a good place")
+
+    def test_shows_previous_descriptor_when_changed(self):
+        self.http.login(username="worker", password="pass")
+        resp = self.http.get(self._url())
+        self.assertContains(resp, "was:")
+        self.assertContains(resp, "Holding steady")
+
+    def test_empty_client_shows_empty_state(self):
+        from apps.clients.models import ClientFile, ClientProgramEnrolment
+        empty_cf = ClientFile()
+        empty_cf.first_name = "Empty"
+        empty_cf.last_name = "Client"
+        empty_cf.save()
+        ClientProgramEnrolment.objects.create(
+            client_file=empty_cf, program=self.program, status="active"
+        )
+        self.http.login(username="worker", password="pass")
+        resp = self.http.get(f"/reports/participant/{empty_cf.pk}/insights/")
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, "No notes recorded")


### PR DESCRIPTION
## Summary

- Replaces the meaningless aggregate percentage breakdown ("In a good place: 26.7%") on the participant Analysis tab with a **per-goal current-status view**
- Each goal shows its latest descriptor (with coloured dot), a link to the most recent note, and a "was: [previous]" line only when the descriptor changed
- Shows a summary line ("All goals: Holding steady") when all goals share the same descriptor
- Works with sparse data — even 1 note is useful (shows "first assessment")
- Program-level Insights page retains its aggregate view unchanged

## What changed

| File | Change |
|------|--------|
| `apps/reports/insights_views.py` | New per-goal status query in `client_insights_partial()` |
| `templates/reports/_insights_client.html` | Replaced pill percentages with `<dl>` per-goal layout |
| `static/css/main.css` | Styles for goal status rows and descriptor dots |
| `locale/fr/LC_MESSAGES/django.po` | French translations for new strings |

## Test plan

- [ ] Check participant with multiple goals and notes — each goal shows current descriptor + previous if changed
- [ ] Check participant with only 1 note — shows "(first assessment)"
- [ ] Check participant with no notes — section doesn't render
- [ ] Check program-level Insights page — aggregate pills still work unchanged
- [ ] Deploy to dev and visually verify on konote-dev.llewelyn.ca

🤖 Generated with [Claude Code](https://claude.com/claude-code)