### PR TITLE
fix: widen follow-up chip picker layout

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -1893,6 +1893,7 @@ label {
 }
 .field-engagement { max-width: 20rem; }
 .field-followup { max-width: 12rem; }
+.field-followup:has(.mp-chips) { max-width: 28rem; }
 
 @media (max-width: 768px) {
     .wrapup-grid {


### PR DESCRIPTION
## Summary
- The `.field-followup` wrapper had `max-width: 12rem`, which was correct for a bare date input but too narrow for the 5 chip buttons injected by `followup-picker.js`
- Chips were stacking vertically instead of flowing horizontally
- Added `.field-followup:has(.mp-chips) { max-width: 28rem }` so the field widens only when the JS picker is active — no-JS fallback keeps 12rem

## Test plan
- [ ] Open a progress note form → verify "Follow up by" chips display horizontally
- [ ] Resize browser to mobile width → chips should wrap to 2 rows, not 5
- [ ] Disable JS → bare date input should still be narrow (12rem)
- [ ] Check French locale → slightly longer labels still fit

🤖 Generated with [Claude Code](https://claude.com/claude-code)