### PR TITLE
fix: client list responsive breakpoint and disable bulk actions

### DIFF
--- a/apps/clients/views.py
+++ b/apps/clients/views.py
@@ -367,10 +367,10 @@ def client_list(request):
     # Show create button if user's role grants client.create permission
     user_role = _get_user_highest_role(request.user)
     can_create = PERMISSIONS.get(user_role, {}).get("client.create", DENY) != DENY
-    # Bulk operation permission flags (UX17)
-    can_bulk_status = PERMISSIONS.get(user_role, {}).get("client.edit", DENY) != DENY
-    can_bulk_transfer = PERMISSIONS.get(user_role, {}).get("client.transfer", DENY) != DENY
-    show_bulk = can_bulk_status or can_bulk_transfer
+    # Bulk operation permission flags (UX17) — disabled until UX is reworked
+    can_bulk_status = False
+    can_bulk_transfer = False
+    show_bulk = False
 
     # Base context shared by both single and split views
     context = {

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -3218,8 +3218,8 @@ article[aria-label="notification"].fading-out {
     }
 }
 
-/* ---- Client table card view on mobile ---- */
-@media (max-width: 600px) {
+/* ---- Client table card view on narrow screens ---- */
+@media (max-width: 768px) {
     .client-table thead {
         display: none;
     }


### PR DESCRIPTION
## Summary
- Raised the client table → card view breakpoint from 600px to 768px so the table doesn't show mangled column headers at medium widths
- Disabled bulk selection checkboxes entirely — the bulk status change and transfer workflows were broken (just showed the same list with unchecked boxes) and confusing to users

## Test plan
- [ ] Resize browser on participants list — card view should appear by 768px, no more squished table columns
- [ ] Confirm no checkboxes appear next to participant names
- [ ] Confirm individual participant status changes still work from the participant detail page

🤖 Generated with [Claude Code](https://claude.com/claude-code)