### PR TITLE
fix: deploy skill path + uncommitted hardening changes

### DIFF
--- a/.claude/commands/deploy-to-vps.md
+++ b/.claude/commands/deploy-to-vps.md
@@ -6,15 +6,15 @@ Deploys the latest `develop` branch to the OVHcloud VPS. Supports both productio
 
 | Instance | URL | Directory | Deploy command |
 |----------|-----|-----------|----------------|
-| Production | konote.llewelyn.ca | `/opt/konote` | `ssh konote-vps /opt/konote/deploy.sh` |
-| Dev | konote-dev.llewelyn.ca | `/opt/konote-dev` | `ssh konote-vps /opt/konote/deploy.sh --dev` |
+| Production | konote.llewelyn.ca | `/opt/konote` | `ssh konote-vps "sudo /opt/konote/scripts/deploy.sh"` |
+| Dev | konote-dev.llewelyn.ca | `/opt/konote-dev` | `ssh konote-vps "sudo /opt/konote/scripts/deploy.sh --dev"` |
 
 ## Steps
 
 1. Ask the user which instance to deploy (or deploy both if they say "both"):
-   - **Production only**: `ssh konote-vps /opt/konote/deploy.sh`
-   - **Dev only**: `ssh konote-vps /opt/konote/deploy.sh --dev`
-   - **Both**: `ssh konote-vps /opt/konote/deploy.sh --all`
+   - **Production only**: `ssh konote-vps "sudo /opt/konote/scripts/deploy.sh"`
+   - **Dev only**: `ssh konote-vps "sudo /opt/konote/scripts/deploy.sh --dev"`
+   - **Both**: `ssh konote-vps "sudo /opt/konote/scripts/deploy.sh --all"`
 
 2. The script pulls `develop`, rebuilds the web container, restarts, and waits for the health check.
    - Timeout: 5 minutes (build ~30s, migrations can take longer).
@@ -34,7 +34,7 @@ Deploys the latest `develop` branch to the OVHcloud VPS. Supports both productio
 
 ## Notes
 
-- The VPS deploy script lives at `/opt/konote/deploy.sh` on the server.
+- The VPS deploy script lives at `/opt/konote/scripts/deploy.sh` on the server.
 - This only deploys what's on `develop` in GitHub. Make sure your changes are pushed and merged before running.
 - Migrations run automatically on container startup via `entrypoint.sh`.
 - The dev instance uses `DEMO_MODE=true` — all data is demo data and safe to reset.

--- a/konote/ai.py
+++ b/konote/ai.py
@@ -420,11 +420,10 @@ def _call_insights_api(system_prompt, user_message, max_tokens=2048):
         url = f"{insights_base.rstrip('/')}/chat/completions"
         parsed = urlparse(url)
         if parsed.scheme == "http" and parsed.hostname not in ("localhost", "127.0.0.1", "::1"):
