### PR TITLE
Add position:relative to interaction-pills label

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -1170,6 +1170,7 @@ output.form-output {
     display: inline-flex;
     align-items: center;
     justify-content: center;
+    position: relative;
     padding: 0.5rem 1rem;
     border: 2px solid var(--kn-border-light, #ccc);
     border-radius: 999px;


### PR DESCRIPTION
## Summary
- Adds `position: relative` to `.interaction-pills label` so the `position: absolute` hidden radio input stays contained within its parent label
- Follow-up to PR #393 — identified during expert panel review

## Test plan
- [ ] Verify interaction pills still render correctly on Log Contact form
- [ ] No visual change expected — this is a defensive containment measure

🤖 Generated with [Claude Code](https://claude.com/claude-code)