### PR TITLE
chore: goal workflow redesign plan

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -2,7 +2,6 @@
 
 ## Flagged
 
-- [ ] Contact Common Approach to position KoNote as a pilot CIDS implementer — early engagement for co-marketing and advance notice of spec changes — GK (CIDS-CA-OUTREACH1)
 - [ ] To go live with demo survey: run `python manage.py seed_demo_survey` on konote-dev (PR #239 and #240 are now merged). The survey will be accessible at `/s/demo-program-feedback/` and the website demo page will embed it automatically — PB (DEMO-SURVEY1)
 
 ## Active Work
@@ -28,6 +27,46 @@ Step-by-step commands for each task are in [tasks/recurring-tasks.md](tasks/recu
 - [ ] **Redeploy to OVHcloud VPS** — after merging to main. SSH in and run `docker compose pull && docker compose up -d` (OPS-DEPLOY1)
 
 ## Coming Up
+
+### Phase: Goal Workflow Redesign (see tasks/goal-workflow-redesign.md)
+
+**Phase A — Fix the blockers**
+- [ ] Create dedicated `goal_create_from_suggestion` save endpoint (HTMX POST, no client-side form) with error handling (soft failure returns form, hard failure returns error card) — (GW-R1)
+- [ ] Auto-create sections silently using priority chain: match existing > match program-wide > AI suggestion > "General" — (GW-R2)
+- [ ] Rename "Shape this target" button to "Suggest a goal" with sparkle icon — (GW-R3)
+
+**Phase B — Suggestion card polish**
+- [ ] Demote "Suggested area" to secondary line on card — (GW-R4)
+- [ ] Default custom metric to included; remove Include/Skip from card; show in success message — (GW-R5)
+- [ ] Rename "Let me edit it" to "Let me review first" — (GW-R6)
+- [ ] Hide entry points after suggestion loads; "Start over" restores them — (GW-R7)
+- [ ] Store suggestion in server-side session, pass reference token to client — (GW-R19)
+- [ ] Animated loading bar with text rotation for AI wait — (GW-T5)
+
+**Phase C — Form improvements ("Let me review first" path)**
+- [ ] Reorder form: participant words > goal name > description (collapsible) > metrics > section (last) — (GW-R8)
+- [ ] Section picker: pre-select most recent; pre-fill AI suggestion; auto-create if empty — (GW-R9)
+- [ ] Add reassurance near submit: "You can revise this goal later" — (GW-R10)
+- [ ] Unify AI/non-AI form HTML into single form, remove SYNC duplication — (GW-T4)
+
+**Phase D — Entry point tuning**
+- [ ] Conditional layout: quick pick first if 3+ common goals, AI first otherwise — (GW-R11)
+- [ ] Increase textarea to rows=3 with CSS min-height — (GW-R12)
+- [ ] Move onboarding hint to contextual help icon on entry point — (GW-R13)
+- [ ] Persistent participant-words blockquote throughout flow — (GW-R21)
+- [ ] Quick pick prompts for participant's words after selection — (GW-R22)
+- [ ] Relabel metric tiers with clinical language — (GW-R23)
+- [ ] Add "Why this suggestion" collapsible with AI reasoning — (GW-R24)
+
+**Phase E — Accessibility fixes**
+- [ ] Fix aria-label: "AI-suggested goal" not "target" — (GW-R14)
+- [ ] Add aria-label to custom metric pre block — (GW-R15)
+- [ ] Change #form-announce to aria-live="assertive" — (GW-R16)
+- [ ] Add "Saving your goal..." screen reader announcement — (GW-R17)
+- [ ] Add hx-sync="this:abort" to shape button — (GW-R18)
+
+**Phase F — Program setup (longer-term)** — GK reviews domain section templates
+- [ ] Pre-seed programs with domain section templates at program setup — (GW-R20)
 
 ### Phase: Session 7 Prep — Admin UX & Configuration
 

--- a/tasks/goal-workflow-implementation-prompt.md
+++ b/tasks/goal-workflow-implementation-prompt.md
@@ -1,0 +1,263 @@
+# Goal Workflow Redesign — Implementation Prompt
+
+**Use this prompt in a fresh Claude Code session (close other sessions first).**
+**Estimated: 2 sessions. Session 1 = Phases A+B+E. Session 2 = Phases C+D.**
+
+Read `tasks/goal-workflow-redesign.md` for the full design rationale, dependency graph, and technical details.
+
+---
+
+## Session 1: Phases A + B + E (Blockers, Card Polish, Accessibility)
+
+### Pre-flight
+
+```
+git pull origin develop
+git worktree prune
+git status
+```
+
+Create a feature branch: `feat/goal-workflow-redesign`
+
+### Overview
+
+The assisted goal creation workflow has critical UX problems. Read these files first to understand the current state:
+
+- `templates/plans/goal_form.html` — main page (entry points, form, all JS)
+- `templates/plans/_ai_suggestion.html` — HTMX partial for AI suggestion card
+- `konote/ai_views.py` — `suggest_target_view()` (lines ~217-294)
+- `apps/plans/views.py` — `goal_create()` and `_create_goal()`
+- `apps/plans/forms.py` — `GoalForm` (lines ~284-381)
+- `apps/plans/urls.py`
+- `tasks/goal-workflow-redesign.md` — full design document
+
+### Agent Plan — 3 parallel agents, then sequential integration
+
+**IMPORTANT:** Phases A and B have dependencies (R1 must exist before R5, R19 can build on R1). Use this execution order:
+
+#### Step 1: Launch 3 agents in parallel
+
+**Agent 1: Backend — New save endpoint + section auto-create (R1, R1a, R2)**
+
+Task: Create a new view `goal_create_from_suggestion` in `apps/plans/views.py` and wire it up in `apps/plans/urls.py`.
+
+Requirements:
+- URL: `participant/<int:client_id>/goals/save-suggestion/` named `plans:goal_save_suggestion`
+- Accepts POST with `suggestion_key` (string) and `client_id`
+- Retrieves validated suggestion from `request.session[suggestion_key]` using `session.pop()`
+- If suggestion not found: return `render(request, "plans/_goal_save_error.html", {"error": "...", "client": client})`
+- Permission checks: same as `goal_create` — `get_client_or_403`, `_can_edit_plan`
+- Section resolution using priority chain (see design doc for detail):
+  1. Match AI's `suggested_section` against existing sections on THIS participant (case-insensitive)
+  2. Match against sections used by OTHER participants in the same program (case-insensitive) — use that name
+  3. Create new section with AI's suggested name
+  4. Fall back to "General" if no suggestion
+- Create goal using existing `_create_goal()` helper
+- Handle custom metric: if `custom_metric` present in suggestion, create `MetricDefinition` with `category="custom"`, `is_library=False`, `owning_program=program`
+- On success: set `messages.success` with goal name and metric names (if custom metric: include name + link hint). Return `HttpResponse(status=204)` with `HX-Redirect` header to `plans:plan_view`
+- On validation error: return rendered form (reuse `GoalForm` pre-populated from suggestion data) with error banner
+- CSRF: the template will include a CSRF token via `hx-headers`
+- Create template `templates/plans/_goal_save_error.html` — simple error card with retry button and "fill in manually" link
+
+Also modify `konote/ai_views.py` `suggest_target_view()` (around line 276):
+- After validating the AI response, store it in the session:
+  ```python
+  from uuid import uuid4
+  suggestion_key = f"goal_suggestion_{client_id}_{uuid4().hex[:8]}"
+  request.session[suggestion_key] = result
+  ```
+- Pass `suggestion_key` to the template context (alongside existing `suggestion_json` for the "Let me review" path)
+
+Write tests in `tests/test_plans.py`:
+- `test_goal_save_suggestion_happy_path`
+- `test_goal_save_suggestion_expired_key`
+- `test_goal_save_suggestion_auto_section_match_existing`
+- `test_goal_save_suggestion_auto_section_match_program`
+- `test_goal_save_suggestion_auto_section_fallback`
+- `test_goal_save_suggestion_custom_metric`
+- `test_goal_save_suggestion_permission_denied`
+
+**Agent 2: Template — Suggestion card redesign (R3, R4, R5, R6, R7, R14, R15, R19-frontend, R1b, T-5)**
+
+Task: Update `templates/plans/_ai_suggestion.html` and the relevant parts of `templates/plans/goal_form.html`.
+
+Changes to `_ai_suggestion.html`:
+- The "Use this suggestion" button becomes an HTMX POST button:
+  ```html
+  <button type="button"
+          id="btn-use-suggestion"
+          hx-post="{% url 'plans:goal_save_suggestion' client_id=client.pk %}"
+          hx-include="[name=csrfmiddlewaretoken]"
+          hx-target="#suggestion-container"
+          hx-swap="innerHTML"
+          hx-indicator="#save-loading"
+          hx-disabled-elt="this"
+          data-suggestion-key="{{ suggestion_key }}">
+      {% trans "Use this suggestion" %}
+  </button>
+  ```
+  Note: `suggestion_key` is passed via `hx-vals` or a hidden input. Include CSRF token.
+  Add a hidden input: `<input type="hidden" name="suggestion_key" value="{{ suggestion_key }}">`
+  Add a hidden CSRF token inside the card (since it's not in a form): `{% csrf_token %}`
+- Add loading state element inside card: `<div id="save-loading" class="htmx-indicator"><small>Saving your goal...</small></div>`
+- Keep `data-suggestion="{{ suggestion_json }}"` on `btn-edit-suggestion` (the "Let me review first" button still populates the form client-side)
+- Rename "Let me edit it" to "Let me review first" (R6)
+- Fix `aria-label`: "AI-suggested goal" not "AI-suggested target" (R14)
+- Demote "Suggested area": move it from a `<dt>/<dd>` pair to a `<small class="secondary">` line at the bottom of the card, before the action buttons (R4)
+- Custom metric (R5): Remove the "Include this metric" / "Skip" buttons. Instead, show metric name and a brief note: "This custom scale will be added to the goal." Add a small "Remove" link that sets a hidden field. Default `custom-metric-accepted` conceptually to true (the save endpoint includes it unless explicitly removed)
+- Add `aria-label="Scale definition, 1 to 5"` on the custom metric `<pre>` block (R15)
+- Add screen reader announcement div: `<div aria-live="assertive" class="sr-only" id="save-announce"></div>` (R17)
+
+Changes to `templates/plans/goal_form.html`:
+- Rename button text: "Shape this target" -> "Suggest a goal" (R3)
+- Add sparkle SVG icon inline before the text (small, 16x16, use a simple path — no external dependency)
+- Add `hx-sync="this:abort"` to the shape button (R18)
+- In JS `htmx:afterSwap` handler: after suggestion card loads, hide `#entry-points` (R7). In "Start over" handler: show `#entry-points` again.
+- In JS: Add handler for `htmx:beforeRequest` on save button to announce "Saving your goal..." to `#save-announce`
+- Loading bar animation (T-5): Add CSS keyframe animation to `.loading-bar`. Add JS timeout that changes loading text after 4 seconds: "Working on a suggestion..." -> "Almost there..."
+- Change `#form-announce` from `aria-live="polite"` to `aria-live="assertive"` (R16)
+
+Update French translations: run `python manage.py translate_strings` after template changes, then fill new entries in `locale/fr/LC_MESSAGES/django.po`.
+
+**Agent 3: Accessibility quick fixes (R16, R18 — if not already done by Agent 2)**
+
+This agent is small — if Agent 2 covers R14-R18, this agent is not needed. Instead, use Agent 3 for:
+
+Task: Write the CSS additions needed for all visual changes.
+
+In `static/css/` (find the relevant stylesheet — likely `pico-overrides.css` or `app.css`):
+- Sparkle icon styling: `.btn-sparkle-icon { width: 1em; height: 1em; vertical-align: -0.1em; margin-right: 0.3em; }`
+- Loading bar animation: `@keyframes loading-pulse { 0%, 100% { opacity: 0.4; } 50% { opacity: 1; } }` applied to `.loading-bar`
+- Save loading indicator styling
+- Suggestion card: ensure `.suggestion-actions` buttons stack on mobile (`@media (max-width: 576px) { flex-direction: column; }`)
+- Custom metric card styling (replace `<pre>` look with a cleaner scale card if feasible)
+- `.ai-suggestion-card` loading overlay state
+
+#### Step 2: Sequential integration
+
+After all 3 agents complete:
+1. Review all changes for consistency
+2. Run `python manage.py translate_strings` and fill French translations
+3. Run `pytest tests/test_plans.py -v` on VPS
+4. Commit, push, create PR to develop, merge
+
+---
+
+## Session 2: Phases C + D (Form Improvements, Entry Point Tuning)
+
+### Pre-flight
+
+```
+git pull origin develop
+```
+
+Create branch: `feat/goal-workflow-form-improvements`
+
+### Agent Plan — 2 parallel agents
+
+**Agent 1: Form restructuring (R8, R9, R10, T-4)**
+
+Task: Restructure `templates/plans/goal_form.html` form section and `apps/plans/forms.py`.
+
+R8 — Reorder form fields:
+- In `GoalForm`, change `field_order` to: `["client_goal", "name", "description", "metrics", "section_choice", "new_section_name"]`
+- In the template, reorder the fieldsets to match: participant words -> goal name -> description -> metrics -> section picker
+- Wrap description in a `<details open>` when pre-filled by AI, `<details>` (collapsed) when empty
+
+R9 — Section picker improvements:
+- When rendering section choices, if sections exist, pre-select the most recently created one (add ordering in `GoalForm.__init__`)
+- When the form is shown via "Let me review first" with AI data, if section_choice is "new" and AI suggested a name, show it as a pre-filled text input (not a dropdown with only "new")
+- In `GoalForm.clean()`: if `section_choice == "new"` and `new_section_name` is blank, instead of raising an error, set `new_section_name` to "General" (or the program name if available). Remove the "You chose to create a new section" error.
+
+R10 — Add reassurance text:
+- Before the submit button div, add: `<p class="secondary"><small>{% trans "You can revise this goal later as things become clearer." %}</small></p>`
+
+T-4 — Unify form HTML:
+- Currently there are TWO form structures: one for AI-enabled (lines ~361-568) and one for non-AI (lines ~111-358 roughly). They have SYNC comments.
+- Merge them into a SINGLE `<form>` element. The AI path hides it initially (`hidden` attribute, removed by JS). The non-AI path shows it immediately.
+- The only AI-specific elements above the form are: entry points div, suggestion container. These are already outside the form.
+- Remove the duplicated fieldsets. If the non-AI path has a "Phase 1 / Phase 2" concept, simplify it: Phase 1 is the entry points (same as AI path but without the AI button — just a textarea + "Next" that reveals the form).
+
+**Agent 2: Entry point tuning (R11, R12, R13, R21, R22, R23, R24)**
+
+Task: Update entry points and suggestion display in `templates/plans/goal_form.html` and `templates/plans/_ai_suggestion.html`.
+
+R11 — Conditional layout:
+- In `apps/plans/views.py` `goal_create()`, add `quick_pick_first = len(common_goals) >= 3` to context
+- In template: `{% if quick_pick_first %}` show quick pick fieldset before AI fieldset, `{% else %}` show AI first (current order)
+
+R12 — Textarea size:
+- Change `rows="2"` to `rows="3"` on `#participant-words`
+- Add CSS: `#participant-words { min-height: 4.5em; }`
+
+R13 — Move onboarding hint:
+- Remove the `<details class="onboarding-hint">` from the top of the page
+- Add a help icon (info circle) next to the AI entry legend text with a tooltip containing the same content
+- Use `title` attribute or a Pico CSS tooltip pattern
+
+R21 — Persistent participant words:
+- In the form (when revealed by "Let me review first"), show a blockquote at the top with the participant's words:
+  ```html
+  <blockquote id="participant-echo" class="participant-words-echo" hidden>
+      <small class="secondary">{% trans "In their words:" %}</small>
+      <em id="participant-echo-text"></em>
+  </blockquote>
+  ```
+- In `revealForm()` JS: populate and show this blockquote from the `client_goal` field value
+- Style it subtly — not a full blockquote, more like a small italic reference
+
+R22 — Quick pick words prompt:
+- After clicking a quick pick card, instead of immediately revealing the form, show a brief prompt:
+  ```html
+  <div id="quick-pick-words" hidden>
+      <label>{% blocktrans with client=term.client %}What did {{ client }} say about this?{% endblocktrans %}</label>
+      <textarea name="quick_pick_words" rows="2" placeholder="{% trans 'Optional — in their own words...' %}"></textarea>
+      <button type="button" id="btn-continue-quick-pick">{% trans "Continue" %}</button>
+  </div>
+  ```
+- "Continue" copies words to `client_goal` field and reveals the form
+- Make the textarea optional (placeholder says "Optional") so it's not a blocker
+
+R23 — Metric tier labels:
+- Change "Recommended" -> "Recommended for all participants"
+- Change "Used in this program" -> "Commonly used for goals like this"
+- Change "All available metrics" -> "Browse all metrics"
+
+R24 — "Why this suggestion":
+- In `_ai_suggestion.html`, after the metrics list, add:
+  ```html
+  {% if suggestion.metrics %}
+  <details class="why-suggestion">
+      <summary><small>{% trans "Why these metrics?" %}</small></summary>
+      <ul>
+          {% for m in suggestion.metrics %}
+          {% if m.reason %}<li><strong>{{ m.name }}:</strong> {{ m.reason }}</li>{% endif %}
+          {% endfor %}
+      </ul>
+  </details>
+  {% endif %}
+  ```
+
+After both agents complete:
+1. Run translations
+2. Test on VPS
+3. Commit, push, PR, merge
+
+---
+
+## Checklist Before Declaring Done
+
+- [ ] "Suggest a goal" button with sparkle icon works and calls AI
+- [ ] "Use this suggestion" saves directly via HTMX POST — no form shown
+- [ ] New participant with no sections: goal saves without section name prompt
+- [ ] Returning participant: existing section matched correctly
+- [ ] Custom metric included by default, visible in success message
+- [ ] "Let me review first" shows pre-populated form with correct field order
+- [ ] Section picker is last field in form, pre-filled, non-blocking
+- [ ] Entry points hide after suggestion loads
+- [ ] Loading states work (AI wait + save)
+- [ ] Screen reader announcements present for key state changes
+- [ ] French translations filled for all new strings
+- [ ] All existing `test_plans.py` tests pass
+- [ ] New tests for save endpoint pass
+- [ ] Mobile: suggestion card and buttons render correctly at 375px width

--- a/tasks/goal-workflow-redesign.md
+++ b/tasks/goal-workflow-redesign.md
@@ -1,0 +1,138 @@
+# Goal Workflow Redesign — Assisted Target & Metric Definition
+
+**Created:** 2026-03-06
+**Expert panel:** UX Designer, Interaction Designer, Service Design Consultant, Frontend Architect, Evaluation Methodologist
+**DRR:** None yet (create after implementation if warranted)
+
+## Problem Statement
+
+The assisted goal creation workflow is KoNote's central workflow. Current pain points:
+
+1. **Section name blocker** — After accepting a good AI suggestion, the user is dumped onto a form that demands a section name. For new participants with no plan, the only option is "+ Create new section" which requires typing a name. This is a complete blocker.
+2. **Unclear button** — "Shape this target" uses jargon ("target") when the page says "Add a Goal." No icon signals it's AI-powered.
+3. **Too much friction** — The "Use this suggestion" path tries to auto-submit a hidden form. When validation fails (section name), the user sees a form they didn't expect with a field they don't understand.
+4. **Cognitive overload** — The suggestion card shows 6 fields simultaneously. The custom metric is presented as a `<pre>` block requiring clinical evaluation during a time-pressured session.
+
+## Recommendations by Phase
+
+### Phase A — Fix the blockers (do first)
+
+| ID | Recommendation | Files to change |
+|----|---------------|----------------|
+| R1 | Create dedicated `goal_create_from_suggestion` endpoint. "Use this suggestion" fires HTMX POST directly — no client-side form, no auto-submit. Server creates goal + section + metrics in one transaction. Returns `HX-Redirect` on success. | `apps/plans/views.py`, `apps/plans/urls.py`, `templates/plans/_ai_suggestion.html`, `templates/plans/goal_form.html` |
+| R1a | Soft failure (validation error) returns pre-populated form with error banner. Hard failure returns error card with retry + manual fallback. | `apps/plans/views.py`, new template `_goal_save_error.html` |
+| R1b | Suggestion card stays visible with "Saving..." loading state during save. Button shows `hx-disabled-elt`, card gets loading overlay. | `templates/plans/_ai_suggestion.html`, CSS |
+| R2 | Auto-create sections using priority chain: (1) program templates if they exist, (2) match existing section on this participant, (3) match section name used by other participants in same program, (4) use AI's suggestion, (5) fall back to "General". Never ask user for section name on happy path. | `apps/plans/views.py` (`_create_goal` + new endpoint) |
+| R3 | Rename button: "Shape this target" -> "Suggest a goal" with sparkle SVG icon. | `templates/plans/goal_form.html`, CSS, translations |
+
+### Phase B — Suggestion card polish
+
+| ID | Recommendation | Files to change |
+|----|---------------|----------------|
+| R4 | Demote "Suggested area" to secondary line at bottom of card (not a full dt/dd pair). | `templates/plans/_ai_suggestion.html` |
+| R5 | Default custom metric to "included." Remove Include/Skip buttons from card. Show metric name in post-save success message with link to review scale details. | `templates/plans/_ai_suggestion.html`, `templates/plans/goal_form.html` (JS), `apps/plans/views.py` |
+| R6 | Rename "Let me edit it" -> "Let me review first". | `templates/plans/_ai_suggestion.html`, translations |
+| R7 | Hide `#entry-points` after suggestion card loads via `htmx:afterSwap`. "Start over" brings them back. | `templates/plans/goal_form.html` (JS) |
+| R19 | Store validated suggestion in session (server-side). Pass only a reference token to the client. Save endpoint retrieves from session. Avoids JSON roundtrip and escaping issues. | `konote/ai_views.py`, new save endpoint, `templates/plans/_ai_suggestion.html` |
+| T-5 | Animated loading bar with text rotation ("Working on a suggestion..." -> "Almost there..." after 4s). | CSS, `templates/plans/goal_form.html` |
+
+### Phase C — Form improvements ("Let me review first" path)
+
+| ID | Recommendation | Files to change |
+|----|---------------|----------------|
+| R8 | Reorder form fields: participant words (editable) -> goal name -> description (collapsible, pre-filled) -> metrics (show selected count, expandable) -> section (last, least important). | `templates/plans/goal_form.html`, `apps/plans/forms.py` (`field_order`) |
+| R9 | Section picker: pre-select most recent for returning participants. For new participants, pre-fill AI suggestion (editable text, not dropdown with only "new"). Remove validation error for empty section — auto-create with default. | `apps/plans/forms.py`, `templates/plans/goal_form.html` |
+| R10 | Add reassurance near submit: "You can revise this goal later as things become clearer." | `templates/plans/goal_form.html`, translations |
+| T-4 | Unify AI/non-AI form HTML into single `<form>` with conditional display. Remove SYNC-comment duplication. AI path hides form initially; non-AI shows it. Entry points + suggestion card are the only AI-specific additions. | `templates/plans/goal_form.html` |
+
+### Phase D — Entry point tuning
+
+| ID | Recommendation | Files to change |
+|----|---------------|----------------|
+| R11 | Conditional layout: show quick pick first if `common_goals|length >= 3`, AI textarea first otherwise. | `templates/plans/goal_form.html`, `apps/plans/views.py` (context) |
+| R12 | Increase textarea to `rows="3"` with CSS `min-height`. | `templates/plans/goal_form.html`, CSS |
+| R13 | Move onboarding hint ("What is a goal?") from page top to contextual help icon/tooltip on the AI entry point. | `templates/plans/goal_form.html` |
+| R21 | Persistent participant-words blockquote throughout flow — visible on suggestion card and form, anchoring caseworker to participant's voice. | `templates/plans/goal_form.html`, `templates/plans/_ai_suggestion.html` |
+| R22 | Quick pick prompts for participant's words after card selection: "What did [name] say about this?" | `templates/plans/goal_form.html` (JS) |
+| R23 | Relabel metric tiers: "Recommended for all participants" / "Commonly used for goals like this" / "Browse all metrics". | `templates/plans/goal_form.html`, translations |
+| R24 | Add collapsible "Why this suggestion" section on card showing AI's metric selection reasoning. | `templates/plans/_ai_suggestion.html` |
+
+### Phase E — Accessibility fixes
+
+| ID | Recommendation | Files to change |
+|----|---------------|----------------|
+| R14 | Fix `aria-label` on suggestion card: "AI-suggested goal" (not "target"). | `templates/plans/_ai_suggestion.html` |
+| R15 | Add `aria-label` to custom metric `<pre>` block (or replace with semantic HTML). | `templates/plans/_ai_suggestion.html` |
+| R16 | Change `#form-announce` to `aria-live="assertive"` for error messages. | `templates/plans/goal_form.html` |
+| R17 | Add "Saving your goal..." screen reader announcement on save submission. | `templates/plans/goal_form.html` |
+| R18 | Add `hx-sync="this:abort"` to shape button to prevent double-submission. | `templates/plans/goal_form.html` |
+
+### Phase F — Program setup (longer-term)
+
+| ID | Recommendation | Files to change |
+|----|---------------|----------------|
+| R20 | Pre-seed programs with domain section templates (housing, employment, health, social, etc.) at program setup. New participants get sections from template. Admin UI to manage. | `apps/programs/models.py`, `apps/programs/admin_views.py`, `apps/plans/views.py`, admin templates |
+
+## Implementation Dependencies
+
+```
+R1 ──> R1a (error handling)
+R1 ──> R1b (loading state)
+R1 ──> R2 (section auto-create in save endpoint)
+R1 ──> R5 (custom metric default in save endpoint)
+R1 ──> R17 (SR announcement on save)
+R1 ──> R19 (session storage for suggestion)
+R2 ──> R9 (section picker improvements depend on auto-create logic)
+```
+
+All other recommendations are independent of each other.
+
+## Section Auto-Create Priority Chain (R2 detail)
+
+When saving from the AI suggestion and no section is explicitly chosen:
+
+1. If the program has template sections (R20, when implemented), use those
+2. If the AI's `suggested_section` matches an existing section on THIS participant (case-insensitive), use it
+3. If the AI's `suggested_section` matches a section used by OTHER participants in the same program (case-insensitive), use that name — creates organic consistency
+4. If none of the above, create a new section with the AI's suggested name
+5. Last resort (no AI suggestion, no program): use "General"
+
+Query for step 3:
+```python
+PlanSection.objects.filter(program=program).values_list('name', flat=True).distinct()
+```
+
+## Server-Side Suggestion Storage (R19 detail)
+
+```python
+# In suggest_target_view, after validation:
+suggestion_key = f"goal_suggestion_{client_id}_{uuid4().hex[:8]}"
+request.session[suggestion_key] = result
+# Pass suggestion_key to template as data attribute
+
+# In goal_create_from_suggestion:
+suggestion = request.session.pop(suggestion_key, None)
+if not suggestion:
+    return render(request, "plans/_goal_save_error.html", {
+        "error": "Suggestion expired. Please try again.",
+        "client": client,
+    })
+```
+
+## Success Message (R5 detail)
+
+After saving with a custom metric included:
+```
+"Goal added: 'Find stable housing' with metric 'Housing Stability Scale.' View scale details."
+```
+The "View scale details" links to the plan view where the metric definition is expandable.
+
+## Test Coverage Needed
+
+- `test_goal_create_from_suggestion_happy_path` — POST with valid suggestion key, verify goal + section + metrics created
+- `test_goal_create_from_suggestion_expired_key` — POST with invalid/expired key, verify error partial returned
+- `test_goal_create_from_suggestion_auto_section` — verify section priority chain (match existing, match program, AI name, "General")
+- `test_goal_create_from_suggestion_custom_metric_included` — verify custom metric created when present
+- `test_goal_create_from_suggestion_csrf` — verify CSRF protection on new endpoint
+- `test_goal_create_form_reorder` — verify field order in rendered form
+- Existing tests in `test_plans.py` should still pass (form path unchanged)


### PR DESCRIPTION
## Summary

- Added 27 recommendations across 6 phases for the assisted goal creation workflow
- Expert panel review (UX, interaction design, service design, frontend architecture, evaluation methodology)
- Key fixes: direct save endpoint removes section-name blocker, button rename, auto-section creation
- Implementation prompt structured for parallel agent execution across 2 sessions

## Files

- `TODO.md` — 27 new tasks under "Goal Workflow Redesign" phase
- `tasks/goal-workflow-redesign.md` — full design document with rationale, dependencies, and test plan
- `tasks/goal-workflow-implementation-prompt.md` — ready-to-paste prompt for implementation sessions

## No code changes

This is planning only — no Python, templates, or CSS modified.

Generated with [Claude Code](https://claude.com/claude-code)