### PR TITLE
fix: UX feedback — notes link, actions dropdown, privacy nav

### DIFF
--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -739,6 +739,11 @@ msgid "Use the Actions menu to add a Quick Note or Detailed Note."
 msgstr ""
 "Utilisez le menu Actions pour ajouter une note rapide ou une note détaillée."
 
+msgid "Use the Actions menu to Log Contact or add a Detailed Note."
+msgstr ""
+"Utilisez le menu Actions pour enregistrer un contact ou ajouter une note "
+"détaillée."
+
 #: templates/plans/_target.html
 msgid "None"
 msgstr "Aucun"
@@ -10513,6 +10518,9 @@ msgstr ""
 
 msgid "Log Contact"
 msgstr "Enregistrer un contact"
+
+msgid "Log a phone call, visit, or message"
+msgstr "Consigner un appel, une visite ou un message"
 
 msgid "Log a contact"
 msgstr "Enregistrer un contact"

--- a/templates/clients/_client_layout.html
+++ b/templates/clients/_client_layout.html
@@ -32,7 +32,7 @@
                 <li role="none"><a role="menuitem" href="{% url 'clients:client_edit' client_id=client.pk %}">{% trans "Edit" %}<small>{% trans "Edit participant record" %}</small></a></li>
                 <li class="dropdown-divider" role="separator"></li>
                 {% endif %}
-                <li role="none"><a role="menuitem" href="{% url 'notes:quick_note_create' client_id=client.pk %}">{% trans "Quick Note" %}<small>{% trans "Log a contact or brief update" %}</small></a></li>
+                <li role="none"><a role="menuitem" href="{% url 'notes:quick_note_create' client_id=client.pk %}">{% trans "Log Contact" %}<small>{% trans "Log a phone call, visit, or message" %}</small></a></li>
                 <li role="none"><a role="menuitem" href="{% url 'notes:note_create' client_id=client.pk %}">{% trans "Detailed Note" %}<small>{% trans "Document a session with outcomes" %}</small></a></li>
                 <li class="dropdown-divider" role="separator"></li>
                 <li role="none"><a role="menuitem" href="{% url 'events:event_create' client_id=client.pk %}">{% trans "Record Event" %}</a></li>
@@ -44,7 +44,6 @@
                 <li class="dropdown-divider" role="separator"></li>
                 {% endif %}
                 {% if can_log_comm %}
-                <li role="none"><a role="menuitem" href="{% url 'notes:quick_note_create' client_id=client.pk %}">{% trans "Log Communication" %}<small>{% trans "Record a phone call, visit, or message" %}</small></a></li>
                 <li role="none"><a role="menuitem" href="{% url 'communications:compose_email' client_id=client.pk %}">{% trans "Send Email" %}</a></li>
                 {% endif %}
                 {% if can_view_metrics %}

--- a/templates/events/_timeline_entries.html
+++ b/templates/events/_timeline_entries.html
@@ -64,7 +64,7 @@
             <summary>{{ entry.obj.notes_text|truncatechars:200 }}</summary>
             <div class="timeline-note-full">
                 <p>{{ entry.obj.notes_text }}</p>
-                <p class="timeline-note-link"><small><a href="{% url 'notes:note_list' client_id=client.pk %}#note-{{ entry.obj.pk }}">{% trans "View in Notes" %} &rarr;</a></small></p>
+                <p class="timeline-note-link"><small><a href="{% url 'notes:note_detail' note_id=entry.obj.pk %}">{% trans "View in Notes" %} &rarr;</a></small></p>
             </div>
         </details>
         {% endif %}

--- a/templates/notes/_tab_notes.html
+++ b/templates/notes/_tab_notes.html
@@ -120,7 +120,7 @@
 <div class="empty-state">
     <p>{% blocktrans with notes=term.progress_note|default:"notes" %}No {{ notes }} recorded yet.{% endblocktrans %}</p>
     {% if active_service_model != "group" %}
-    <p><small>{% trans "Use the Actions menu to add a Quick Note or Detailed Note." %}</small></p>
+    <p><small>{% trans "Use the Actions menu to Log Contact or add a Detailed Note." %}</small></p>
     <a href="{% url 'notes:quick_note_create' client_id=client.pk %}" role="button">{% trans "Add the first note" %}</a>
     {% endif %}
 </div>

--- a/templates/pages/privacy.html
+++ b/templates/pages/privacy.html
@@ -231,16 +231,33 @@
 }
 
 .privacy-nav ul {
-    columns: 2;
-    margin-bottom: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
     list-style: none;
     padding: 0;
+    margin: 0;
 }
 
-@media (max-width: 600px) {
-    .privacy-nav ul {
-        columns: 1;
-    }
+.privacy-nav li {
+    margin: 0;
+}
+
+.privacy-nav a {
+    display: block;
+    padding: 0.4rem 0.9rem;
+    background: var(--pico-primary-background, #3176aa);
+    color: var(--pico-primary-inverse, #fff);
+    border-radius: 2rem;
+    text-decoration: none;
+    font-size: 0.85rem;
+    white-space: nowrap;
+    transition: opacity 0.15s;
+}
+
+.privacy-nav a:hover,
+.privacy-nav a:focus {
+    opacity: 0.85;
 }
 
 .privacy-page section {


### PR DESCRIPTION
## Summary

Addresses three UX issues from feedback review:

- **View in Notes link**: Changed from fragment anchor (`#note-<id>`) to direct link to `notes:note_detail`. The anchor didn't work when the note was on a paginated page beyond page 1.
- **Actions dropdown consolidation**: Removed duplicate "Log Communication" item (identical URL to Quick Note). Renamed "Quick Note" to "Log Contact" for consistent terminology across the app.
- **Privacy Policy nav**: Restyled from plain text links in 2-column layout to pill buttons matching the Help page navigation pattern.

## Changes
- `templates/events/_timeline_entries.html` — link to note detail view
- `templates/clients/_client_layout.html` — remove duplicate, rename item
- `templates/notes/_tab_notes.html` — update empty-state help text
- `templates/pages/privacy.html` — restyle nav CSS
- `locale/fr/LC_MESSAGES/django.po` — French translations for new strings

## Test plan
- [ ] Click "View in Notes" from History tab — should open the individual note page
- [ ] Check Actions dropdown — should show "Log Contact" (not "Quick Note" or "Log Communication")
- [ ] Verify inline "Log Contact" button still works on Notes tab
- [ ] Visit Privacy Policy page — nav should show pill buttons matching Help page
- [ ] Switch to French — verify translated labels appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)