### PR TITLE
fix: security review hardening — session key, cross-program filtering

### DIFF
--- a/apps/plans/views.py
+++ b/apps/plans/views.py
@@ -741,6 +741,8 @@ def goal_create_from_suggestion(request, client_id):
         raise PermissionDenied(_("You don't have permission to edit this plan."))
 
     suggestion_key = request.POST.get("suggestion_key", "")
+    if suggestion_key and not suggestion_key.startswith("goal_suggestion_"):
+        suggestion_key = ""
     suggestion = request.session.pop(suggestion_key, None) if suggestion_key else None
 
     if not suggestion:

--- a/apps/reports/insights.py
+++ b/apps/reports/insights.py
@@ -192,7 +192,7 @@ def get_structured_insights(program=None, client_file=None, date_from=None, date
 
 
 def collect_quotes(program=None, client_file=None, date_from=None, date_to=None,
-                   max_quotes=50, include_dates=True):
+                   max_quotes=50, include_dates=True, program_ids=None):
     """Decrypt text fields and surface notable quotes.
 
     Args:
@@ -202,6 +202,7 @@ def collect_quotes(program=None, client_file=None, date_from=None, date_to=None,
         date_to: End date.
         max_quotes: Maximum quotes to return.
         include_dates: Whether to include dates (False for program-level privacy).
+        program_ids: Optional set/list of program IDs to restrict quotes to.
 
     Returns:
         list of dicts with keys: text, target_name, note_id, date (if include_dates).
@@ -238,6 +239,10 @@ def collect_quotes(program=None, client_file=None, date_from=None, date_to=None,
 
     if client_file:
         targets_qs = targets_qs.filter(progress_note__client_file=client_file)
+    if program_ids is not None:
+        targets_qs = targets_qs.filter(
+            plan_target__plan_section__program_id__in=program_ids,
+        )
     if program:
         targets_qs = targets_qs.filter(
             progress_note__client_file__enrolments__program=program,

--- a/apps/reports/insights_views.py
+++ b/apps/reports/insights_views.py
@@ -8,7 +8,7 @@ from django.http import HttpResponseForbidden
 from django.shortcuts import render
 from django.utils.translation import gettext as _
 
-from django.db.models import Count
+from django.db.models import Count, Q
 
 from apps.auth_app.constants import ROLE_EXECUTIVE, ROLE_PROGRAM_MANAGER
 from apps.auth_app.decorators import requires_permission
@@ -431,6 +431,10 @@ def client_insights_partial(request, client_id):
     )
     active_targets = list(
         PlanTarget.objects.filter(client_file=client, status="default")
+        .filter(
+            Q(plan_section__program_id__isnull=True)
+            | Q(plan_section__program_id__in=user_program_ids)
+        )
         .select_related("plan_section")
         .order_by("plan_section__name", "pk")
     )
@@ -486,11 +490,13 @@ def client_insights_partial(request, client_id):
             summary_line = goal_statuses[0]["descriptor_label"]
 
     # Client-level: no participant threshold, dates included
+    # Restrict quotes to programs the user has access to
     quotes = collect_quotes(
         client_file=client,
         date_from=date_from,
         date_to=date_to,
         include_dates=True,
+        program_ids=user_program_ids,
     )
 
     # Check AI availability


### PR DESCRIPTION
## Summary

Defence-in-depth fixes from security review of PRs #357–#378. No exploitable vulnerabilities were found, but three hardening improvements were identified:

- **Session key prefix validation** (`apps/plans/views.py`): Validate that `suggestion_key` starts with `goal_suggestion_` before passing to `session.pop()`, preventing arbitrary session key deletion
- **Cross-program goal filtering** (`apps/reports/insights_views.py`): Filter `active_targets` in client insights to only show goals from programs the user is assigned to
- **Cross-program quote filtering** (`apps/reports/insights.py` + `insights_views.py`): Add `program_ids` parameter to `collect_quotes()` and pass user's program IDs from client insights view

## Test plan

- [ ] Verify goal creation from AI suggestion still works (session key with correct prefix)
- [ ] Verify client insights page shows goals only from user's assigned programs
- [ ] Verify client insights quotes are scoped to user's programs

🤖 Generated with [Claude Code](https://claude.com/claude-code)