### PR TITLE
chore: improve deploy docs and script for Windows compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ venv/
 # Environment
 .env
 *.env.local
+konote-credentials-*
 
 # IDE
 .vscode/

--- a/docs/deploy-ovhcloud.md
+++ b/docs/deploy-ovhcloud.md
@@ -13,7 +13,7 @@ The deploy script automates 9 of 15 steps below — from securing the OS through
 
 ```bash
 ./scripts/deploy-konote-vps.sh \
-  --host 141.227.151.7 \
+  --host YOUR_VPS_IP \
   --domain konote.youragency.ca \
   --admin-email admin@youragency.ca \
   --org-name "Your Agency Name"
@@ -78,12 +78,12 @@ Open **PowerShell** or **Windows Terminal** and type:
 ssh ubuntu@YOUR_VPS_IP
 ```
 
-Replace `YOUR_VPS_IP` with the IP address from your OVHcloud email (e.g., `141.227.151.7`).
+Replace `YOUR_VPS_IP` with the IP address from your OVHcloud email.
 
 The first time you connect, you will see a message like:
 
 ```
-The authenticity of host '141.227.151.7' can't be established.
+The authenticity of host 'YOUR_VPS_IP' can't be established.
 ED25519 key fingerprint is SHA256:abc123...
 Are you sure you want to continue connecting (yes/no)?
 ```
@@ -114,21 +114,33 @@ Use your new password this time.
 
 ### Set Up SSH Key (Recommended)
 
-Using an SSH key means you will not need to type your password every time. On your **local Windows machine** (not the VPS):
+Using an SSH key means you will not need to type your password every time.
+
+> **Important:** Complete the password change above **before** setting up the SSH key. The piped command below will fail if the password is still expired.
+
+> **Note:** `ssh-copy-id` is not available on Windows. Use the manual method below.
+
+**Step 1 — Generate a key** (on your local Windows machine, not the VPS):
 
 ```powershell
-# Generate a key with a descriptive name
 ssh-keygen -t ed25519 -f $env:USERPROFILE\.ssh\ovh_konote
-
-# Copy the public key to the VPS
-type $env:USERPROFILE\.ssh\ovh_konote.pub | ssh ubuntu@YOUR_VPS_IP "mkdir -p ~/.ssh && cat >> ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys"
 ```
 
-After this, connect without a password:
+**Step 2 — Copy the public key to the VPS:**
 
-```bash
-ssh -i ~/.ssh/ovh_konote ubuntu@YOUR_VPS_IP
+```powershell
+type $env:USERPROFILE\.ssh\ovh_konote.pub | ssh ubuntu@YOUR_VPS_IP "mkdir -p ~/.ssh && cat >> ~/.ssh/authorized_keys && chmod 700 ~/.ssh && chmod 600 ~/.ssh/authorized_keys"
 ```
+
+Enter your **new** password (the one you set in the previous step) when prompted.
+
+**Step 3 — Test key-based login:**
+
+```powershell
+ssh -i $env:USERPROFILE\.ssh\ovh_konote ubuntu@YOUR_VPS_IP
+```
+
+This should connect **without asking for a password**.
 
 > **Tip:** Add this to your SSH config (`~/.ssh/config`) for convenience:
 > ```
@@ -347,7 +359,7 @@ You need to create a DNS **A record** that points your domain to the VPS IP addr
 4. Add a new record:
    - **Type:** A
    - **Name:** `konote` (or whatever subdomain you want, e.g., `konote` for `konote.yourdomain.ca`)
-   - **Value:** Your VPS IP address (e.g., `141.227.151.7`)
+   - **Value:** Your VPS IP address (e.g., `YOUR_VPS_IP`)
    - **TTL:** 300 (5 minutes) or Auto
 5. If using Cloudflare: set the **proxy status to DNS only** (grey cloud, not orange). Caddy handles HTTPS directly -- Cloudflare's proxy would interfere with Let's Encrypt certificate issuance.
 

--- a/docs/llm-deployment-guide.md
+++ b/docs/llm-deployment-guide.md
@@ -12,7 +12,7 @@ Before starting, collect these from the user:
 
 | Item | Example | Notes |
 |------|---------|-------|
-| VPS IP address | `141.227.151.7` | From the hosting provider (OVHcloud, DigitalOcean, etc.) |
+| VPS IP address | `YOUR_VPS_IP` | From the hosting provider (OVHcloud, DigitalOcean, etc.) |
 | VPS SSH user | `ubuntu` | OVHcloud default is `ubuntu` |
 | SSH access method | Key-based or password | Must be able to run `ssh ubuntu@IP` successfully |
 | Production domain | `konote.agency.ca` | DNS A record must point to VPS IP |

--- a/scripts/deploy-konote-vps.sh
+++ b/scripts/deploy-konote-vps.sh
@@ -8,7 +8,7 @@
 #
 # Usage:
 #   ./scripts/deploy-konote-vps.sh \
-#     --host 141.227.151.7 \
+#     --host YOUR_VPS_IP \
 #     --domain konote.agency.ca \
 #     --admin-email admin@agency.ca \
 #     --org-name "My Nonprofit"
