### PR TITLE
chore: document dev VPS deploy flow

### DIFF
--- a/.claude/commands/deploy-to-vps.md
+++ b/.claude/commands/deploy-to-vps.md
@@ -2,6 +2,18 @@
 
 Deploys the latest `develop` branch to the OVHcloud VPS. Supports both production and dev instances.
 
+## Default Behaviour
+
+Use the remote deploy script first. Do not inspect git state, docker state, or server directories before the first deploy attempt unless the user specifically asks.
+
+Preferred local wrapper:
+
+- `./scripts/deploy-vps.ps1 -Instance dev -ShowLogsOnFailure`
+- `./scripts/deploy-vps.ps1 -Instance prod -ShowLogsOnFailure`
+- `./scripts/deploy-vps.ps1 -Instance all -ShowLogsOnFailure`
+
+If the wrapper script is unavailable, fall back to the direct SSH commands below.
+
 ## Instances
 
 | Instance | URL | Directory | Deploy command |
@@ -11,25 +23,31 @@ Deploys the latest `develop` branch to the OVHcloud VPS. Supports both productio
 
 ## Steps
 
-1. Ask the user which instance to deploy (or deploy both if they say "both"):
+1. Ask the user which instance to deploy only if they did not already say.
    - **Production only**: `ssh konote-vps "sudo /opt/konote/scripts/deploy.sh"`
    - **Dev only**: `ssh konote-vps "sudo /opt/konote/scripts/deploy.sh --dev"`
    - **Both**: `ssh konote-vps "sudo /opt/konote/scripts/deploy.sh --all"`
 
-2. The script pulls `develop`, rebuilds the web container, restarts, and waits for the health check.
+2. Run the deploy command immediately.
+
+3. The script pulls `develop`, rebuilds the web container, restarts, and waits for the health check.
    - Timeout: 5 minutes (build ~30s, migrations can take longer).
    - For dev: if migrations fail, the script auto-resets the database (drop, recreate, re-migrate, re-seed demo data). This is safe because dev only has demo data.
 
-3. If the script exits 0 and prints "Deploy complete", tell the user the deploy succeeded.
+4. If the script exits `0` and prints `Deploy complete`, tell the user the deploy succeeded.
 
-4. If the script exits non-zero or prints "WARNING", show the user the last 20 lines of web container logs:
+5. Only if the deploy fails or prints a warning, inspect logs.
+
+   For production:
    ```
-   ssh konote-vps "docker compose -f /opt/konote/docker-compose.yml logs web --tail=20"
+   ssh konote-vps "cd /opt/konote && sudo docker compose -f docker-compose.yml logs web --tail=20"
    ```
-   For dev instance:
+
+   For dev:
    ```
-   ssh konote-vps "docker compose -f /opt/konote-dev/docker-compose.yml logs web --tail=20"
+   ssh konote-vps "cd /opt/konote-dev && sudo docker compose -f docker-compose.yml -f docker-compose.override.yml logs web --tail=20"
    ```
+
    Then help diagnose the issue.
 
 ## Notes
@@ -39,3 +57,5 @@ Deploys the latest `develop` branch to the OVHcloud VPS. Supports both productio
 - Migrations run automatically on container startup via `entrypoint.sh`.
 - The dev instance uses `DEMO_MODE=true` — all data is demo data and safe to reset.
 - Both instances share the same Caddy container (from `/opt/konote`) for TLS termination.
+- The Dev repo is root-owned on the server, so ad hoc git and docker commands usually need `sudo`.
+- The Dev instance keeps a `docker-compose.override.yml` on the server; do not treat that as an unexpected repo problem during normal deploys.

