### PR TITLE
Fix duplicate participant words field on Add Target form

### DIFF
--- a/templates/plans/goal_form.html
+++ b/templates/plans/goal_form.html
@@ -150,27 +150,27 @@
         </blockquote>
 
         {# ── 1. Participant's words ── #}
+        {% if not ai_enabled %}
         <fieldset>
             <legend>{{ form.client_goal.label }}</legend>
             <small>{{ form.client_goal.help_text }}</small>
-            {% if not ai_enabled %}
             {# Non-AI: hidden field preserves Phase 1 value for POST #}
             <input type="hidden"
                    id="{{ form.client_goal.id_for_label }}-phase2"
                    name="client_goal"
                    value="{{ form.client_goal.value|default_if_none:'' }}">
-            {% else %}
-            <input type="text"
-                   id="{{ form.client_goal.id_for_label }}"
-                   name="client_goal"
-                   value="{{ form.client_goal.value|default_if_none:'' }}"
-                   placeholder="{% trans 'In their own words…' %}"
-                   maxlength="255">
-            {% endif %}
             {% if form.client_goal.errors %}
             <small class="error" role="alert">{{ form.client_goal.errors.0 }}</small>
             {% endif %}
         </fieldset>
+        {% else %}
+        {# AI path: hidden field — participant words are captured in the AI
+           entry textarea and copied here by JS (populateForm / manual-entry). #}
+        <input type="hidden"
+               id="{{ form.client_goal.id_for_label }}"
+               name="client_goal"
+               value="{{ form.client_goal.value|default_if_none:'' }}">
+        {% endif %}
 
         {# ── SMART guidance (AI path only — non-AI gets it via the phase 1 flow) ── #}
         {% if ai_enabled %}


### PR DESCRIPTION
## Summary

- When AI is enabled, the Add Target form showed **two fields** both asking for the participant's own words — one in the AI helper section and one in the main form below it
- Changed the main form's `client_goal` field from a visible text input to a hidden input when AI is enabled
- The participant's words are already captured by the AI helper textarea and copied to `client_goal` by JavaScript (via `populateForm`, manual entry link, or quick pick flow)

## Test plan

- [ ] Open Add Target form as a staff user with AI enabled — confirm only one "participant words" textarea appears (inside the "Need help drafting?" section)
- [ ] Use "Suggest a draft" flow — confirm participant words are saved to the target's `client_goal` field
- [ ] Use "Review in the form" — confirm words carry over to the hidden field
- [ ] Use "Or fill in manually" — confirm words carry over
- [ ] Open Add Target form with AI **disabled** — confirm the two-phase flow still works normally

Generated with [Claude Code](https://claude.com/claude-code)