### PR TITLE
Add accessibility and privacy review follow-ups

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -156,7 +156,10 @@ DOMAIN=localhost
 # OPENROUTER_MODEL=qwen/qwen3.5-35b-a3b
 
 # Optional custom provider for participant-data insights.
-# Leave blank to use OpenRouter for de-identified insights traffic.
+# Use this for the self-hosted open-source path when participant suggestion
+# categorisation or other participant-text analysis must stay on infrastructure
+# managed by the KoNote operator. Leave blank to use OpenRouter for any
+# remaining de-identified insights traffic.
 # Remote providers MUST use HTTPS. Local self-hosted endpoints may use HTTP.
 # INSIGHTS_API_BASE=http://localhost:11434/v1
 # INSIGHTS_API_KEY=

--- a/tasks/design-rationale/ai-feature-toggles.md
+++ b/tasks/design-rationale/ai-feature-toggles.md
@@ -42,6 +42,7 @@ Processes **de-identified participant content** — survey responses, open-ended
 |---------|-------------|----------------|
 | Outcome insights | Summarise themes from participant feedback | De-identified participant quotes and responses |
 | Qualitative analysis | Identify patterns in open-ended responses | Scrubbed participant text |
+| Suggestion categorisation | Group and tag open-ended participant suggestions | Scrubbed suggestion text processed on a self-hosted open-source model managed by KoNote |
 
 **Privacy classification:** Even with name scrubbing, this is **de-identified personal information** under PIPEDA s.2 and potentially **personal health information** under PHIPA s.4 if it relates to health services. Context, small sample sizes, or distinctive phrasing can re-identify participants.
 
@@ -123,7 +124,7 @@ The scrubbed quotes are sent via HTTPS POST to one of two endpoints:
 ### What is NOT protected (known gaps)
 
 1. **Content re-identification risk** — Even after name scrubbing, distinctive phrasing or unusual situations described in participant quotes could identify someone in a small community. The 15-participant minimum helps but doesn't eliminate this risk.
-2. **AI provider data retention** — OpenRouter and the underlying model provider (Anthropic) have their own data retention policies. KoNote does not control what happens to data after it reaches the API. This is the core reason the self-hosted LLM path is important.
+2. **AI provider data retention** — For any participant-data flow that still uses OpenRouter or another external endpoint, the provider has its own data retention policies. KoNote does not control what happens to data after it reaches that API. Open-ended suggestion categorisation should instead use the self-hosted LLM path described below.
 3. **Toggle change audit** — Currently no audit log entry when `ai_assist` is toggled on or off. The DRR recommends adding this.
 4. **No participant notification** — Participants are not currently informed whether AI processes their feedback. The DRR recommends adding a portal transparency statement.
 
@@ -202,8 +203,16 @@ Log when `ai_assist_participant_data` is toggled: who, when, on/off. Use the exi
 
 The participant portal should state the current AI posture:
 
-- **If participant insights ON:** "This agency uses AI to summarise feedback themes. Your name is removed before processing. No individual responses are shared."
-- **If participant insights OFF:** "This agency does not use AI to process your responses."
+- **If participant insights ON:** "This agency uses AI to help group feedback themes from survey responses and suggestions. Direct identifiers such as your name are removed before that processing. Open-ended suggestions are categorised using a self-hosted model managed by KoNote. Staff still review the results before using them."
+- **If participant insights OFF:** "This agency does not use AI to process your survey responses or suggestions."
+
+Recommended participant-facing privacy notice wording:
+
+> We collect your responses so staff can understand program outcomes, improve services, and meet reporting requirements. Your information is stored in KoNote on systems managed for this agency. If this agency enables AI-assisted feedback analysis, direct identifiers are removed before participant text is processed. Open-ended suggestions are categorised using a self-hosted model managed by KoNote, and staff review AI-generated summaries before using them. If this agency does not enable that feature, your responses are reviewed only by authorised staff and reporting tools.
+
+Short portal disclosure variant:
+
+> Your responses help improve services. If AI-assisted feedback analysis is enabled for this agency, KoNote removes direct identifiers before processing participant text and uses a self-hosted model for open-ended suggestion categorisation.
 
 ### UI guardrails on goal builder
 
