### PR TITLE
Add AI visibility and admin accessibility coverage

### DIFF
--- a/apps/admin_settings/views.py
+++ b/apps/admin_settings/views.py
@@ -5,6 +5,7 @@ from django.core.cache import cache
 from django.shortcuts import redirect, render
 from django.utils import timezone as tz
 from django.utils.translation import gettext as _, gettext_lazy as _lazy
+from urllib.parse import urlparse
 
 from apps.auth_app.decorators import admin_required, demo_read_only
 
@@ -425,6 +426,82 @@ DEFAULT_FEATURES = {
 FEATURES_DEFAULT_ENABLED = {"require_client_consent", "portal_journal", "portal_messaging", "cross_program_note_sharing", "portal_resources", "ai_assist_tools_only"}
 
 
+def _build_ai_processing_summary(current_flags):
+    """Return operator-facing status details for AI processing modes."""
+    from django.conf import settings as django_settings
+
+    tools_enabled = current_flags.get("ai_assist_tools_only", "ai_assist_tools_only" in FEATURES_DEFAULT_ENABLED)
+    participant_enabled = current_flags.get("ai_assist_participant_data", False)
+    openrouter_key = bool(getattr(django_settings, "OPENROUTER_API_KEY", ""))
+    openrouter_model = getattr(django_settings, "OPENROUTER_MODEL", "")
+    insights_api_base = (getattr(django_settings, "INSIGHTS_API_BASE", "") or "").strip()
+    insights_model = getattr(django_settings, "INSIGHTS_MODEL", "")
+    allowed_hosts = getattr(django_settings, "INSIGHTS_ALLOWED_HOSTS", []) or []
+
+    participant_provider_mode = _("Disabled")
+    participant_provider_detail = _("Participant-data AI is turned off.")
+    residency_note = _("No participant text is sent to AI services.")
+
+    if participant_enabled:
+        if insights_api_base:
+            parsed = urlparse(insights_api_base)
+            hostname = (parsed.hostname or "").lower()
+            is_local = hostname in {"localhost", "127.0.0.1", "::1"} or hostname.endswith(".local")
+            if is_local:
+                participant_provider_mode = _("Self-hosted local provider")
+                participant_provider_detail = _(
+                    "Participant-data AI uses a self-hosted OpenAI-compatible endpoint at %(host)s with model %(model)s."
+                ) % {
+                    "host": hostname or insights_api_base,
+                    "model": insights_model or _("configured model"),
+                }
+                residency_note = _("Participant text stays on infrastructure managed by your KoNote operator.")
+            else:
+                participant_provider_mode = _("Approved remote custom provider")
+                participant_provider_detail = _(
+                    "Participant-data AI uses the approved remote host %(host)s with model %(model)s."
+                ) % {
+                    "host": hostname or insights_api_base,
+                    "model": insights_model or _("configured model"),
+                }
+                if allowed_hosts:
+                    residency_note = _(
+                        "Only hosts in INSIGHTS_ALLOWED_HOSTS may be used for participant-data AI."
+                    )
+                else:
+                    residency_note = _("This provider is remote. Confirm residency and contractual requirements separately.")
+        elif openrouter_key:
+            participant_provider_mode = _("OpenRouter fallback")
+            participant_provider_detail = _(
+                "Participant-data AI falls back to OpenRouter using model %(model)s because no custom insights provider is configured."
+            ) % {"model": openrouter_model or _("configured model")}
+            residency_note = _("Participant text is processed by an external provider; confirm your agency policy before enabling this mode.")
+        else:
+            participant_provider_mode = _("Enabled but unavailable")
+            participant_provider_detail = _(
+                "Participant-data AI is enabled in feature toggles, but no usable provider credentials are configured."
+            )
+            residency_note = _("No participant-data AI requests can run until a provider is configured.")
+
+    tools_provider_mode = _("Unavailable")
+    tools_provider_detail = _("Tools-only AI is unavailable because no OpenRouter API key is configured.")
+    if openrouter_key:
+        tools_provider_mode = _("OpenRouter")
+        tools_provider_detail = _(
+            "Tools-only AI uses OpenRouter with model %(model)s and sends only non-participant metadata."
+        ) % {"model": openrouter_model or _("configured model")}
+
+    return {
+        "tools_enabled": tools_enabled,
+        "participant_enabled": participant_enabled,
+        "tools_provider_mode": tools_provider_mode,
+        "tools_provider_detail": tools_provider_detail,
+        "participant_provider_mode": participant_provider_mode,
+        "participant_provider_detail": participant_provider_detail,
+        "residency_note": residency_note,
+    }
+
+
 @login_required
 @admin_required
 @demo_read_only
@@ -462,15 +539,11 @@ def features(request):
             "is_enabled": current_flags.get(key, default_state),
         })
 
