### PR TITLE
fix: review fixes — hx-indicator and empty name test

### DIFF
--- a/templates/plans/_ai_suggestion.html
+++ b/templates/plans/_ai_suggestion.html
@@ -68,7 +68,8 @@
                 hx-include="closest .suggestion-actions"
                 hx-target="#suggestion-container"
                 hx-swap="innerHTML"
-                hx-disabled-elt="this">
+                hx-disabled-elt="this"
+                hx-indicator="#save-loading">
             {% trans "Use this suggestion" %}
         </button>
         <button type="button"

--- a/tests/test_plans.py
+++ b/tests/test_plans.py
@@ -1408,3 +1408,22 @@ class GoalSaveFromSuggestionTest(TestCase):
         response = self.client.post(self.url, {"suggestion_key": "goal_suggestion_test_perm"})
         self.assertEqual(response.status_code, 403)
 
+    def test_create_goal_empty_name_raises(self):
+        """_create_goal raises ValueError when name is empty or whitespace."""
+        from apps.plans.views import _create_goal
+
+        section = PlanSection.objects.create(
+            client_file=self.client_file,
+            name="Test Section",
+            program=self.program,
+        )
+
+        for empty_name in ["", "   ", None]:
+            with self.assertRaises(ValueError, msg=f"Should raise for name={empty_name!r}"):
+                _create_goal(
+                    client_file=self.client_file,
+                    user=self.user,
+                    name=empty_name,
+                    section=section,
+                )
+


### PR DESCRIPTION
## Summary
- Add missing `hx-indicator="#save-loading"` to "Use this suggestion" button so the loading spinner activates during save
- Add `test_create_goal_empty_name_raises` covering empty string, whitespace, and `None` name inputs to `_create_goal()`

Addresses findings from `/review-session` expert panel on PR #365/#366.

## Test plan
- [ ] Verify loading spinner appears when clicking "Use this suggestion"
- [ ] Run `pytest tests/test_plans.py::GoalSaveFromSuggestionTest::test_create_goal_empty_name_raises`

🤖 Generated with [Claude Code](https://claude.com/claude-code)