--- a/docs/deploy-dev-vps.md
+++ b/docs/deploy-dev-vps.md
@@ -1,0 +1,81 @@
+# Dev VPS Deploy
+
+This is the fastest reliable way to deploy KoNote to the Dev instance.
+
+## What Dev Means
+
+- Host alias: `konote-vps`
+- Server path: `/opt/konote-dev`
+- Branch deployed: `origin/develop`
+- Remote deploy script: `/opt/konote/scripts/deploy.sh --dev`
+
+Do **not** manually SSH around the server first unless the deploy fails. The remote deploy script already handles the normal path.
+
+## One Command
+
+From the repo root on your Windows machine:
+
+```powershell
+.\scripts\deploy-vps.ps1 -Instance dev -ShowLogsOnFailure
+```
+
+That connects to `konote-vps` over SSH and runs:
+
+```sh
+sudo /opt/konote/scripts/deploy.sh --dev
+```
+
+## What The Remote Script Does
+
+The remote script already knows the Dev setup. It:
+
+1. Changes into `/opt/konote-dev`
+2. Pulls the latest `origin/develop`
+3. Rebuilds the web container
+4. Restarts the Dev compose stack
+5. Waits for the web container health check
+6. If Dev migrations fail, it can reset the demo database and re-seed demo data
+
+This is safe for Dev because the Dev instance only has demo data.
+
+## Success Looks Like This
+
+The command should end with output like:
+
+```text
+=== Dev: Deploy complete — web is healthy (...) ===
+=== All deployments complete ===
+```
+
+If you see that and the command exits `0`, the Dev deploy succeeded.
+
+## If It Fails
+
+Run the same wrapper with `-ShowLogsOnFailure`:
+
+```powershell
+.\scripts\deploy-vps.ps1 -Instance dev -ShowLogsOnFailure
+```
+
+That prints the last 20 web-container log lines automatically after a failed deploy.
+
+If you need to inspect the server manually after that, use:
+
+```powershell
+ssh konote-vps
+```
+
+Then on the server:
+
+```sh
+cd /opt/konote-dev
+sudo docker compose -f docker-compose.yml -f docker-compose.override.yml ps
+sudo docker compose -f docker-compose.yml -f docker-compose.override.yml logs web --tail=50
+```
+
+## Important Notes
+
+- The Dev repo on the server is root-owned, so git and docker commands there usually need `sudo`.
+- Keep `docker-compose.override.yml` on the server. It is expected and should not be deleted during normal deploys.
+- Dev is behind `develop` until you merge your PR. Merge first, then deploy.
+- Production and Dev both use the same VPS, but the Dev deploy target is `/opt/konote-dev`.

--- a/scripts/deploy-vps.ps1
+++ b/scripts/deploy-vps.ps1
@@ -1,0 +1,57 @@
+param(
+    [ValidateSet("dev", "prod", "all")]
+    [string]$Instance = "dev",
+
+    [string]$SshHost = "konote-vps",
+
+    [switch]$ShowLogsOnFailure
+)
+
+$ErrorActionPreference = "Stop"
+
+function Get-DeployCommand {
+    param([string]$SelectedInstance)
+
+    switch ($SelectedInstance) {
+        "prod" { return "sudo /opt/konote/scripts/deploy.sh" }
+        "all" { return "sudo /opt/konote/scripts/deploy.sh --all" }
+        default { return "sudo /opt/konote/scripts/deploy.sh --dev" }
+    }
+}
+
+function Get-LogCommand {
+    param([string]$SelectedInstance)
+
+    switch ($SelectedInstance) {
+        "prod" {
+            return "cd /opt/konote && sudo docker compose -f docker-compose.yml logs web --tail=20"
+        }
+        "all" {
+            return "printf '\n== Production ==\n'; cd /opt/konote && sudo docker compose -f docker-compose.yml logs web --tail=20; printf '\n== Dev ==\n'; cd /opt/konote-dev && sudo docker compose -f docker-compose.yml -f docker-compose.override.yml logs web --tail=20"
+        }
+        default {
+            return "cd /opt/konote-dev && sudo docker compose -f docker-compose.yml -f docker-compose.override.yml logs web --tail=20"
+        }
+    }
+}
+
+$remoteCommand = Get-DeployCommand -SelectedInstance $Instance
+Write-Host "Deploying '$Instance' via $SshHost..." -ForegroundColor Cyan
+Write-Host "Remote command: $remoteCommand" -ForegroundColor DarkGray
+
+ssh $SshHost $remoteCommand
+$exitCode = $LASTEXITCODE
+
+if ($exitCode -ne 0) {
+    Write-Error "Deploy failed with exit code $exitCode."
+
+    if ($ShowLogsOnFailure) {
+        $logCommand = Get-LogCommand -SelectedInstance $Instance
+        Write-Host "Fetching recent web logs..." -ForegroundColor Yellow
+        ssh $SshHost $logCommand
+    }
+
+    exit $exitCode
+}
+
+Write-Host "Deploy finished successfully." -ForegroundColor Green


### PR DESCRIPTION
## Summary
- add a one-command local wrapper for VPS deploys
- document the Dev VPS deploy path and failure follow-up steps
- update the /deploy-to-vps command to use the remote deploy script first

## Testing
- .\\scripts\\deploy-vps.ps1 -Instance dev