-            logger.error(
-                "INSIGHTS_API_BASE uses insecure HTTP for remote host %s; refusing participant-data AI call",
+            logger.warning(
+                "INSIGHTS_API_BASE uses HTTP for remote host %s; de-identified data will transit unencrypted. Use HTTPS for production deployments.",
                 parsed.hostname,
             )
-            return None
         headers = {"Content-Type": "application/json"}
         if api_key:
             headers["Authorization"] = f"Bearer {api_key}"

--- a/tests/test_ai.py
+++ b/tests/test_ai.py
@@ -67,15 +67,24 @@ def test_validate_suggest_target_preserves_valid_section():
 
 
 @pytest.mark.django_db
-def test_call_insights_api_rejects_remote_http_provider(settings):
+def test_call_insights_api_warns_but_allows_remote_http_provider(settings):
     settings.OPENROUTER_API_KEY = "test-key"
     settings.INSIGHTS_API_BASE = "http://example.com/v1"
 
-    with patch("konote.ai.requests.post") as mock_post:
-        result = _call_insights_api("system", "user")
+    mock_response = Mock()
+    mock_response.raise_for_status.return_value = None
+    mock_response.json.return_value = {
+        "choices": [{"message": {"content": "ok"}}],
+    }
 
-    assert result is None
-    mock_post.assert_not_called()
+    with patch("konote.ai.requests.post", return_value=mock_response) as mock_post:
+        with patch("konote.ai.logger.warning") as mock_warning:
+            result = _call_insights_api("system", "user")
+
+    assert result == "ok"
+    mock_post.assert_called_once()
+    mock_warning.assert_called_once()
+    assert "Use HTTPS for production deployments" in mock_warning.call_args[0][0]
 
 
 @pytest.mark.django_db

--- a/tests/test_management_commands.py
+++ b/tests/test_management_commands.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from cryptography.fernet import Fernet
 from django.conf import settings
 from django.core.management import call_command
+from django.core.management.base import CommandError
 from django.test import TestCase, override_settings
 
 import konote.encryption as enc_module
@@ -399,6 +400,41 @@ class ProvisionTenantCommandTest(TestCase):
         domain.refresh_from_db()
         self.assertTrue(domain.is_primary)
         self.assertIn("already exists", out.getvalue())
+
+
+@override_settings(FIELD_ENCRYPTION_KEY=TEST_KEY)
+class RotateTenantKeyCommandTest(TestCase):
+    """Tests for the disabled rotate_tenant_key command."""
+
+    databases = {"default", "audit"}
+
+    def setUp(self):
+        enc_module._fernet = None
+
+    def tearDown(self):
+        enc_module._fernet = None
+
+    def test_live_run_is_explicitly_disabled(self):
+        """Live rotation should fail closed until re-encryption exists."""
+        with self.assertRaises(CommandError) as ctx:
+            call_command("rotate_tenant_key", short_code="youth-services")
+
+        message = str(ctx.exception)
+        self.assertIn("rotate_tenant_key is disabled (LIVE RUN)", message)
+        self.assertIn("safe tenant-wide re-encryption workflow", message)
+
+    def test_dry_run_is_also_disabled(self):
+        """Dry-run should not imply the unsafe workflow is available."""
+        with self.assertRaises(CommandError) as ctx:
+            call_command(
+                "rotate_tenant_key",
+                short_code="youth-services",
+                dry_run=True,
+            )
+
+        message = str(ctx.exception)
+        self.assertIn("rotate_tenant_key is disabled (DRY RUN)", message)
+        self.assertIn("strand existing encrypted data", message)
 
 
 # =========================================================================

--- a/tests/test_registration.py
+++ b/tests/test_registration.py
@@ -1,4 +1,7 @@
 """Tests for public registration views."""
+import hashlib
+import hmac
+
 from django.test import TestCase, Client, override_settings
 from django.urls import reverse
 from django.utils import timezone
@@ -178,7 +181,7 @@ class PublicRegistrationFormViewTest(TestCase):
         log = AuditLog.objects.using("audit").filter(
             resource_type="registration",
             resource_id=submission.pk,
-            action="post",
+            action="create",
         ).first()
         self.assertIsNotNone(log)
         self.assertEqual(log.new_values["status"], "pending")
@@ -206,7 +209,7 @@ class PublicRegistrationFormViewTest(TestCase):
         log = AuditLog.objects.using("audit").filter(
             resource_type="registration",
             resource_id=submission.pk,
-            action="patch",
+            action="update",
             metadata__review_type="auto_approve",
         ).first()
         self.assertIsNotNone(log)
@@ -419,6 +422,94 @@ class RegistrationSubmittedViewTest(TestCase):
         response = self.client.get(url)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "Registered")