@@ -83,16 +83,16 @@ Optional:
 
 Examples:
   # Basic deployment
-  $(basename "$0") --host 141.227.151.7 --domain konote.example.ca \\
+  $(basename "$0") --host YOUR_VPS_IP --domain konote.example.ca \\
     --admin-email admin@example.ca --org-name "Example Nonprofit"
 
   # With SSH key and custom branch
-  $(basename "$0") --host 141.227.151.7 --domain konote.example.ca \\
+  $(basename "$0") --host YOUR_VPS_IP --domain konote.example.ca \\
     --admin-email admin@example.ca --org-name "Example Nonprofit" \\
     --ssh-key ~/.ssh/ovh_konote --branch develop
 
   # Dry run (preview commands)
-  $(basename "$0") --host 141.227.151.7 --domain konote.example.ca \\
+  $(basename "$0") --host YOUR_VPS_IP --domain konote.example.ca \\
     --admin-email admin@example.ca --org-name "Example Nonprofit" --dry-run
 EOF
     exit 0
@@ -139,18 +139,23 @@ if [[ ${#MISSING[@]} -gt 0 ]]; then
 fi
 
 # ==============================================================================
-# SSH setup (ControlMaster for connection reuse)
+# SSH setup (ControlMaster for connection reuse — disabled on Windows/MSYS2)
 # ==============================================================================
-SSH_CONTROL_DIR=$(mktemp -d)
-SSH_CONTROL_PATH="${SSH_CONTROL_DIR}/konote-%r@%h:%p"
-
 SSH_OPTS=(
     -o "StrictHostKeyChecking=accept-new"
-    -o "ControlMaster=auto"
-    -o "ControlPath=${SSH_CONTROL_PATH}"
-    -o "ControlPersist=300"
     -o "ConnectTimeout=15"
 )
+
+# ControlMaster uses Unix domain sockets which don't work on Windows/MSYS2/Git Bash
+if [[ "$(uname -s)" != MINGW* && "$(uname -s)" != MSYS* && "$(uname -s)" != CYGWIN* ]]; then
+    SSH_CONTROL_DIR=$(mktemp -d)
+    SSH_CONTROL_PATH="${SSH_CONTROL_DIR}/konote-%r@%h:%p"
+    SSH_OPTS+=(
+        -o "ControlMaster=auto"
+        -o "ControlPath=${SSH_CONTROL_PATH}"
+        -o "ControlPersist=300"
+    )
+fi
 
 if [[ -n "$SSH_KEY" ]]; then
     SSH_OPTS+=(-i "$SSH_KEY")
@@ -172,10 +177,12 @@ run_remote_sudo() {
     run_remote "sudo bash -c '$*'"
 }
 
-# Cleanup: close SSH ControlMaster on exit
+# Cleanup: close SSH ControlMaster on exit (only if enabled)
 cleanup() {
-    ssh "${SSH_OPTS[@]}" -O exit "${SSH_TARGET}" 2>/dev/null || true
-    rm -rf "${SSH_CONTROL_DIR}" 2>/dev/null || true
+    if [[ -n "${SSH_CONTROL_DIR:-}" ]]; then
+        ssh "${SSH_OPTS[@]}" -O exit "${SSH_TARGET}" 2>/dev/null || true
+        rm -rf "${SSH_CONTROL_DIR}" 2>/dev/null || true
+    fi
 }
 trap cleanup EXIT
 

--- a/tasks/vps-migration.md
+++ b/tasks/vps-migration.md
@@ -1,12 +1,13 @@
 # VPS Migration: Swiss Server to Canadian Server
 
-**Status:** Ready to execute
+**Status:** Complete
 **Created:** 2026-03-06
+**Completed:** 2026-03-06
 **Task ID:** OPS-MIGRATE1
 
 ## Context
 
-Moving the current KoNote deployment from the OVHcloud VPS in Switzerland (141.227.151.7) to a new OVHcloud VPS hosted in Canada. The new VPS is currently being configured by OVH.
+Migrated the KoNote deployment from an OVHcloud VPS in Switzerland to a new OVHcloud VPS hosted in Canada (Beauharnois, QC). Both production and dev instances are running on the new server.
 
 **Why:** Canadian data residency for PHIPA compliance. The Swiss VPS was the original deployment; the Canadian server aligns with the data residency policy in `tasks/design-rationale/data-access-residency-policy.md`.
 


### PR DESCRIPTION
## Summary
- Fix SSH ControlMaster options in deploy script for Windows/MSYS2 (Unix domain sockets unsupported)
- Remove hardcoded VPS IPs from public docs, replace with `YOUR_VPS_IP` placeholders
- Improve SSH key setup instructions in deploy guide with clear step-by-step
- Add `konote-credentials-*` to `.gitignore` to prevent credential files from being committed
- Mark VPS migration task as complete

## Test plan
- [ ] Verify deploy script runs on Windows (Git Bash) without ControlMaster errors
- [ ] Confirm no private IPs remain in public docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)