### PR TITLE
fix: demo engine survey assignments not created

### DIFF
--- a/apps/admin_settings/demo_engine.py
+++ b/apps/admin_settings/demo_engine.py
@@ -1518,21 +1518,28 @@ class DemoDataEngine:
         # Create survey definitions
         surveys = []
         for sdef in survey_defs[:2]:  # Max 2 surveys
-            survey, created = Survey.objects.get_or_create(
-                name=sdef["name"],
-                created_by=creator,
-                defaults={
-                    "name_fr": sdef.get("name_fr", ""),
-                    "description": sdef.get("description", ""),
-                    "description_fr": sdef.get("description_fr", ""),
-                    "status": "active",
-                    "portal_visible": True,
-                    "show_scores_to_participant": True,
-                },
-            )
-            if not created:
+            survey = Survey.objects.filter(name=sdef["name"]).first()
+            if survey:
+                # Ensure existing survey is active and portal-visible
+                Survey.objects.filter(pk=survey.pk).update(
+                    status="active",
+                    portal_visible=True,
+                    show_scores_to_participant=True,
+                )
+                survey.refresh_from_db()
                 surveys.append(survey)
                 continue
+
+            survey = Survey.objects.create(
+                name=sdef["name"],
+                name_fr=sdef.get("name_fr", ""),
+                description=sdef.get("description", ""),
+                description_fr=sdef.get("description_fr", ""),
+                status="active",
+                portal_visible=True,
+                show_scores_to_participant=True,
+                created_by=creator,
+            )
 
             # Create sections and questions
             for s_idx, sec_def in enumerate(sdef.get("sections", [])):


### PR DESCRIPTION
## Summary
- Fixed root cause of demo survey assignments never being created
- The `get_or_create` lookup used `name` + `created_by`, which never matched existing surveys that had `created_by=None` (created via `seed_demo_survey` or admin UI)
- Changed to look up by `name` only; ensures existing surveys are active and portal-visible

## Test plan
- [ ] Run `generate_demo_data --force` on dev VPS
- [ ] Verify survey assignments are created for demo participants
- [ ] Verify completed surveys have answers and pending surveys are empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)