@@ -213,15 +222,15 @@ The goal builder input should include helper text: "Describe the general goal ar
 
 When AI generates a suggested target or metric, staff should see a small "AI-suggested" indicator — not as a warning, but as transparency. Preserves human agency in the decision.
 
-## Future: Self-Hosted Open-Source LLM for Participant Data
+## Self-Hosted Open-Source LLM for Open-Ended Suggestions
 
-For agencies with heightened data sovereignty concerns (Indigenous communities under OCAP principles, newcomer-serving organisations), even de-identified data leaving the agency's infrastructure may be unacceptable.
+Open-ended suggestion categorisation should be planned and operated as a self-hosted open-source workflow managed by KoNote. This keeps the suggestion-tagging path on infrastructure controlled by the operator rather than a public AI API.
 
-**Future architectural direction:** For `ai_assist_participant_data`, support a self-hosted open-source LLM (e.g., Llama, Mistral) so participant data never leaves the agency's infrastructure.
+For agencies with heightened data sovereignty concerns (Indigenous communities under OCAP principles, newcomer-serving organisations), even de-identified data leaving the operator-controlled environment may be unacceptable. Those agencies may still decide to disable participant-data AI entirely.
 
-The toggle design already supports this — `ai_assist_participant_data` can switch between external API and local model without changing the user-facing feature. The existing `INSIGHTS_API_BASE` environment variable already supports pointing to a local Ollama endpoint.
+The toggle design already supports this — `ai_assist_participant_data` can use a local model endpoint without changing the user-facing feature. The existing `INSIGHTS_API_BASE` environment variable already supports pointing to a self-hosted OpenAI-compatible endpoint.
 
-**When to build:** After the first agency deployment, when real data sovereignty requirements are articulated by a specific partner. Do not build speculatively.
+This does not require a product-level distinction in the UI. The operator decision is infrastructural: if open-ended suggestions are enabled for AI processing at all, the default posture should be the self-hosted managed model described in the self-hosted LLM DRR.
 
 ## Migration Notes
 

--- a/tasks/design-rationale/self-hosted-llm-infrastructure.md
+++ b/tasks/design-rationale/self-hosted-llm-infrastructure.md
@@ -13,13 +13,15 @@ KoNote's current AI integration routes participant data (scrubbed quotes, sugges
 
 Beyond KoNote, LogicalOutcomes needs a general-purpose LLM inference endpoint for:
 
-1. **KoNote suggestion theme tagging** — nightly batch processing of participant suggestions across all agencies
+1. **KoNote suggestion theme tagging** — nightly batch processing of participant suggestions across all agencies; this is the assumed production path for open-ended suggestion categorisation
 2. **KoNote outcome insights** — on-demand qualitative analysis of scrubbed participant quotes
 3. **OpenWebUI connections** — external OpenWebUI instances at multiple organisations connect to this central model server
 4. **Survey qualitative analysis** — two-stage pipeline: PII stripping and data cleanup (self-hosted), then deep thematic analysis (frontier LLM API)
 5. **General analytical work** — document analysis, report drafting, data interpretation
 
 This is a **lean shared inference endpoint** — one VPS running Ollama + Caddy, serving multiple KoNote deployments, external OpenWebUI instances, and analytical workloads. OpenWebUI is deployed separately by each organisation, not on this server.
+
+For operator documentation and privacy planning, treat this shared Canadian-hosted server as the default execution path for AI categorisation of open-ended participant suggestions.
 
 ## Decision: Shared Ollama VPS on OVHcloud Beauharnois
 

