### PR TITLE
Fix radio pill buttons clipping text in Log Contact form

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -1169,8 +1169,8 @@ output.form-output {
 .interaction-pills label {
     display: inline-flex;
     align-items: center;
-    gap: 0.375rem;
-    padding: 0.5rem 0.75rem;
+    justify-content: center;
+    padding: 0.5rem 1rem;
     border: 2px solid var(--kn-border-light, #ccc);
     border-radius: 999px;
     cursor: pointer;
@@ -1178,15 +1178,26 @@ output.form-output {
     min-height: 44px;
     transition: border-color 0.15s, background 0.15s;
     user-select: none;
+    color: var(--kn-text);
+    margin-bottom: 0;
 }
 .interaction-pills input[type="radio"] {
-    width: auto;
-    margin: 0;
+    position: absolute;
+    opacity: 0;
+    width: 0;
+    height: 0;
 }
-.interaction-pills input[type="radio"]:checked + span,
 .interaction-pills label:has(input:checked) {
     border-color: var(--kn-primary);
     background: var(--kn-primary-subtle, #e8f0fe);
+    font-weight: 500;
+}
+.interaction-pills label:hover {
+    border-color: var(--kn-primary);
+}
+.interaction-pills label:has(input:focus-visible) {
+    outline: 2px solid var(--kn-primary-focus, var(--kn-primary));
+    outline-offset: 2px;
 }
 
 /* ---- Chip buttons (quick-pick pills — shared by meeting picker & follow-up picker) ---- */
@@ -2861,9 +2872,10 @@ input[type="radio"] {
     min-width: 24px;
     min-height: 24px;
 }
-/* Enlarge click/tap area for labels containing checkboxes or radios */
-label:has(input[type="checkbox"]),
-label:has(input[type="radio"]) {
+/* Enlarge click/tap area for labels containing checkboxes or radios.
+   :where() keeps specificity at 0 so pill-style radio groups can override. */
+:where(label:has(input[type="checkbox"])),
+:where(label:has(input[type="radio"])) {
     padding: 0.5rem 0;
     cursor: pointer;
 }


### PR DESCRIPTION
## Summary
- Hides the native radio input in `.interaction-pills` (Log Contact / Quick Note forms), matching the pattern used by all other pill-style radio groups (scale-pills, achievement-pills, engagement-pills, descriptor-pills)
- Adds missing hover and focus-visible states for keyboard accessibility
- Wraps the global `label:has(input[type="radio"])` padding rule in `:where()` to prevent it from overriding pill-specific padding via cascade order

## Context
The interaction-pills were the **only** pill variant that kept the native radio circle visible (`width: auto`). This caused the radio to consume space inside the pill, clipping the text labels. All other pill patterns already hide the native input with `position: absolute; opacity: 0`.

## Test plan
- [ ] Verify Log Contact form pills on client Timeline tab — text should not be clipped
- [ ] Verify Quick Note standalone form pills — same fix applies
- [ ] Verify selected state shows blue border + background
- [ ] Verify keyboard navigation: Tab focuses pills, focus ring visible
- [ ] Verify other radio groups (group type cards, report format, erasure tier) are unaffected
- [ ] Verify scale-pills, achievement-pills, engagement-pills, descriptor-pills still styled correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)