### PR TITLE
fix: show AI nudge to admins when goal builder AI not configured

### DIFF
--- a/apps/plans/views.py
+++ b/apps/plans/views.py
@@ -696,7 +696,15 @@ def goal_create(request, client_id):
 
     # Check if AI Goal Builder is available
     from konote.ai_views import _ai_tools_enabled
+    from konote.ai import is_ai_available
     ai_enabled = _can_edit_plan(request.user, client) and _ai_tools_enabled()
+
+    # Nudge admins when AI could be enabled but isn't configured
+    ai_nudge_admin = (
+        not ai_enabled
+        and request.user.is_admin
+        and not is_ai_available()
+    )
 
     breadcrumbs = [
         {"url": reverse("clients:client_list"), "label": request.get_term("client_plural")},
@@ -718,6 +726,7 @@ def goal_create(request, client_id):
         "common_goals": common_goals,
         "selected_metric_ids": selected_metric_ids,
         "ai_enabled": ai_enabled,
+        "ai_nudge_admin": ai_nudge_admin,
         "participant_words": request.POST.get("participant_words", ""),
         "quick_pick_first": quick_pick_first,
     }

--- a/templates/plans/goal_form.html
+++ b/templates/plans/goal_form.html
@@ -10,6 +10,16 @@
     <p>{{ client.display_name }} {{ client.last_name }}</p>
 </hgroup>
 
+{% if ai_nudge_admin %}
+<article class="ai-nudge" role="note" style="border-left: 4px solid var(--pico-primary); padding: 0.75rem 1rem; margin-bottom: 1.5rem;">
+    <strong>{% trans "AI-assisted goal setting is available" %}</strong>
+    <p style="margin: 0.25rem 0 0;">
+        {% trans "KoNote can use AI to turn a participant's own words into a structured, measurable goal with suggested metrics. To enable it, add an OpenRouter API key in" %}
+        <a href="{% url 'admin_settings:features' %}">{% trans "Features" %}</a>.
+    </p>
+</article>
+{% endif %}
+
 {% if form.errors %}
 <div class="form-notice" role="alert" id="error-summary" tabindex="-1">
     <strong>{% trans "Almost there — a few things need your attention:" %}</strong>


### PR DESCRIPTION
## Summary
- When AI isn't configured (no OpenRouter API key), the goal form silently falls back to the manual flow with no indication that AI-assisted goal setting exists
- Now admins see a brief banner on the goal form: "AI-assisted goal setting is available" with a link to the Features page
- Non-admin staff see no change (they can't configure the key anyway)

## Also in this session
- Added `OPENROUTER_API_KEY` to the dev VPS `.env` and restarted the web container — AI should now be active on konote-dev

## Test plan
- [ ] Visit Add a Goal page as admin with no API key → nudge banner appears with link to Features
- [ ] Visit Add a Goal page as admin with API key set → no nudge, AI entry points shown
- [ ] Visit Add a Goal page as non-admin with no API key → no nudge, just manual form

🤖 Generated with [Claude Code](https://claude.com/claude-code)