--- a/tasks/privacy-retention-breach-template.md
+++ b/tasks/privacy-retention-breach-template.md
@@ -1,0 +1,148 @@
+# Privacy, Retention, and Breach Operations Template
+
+Status: Fill-in-ready template for organisation-specific decisions
+Related: [SaaS service agreement](saas-service-agreement.md), [Agency data offboarding](agency-data-offboarding.md), [Serious reportable events](serious-reportable-events.md), [Deployment protocol](deployment-protocol.md)
+
+## Purpose
+
+This template turns KoNote's existing technical controls into organisation-specific operating decisions. It is intentionally incomplete: each agency still needs to confirm retention periods, named contacts, approval thresholds, and regulator or funder notification rules.
+
+## Current AI Assumption for Open-Ended Suggestions
+
+For planning and policy purposes, assume open-ended suggestion categorisation runs on a self-hosted open-source LLM managed by the KoNote operator. That means:
+
+- suggestion text is processed on infrastructure controlled by the KoNote operator, not a third-party public API
+- the model endpoint, access keys, logs, and server hardening remain operator responsibilities
+- any future change to an external provider requires a fresh privacy review and explicit approval before production use
+
+If your organisation does not permit AI processing of participant text at all, keep the participant-data AI toggle disabled.
+
+## Section 1: Roles and Contacts
+
+Fill in the table below before go-live.
+
+| Role | Name | Email / Phone | Backup Contact | Notes |
+|---|---|---|---|---|
+| Privacy officer / delegate | [fill in] | [fill in] | [fill in] | Responsible for privacy decisions and breach notifications |
+| Executive director / sponsor | [fill in] | [fill in] | [fill in] | Approves policy exceptions |
+| IT / KoNote operator | [fill in] | [fill in] | [fill in] | Maintains backups, restores, access revocation |
+| Clinical / program lead | [fill in] | [fill in] | [fill in] | Advises on program-specific sensitivity |
+| Legal / external advisor | [fill in] | [fill in] | [fill in] | Optional but recommended |
+
+## Section 2: Retention Schedule
+
+Replace placeholders with the organisation's approved schedule.
+
+| Data set | Default holder | Retention period | Trigger for deletion / archival | Legal or contract basis | Notes |
+|---|---|---|---|---|---|
+| Participant record | KoNote primary database | [fill in] | [fill in] | [fill in] | Include discharged clients |
+| Progress notes and outcomes | KoNote primary database | [fill in] | [fill in] | [fill in] | |
+| Survey responses | KoNote primary database | [fill in] | [fill in] | [fill in] | Distinguish anonymous vs identified if needed |
+| Audit logs | KoNote audit database | [fill in] | [fill in] | [fill in] | Usually longer than operational data |
+| Database backups | Backup storage | [fill in] | [fill in] | [fill in] | Include main and audit backups |
+| Export files | Temporary export directory | [fill in] | [fill in] | [fill in] | Confirm download expiry and admin review window |
+| Offboarding package | Agency-controlled storage | [fill in] | [fill in] | [fill in] | See agency-data-offboarding.md |
+
+Retention decision notes:
+
+- [fill in] minimum retention required by contract, funder, or regulator
+- [fill in] whether anonymised aggregate reporting can be kept longer
+- [fill in] whether litigation hold or investigation hold pauses deletion
+
+## Section 3: Privacy Notice Inputs
+
+Use these points when finalising the organisation's privacy notice or participant-facing policy.
+
+| Topic | Organisation-specific wording to confirm |
+|---|---|
+| Purpose of collection | [fill in] |
+| Authority / consent basis | [fill in] |
+| Where data is stored | [fill in] |
+| Who can access KoNote data | [fill in] |
+| AI processing of participant text | [fill in: enabled or disabled, and for which features] |
+| Cross-border disclosures | [fill in] |
+| Participant rights / complaints contact | [fill in] |
+| Retention summary for participants | [fill in] |
+
+### Suggested participant-facing wording
+
+Use or adapt the wording below once organisation-specific details are confirmed.
+
+#### Full privacy notice paragraph
+
+> We collect your survey responses, service information, and related notes so authorised staff can deliver services, understand outcomes, improve programs, and meet reporting obligations. Your information is stored in KoNote on systems managed for this organisation or its approved operators. If this organisation enables AI-assisted feedback analysis, direct identifiers are removed before participant text is processed. Open-ended suggestions are categorised using a self-hosted model managed by KoNote, and staff review AI-generated summaries before they are used in reporting or program improvement. If that feature is not enabled, your responses are reviewed only by authorised staff and KoNote reporting tools.
+
+#### Short portal disclosure
+
+> Your responses help staff improve services and report on program outcomes. If AI-assisted feedback analysis is enabled for this organisation, direct identifiers are removed before participant text is processed, and open-ended suggestions are categorised using a self-hosted model managed by KoNote.
+
+#### Optional "AI disabled" variant
+
+> This organisation does not use AI to process participant responses or suggestions. Your responses are reviewed only by authorised staff and standard KoNote reporting tools.
+
+## Section 4: Breach and Security Incident Workflow
+
+Set concrete time targets and contacts before production use.
+
+### 1. Triage
+
+- Incident intake point: [fill in]
+- Required initial facts: date/time, reporter, systems involved, data types involved, whether data was actually disclosed, and whether KoNote is still actively exposed
+- Initial containment target: [fill in, for example within 1 hour]
+
+### 2. Containment
+
+- Disable affected accounts, tokens, or integrations
+- Preserve logs, exports, backups, and screenshots needed for investigation
+- If the issue involves infrastructure, decide who can stop services or block traffic: [fill in]
+- If the issue involves participant-data AI, suspend the participant-data AI toggle until review is complete
+
+### 3. Assessment
+
+Document the following:
+
+- categories of data involved
+- number of affected participants or staff, if known
+- whether encrypted data, plain-text exports, or emailed reports were exposed
+- whether the incident triggers contractual, funder, insurer, PIPEDA, PHIPA, or other reporting duties
+- whether the self-hosted LLM server, OpenWebUI connection, or external AI provider was involved
+
+### 4. Notification Matrix
+
+| Audience | Notify when | Owner | Deadline / target | Method |
+|---|---|---|---|---|
+| Internal leadership | [fill in] | [fill in] | [fill in] | [fill in] |
+| Privacy officer | [fill in] | [fill in] | [fill in] | [fill in] |
+| Affected partner agency | [fill in] | [fill in] | [fill in] | [fill in] |
+| Participants / clients | [fill in] | [fill in] | [fill in] | [fill in] |
+| Regulator / commissioner | [fill in] | [fill in] | [fill in] | [fill in] |
+| Funder / insurer | [fill in] | [fill in] | [fill in] | [fill in] |
+
+### 5. Closure
+
+- Root cause documented: [fill in]
+- Corrective action owner assigned: [fill in]
+- Evidence of completion stored at: [fill in]
+- Policy, training, or configuration changes required: [fill in]
+
+## Section 5: Review Cadence
+
+Confirm a recurring review schedule.
+
+| Review item | Owner | Frequency |
+|---|---|---|
+| Retention schedule | [fill in] | [fill in] |
+| Breach contact list | [fill in] | [fill in] |
+| Backup restore drill | [fill in] | [fill in] |
+| Participant-data AI posture | [fill in] | [fill in] |
+| Privacy notice wording | [fill in] | [fill in] |
+
+## Minimum Decisions Still Required
+
+The template is not complete until the organisation confirms:
+
+1. Named privacy and incident contacts.
+2. Record retention periods for live data, backups, audit logs, and exports.
+3. Notification thresholds and deadlines that apply to the organisation.
+4. Whether participant-data AI is enabled, and if so which features are in scope.
+5. Whether any contract, funder, or regulator imposes stricter rules than the default KoNote setup.

