### PR TITLE
fix: prevent template comment from rendering on goal form

### DIFF
--- a/templates/plans/goal_form.html
+++ b/templates/plans/goal_form.html
@@ -56,10 +56,11 @@
 <div id="suggestion-container" aria-live="polite"></div>
 {% endif %}
 
-{# ====== UNIFIED FORM (T-4) ====== #}
-{# Single form for both AI and non-AI paths. Hidden when AI enabled until
-   "Let me review first" / manual entry / quick pick reveals it.
-   Non-AI path uses phase 1 (listen) + phase 2 (shape) progressive disclosure. #}
+{% comment %}
+    UNIFIED FORM (T-4): Single form for both AI and non-AI paths.
+    Hidden when AI enabled until "Let me review first" / manual entry / quick pick reveals it.
+    Non-AI path uses phase 1 (listen) + phase 2 (shape) progressive disclosure.
+{% endcomment %}
 <form method="post" id="goal-form" novalidate {% if ai_enabled and not form.errors %}hidden{% endif %}>
     {% csrf_token %}
 


### PR DESCRIPTION
## Summary
- Django's `{# ... #}` comment syntax is single-line only — the multi-line developer note on the goal form was rendering as visible text to users
- Replaced with `{% comment %}{% endcomment %}` block tags which properly handle multi-line comments

## Test plan
- [ ] Visit Add a Goal page (non-AI path) and confirm no developer comment text is visible
- [ ] Confirm the form still works correctly (phase 1 → phase 2 disclosure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)