### PR TITLE
fix: harden AI JSON response parsing

### DIFF
--- a/konote/ai.py
+++ b/konote/ai.py
@@ -6,6 +6,7 @@ program names, aggregate stats). Client PII never reaches this module.
 """
 import json
 import logging
+import re
 from urllib.parse import urlparse
 
 import requests
@@ -24,6 +25,77 @@ _SAFETY_FOOTER = (
     "(names, dates of birth, addresses, or record IDs). "
     "Work only with the program context and metrics provided."
 )
+
+
+def _extract_json_payload(text):
+    """Extract the first balanced JSON object or array from model output."""
+    if not isinstance(text, str):
+        return None
+
+    cleaned = text.strip()
+    if not cleaned:
+        return None
+
+    cleaned = re.sub(r"<think>.*?</think>", "", cleaned, flags=re.IGNORECASE | re.DOTALL).strip()
+
+    if cleaned.startswith("```"):
+        lines = cleaned.split("\n")
+        lines = [line for line in lines if not line.strip().startswith("```")]
+        cleaned = "\n".join(lines).strip()
+
+    start = None
+    opener = None
+    for index, char in enumerate(cleaned):
+        if char in "[{":
+            start = index
+            opener = char
+            break
+
+    if start is None:
+        return None
+
+    closer = "}" if opener == "{" else "]"
+    depth = 0
+    in_string = False
+    escape = False
+
+    for index in range(start, len(cleaned)):
+        char = cleaned[index]
+        if in_string:
+            if escape:
+                escape = False
+            elif char == "\\":
+                escape = True
+            elif char == '"':
+                in_string = False
+            continue
+
+        if char == '"':
+            in_string = True
+            continue
+
+        if char == opener:
+            depth += 1
+        elif char == closer:
+            depth -= 1
+            if depth == 0:
+                return cleaned[start:index + 1]
+
+    return None
+
+
+def _parse_ai_json(result, log_label):
+    """Parse a JSON payload from model output, tolerating wrapper text."""
+    text = _extract_json_payload(result)
+    if text is None:
+        logger.warning("Could not find JSON in %s response: %s", log_label, str(result)[:300])
+        return None
+
+    try:
+        return json.loads(text)
+    except (json.JSONDecodeError, TypeError):
+        logger.warning("Could not parse %s response: %s", log_label, text[:300])
+        return None
 
 
 def is_ai_available():
@@ -127,12 +199,9 @@ def generate_metric_rationale(name, definition, category, metric_type, scale_ran
     result = _call_openrouter(system, user_msg, max_tokens=512)
     if result is None:
         return None
-    try:
-        parsed = json.loads(result)
-        if isinstance(parsed, dict) and "note" in parsed:
-            return parsed
-    except (json.JSONDecodeError, TypeError):
-        logger.warning("Could not parse metric rationale response")
+    parsed = _parse_ai_json(result, "metric rationale")
+    if isinstance(parsed, dict) and "note" in parsed:
+        return parsed
     return None
 
 
@@ -186,11 +255,7 @@ def suggest_metrics(target_description, metric_catalogue):
     result = _call_openrouter(system, user_msg)
     if result is None:
         return None
-    try:
-        return json.loads(result)
-    except (json.JSONDecodeError, TypeError):
-        logger.warning("Could not parse metric suggestions response")
-        return None
+    return _parse_ai_json(result, "metric suggestions")
 
 
 def improve_outcome(draft_text):
@@ -323,17 +388,8 @@ def suggest_target(participant_words, program_name, metric_catalogue, existing_s
     if result is None:
         return None
 
-    # Strip markdown fences if present
-    text = result.strip()
-    if text.startswith("```"):
-        lines = text.split("\n")
-        lines = [l for l in lines if not l.strip().startswith("```")]
-        text = "\n".join(lines).strip()
-
-    try:
-        parsed = json.loads(text)
-    except (json.JSONDecodeError, TypeError):
-        logger.warning("Could not parse suggest_target response: %s", text[:300])
+    parsed = _parse_ai_json(result, "suggest_target")
+    if parsed is None:
         return None
 
     return _validate_suggest_target_response(parsed, metric_catalogue)
@@ -613,17 +669,8 @@ def generate_outcome_insights(
     if result is None:
         return None
 
-    # Strip markdown fences if present
-    text = result.strip()
-    if text.startswith("```"):
-        lines = text.split("\n")
-        lines = [l for l in lines if not l.strip().startswith("```")]
-        text = "\n".join(lines).strip()
-
-    try:
-        parsed = json.loads(text)
-    except (json.JSONDecodeError, TypeError):
-        logger.warning("Could not parse outcome insights response")
+    parsed = _parse_ai_json(result, "outcome insights")
+    if parsed is None:
         return None
 
     # Validate response structure
@@ -837,17 +884,8 @@ def build_goal_chat(messages, program_name, metric_catalogue, existing_sections)
     if result is None:
         return None
 
-    # Strip markdown fences if present
-    text = result.strip()
-    if text.startswith("```"):
-        lines = text.split("\n")
-        lines = [l for l in lines if not l.strip().startswith("```")]
-        text = "\n".join(lines).strip()
-
-    try:
-        parsed = json.loads(text)
-    except (json.JSONDecodeError, TypeError):
-        logger.warning("Could not parse goal builder response")
+    parsed = _parse_ai_json(result, "goal builder")
+    if parsed is None:
         return None
 
     return _validate_goal_chat_response(parsed, metric_catalogue)
@@ -938,11 +976,7 @@ def suggest_note_structure(target_name, target_description, metric_names):
     result = _call_openrouter(system, user_msg)
     if result is None:
         return None
-    try:
-        return json.loads(result)
-    except (json.JSONDecodeError, TypeError):
-        logger.warning("Could not parse note structure response")
-        return None
+    return _parse_ai_json(result, "note structure")
 
 
 def generate_focused_analysis(question, suggestions, program_name):
@@ -1002,17 +1036,8 @@ def generate_focused_analysis(question, suggestions, program_name):
     if result is None:
         return None
 
-    # Strip markdown fences if present
-    text = result.strip()
-    if text.startswith("```"):
-        lines = text.split("\n")
-        lines = [ln for ln in lines if not ln.strip().startswith("```")]
-        text = "\n".join(lines).strip()
-
-    try:
-        parsed = json.loads(text)
-    except (json.JSONDecodeError, TypeError):
-        logger.warning("Could not parse focused analysis response")
+    parsed = _parse_ai_json(result, "focused analysis")
+    if parsed is None:
         return None
 
     return _validate_focused_analysis(parsed, len(suggestions))

--- a/tests/test_ai.py
+++ b/tests/test_ai.py
@@ -31,6 +31,62 @@ def test_suggest_target_prompt_includes_validation_criteria():
         assert "custom_metric" in system_prompt.lower() or "target-specific metric" in system_prompt.lower()
 
 
+def test_suggest_target_parses_reasoning_wrapped_json():
+    """suggest_target should tolerate reasoning text around the JSON payload."""
+    from konote.ai import suggest_target
+
+    wrapped_response = """
+<think>I should draft a SMART target.</think>
+Here is the JSON:
+```json
+{
+  "name": "Build friendships",
+  "description": "Participant will attend one community activity each week for the next 8 weeks to build a new friendship.",
+  "client_goal": "I want to make a friend",
+  "suggested_section": "Social",
+  "metrics": [],
+  "custom_metric": null
+}
+```
+"""
+
+    with patch("konote.ai._call_openrouter", return_value=wrapped_response):
+        result = suggest_target("I want to make a friend", "Test Program", [], [])
+
+    assert result is not None
+    assert result["name"] == "Build friendships"
+    assert result["suggested_section"] == "Social"
+
+
+def test_suggest_metrics_parses_reasoning_wrapped_json_array():
+    """Array-style AI responses should also tolerate wrapper text."""
+    from konote.ai import suggest_metrics
+
+    wrapped_response = """
+I found the best matches below.
+```json
+[
+  {
+    "metric_id": 12,
+    "name": "Community participation",
+    "reason": "Tracks whether the participant is showing up in social settings."
+  }
+]
+```
+"""
+
+    with patch("konote.ai._call_openrouter", return_value=wrapped_response):
+        result = suggest_metrics("Attend a weekly community activity", [])
+
+    assert result == [
+        {
+            "metric_id": 12,
+            "name": "Community participation",
+            "reason": "Tracks whether the participant is showing up in social settings.",
+        }
+    ]
+
+
 def _make_valid_response(**overrides):
     """Build a minimal valid suggest_target response dict."""
     base = {

--- a/tests/test_ai_endpoints.py
+++ b/tests/test_ai_endpoints.py
@@ -394,7 +394,10 @@ class SuggestTargetViewTest(AIEndpointBaseTest):
             "client_id": self.client_file.pk,
         })
         self.assertEqual(resp.status_code, 200)
-        self.assertContains(resp, "couldn't be generated")
+        self.assertContains(
+            resp,
+            "AI suggestion couldn't be generated right now. You can add the target manually.",
+        )
         self.assertContains(resp, "btn-show-manual-form")
 
     @patch("konote.ai.suggest_target")


### PR DESCRIPTION
Summary
- make AI JSON parsing tolerate wrapper text, fenced blocks, and think tags
- reuse the shared parser across target drafting and related AI endpoints
- add focused regression tests for object and array responses

Testing
- pytest tests/test_ai.py tests/test_ai_endpoints.py -k suggest_target or suggest_metrics or ai_failure_returns_error_partial --ds=konote.settings.test