### PR TITLE
fix: darken warning text colour for WCAG AA contrast

### DIFF
--- a/static/css/theme.css
+++ b/static/css/theme.css
@@ -24,7 +24,7 @@
     --kn-info-bg: #d1ecf1;
     --kn-info-fg: #0c5460;
     --kn-warning-bg: #fff3cd;
-    --kn-warning-fg: #856404;
+    --kn-warning-fg: #6c5a1e;   /* Darkened for WCAG AA (6.08:1 on #fff3cd) */
     --kn-danger-bg: #f8d7da;
     --kn-danger-fg: #842029;
     --kn-urgent: #c0392b;


### PR DESCRIPTION
## Summary
- Darkened `--kn-warning-fg` from `#856404` (4.96:1) to `#6c5a1e` (6.08:1) on warning background `#fff3cd`
- Previous value barely passed WCAG AA; new value provides comfortable margin
- No visible design change — slightly darker amber text
- Dark mode already excellent at 9.88:1 (unchanged)

## Context
Follow-up from PR #358 review panel recommendation.

## Test plan
- [ ] Verify `.form-notice` on goal creation form looks correct in light mode
- [ ] Verify warning-styled elements (alerts, notices) still readable in both themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)