-    # AI processing info for admin awareness
-    from django.conf import settings as django_settings
-    ai_key_set = bool(getattr(django_settings, "OPENROUTER_API_KEY", ""))
-    ai_model = getattr(django_settings, "OPENROUTER_MODEL", "")
+    ai_processing_summary = _build_ai_processing_summary(current_flags)
 
     return render(request, "admin_settings/features.html", {
         "feature_rows": feature_rows,
-        "ai_key_set": ai_key_set,
-        "ai_model": ai_model,
+        "ai_processing_summary": ai_processing_summary,
     })
 
 

--- a/apps/portal/templates/portal/goal_detail.html
+++ b/apps/portal/templates/portal/goal_detail.html
@@ -93,6 +93,7 @@
 <script nonce="{{ request.csp_nonce }}">
 (function() {
     var allData = JSON.parse(document.getElementById('chart-data').textContent);
+    var prefersReducedMotion = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
     var descContainer = document.getElementById('chart-descriptions');
     var chartContainer = document.querySelector('.portal-chart-container');
 
@@ -145,6 +146,9 @@
             options: {
                 responsive: true,
                 maintainAspectRatio: true,
+                animation: {
+                    duration: prefersReducedMotion ? 0 : undefined
+                },
                 plugins: {
                     legend: { display: allData.length > 1 },
                     tooltip: {

--- a/apps/portal/templates/portal/progress.html
+++ b/apps/portal/templates/portal/progress.html
@@ -164,6 +164,7 @@
             ? chartInfo.max_value : undefined;
 
         var ctx = canvas.getContext('2d');
+        var prefersReducedMotion = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
         new Chart(ctx, {
             type: 'line',
             data: {
@@ -186,6 +187,9 @@
             options: {
                 responsive: true,
                 maintainAspectRatio: false,
+                animation: {
+                    duration: prefersReducedMotion ? 0 : undefined
+                },
                 plugins: {
                     legend: { display: false },
                     tooltip: {

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -1805,6 +1805,10 @@ button.outline.secondary:hover {
     border-radius: var(--kn-radius, 4px);
     margin-bottom: 1.5rem;
 }
+.page-help summary,
+.page-help summary strong {
+    color: var(--kn-info-fg);
+}
 .page-help-content {
     font-size: 0.875rem;
     color: var(--kn-info-fg);

--- a/static/offline.html
+++ b/static/offline.html
@@ -6,18 +6,73 @@
     <title>Offline — KoNote</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css">
     <style>
-        body { display: flex; justify-content: center; align-items: center; min-height: 100vh; margin: 0; }
-        .offline-card { text-align: center; max-width: 28rem; padding: 2rem; }
+        body { display: flex; justify-content: center; align-items: center; min-height: 100vh; margin: 0; padding: 1rem; }
+        .offline-card { text-align: center; max-width: 32rem; padding: 2rem; }
         .offline-icon { font-size: 3rem; margin-bottom: 1rem; }
+        .visually-hidden-focusable {
+            position: absolute;
+            width: 1px;
+            height: 1px;
+            padding: 0;
+            margin: -1px;
+            overflow: hidden;
+            clip: rect(0, 0, 0, 0);
+            white-space: nowrap;
+            border: 0;
+        }
+        .visually-hidden-focusable:focus {
+            position: static;
+            width: auto;
+            height: auto;
+            padding: .5rem 1rem;
+            margin: 0 0 1rem;
+            overflow: visible;
+            clip: auto;
+            white-space: normal;
+            background: #3176aa;
+            color: #fff;
+            z-index: 9999;
+        }
     </style>
 </head>
 <body>
-    <main class="offline-card">
+    <a id="skip-link" href="#main-content" class="visually-hidden-focusable">Skip to main content</a>
+    <main id="main-content" tabindex="-1" class="offline-card">
         <div class="offline-icon" aria-hidden="true">&#x1F4E1;</div>
-        <h1>You're offline</h1>
-        <p>It looks like your internet connection was lost. Your data is safe — any unsaved work is stored locally.</p>
-        <p>Check your connection and try again.</p>
-        <button onclick="window.location.reload()">Try again</button>
+        <h1 id="offline-title">You're offline</h1>
+        <p id="offline-body-1">It looks like your internet connection was lost. Your data is safe and any unsaved work is stored locally.</p>
+        <p id="offline-body-2">Check your connection and try again.</p>
+        <button id="offline-retry" type="button" onclick="window.location.reload()">Try again</button>
     </main>
+    <script>
+    (function() {
+        var isFrench = ((navigator.language || navigator.userLanguage || 'en').toLowerCase().indexOf('fr') === 0);
+        var copy = isFrench ? {
+            lang: 'fr',
+            title: 'Hors ligne — KoNote',
+            skip: 'Aller au contenu principal',
+            heading: 'Vous êtes hors ligne',
+            body1: 'Il semble que votre connexion Internet ait été interrompue. Vos données sont en sécurité et tout travail non enregistré reste stocké localement.',
+            body2: 'Vérifiez votre connexion et réessayez.',
+            retry: 'Réessayer'
+        } : {
+            lang: 'en',
+            title: 'Offline — KoNote',
+            skip: 'Skip to main content',
+            heading: "You're offline",
+            body1: 'It looks like your internet connection was lost. Your data is safe and any unsaved work is stored locally.',
+            body2: 'Check your connection and try again.',
+            retry: 'Try again'
+        };
+
+        document.documentElement.lang = copy.lang;
+        document.title = copy.title;
+        document.getElementById('skip-link').textContent = copy.skip;
+        document.getElementById('offline-title').textContent = copy.heading;
+        document.getElementById('offline-body-1').textContent = copy.body1;
+        document.getElementById('offline-body-2').textContent = copy.body2;
+        document.getElementById('offline-retry').textContent = copy.retry;
+    })();
+    </script>
 </body>
 </html>

--- a/templates/500.html
+++ b/templates/500.html
@@ -1,6 +1,5 @@
-{% load i18n %}<!DOCTYPE html>
-{# Django's default 500 handler renders with an empty context, so LANGUAGE_CODE is unavailable. Hardcode lang="en". #}
-<html lang="en">
+{% load i18n %}{% get_current_language as LANGUAGE_CODE %}<!DOCTYPE html>
+<html lang="{{ LANGUAGE_CODE|default:'en' }}">
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -140,7 +139,7 @@
     </style>
 </head>
 <body>
-    <a href="#main-content" class="visually-hidden-focusable">Skip to main content</a>
+    <a href="#main-content" class="visually-hidden-focusable">{% trans "Skip to main content" %}</a>
     <main id="main-content" tabindex="-1">
         <article class="error-page" role="alert">
             <header>

--- a/templates/admin_settings/features.html
+++ b/templates/admin_settings/features.html
@@ -14,23 +14,37 @@
 {% include "admin_settings/_page_help.html" with content=_('Feature toggles turn modules on or off for your whole organisation. Disabling a feature hides it from all users but preserves existing data. Some features depend on others — the confirmation dialog will show you the impact before you commit.') %}
 
 {# -- AI Processing Notice -- #}
-{% if ai_key_set %}
 <article style="background: var(--pico-card-background-color); border-left: 4px solid var(--pico-primary); padding: 1rem 1.25rem; margin-bottom: 1.5rem;">
     <strong style="font-size: 1.1em;">{% trans "AI Processing" %}</strong>
-    <p style="margin: 0.5rem 0 0;">
-        {% blocktrans with model=ai_model %}AI requests are sent to <strong>OpenRouter</strong> (external API) using model: <code>{{ model }}</code>.{% endblocktrans %}
-        <br>
-        <small class="secondary">{% trans "Data sent depends on which AI features are enabled below. Tools-only AI sends program metadata only (no personal information). Participant-data AI sends de-identified quotes." %}</small>
+    <p style="margin: 0.5rem 0 1rem;">
+        {% trans "Use this summary to confirm which provider mode is active before enabling participant-data AI." %}
+    </p>
+    <dl style="margin-bottom: 0.75rem;">
+        <dt><strong>{% trans "Tools-only AI" %}</strong></dt>
+        <dd>
+            {% if ai_processing_summary.tools_enabled %}
+                <span class="badge badge-success">{% trans "Enabled" %}</span>
+            {% else %}
+                <span class="badge badge-neutral">{% trans "Disabled" %}</span>
+            {% endif %}
+            <span style="margin-left: 0.5rem;"><strong>{% trans "Provider:" %}</strong> {{ ai_processing_summary.tools_provider_mode }}</span>
+            <br><small class="secondary">{{ ai_processing_summary.tools_provider_detail }}</small>
+        </dd>
+        <dt style="margin-top: 0.75rem;"><strong>{% trans "Participant-data AI" %}</strong></dt>
+        <dd>
+            {% if ai_processing_summary.participant_enabled %}
+                <span class="badge badge-success">{% trans "Enabled" %}</span>
+            {% else %}
+                <span class="badge badge-neutral">{% trans "Disabled" %}</span>
+            {% endif %}
+            <span style="margin-left: 0.5rem;"><strong>{% trans "Provider mode:" %}</strong> {{ ai_processing_summary.participant_provider_mode }}</span>
+            <br><small class="secondary">{{ ai_processing_summary.participant_provider_detail }}</small>
+        </dd>
+    </dl>
+    <p style="margin: 0;">
+        <small class="secondary">{{ ai_processing_summary.residency_note }}</small>
     </p>
 </article>
-{% else %}
-<article style="background: var(--pico-card-background-color); border-left: 4px solid var(--pico-del-color); padding: 1rem 1.25rem; margin-bottom: 1.5rem;">
-    <strong style="font-size: 1.1em;">{% trans "AI Processing" %}</strong>
-    <p style="margin: 0.5rem 0 0;">
-        {% trans "No AI API key is configured. AI features are unavailable even if enabled below." %}
-    </p>
-</article>
-{% endif %}
 
 <figure>
 <table role="grid" aria-label="{% trans 'Feature toggles' %}">

--- a/templates/consortia/dashboard.html
+++ b/templates/consortia/dashboard.html
@@ -194,6 +194,7 @@ function makeBarChart(canvasId, tableId, dataKey, labelKey) {
     const rows = (rollupData.demographics || {})[dataKey] || [];
     const labels = rows.map(r => r.label || '');
     const counts = rows.map(r => typeof r.count === 'number' ? r.count : 0);
+    const prefersReducedMotion = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
     // Chart
     const ctx = document.getElementById(canvasId);
@@ -210,6 +211,9 @@ function makeBarChart(canvasId, tableId, dataKey, labelKey) {
             },
             options: {
                 responsive: true,
+                animation: {
+                    duration: prefersReducedMotion ? 0 : undefined,
+                },
                 plugins: {
                     legend: { display: false },
                     // Data labels for colourblind accessibility

--- a/templates/offline.html
+++ b/templates/offline.html
@@ -1,6 +1,5 @@
-<!DOCTYPE html>
-<!-- Served by the service worker — no Django context is available. Hardcode lang="en". -->
-<html lang="en">
+{% load i18n %}{% get_current_language as LANGUAGE_CODE %}<!DOCTYPE html>
+<html lang="{{ LANGUAGE_CODE|default:'en' }}">
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -24,12 +23,12 @@
     </style>
 </head>
 <body>
-    <a href="#main-content" class="visually-hidden-focusable">Skip to main content</a>
+    <a href="#main-content" class="visually-hidden-focusable">{% trans "Skip to main content" %}</a>
     <main id="main-content" tabindex="-1">
         <div class="icon" aria-hidden="true">&#128268;</div>
-        <h1>You're offline</h1>
-        <p>This page requires an internet connection. Please check your network and try again.</p>
-        <button type="button" data-reload-page="true">Try again</button>
+        <h1>{% trans "You're offline" %}</h1>
+        <p>{% trans "This page requires an internet connection. Please check your network and try again." %}</p>
+        <button type="button" data-reload-page="true">{% trans "Try again" %}</button>
     </main>
 </body>
 </html>

--- a/templates/reports/_insights_basic.html
+++ b/templates/reports/_insights_basic.html
@@ -471,6 +471,7 @@
 {% trans "Something's shifting" as lbl_shifting %}
 {% trans "In a good place" as lbl_good %}
 (function() {
+    var prefersReducedMotion = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
     function initDescriptorTrendChart() {
         var rawData = JSON.parse(document.getElementById('descriptor-trend-data').textContent);
         if (!Array.isArray(rawData) || rawData.length === 0) return;
@@ -520,6 +521,9 @@
             options: {
                 responsive: true,
                 maintainAspectRatio: false,
+                animation: {
+                    duration: prefersReducedMotion ? 0 : undefined
+                },
                 plugins: {
                     legend: { position: 'bottom' },
                     tooltip: {
@@ -559,6 +563,7 @@
 {% trans "More support needed" as lbl_band_low %}
 {% trans "Goals within reach" as lbl_band_high %}
 (function() {
+    var prefersReducedMotion = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
     function initDistributionTrendCharts() {
         var trendsData = JSON.parse(document.getElementById('metric-trends-data').textContent);
         if (!trendsData) return;
@@ -594,6 +599,9 @@
                 options: {
                     responsive: true,
                     maintainAspectRatio: false,
+                    animation: {
+                        duration: prefersReducedMotion ? 0 : undefined
+                    },
                     plugins: {
                         legend: { position: 'bottom' },
                         tooltip: {

--- a/templates/reports/_insights_client.html
+++ b/templates/reports/_insights_client.html
@@ -122,6 +122,7 @@
 {% trans "Something's shifting" as lbl_shifting %}
 {% trans "In a good place" as lbl_good %}
 (function() {
+    var prefersReducedMotion = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
     function initClientTrendChart() {
         var rawData = JSON.parse(document.getElementById('client-trend-data').textContent);
         if (!Array.isArray(rawData) || rawData.length === 0) return;
@@ -141,6 +142,9 @@
             options: {
                 responsive: true,
                 maintainAspectRatio: false,
+                animation: {
+                    duration: prefersReducedMotion ? 0 : undefined
+                },
                 plugins: { legend: { position: 'bottom' }, tooltip: { callbacks: { label: function(c) { return c.dataset.label + ': ' + c.parsed.y + '%'; } } } },
                 scales: { y: { beginAtZero: true, max: 100, ticks: { callback: function(v) { return v + '%'; } } } },
             },

--- a/templates/reports/_tab_analysis.html
+++ b/templates/reports/_tab_analysis.html
@@ -124,6 +124,7 @@
 <script nonce="{{ request.csp_nonce }}">
 {# Chart.js is loaded AFTER block content in base.html, so defer until ready #}
 (function() {
+    var prefersReducedMotion = window.matchMedia && window.matchMedia('(prefers-reduced-motion: reduce)').matches;
     function initAnalysisCharts() {
         var chartData = JSON.parse(document.getElementById('chart-data').textContent);
         if (!Array.isArray(chartData)) {
@@ -172,6 +173,9 @@
             options: {
                 responsive: true,
                 maintainAspectRatio: false,
+                animation: {
+                    duration: prefersReducedMotion ? 0 : undefined
+                },
                 plugins: { legend: { position: 'bottom' } },
                 scales: {
                     y: { beginAtZero: false, title: { display: true, text: chart.unit || '{% trans "Value" %}' } },

--- a/tests/test_a11y_ci.py
+++ b/tests/test_a11y_ci.py
@@ -37,6 +37,7 @@ SMOKE_PAGES = [
     ("/auth/login/", "Login page", False),
     ("/", "Dashboard", True),
     ("/participants/", "Participant list", True),
+    ("/admin/settings/features/", "Admin feature settings", True),
 ]
 
 

--- a/tests/test_accessibility_templates.py
+++ b/tests/test_accessibility_templates.py
@@ -1,0 +1,34 @@
+from pathlib import Path
+
+from django.conf import settings
+from django.template.loader import render_to_string
+from django.test import SimpleTestCase
+from django.utils.translation import override as translation_override
+
+
+class StandaloneAccessibilityTemplateTests(SimpleTestCase):
+    def test_500_template_uses_active_language_for_html_lang(self):
+        with translation_override("fr"):
+            content = render_to_string("500.html")
+
+        self.assertIn('lang="fr"', content)
+        self.assertIn('href="#main-content"', content)
+        self.assertNotIn("Skip to main content", content)
+
+    def test_offline_template_uses_active_language_for_html_lang(self):
+        with translation_override("fr"):
+            content = render_to_string("offline.html")
+
+        self.assertIn('lang="fr"', content)
+        self.assertIn('href="#main-content"', content)
+        self.assertNotIn("Skip to main content", content)
+
+
+class StaticOfflineFallbackTests(SimpleTestCase):
+    def test_static_offline_page_has_skip_link_and_language_detection(self):
+        content = (Path(settings.BASE_DIR) / "static" / "offline.html").read_text(encoding="utf-8")
+
+        self.assertIn('href="#main-content"', content)
+        self.assertIn('id="main-content"', content)
+        self.assertIn("navigator.language", content)
+        self.assertIn("document.documentElement.lang", content)

--- a/tests/test_admin_settings.py
+++ b/tests/test_admin_settings.py
@@ -213,6 +213,39 @@ class FeatureToggleTest(TestCase):
         self.assertEqual(resp.status_code, 302)
         self.assertFalse(FeatureToggle.objects.get(feature_key="programs").is_enabled)
 
+    @override_settings(OPENROUTER_API_KEY="sk-test", OPENROUTER_MODEL="qwen/test-model")
+    def test_features_page_shows_openrouter_tools_mode(self):
+        self.client.login(username="admin", password="testpass123")
+        resp = self.client.get("/admin/settings/features/")
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, "Tools-only AI")
+        self.assertContains(resp, "Provider:")
+        self.assertContains(resp, "OpenRouter")
+        self.assertContains(resp, "qwen/test-model")
+
+    @override_settings(
+        OPENROUTER_API_KEY="sk-test",
+        INSIGHTS_API_BASE="http://localhost:11434/v1",
+        INSIGHTS_MODEL="llama3.2",
+    )
+    def test_features_page_shows_self_hosted_participant_mode(self):
+        self.client.login(username="admin", password="testpass123")
+        FeatureToggle.objects.create(feature_key="ai_assist_participant_data", is_enabled=True)
+        resp = self.client.get("/admin/settings/features/")
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, "Participant-data AI")
+        self.assertContains(resp, "Provider mode:")
+        self.assertContains(resp, "Self-hosted local provider")
+        self.assertContains(resp, "llama3.2")
+
+    @override_settings(OPENROUTER_API_KEY="")
+    def test_features_page_shows_unavailable_tools_mode_without_api_key(self):
+        self.client.login(username="admin", password="testpass123")
+        resp = self.client.get("/admin/settings/features/")
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, "Tools-only AI")
+        self.assertContains(resp, "Unavailable")
+
 
 @override_settings(FIELD_ENCRYPTION_KEY=TEST_KEY)
 class FeatureToggleConfirmTest(TestCase):

--- a/tests/test_surveys.py
+++ b/tests/test_surveys.py
@@ -1284,6 +1284,19 @@ class PublicSurveyViewTests(TestCase):
             section=self.section, question_text="How was your experience?",
             question_type="short_text", sort_order=1, required=True,
         )
+        self.q2 = SurveyQuestion.objects.create(
+            section=self.section,
+            question_text="Rate accessibility",
+            question_type="rating_scale",
+            sort_order=2,
+            required=True,
+            min_value=1,
+            max_value=5,
+            options_json=[
+                {"value": "1", "label": "Poor", "label_fr": "Faible"},
+                {"value": "5", "label": "Excellent", "label_fr": "Excellent"},
+            ],
+        )
         self.link = SurveyLink.objects.create(
             survey=self.survey, created_by=self.staff,
         )
@@ -1292,6 +1305,13 @@ class PublicSurveyViewTests(TestCase):
         resp = self.client.get(f"/s/{self.link.token}/")
         self.assertEqual(resp.status_code, 200)
         self.assertContains(resp, "Public Survey")
+
+    def test_public_rating_scale_uses_fieldset_and_legend(self):
+        resp = self.client.get(f"/s/{self.link.token}/")
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, '<fieldset class="survey-question-group">', html=False)
+        self.assertContains(resp, "<legend>")
+        self.assertContains(resp, "Rate accessibility")
 
     def test_public_form_submit_creates_response(self):
         resp = self.client.post(


### PR DESCRIPTION
Summary
- add operator-facing AI provider visibility on the admin feature settings page
- extend browser accessibility smoke coverage to the admin feature settings page
- fix shared page-help summary contrast exposed by the new smoke coverage

Testing
- python -m pytest tests/test_admin_settings.py
- python -m pytest tests/test_a11y_ci.py -k test_axe_smoke_all_pages