### PR TITLE
fix: deploy script auto-switches dev instance to develop branch

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -108,6 +108,20 @@ deploy_instance() {
     # --- Pull latest code ---
     echo "=== Pulling latest code ==="
     git checkout -- . 2>/dev/null || true  # Reset any local modifications (e.g. CRLF fixes)
+
+    # Ensure dev instance is on the develop branch (not main).
+    # Production stays on whatever branch it's on (typically main).
+    if [ "$is_dev" = "true" ]; then
+        local current_branch
+        current_branch=$(git branch --show-current 2>/dev/null || echo "unknown")
+        if [ "$current_branch" != "develop" ]; then
+            echo -e "  ${YELLOW}Dev instance on '${current_branch}' — switching to 'develop'${NC}"
+            git fetch origin develop
+            git checkout develop
+            git reset --hard origin/develop
+        fi
+    fi
+
     git pull origin develop
 
     # --- Record after-commit ---


### PR DESCRIPTION
## Summary
- The dev VPS instance was on `main` instead of `develop`, causing `git pull origin develop` to fail with "divergent branches"
- Deploy script now checks the current branch for dev instances and switches to `develop` if needed
- Also updated konote-ops runbook with correct deploy paths, sudo requirement, and branch mapping

## Test plan
- [ ] Deploy to dev VPS after DNS migration completes: `ssh konote-vps "sudo /opt/konote/scripts/deploy.sh --dev"`
- [ ] Verify dev instance switches from `main` to `develop` and pulls latest code
- [ ] Verify admin settings help screen is visible at konote-dev.llewelyn.ca/admin/settings/

🤖 Generated with [Claude Code](https://claude.com/claude-code)