### PR TITLE
fix: review follow-ups for demographic group collapsibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [Unreleased]
+
+### Changed
+
+**Demographics collapsed by default**
+- Sensitive demographic fields (gender identity, racial identity, LGBTQ+ status, Indigenous identity) are now collapsed behind a disclosure toggle on the participant Info tab. Staff can expand with one click when needed, but the data is no longer displayed every time a file is opened.
+- This is a clinical best-practice change — demographic data collected for equity reporting should not be surfaced during routine service interactions.
+- Admins can control which field groups are collapsed via Custom Fields settings (Admin → Custom Fields → Edit Group → "Collapsed by default" checkbox).
+- **Recommendation for agencies:** Consider moving Disability and Caregiver Status into a separate "Service Accommodations" group that stays open, since these fields are relevant to daily service delivery. This can be done in Admin → Custom Fields without any code changes.
+
+---
+
 ## [2.2.0] — 2026-02-18
 
 ### Added

--- a/apps/clients/forms.py
+++ b/apps/clients/forms.py
@@ -333,6 +333,7 @@ class CustomFieldGroupForm(forms.ModelForm):
         fields = ["title", "sort_order", "collapsed_by_default", "status"]
         labels = {
             "sort_order": _("Display order"),
+            "collapsed_by_default": _("Collapsed by default (display only — does not restrict access)"),
         }
 
 

--- a/apps/clients/models.py
+++ b/apps/clients/models.py
@@ -712,7 +712,8 @@ class CustomFieldGroup(models.Model):
         default=False,
         help_text=_(
             "When checked, this group is collapsed on the participant info tab. "
-            "Use for sensitive demographics that aren't needed for daily service delivery."
+            "Use for sensitive demographics that aren't needed for daily service delivery. "
+            "This is a display preference — it does not restrict access to the data."
         ),
     )
     status = models.CharField(

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -19719,3 +19719,15 @@ msgstr "Les données envoyées dépendent des fonctionnalités IA activées ci-d
 msgid "No AI API key is configured. AI features are unavailable even if enabled below."
 msgstr "Aucune clé API IA n’est configurée. Les fonctionnalités IA ne sont pas disponibles même si elles sont activées ci-dessous."
 
+#: templates/clients/custom_fields_admin.html
+msgid "Collapsed by default"
+msgstr "Réduit par défaut"
+
+#: apps/clients/models.py
+msgid "When checked, this group is collapsed on the participant info tab. Use for sensitive demographics that aren’t needed for daily service delivery. This is a display preference — it does not restrict access to the data."
+msgstr "Lorsque coché, ce groupe est réduit dans l’onglet d’information du participant. Utilisez cette option pour les données démographiques sensibles qui ne sont pas nécessaires pour la prestation quotidienne des services. Il s’agit d’une préférence d’affichage — cela ne restreint pas l’accès aux données."
+
+#: apps/clients/forms.py
+msgid "Collapsed by default (display only — does not restrict access)"
+msgstr "Réduit par défaut (affichage seulement — ne restreint pas l’accès)"
+

--- a/templates/clients/_tab_info.html
+++ b/templates/clients/_tab_info.html
@@ -139,24 +139,20 @@
 {# Additional details - only if client has middle name or custom data #}
 {% if client.middle_name or custom_data %}
 <section>
-    <details open>
-        <summary><h2 style="display: inline; font-size: 1rem; margin: 0;">{% trans "Details" %}</h2></summary>
-
-        {% if client.middle_name %}
-        <dl class="info-grid-compact" style="margin-top: var(--kn-space-base);">
-            <div class="info-field">
-                <dt>{% trans "Middle Name" %}</dt>
-                <dd>{{ client.middle_name }}</dd>
-            </div>
-        </dl>
-        {% endif %}
-
-        {% if custom_data %}
-        <div id="custom-fields-section">
-            {% include "clients/_custom_fields_display.html" %}
+    {% if client.middle_name %}
+    <dl class="info-grid-compact" style="margin-top: var(--kn-space-base);">
+        <div class="info-field">
+            <dt>{% trans "Middle Name" %}</dt>
+            <dd>{{ client.middle_name }}</dd>
         </div>
-        {% endif %}
-    </details>
+    </dl>
+    {% endif %}
+
+    {% if custom_data %}
+    <div id="custom-fields-section">
+        {% include "clients/_custom_fields_display.html" %}
+    </div>
+    {% endif %}
 </section>
 {% endif %}
 

--- a/tests/test_clients.py
+++ b/tests/test_clients.py
@@ -948,6 +948,37 @@ class MultiSelectFieldTest(TestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertContains(resp, "Black, South Asian")
 
+    def test_collapsed_group_renders_without_open(self):
+        """Groups with collapsed_by_default=True render <details> without open attribute."""
+        self.group.collapsed_by_default = True
+        self.group.save()
+        cdv = ClientDetailValue.objects.create(
+            client_file=self.cf, field_def=self.racial_field, value="White"
+        )
+        resp = self.client.get(
+            f"/participants/{self.cf.pk}/custom-fields/display/",
+            HTTP_HX_REQUEST="true",
+        )
+        self.assertEqual(resp.status_code, 200)
+        content = resp.content.decode()
+        # Collapsed group should have <details> without open
+        self.assertIn("<details>", content)
+        self.assertNotIn("<details open>", content)
+
+    def test_open_group_renders_with_open(self):
+        """Groups with collapsed_by_default=False render <details open>."""
+        self.group.collapsed_by_default = False
+        self.group.save()
+        cdv = ClientDetailValue.objects.create(
+            client_file=self.cf, field_def=self.racial_field, value="White"
+        )
+        resp = self.client.get(
+            f"/participants/{self.cf.pk}/custom-fields/display/",
+            HTTP_HX_REQUEST="true",
+        )
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, "<details open>")
+
 
 @override_settings(FIELD_ENCRYPTION_KEY=TEST_KEY)
 class ConsentRecordingTest(TestCase):


### PR DESCRIPTION
## Summary

Follow-up fixes from expert panel review of PR #359 (collapse sensitive demographic groups).

- **French translations** added for "Collapsed by default", form label, and model help text
- **Form label** now explicitly says "(display only — does not restrict access)" to prevent admins from misunderstanding this as a security control
- **Removed redundant outer `<details>` wrapper** from `_tab_info.html` — the outer "Details" accordion was always open and created confusing nested disclosure triangles now that each group has its own collapsibility
- **Tests added** for collapsed vs open group rendering (2 new test methods)
- **Changelog entry** with agency recommendation to move disability/caregiver status into a separate open "Service Accommodations" group

## Test plan

- [ ] Verify custom field groups render directly on the Info tab without the outer "Details" disclosure triangle
- [ ] Verify collapsed groups still work (Demographics collapsed, Contact Info open)
- [ ] Run `pytest tests/test_clients.py::MultiSelectFieldTest::test_collapsed_group_renders_without_open`
- [ ] Run `pytest tests/test_clients.py::MultiSelectFieldTest::test_open_group_renders_with_open`
- [ ] Verify French translation appears for Francophone admin users

🤖 Generated with [Claude Code](https://claude.com/claude-code)