--- a/tasks/self-hosted-llm-summary.md
+++ b/tasks/self-hosted-llm-summary.md
@@ -8,6 +8,8 @@ You add it as a connection in OpenWebUI — point to the server's address in the
 
 ## What It's For
 
+For KoNote operations, assume open-ended participant suggestion categorisation uses this self-hosted open-source model rather than a public AI API.
+
 The main use case is **data cleaning for qualitative analysis** — preparing raw survey responses so they're ready for deep analysis by a frontier model.
 
 ### How the Two-Stage Workflow Works

--- a/tests/test_a11y_ci.py
+++ b/tests/test_a11y_ci.py
@@ -99,7 +99,7 @@ class AxeA11ySmokeTest(StaticLiveServerTestCase):
     def setUp(self):
         enc_module._fernet = None
         self._create_minimal_data()
-        self._context = self._browser.new_context()
+        self._context = self._browser.new_context(bypass_csp=True)
         self.page = self._context.new_page()
 
     def tearDown(self):
@@ -111,6 +111,7 @@ class AxeA11ySmokeTest(StaticLiveServerTestCase):
         """Create just enough data for pages to render."""
         from apps.auth_app.models import User
         from apps.programs.models import Program, UserProgramRole
+        from apps.surveys.models import Survey, SurveyLink, SurveyQuestion, SurveySection
 
         self.user = User.objects.create_user(
             username="a11y_staff", password="testpass123",
@@ -122,6 +123,26 @@ class AxeA11ySmokeTest(StaticLiveServerTestCase):
         UserProgramRole.objects.create(
             user=self.user, program=self.program, role=ROLE_PROGRAM_MANAGER,
         )
+
+        survey = Survey.objects.create(
+            name="Accessibility Smoke Survey",
+            status="active",
+            created_by=self.user,
+        )
+        section = SurveySection.objects.create(
+            survey=survey,
+            title="Feedback",
+            sort_order=1,
+        )
+        SurveyQuestion.objects.create(
+            section=section,
+            question_text="How was your visit?",
+            question_type="short_text",
+            sort_order=1,
+            required=True,
+        )
+        link = SurveyLink.objects.create(survey=survey, created_by=self.user)
+        self.public_survey_path = f"/s/{link.token}/"
 
     def _login(self):
         """Log in via the login form."""
@@ -174,8 +195,12 @@ class AxeA11ySmokeTest(StaticLiveServerTestCase):
         """Run axe-core on key pages — fail on critical/serious violations."""
         logged_in = False
         all_violations = {}
+        pages_to_check = [
+            *SMOKE_PAGES,
+            (self.public_survey_path, "Public survey", False),
+        ]
 
-        for path, description, requires_login in SMOKE_PAGES:
+        for path, description, requires_login in pages_to_check:
             if requires_login and not logged_in:
                 self._login()
                 logged_in = True

--- a/tests/ux_walkthrough/browser_base.py
+++ b/tests/ux_walkthrough/browser_base.py
@@ -134,7 +134,7 @@ class BrowserTestBase(StaticLiveServerTestCase):
     def setUp(self):
         enc_module._fernet = None
         self._create_test_data()
-        self._context = self._browser.new_context()
+        self._context = self._browser.new_context(bypass_csp=True)
         self.page = self._context.new_page()
 
     def tearDown(self):
@@ -353,7 +353,7 @@ class BrowserTestBase(StaticLiveServerTestCase):
         """Switch to a different user (new browser context)."""
         self.page.close()
         self._context.close()
-        self._context = self._browser.new_context()
+        self._context = self._browser.new_context(bypass_csp=True)
         self.page = self._context.new_page()
         self.login_via_browser(username)
 
@@ -361,7 +361,10 @@ class BrowserTestBase(StaticLiveServerTestCase):
         """Switch to a different user with a specific colour scheme."""
         self.page.close()
         self._context.close()
-        self._context = self._browser.new_context(color_scheme=color_scheme)
+        self._context = self._browser.new_context(
+            color_scheme=color_scheme,
+            bypass_csp=True,
+        )
         self.page = self._context.new_page()
         self.login_via_browser(username)
 


### PR DESCRIPTION
## Summary
- add public survey coverage to the browser accessibility smoke suite
- make the Playwright accessibility harness compatible with the tightened CSP
- document the self-hosted AI posture, participant-facing privacy wording, and a fill-in-ready privacy operations template

## Verification
- python -m pytest tests/test_surveys.py -k ""PublicSurveyViewTests or PublicSurveySubmissionTests or PublicSurveyBilingualTests or PublicSurveyConditionalTests or PublicSurveyConsentTests"" -q
- python -m pytest tests/test_a11y_ci.py -k test_axe_smoke_all_pages -q
