### PR TITLE
fix: guard demo engine metric visibility and restore on cleanup

### DIFF
--- a/apps/admin_settings/demo_engine.py
+++ b/apps/admin_settings/demo_engine.py
@@ -411,13 +411,13 @@ PORTAL_SURVEY_DEFINITIONS = [
         ],
     },
     {
-        "name": "Programme Feedback",
-        "name_fr": "Rétroaction sur le programme",
+        "name": "Program Feedback Survey",
+        "name_fr": "Sondage de rétroaction sur le programme",
         "description": "Help us improve — tell us what's working and what could be better.",
         "description_fr": "Aidez-nous à nous améliorer — dites-nous ce qui fonctionne et ce qui pourrait être mieux.",
         "sections": [
             {
-                "title": "About the Programme",
+                "title": "About the Program",
                 "title_fr": "À propos du programme",
                 "questions": [
                     {
@@ -596,6 +596,16 @@ class DemoDataEngine:
         SurveyResponse.objects.filter(client_file__is_demo=True).delete()
         SurveyAssignment.objects.filter(client_file__is_demo=True).delete()
 
+        # Restore metric portal_visibility to pre-demo values
+        originals = getattr(self, "_metric_visibility_originals", {})
+        for metric_pk, original_value in originals.items():
+            MetricDefinition.objects.filter(pk=metric_pk).update(
+                portal_visibility=original_value,
+            )
+        if originals:
+            self.log(f"  Restored portal_visibility on {len(originals)} metrics.")
+        self._metric_visibility_originals = {}
+
         # Registration submissions for demo links
         counts["registrations"] = RegistrationSubmission.objects.filter(
             registration_link__slug="demo"
@@ -716,18 +726,34 @@ class DemoDataEngine:
         If all metrics have portal_visibility='no', progress charts will be
         empty. This sets universal and program metrics to 'summary' so the
         portal progress page has data to display.
+
+        Only runs when DEMO_MODE is enabled to prevent accidentally modifying
+        an agency's intentional metric visibility settings on production
+        instances. Original values are stored in _metric_visibility_originals
+        so cleanup_demo_data() can restore them.
         """
-        updated = MetricDefinition.objects.filter(
+        from django.conf import settings
+        if not getattr(settings, "DEMO_MODE", False):
+            return
+
+        self._metric_visibility_originals = {}
+
+        # Collect metrics that need changing
+        qs = MetricDefinition.objects.filter(
             is_universal=True, is_enabled=True, portal_visibility="no",
-        ).update(portal_visibility="summary")
-
+        )
         for program in programs:
-            updated += MetricDefinition.objects.filter(
+            qs = qs | MetricDefinition.objects.filter(
                 owning_program=program, is_enabled=True, portal_visibility="no",
-            ).update(portal_visibility="summary")
+            )
 
+        # Store originals before modifying
+        for m in qs:
+            self._metric_visibility_originals[m.pk] = m.portal_visibility
+
+        updated = qs.update(portal_visibility="yes")
         if updated:
-            self.log(f"  Set {updated} metrics to portal_visibility='summary'.")
+            self.log(f"  Set {updated} metrics to portal_visibility='yes'.")
 
     # ----- Demo user creation -----
 

--- a/tests/test_demo_engine_cleanup.py
+++ b/tests/test_demo_engine_cleanup.py
@@ -1,0 +1,121 @@
+"""Tests that demo data cleanup restores configuration to pre-demo state.
+
+Verifies that _ensure_portal_visible_metrics() stores original values
+and cleanup_demo_data() restores them, and that the method is skipped
+when DEMO_MODE is not enabled.
+"""
+from django.test import TestCase, override_settings
+from cryptography.fernet import Fernet
+
+from apps.admin_settings.demo_engine import DemoDataEngine
+from apps.plans.models import MetricDefinition
+from apps.programs.models import Program
+import konote.encryption as enc_module
+
+TEST_KEY = Fernet.generate_key().decode()
+
+
+@override_settings(FIELD_ENCRYPTION_KEY=TEST_KEY)
+class MetricVisibilityRestorationTest(TestCase):
+    """Test that demo engine restores metric portal_visibility after cleanup."""
+
+    def setUp(self):
+        enc_module._fernet = None
+        self.program = Program.objects.create(
+            name="Test Program", status="active",
+        )
+        self.metric_hidden = MetricDefinition.objects.create(
+            name="Hidden Metric",
+            unit="score",
+            min_value=1,
+            max_value=5,
+            is_universal=True,
+            is_enabled=True,
+            portal_visibility="no",
+        )
+        self.metric_visible = MetricDefinition.objects.create(
+            name="Already Visible",
+            unit="score",
+            min_value=1,
+            max_value=5,
+            is_universal=True,
+            is_enabled=True,
+            portal_visibility="yes",
+        )
+        self.metric_program = MetricDefinition.objects.create(
+            name="Program Metric",
+            unit="score",
+            min_value=1,
+            max_value=5,
+            owning_program=self.program,
+            is_enabled=True,
+            portal_visibility="no",
+        )
+
+    @override_settings(DEMO_MODE=True)
+    def test_ensure_visibility_stores_originals(self):
+        engine = DemoDataEngine()
+        engine._ensure_portal_visible_metrics([self.program])
+
+        # Hidden metrics should now be visible
+        self.metric_hidden.refresh_from_db()
+        self.assertEqual(self.metric_hidden.portal_visibility, "yes")
+
+        # Already-visible metric should be unchanged
+        self.metric_visible.refresh_from_db()
+        self.assertEqual(self.metric_visible.portal_visibility, "yes")
+
+        # Program metric should now be visible
+        self.metric_program.refresh_from_db()
+        self.assertEqual(self.metric_program.portal_visibility, "yes")
+
+        # Originals should be stored
+        self.assertIn(self.metric_hidden.pk, engine._metric_visibility_originals)
+        self.assertEqual(
+            engine._metric_visibility_originals[self.metric_hidden.pk], "no",
+        )
+        # Already-visible metric should NOT be in originals
+        self.assertNotIn(self.metric_visible.pk, engine._metric_visibility_originals)
+
+    @override_settings(DEMO_MODE=True)
+    def test_cleanup_restores_original_visibility(self):
+        engine = DemoDataEngine()
+        engine._ensure_portal_visible_metrics([self.program])
+
+        # Verify they changed
+        self.metric_hidden.refresh_from_db()
+        self.assertEqual(self.metric_hidden.portal_visibility, "yes")
+
+        # Run cleanup
+        engine.cleanup_demo_data()
+
+        # Should be restored to original
+        self.metric_hidden.refresh_from_db()
+        self.assertEqual(self.metric_hidden.portal_visibility, "no")
+
+        self.metric_program.refresh_from_db()
+        self.assertEqual(self.metric_program.portal_visibility, "no")
+
+        # Already-visible should still be visible
+        self.metric_visible.refresh_from_db()
+        self.assertEqual(self.metric_visible.portal_visibility, "yes")
+
+    @override_settings(DEMO_MODE=False)
+    def test_skips_when_demo_mode_disabled(self):
+        engine = DemoDataEngine()
+        engine._ensure_portal_visible_metrics([self.program])
+
+        # Should not have changed anything
+        self.metric_hidden.refresh_from_db()
+        self.assertEqual(self.metric_hidden.portal_visibility, "no")
+
+        self.metric_program.refresh_from_db()
+        self.assertEqual(self.metric_program.portal_visibility, "no")
+
+    def test_skips_when_demo_mode_not_set(self):
+        """DEMO_MODE not in settings at all — should skip safely."""
+        engine = DemoDataEngine()
+        engine._ensure_portal_visible_metrics([self.program])
+
+        self.metric_hidden.refresh_from_db()
+        self.assertEqual(self.metric_hidden.portal_visibility, "no")


### PR DESCRIPTION
## Summary
Addresses all 4 issues from expert panel review of PRs #408/#409:

1. **DEMO_MODE guard** — `_ensure_portal_visible_metrics()` skips entirely when `DEMO_MODE` is not `True`, preventing accidental modification of agency metric settings on production
2. **Restore on cleanup** — original `portal_visibility` values stored before modification, restored by `cleanup_demo_data()`
3. **Survey name mismatch** — "Programme Feedback" → "Program Feedback Survey" (matches VPS, uses Canadian English)
4. **Tests** — `test_demo_engine_cleanup.py` verifies store/restore lifecycle and DEMO_MODE guard

Also fixed `portal_visibility` value from invalid "summary" to valid "yes" (matching model choices).

## Test plan
- [ ] `pytest tests/test_demo_engine_cleanup.py` passes
- [ ] `generate_demo_data --force` on dev VPS still works (DEMO_MODE=true)
- [ ] Survey no longer creates orphan "Programme Feedback" survey

🤖 Generated with [Claude Code](https://claude.com/claude-code)