### PR TITLE
docs: add OPENROUTER_MODEL to .env.example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -153,6 +153,7 @@ DOMAIN=localhost
 #   2. Enable the "ai_assist" feature toggle in Admin → Settings
 # Features are hidden from the UI when either is missing.
 # OPENROUTER_API_KEY=sk-or-...
+# OPENROUTER_MODEL=qwen/qwen3.5-35b-a3b
 
 # Optional custom provider for participant-data insights.
 # Leave blank to use OpenRouter for de-identified insights traffic.


### PR DESCRIPTION
## Summary
- Adds `OPENROUTER_MODEL` env var to `.env.example` so dev instances don't default to Claude Sonnet (which returned 400 from OpenRouter)
- Sets default to `qwen/qwen3.5-35b-a3b` for development/testing (temporary — will move to self-hosted LLM)

## Test plan
- [ ] Docs-only change, no runtime impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)