### PR TITLE
fix: address 5 review findings for goal form

### DIFF
--- a/apps/plans/forms.py
+++ b/apps/plans/forms.py
@@ -371,7 +371,7 @@ class GoalForm(forms.Form):
 
         # R9: If "new" chosen but no name given, default to "General"
         if section_choice == "new" and not new_name:
-            cleaned["new_section_name"] = "General"
+            cleaned["new_section_name"] = str(_("General"))
         elif not section_choice:
             raise forms.ValidationError(
                 _("Please choose which area of the plan this goal belongs to.")

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -19786,5 +19786,5 @@ msgstr "Pourquoi ces mesures?"
 
 #: templates/plans/goal_form.html — R22: Quick pick words prompt (blocktrans)
 #, python-format
-msgid "What did the %(client)s say about this?"
-msgstr "Qu'est-ce que le/la %(client)s a dit à ce sujet?"
+msgid "What did %(client)s say about this?"
+msgstr "Qu'a dit %(client)s à ce sujet?"

--- a/templates/plans/_goal_ai_entry.html
+++ b/templates/plans/_goal_ai_entry.html
@@ -4,8 +4,9 @@
     <legend>
         {% blocktrans with client=term.client|default:"participant" %}What does the {{ client }} want to work on?{% endblocktrans %}
         {# R13: Contextual help tooltip replacing onboarding hint #}
-        <span class="help-icon" title="{% blocktrans with client=term.client|default:'participant' %}A goal is something the {{ client }} wants to achieve. You'll capture what they said in their own words, then shape it into a short, trackable goal with a way to measure progress.{% endblocktrans %}" aria-label="{% trans 'Help' %}">&#9432;</span>
+        <span class="help-icon" aria-describedby="goal-help-text" tabindex="0" title="{% blocktrans with client=term.client|default:'participant' %}A goal is something the {{ client }} wants to achieve. You'll capture what they said in their own words, then shape it into a short, trackable goal with a way to measure progress.{% endblocktrans %}" aria-label="{% trans 'Help' %}">&#9432;</span>
     </legend>
+    <span id="goal-help-text" hidden>{% blocktrans with client=term.client|default:'participant' %}A goal is something the {{ client }} wants to achieve. You'll capture what they said in their own words, then shape it into a short, trackable goal with a way to measure progress.{% endblocktrans %}</span>
     <small>{% trans "Write what they said, in their own words." %}</small>
     <small class="secondary">
         {% trans "Names and personal details are removed before sending to AI." %}

--- a/templates/plans/_goal_quick_pick_entry.html
+++ b/templates/plans/_goal_quick_pick_entry.html
@@ -24,7 +24,7 @@
 
 {# R22: Quick pick words prompt (hidden until a card is clicked) #}
 <div id="quick-pick-words" hidden>
-    <label>{% blocktrans with client=term.client|default:"participant" %}What did the {{ client }} say about this?{% endblocktrans %}</label>
+    <label>{% blocktrans with client=term.client|default:"participant" %}What did {{ client }} say about this?{% endblocktrans %}</label>
     <textarea name="quick_pick_words" rows="2" placeholder="{% trans 'Optional — in their own words…' %}"></textarea>
     <button type="button" id="btn-continue-quick-pick">{% trans "Continue" %}</button>
 </div>

--- a/templates/plans/goal_form.html
+++ b/templates/plans/goal_form.html
@@ -47,7 +47,7 @@
     {% include "plans/_goal_quick_pick_entry.html" %}
     {% endif %}{# end quick_pick_first conditional #}
 
-    <p><a href="#" id="btn-manual-entry" class="secondary">
+    <p id="manual-entry-row"><a href="#" id="btn-manual-entry" class="secondary">
         {% trans "Or fill in the form manually" %}
     </a></p>
 </div>
@@ -691,7 +691,7 @@
                 var aiEntry = document.getElementById("ai-entry");
                 var quickPickEntry = document.getElementById("quick-pick-entry");
                 var dividers = entryPoints ? entryPoints.querySelectorAll(".entry-divider") : [];
-                var manualLink = entryPoints ? entryPoints.querySelector("p:last-child") : null;
+                var manualLink = document.getElementById("manual-entry-row");
 
                 if (aiEntry) aiEntry.hidden = true;
                 if (quickPickEntry) quickPickEntry.hidden = true;

--- a/tests/test_plan_crud.py
+++ b/tests/test_plan_crud.py
@@ -576,17 +576,19 @@ class GoalCreateTest(PlanCRUDBaseTest):
         self.assertEqual(target.name, "Manage anxiety")
         self.assertEqual(PlanTargetMetric.objects.filter(plan_target=target).count(), 0)
 
-    def test_new_section_requires_name(self):
-        """If 'Create new section' is selected, a name must be provided."""
+    def test_new_section_defaults_to_general(self):
+        """If 'Create new section' is selected with no name, defaults to 'General'."""
         self.http.login(username="counsellor", password="pass")
         url = reverse("plans:goal_create", args=[self.client_file.pk])
         resp = self.http.post(url, {
             "name": "Some goal",
             "section_choice": "new",
-            "new_section_name": "",  # empty
+            "new_section_name": "",  # empty — should default to "General"
         })
-        self.assertEqual(resp.status_code, 200)  # form redisplayed with error
-        self.assertEqual(PlanTarget.objects.count(), 0)
+        self.assertEqual(resp.status_code, 302)  # redirect on success
+        self.assertEqual(PlanTarget.objects.count(), 1)
+        section = PlanSection.objects.get(name="General")
+        self.assertEqual(PlanTarget.objects.first().plan_section, section)
 
     def test_manager_cannot_create_goal(self):
         """Program manager has plan.edit: DENY — cannot create goals."""


### PR DESCRIPTION
## Summary
Fixes all 5 issues identified by `/review-session` expert panel on PRs #370-371:

1. **Translate "General" default** — `_("General")` so French users see "Général"
2. **Update test** — `test_new_section_defaults_to_general` matches new validation behaviour
3. **Fix fragile selector** — `id="manual-entry-row"` replaces `p:last-child`
4. **Fix French gender** — dropped article to avoid "le/la" in quick-pick prompt
5. **Help icon a11y** — added `aria-describedby` + `tabindex="0"` for screen readers

## Test plan
- [ ] Run `pytest tests/test_plan_crud.py` on VPS — verify updated test passes
- [ ] Verify French UI shows "Général" when section defaults
- [ ] Verify help icon is announced by screen readers on focus

🤖 Generated with [Claude Code](https://claude.com/claude-code)