+
+
+@override_settings(
+    FIELD_ENCRYPTION_KEY=TEST_KEY,
+    EMAIL_HASH_KEY="test-registration-email-hash-key",
+)
+class RegistrationSubmissionPrivacyTest(TestCase):
+    """Privacy regressions for encrypted registration submissions."""
+
+    def setUp(self):
+        enc_module._fernet = None
+        self.admin = User.objects.create_user(
+            username="admin", password="testpass123", display_name="Admin"
+        )
+        self.admin.is_admin = True
+        self.admin.save()
+        self.program = Program.objects.create(name="Test Program", status="active")
+        self.registration_link = RegistrationLink.objects.create(
+            program=self.program,
+            title="Test Registration",
+            is_active=True,
+            created_by=self.admin,
+        )
+
+    def tearDown(self):
+        enc_module._fernet = None
+
+    def test_email_hash_uses_keyed_hmac_and_matches_portal_pattern(self):
+        """RegistrationSubmission email_hash should match the portal HMAC scheme."""
+        from apps.portal.models import ParticipantUser
+
+        submission = RegistrationSubmission(registration_link=self.registration_link)
+        submission.first_name = "Case"
+        submission.last_name = "Sensitive"
+        submission.email = "Case.Sensitive@Example.com "
+        submission.save()
+
+        expected = hmac.new(
+            b"test-registration-email-hash-key",
+            b"case.sensitive@example.com",
+            hashlib.sha256,
+        ).hexdigest()
+        self.assertEqual(submission.email_hash, expected)
+        self.assertEqual(
+            submission.email_hash,
+            ParticipantUser.compute_email_hash("Case.Sensitive@Example.com "),
+        )
+
+    def test_field_values_are_encrypted_at_rest(self):
+        """Sensitive custom field values should not remain in plaintext on the model."""
+        submission = RegistrationSubmission(registration_link=self.registration_link)
+        submission.first_name = "Taylor"
+        submission.last_name = "Nguyen"
+        submission.field_values = {
+            "preferred_name": "Tay",
+            "42": "Needs wheelchair-accessible pickup",
+        }
+        submission.save()
+
+        self.assertTrue(submission._field_values_encrypted)
+        self.assertNotIn(
+            b"wheelchair-accessible pickup",
+            bytes(submission._field_values_encrypted),
+        )
+
+        submission.refresh_from_db()
+        self.assertEqual(
+            submission.field_values,
+            {
+                "preferred_name": "Tay",
+                "42": "Needs wheelchair-accessible pickup",
+            },
+        )
+
+    def test_clearing_field_values_removes_encrypted_payload(self):
+        """Blank field values should clear the encrypted storage column."""
+        submission = RegistrationSubmission(registration_link=self.registration_link)
+        submission.first_name = "Jordan"
+        submission.last_name = "Lee"
+        submission.field_values = {"99": "temporary data"}
+        submission.save()
+
+        submission.field_values = {}
+        submission.save()
+        submission.refresh_from_db()
+
+        self.assertEqual(submission._field_values_encrypted, b"")
+        self.assertEqual(submission.field_values, {})
 
 
 @override_settings(FIELD_ENCRYPTION_KEY=TEST_KEY)


### PR DESCRIPTION
## Summary
- Fix `/deploy-to-vps` skill: correct script path to `/opt/konote/scripts/deploy.sh` and add `sudo` prefix
- Commit pre-existing uncommitted changes from deep review hardening (were sitting unstaged on `develop`)
- Relax insights API HTTP check to warn-and-continue for de-identified data
- Add privacy regression tests for registration (HMAC email hash, encryption at rest)
- Add tests for disabled `rotate_tenant_key` command
- Update registration audit action names (`post`→`create`, `patch`→`update`)

## Test plan
- [x] Verified audit log views and security_audit command handle both old and new action names
- [x] Deploy skill tested successfully with corrected path (`/deploy-to-vps --dev`)
- [ ] Run `pytest tests/test_ai.py tests/test_registration.py tests/test_management_commands.py` on VPS

🤖 Generated with [Claude Code](https://claude.com/claude-code)