### PR TITLE
Add helper copy to admin destination pages

### DIFF
--- a/templates/admin_settings/setup_wizard/_wizard_base.html
+++ b/templates/admin_settings/setup_wizard/_wizard_base.html
@@ -73,7 +73,7 @@
 {% block content %}
 <hgroup>
     <h1>{% trans "Setup Wizard" %}</h1>
-    <p>{% trans "Configure your KoNote instance step by step." %}</p>
+    <p>{% trans "Guided setup for a new or reconfigured instance. Work through settings, terminology, features, programs, metrics, and templates in order." %}</p>
 </hgroup>
 
 <nav aria-label="{% trans 'Wizard progress' %}">

--- a/templates/audit/log_list.html
+++ b/templates/audit/log_list.html
@@ -19,7 +19,7 @@
 <div class="container">
     <hgroup>
         <h1>{% trans "Audit Log" %}</h1>
-        <p>{% trans "Review all system activity. Use filters to narrow results." %}</p>
+        <p>{% trans "Review system activity, exports, and permission-sensitive actions." %}</p>
     </hgroup>
 
     {# ---- Filter form ---- #}

--- a/templates/reports/oversight_list.html
+++ b/templates/reports/oversight_list.html
@@ -13,7 +13,7 @@
 
 <header class="page-header">
     <h1>{% trans "Safety Oversight Reports" %}</h1>
-    <p class="page-subtitle">{% trans "Quarterly safety reports for board, funders, and accreditation." %}</p>
+    <p class="page-subtitle">{% trans "Review safety report snapshots and follow-up items that need leadership attention." %}</p>
 </header>
 
 <div class="action-bar">

--- a/tests/test_audit_views.py
+++ b/tests/test_audit_views.py
@@ -50,6 +50,10 @@ class AuditLogListTests(TestCase):
         self.client.login(username="admin", password="testpass123")
         resp = self.client.get("/manage/audit/")
         self.assertEqual(resp.status_code, 200)
+        self.assertContains(
+            resp,
+            "Review system activity, exports, and permission-sensitive actions.",
+        )
 
     def test_non_admin_gets_403(self):
         self.client.login(username="staff", password="testpass123")

--- a/tests/test_safety_oversight.py
+++ b/tests/test_safety_oversight.py
@@ -280,6 +280,10 @@ class OversightReportViewTest(TestCase):
         resp = self.http.get("/reports/oversight/")
         self.assertEqual(resp.status_code, 200)
         self.assertContains(resp, "Safety Oversight Reports")
+        self.assertContains(
+            resp,
+            "Review safety report snapshots and follow-up items that need leadership attention.",
+        )
 
     def test_generate_page_loads(self):
         self.http.login(username="admin_view", password="testpass123")

--- a/tests/test_setup_wizard.py
+++ b/tests/test_setup_wizard.py
@@ -27,6 +27,10 @@ class SetupWizardAccessTest(TestCase):
         resp = self.client.get("/admin/settings/setup-wizard/")
         self.assertEqual(resp.status_code, 200)
         self.assertContains(resp, "Setup Wizard")
+        self.assertContains(
+            resp,
+            "Guided setup for a new or reconfigured instance. Work through settings, terminology, features, programs, metrics, and templates in order.",
+        )
 
     def test_staff_cannot_access_wizard(self):
         self.client.login(username="staff", password="testpass123")


### PR DESCRIPTION
## Summary
- add the missing helper copy to the setup wizard destination page
- update the admin audit log and oversight list headers to match the dashboard entry guidance
- extend focused tests for those destination pages

## Validation
- pytest tests/test_setup_wizard.py tests/test_audit_views.py tests/test_safety_oversight.py -q