### PR TITLE
Fix review findings: migration guard, JS allowlist, suggestion validation

### DIFF
--- a/apps/plans/views.py
+++ b/apps/plans/views.py
@@ -755,7 +755,7 @@ def goal_create_from_suggestion(request, client_id):
         suggestion_key = ""
     suggestion = request.session.pop(suggestion_key, None) if suggestion_key else None
 
-    if not suggestion:
+    if not suggestion or not isinstance(suggestion, dict) or not suggestion.get("name", "").strip():
         return render(request, "plans/_goal_save_error.html", {
             "error": _("Suggestion expired or was already used. Please try again."),
             "client": client,

--- a/apps/surveys/migrations/0010_encrypt_respondent_name.py
+++ b/apps/surveys/migrations/0010_encrypt_respondent_name.py
@@ -1,9 +1,14 @@
+import os
+
 from django.db import migrations, models
 
 from konote.encryption import DecryptionError, decrypt_field, encrypt_field
 
 
 def encrypt_existing_respondent_names(apps, schema_editor):
+    if not os.environ.get("FERNET_KEY"):
+        # No encryption key available (CI/test). Skip — no real data to encrypt.
+        return
     SurveyResponse = apps.get_model("surveys", "SurveyResponse")
     for response in SurveyResponse.objects.exclude(respondent_name_display="").iterator():
         response._respondent_name_encrypted = encrypt_field(
@@ -13,6 +18,8 @@ def encrypt_existing_respondent_names(apps, schema_editor):
 
 
 def decrypt_existing_respondent_names(apps, schema_editor):
+    if not os.environ.get("FERNET_KEY"):
+        return
     SurveyResponse = apps.get_model("surveys", "SurveyResponse")
     for response in SurveyResponse.objects.exclude(_respondent_name_encrypted=b"").iterator():
         try:

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -21,8 +21,13 @@ function _knParseCallArgs(raw, el) {
     }
 }
 
+var _KN_ALLOWED_FNS = {
+    toggleView: 1, closeBulkModal: 1, resetRow: 1,
+    addGroup: 1, toggleAll: 1, addProgram: 1, addTemplate: 1
+};
+
 function _knCallFunction(name, el, rawArgs) {
-    if (!name || typeof window[name] !== "function") return false;
+    if (!name || !_KN_ALLOWED_FNS[name] || typeof window[name] !== "function") return false;
     var args = _knParseCallArgs(rawArgs, el);
     window[name].apply(window, args);
     return true;


### PR DESCRIPTION
## Summary
Addresses three findings from the end-of-day code review:

- **Migration encryption guard** — `0010_encrypt_respondent_name` now skips when `FERNET_KEY` is unavailable (CI/test), preventing data loss or migration crash
- **JS function dispatch allowlist** — `_knCallFunction` in `app.js` restricted to 7 named functions instead of any function on `window`, closing a theoretical XSS escalation path
- **AI suggestion validation** — `goal_create_from_suggestion` validates that session data is a dict with a non-empty `name` before using it

## Test plan
- [ ] Verify migration runs cleanly with `FERNET_KEY` set (production path)
- [ ] Verify migration skips gracefully without `FERNET_KEY` (CI/test path)
- [ ] Verify `data-call-function` still works for existing buttons (toggleView, closeBulkModal, etc.)
- [ ] Verify goal save from AI suggestion still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)