### PR TITLE
fix: deploy script connects Caddy to dev frontend network

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -147,6 +147,21 @@ deploy_instance() {
     echo "=== Restarting ==="
     docker compose up -d
 
+    # --- Ensure Caddy can reach this instance's web container ---
+    # Caddy runs in the production stack. For the dev instance, Caddy needs to
+    # be connected to the dev frontend network so it can reverse-proxy to
+    # konote-dev-web. This is idempotent — it's a no-op if already connected.
+    if [ "$is_dev" = "true" ]; then
+        local caddy_container="konote-caddy-1"
+        local dev_network="konote-dev_frontend"
+        if docker ps --format '{{.Names}}' | grep -q "^${caddy_container}$"; then
+            if ! docker inspect "$caddy_container" --format '{{json .NetworkSettings.Networks}}' | grep -q "$dev_network"; then
+                echo "=== Connecting Caddy to dev frontend network ==="
+                docker network connect "$dev_network" "$caddy_container" 2>/dev/null || true
+            fi
+        fi
+    fi
+
     # --- Wait for health check (time-based migration failure detection) ---
     echo "=== Waiting for health check ==="
     local healthy=false


### PR DESCRIPTION
## Summary
- After deploying the dev instance, the deploy script now ensures the production Caddy container is connected to the `konote-dev_frontend` Docker network
- Without this, Caddy can't reverse-proxy to `konote-dev-web` because they're in separate Docker Compose stacks with separate networks
- Idempotent — skips if already connected

## Test plan
- [x] Verified fix manually on VPS (connected Caddy to dev network, dev site came up)
- [ ] Run `deploy.sh --dev` on next deploy to confirm automatic connection

🤖 Generated with [Claude Code](https://claude.com/claude-code)