### PR TITLE
fix: /simplify review — goal workflow cleanup

### DIFF
--- a/apps/plans/views.py
+++ b/apps/plans/views.py
@@ -489,6 +489,9 @@ def _create_goal(*, client_file, user, name, description="", client_goal="",
         if section is None:
             raise ValueError("A section or new_section_name is required.")
 
+        if not name or not name.strip():
+            raise ValueError("A goal name is required.")
+
         # 2. Create PlanTarget with encrypted fields
         target = PlanTarget(
             plan_section=section,
@@ -719,6 +722,7 @@ def goal_create(request, client_id):
 
 @login_required
 @require_POST
+@requires_permission("plan.edit", _get_program_from_client)
 def goal_create_from_suggestion(request, client_id):
     """Save a goal directly from an AI suggestion — HTMX POST endpoint.
 
@@ -793,44 +797,41 @@ def goal_create_from_suggestion(request, client_id):
         )
 
     # --- Resolve metrics ---
-    metric_ids = []
-    for m in suggestion.get("metrics", []):
-        mid = m.get("metric_id")
-        if mid:
-            exists = MetricDefinition.objects.filter(
-                pk=mid, is_enabled=True, status="active",
-            ).exists()
-            if exists:
-                metric_ids.append(mid)
+    raw_ids = [m.get("metric_id") for m in suggestion.get("metrics", []) if m.get("metric_id")]
+    metric_ids = list(
+        MetricDefinition.objects.filter(
+            pk__in=raw_ids, is_enabled=True, status="active",
+        ).values_list("pk", flat=True)
+    ) if raw_ids else []
 
-    # --- Custom metric (R5: included by default) ---
+    # --- Custom metric + goal creation in single transaction (R5) ---
     skip_custom = request.POST.get("skip_custom_metric") == "true"
     custom = suggestion.get("custom_metric")
-    if custom and not skip_custom:
-        custom_metric = MetricDefinition.objects.create(
-            name=custom.get("name", "Custom metric")[:255],
-            definition=custom.get("definition", ""),
-            min_value=custom.get("min_value", 1),
-            max_value=custom.get("max_value", 5),
-            unit=custom.get("unit", "score"),
-            is_library=False,
-            owning_program=program,
-            category="custom",
-        )
-        metric_ids.append(custom_metric.pk)
-
-    # --- Create goal ---
     try:
-        target = _create_goal(
-            client_file=client,
-            user=request.user,
-            name=suggestion.get("name", ""),
-            description=suggestion.get("description", ""),
-            client_goal=suggestion.get("client_goal", ""),
-            section=section,
-            program=program,
-            metric_ids=metric_ids,
-        )
+        with transaction.atomic():
+            if custom and not skip_custom:
+                custom_metric = MetricDefinition.objects.create(
+                    name=custom.get("name", "Custom metric")[:255],
+                    definition=custom.get("definition", ""),
+                    min_value=custom.get("min_value", 1),
+                    max_value=custom.get("max_value", 5),
+                    unit=custom.get("unit", "score"),
+                    is_library=False,
+                    owning_program=program,
+                    category="custom",
+                )
+                metric_ids.append(custom_metric.pk)
+
+            target = _create_goal(
+                client_file=client,
+                user=request.user,
+                name=suggestion.get("name", ""),
+                description=suggestion.get("description", ""),
+                client_goal=suggestion.get("client_goal", ""),
+                section=section,
+                program=program,
+                metric_ids=metric_ids,
+            )
     except ValueError as e:
         return render(request, "plans/_goal_save_error.html", {
             "error": str(e),

--- a/konote/ai_views.py
+++ b/konote/ai_views.py
@@ -2,6 +2,7 @@
 import json
 import logging
 from datetime import date
+from uuid import uuid4
 
 from django.contrib.auth.decorators import login_required
 from django.db.models import Q as models_Q
@@ -277,10 +278,8 @@ def suggest_target_view(request):
         suggestion_json = json.dumps(result)
 
         # Store suggestion in session for one-click save (R1)
-        from uuid import uuid4
         suggestion_key = f"goal_suggestion_{client_id}_{uuid4().hex[:8]}"
         request.session[suggestion_key] = result
-        request.session.modified = True
 
         return render(request, "plans/_ai_suggestion.html", {
             "suggestion": result,

--- a/templates/plans/_goal_save_error.html
+++ b/templates/plans/_goal_save_error.html
@@ -3,9 +3,8 @@
 <div class="ai-suggest-error" role="alert">
     <p>{{ error }}</p>
     <div role="group">
-        <button type="button" id="btn-retry-suggestion" class="outline"
-                onclick="history.back()">
-            {% trans "Try again" %}
+        <button type="button" id="btn-retry-suggestion" class="outline">
+            {% trans "Start over" %}
         </button>
         <button type="button" id="btn-show-manual-form" class="outline secondary">
             {% trans "Fill in the form manually" %}

--- a/templates/plans/goal_form.html
+++ b/templates/plans/goal_form.html
@@ -765,6 +765,16 @@
                     revealForm();
                 });
             }
+            // Wire up "Start over" button in error partial
+            var retryBtn = document.getElementById("btn-retry-suggestion");
+            if (retryBtn) {
+                retryBtn.addEventListener("click", function() {
+                    suggestionContainer.innerHTML = "";
+                    if (entryPoints) entryPoints.hidden = false;
+                    var pw = document.getElementById("participant-words");
+                    if (pw) { pw.value = ""; pw.focus(); }
+                });
+            }
         });
 
         // Handle suggestion card button clicks
@@ -804,12 +814,23 @@
     }
 
     // ────────────────────────────────────────
-    // Screen reader announcement on save (R17)
+    // HTMX request lifecycle — screen reader + loading text (R17, T-5)
     // ────────────────────────────────────────
     document.addEventListener("htmx:beforeRequest", function(evt) {
-        if (evt.detail.elt && evt.detail.elt.id === "btn-use-suggestion") {
+        if (!evt.detail.elt) return;
+        var id = evt.detail.elt.id;
+        if (id === "btn-use-suggestion") {
             var announce = document.getElementById("save-announce");
             if (announce) announce.textContent = "{% trans 'Saving your goal…' %}";
+        }
+        if (id === "btn-shape-target") {
+            var loadingEl = document.querySelector("#ai-loading small");
+            if (loadingEl) {
+                loadingEl.textContent = "{% trans 'Working on a suggestion…' %}";
+                setTimeout(function() {
+                    if (loadingEl) loadingEl.textContent = "{% trans 'Almost there…' %}";
+                }, 4000);
+            }
         }
     });
 
@@ -849,20 +870,7 @@
         });
     }
 
-    // ────────────────────────────────────────
-    // AI loading text rotation (T-5)
-    // ────────────────────────────────────────
-    document.addEventListener("htmx:beforeRequest", function(evt) {
-        if (evt.detail.elt && evt.detail.elt.id === "btn-shape-target") {
-            var loadingEl = document.querySelector("#ai-loading small");
-            if (loadingEl) {
-                loadingEl.textContent = "{% trans 'Working on a suggestion…' %}";
-                setTimeout(function() {
-                    if (loadingEl) loadingEl.textContent = "{% trans 'Almost there…' %}";
-                }, 4000);
-            }
-        }
-    });
+
 
     // ────────────────────────────────────────
     // Quick pick cards (entry point version — AI mode)


### PR DESCRIPTION
## Summary

Follow-up fixes from `/simplify` review of PR #365 (goal workflow redesign).

- **Bug fix:** Retry button in error partial used `history.back()` which navigated away from page — now re-shows entry points like "Start over"
- **Transaction safety:** Custom metric creation + `_create_goal()` wrapped in single `transaction.atomic()` — prevents orphaned MetricDefinitions on failure
- **N+1 fix:** Per-metric `.exists()` queries replaced with single `pk__in` query
- **Validation:** `_create_goal()` now rejects empty/whitespace goal names
- **Permission consistency:** Added `@requires_permission` decorator to `goal_create_from_suggestion` matching `goal_create`
- **Cleanup:** `uuid4` import moved to module level, redundant `session.modified` removed, two `htmx:beforeRequest` listeners combined into one

## Test plan

- [ ] Existing `GoalSaveFromSuggestionTest` tests still pass
- [ ] Manual: trigger save error (expired suggestion) → "Start over" re-shows entry points (not browser back)

🤖 Generated with [Claude Code](https://claude.com/claude-code)