### PR TITLE
chore: translation cleanup + deployment resumability (REV26-I18N2, REV26-DEP3)

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -23,8 +23,8 @@
 
 ### Phase: Deep Review Fixes (2026-03-06)
 
-- [ ] Clean up translation catalog health: remove duplicate `msgid`s, fill missing and empty French strings, and rebuild `django.mo` (REV26-I18N2)
-- [ ] Make tenant provisioning and backup recovery paths more resumable and consistent (REV26-DEP3)
+- [ ] 🔨 Clean up translation catalog health: remove duplicate `msgid`s, fill missing and empty French strings, and rebuild `django.mo` (REV26-I18N2)
+- [ ] 🔨 Make tenant provisioning and backup recovery paths more resumable and consistent (REV26-DEP3)
 - [ ] Expand automated accessibility coverage across one public survey flow, one portal flow, and one report/chart flow — PB (REV26-A11Y1)
 - [ ] Document the active participant-data AI provider mode and data residency expectations for operators — SG (REV26-AI4)
 - [ ] Complete organization-specific privacy policy, retention schedule, and breach workflow documentation — SG (REV26-PRIV1)
@@ -105,8 +105,6 @@ _All documentation tasks completed — see Recently Done._
 
 Scope is clear, just needs time. A session can pick these up without special approval.
 
-- [ ] Extract role string constants (ROLE_STAFF, ROLE_PROGRAM_MANAGER, etc.) into auth_app/constants.py — 400+ raw string literals across the codebase use "staff", "program_manager" etc. (REFACTOR1)
-- [ ] Add smoke test for all-programs HTML export path (CHORE-RPT-TEST1)
 
 ## Parking Lot: Needs Review
 
@@ -122,6 +120,8 @@ Not yet clear we should build these, or the design isn't settled. May be too com
 
 ## Recently Done
 
+- [x] Extract role string constants into auth_app/constants.py — 5 PRs merged, 107 files updated — 2026-03-07 (REFACTOR1)
+- [x] Add smoke test for all-programs HTML export path — PR #340 — 2026-03-07 (CHORE-RPT-TEST1)
 - [x] Deep review follow-up hardening pass — AI scrubber expanded, focused analysis and note-structure flows scrubbed, insecure remote insights HTTP blocked, Docker build inputs tightened, tenant-key rotation disabled, `/health/` healthcheck wired, production startup fails closed on public-tenant bootstrap, French survey/export fixes landed, public survey page-step validation improved, registration intake/review audit coverage added — 2026-03-06 (REV26-SEC1, REV26-DEP1, REV26-DEP2, REV26-AI1, REV26-AI2, REV26-AI3, REV26-I18N1)
 - [x] Graduated privacy threshold + focused theme analysis — N=5 self-hosted / N=15 external, Ask a Question UI, AI-powered suggestion search, DRR updates — 2026-03-05 (AI-FOCUSED-THEME1)
 

--- a/apps/audit/management/commands/verify_backup_restore.py
+++ b/apps/audit/management/commands/verify_backup_restore.py
@@ -8,9 +8,11 @@ Usage:
     python manage.py verify_backup_restore
     python manage.py verify_backup_restore --database default
     python manage.py verify_backup_restore --sample-size 25
+    python manage.py verify_backup_restore --pre-restore /path/to/backup.sql
+    python manage.py verify_backup_restore --full
 """
 
-from django.core.management.base import BaseCommand
+from django.core.management.base import BaseCommand, CommandError
 from django.core.management import call_command
 from django.contrib.auth import get_user_model
 from django.db import connections
@@ -22,6 +24,7 @@ from apps.audit.models import AuditLog
 from apps.programs.models import Program
 
 import io
+import os
 import sys
 
 User = get_user_model()
@@ -43,10 +46,29 @@ class Command(BaseCommand):
             default=10,
             help="Number of encrypted client records to test (default: 10).",
         )
+        parser.add_argument(
+            "--pre-restore",
+            metavar="DUMP_FILE",
+            help="Validate a backup dump file before restoring. "
+                 "Checks that the file exists, is non-empty, and looks like a pg_dump output.",
+        )
+        parser.add_argument(
+            "--full",
+            action="store_true",
+            help="Test ALL encrypted records instead of just a sample.",
+        )
 
     def handle(self, *args, **options):
+        # Handle --pre-restore mode: validate the dump file and exit.
+        if options["pre_restore"]:
+            ok = self._validate_dump_file(options["pre_restore"])
+            if not ok:
+                raise CommandError("Pre-restore validation failed. Do not proceed with restore.")
+            return
+
         db_choice = options["database"]
         sample_size = options["sample_size"]
+        full_check = options["full"]
         results = {}
 
         check_default = db_choice in ("default", "both")
@@ -60,7 +82,7 @@ class Command(BaseCommand):
 
         # ── 2. Encryption health ───────────────────────────────────
         if check_default:
-            results["encryption"] = self._check_encryption(sample_size)
+            results["encryption"] = self._check_encryption(sample_size, full_check)
 
         # ── 3. Audit DB connectivity ───────────────────────────────
         if check_audit:
@@ -93,34 +115,74 @@ class Command(BaseCommand):
         self.stdout.write("")
         return True
 
-    def _check_encryption(self, sample_size):
+    def _check_encryption(self, sample_size, full_check=False):
         self.stdout.write(self.style.MIGRATE_HEADING("2. Encryption Health"))
-        total = ClientFile.objects.using("default").count()
+        all_passed = True
+
+        # Check ClientFile (first_name, last_name)
+        all_passed = self._check_encrypted_model(
+            model=ClientFile,
+            model_label="ClientFile",
+            fields=["first_name", "last_name"],
+            error_sentinel="[DECRYPTION ERROR]",
+            sample_size=sample_size,
+            full_check=full_check,
+        ) and all_passed
+
+        # Check ProgressNote (notes_text, summary)
+        all_passed = self._check_encrypted_model(
+            model=ProgressNote,
+            model_label="ProgressNote",
+            fields=["notes_text", "summary"],
+            error_sentinel="[DECRYPTION ERROR]",
+            sample_size=sample_size,
+            full_check=full_check,
+            # Only check notes that actually have encrypted content
+            filter_kwargs={"_notes_text_encrypted__gt": b""},
+        ) and all_passed
+
+        self.stdout.write("")
+        return all_passed
+
+    def _check_encrypted_model(self, model, model_label, fields, error_sentinel,
+                               sample_size, full_check=False, filter_kwargs=None):
+        """Check decryption health for a single model's encrypted fields."""
+        qs = model.objects.using("default")
+        if filter_kwargs:
+            qs = qs.filter(**filter_kwargs)
+        total = qs.count()
+
         if total == 0:
-            self.stdout.write("   No client records found — skipping encryption check.")
-            self.stdout.write("")
+            self.stdout.write(f"   {model_label}: no records — skipped.")
             return True
 
-        sample = list(ClientFile.objects.using("default").order_by("pk")[:sample_size])
+        if full_check:
+            records = qs.order_by("pk").iterator()
+            limit_label = f"all {total:,}"
+        else:
+            records = list(qs.order_by("pk")[:sample_size])
+            limit_label = f"sample of {min(sample_size, total)}/{total:,}"
+
         passed = 0
         failed = 0
-        for client in sample:
+        for record in records:
             try:
-                # Access the property accessors — these decrypt under the hood
-                _ = client.first_name
-                _ = client.last_name
-                if client.first_name == "[DECRYPTION ERROR]" or client.last_name == "[DECRYPTION ERROR]":
+                has_error = False
+                for field in fields:
+                    val = getattr(record, field)
+                    if val == error_sentinel:
+                        has_error = True
+                        break
+                if has_error:
                     failed += 1
                 else:
                     passed += 1
             except Exception as exc:
                 failed += 1
-                self.stdout.write(self.style.ERROR(f"   Client #{client.pk}: {exc}"))
+                self.stdout.write(self.style.ERROR(f"   {model_label} #{record.pk}: {exc}"))
 
         tested = passed + failed
-        self.stdout.write(f"   Tested {tested} of {total:,} client records.")
-        self.stdout.write(f"   Decrypted OK: {passed}   Failed: {failed}")
-        self.stdout.write("")
+        self.stdout.write(f"   {model_label}: tested {tested} ({limit_label}). OK: {passed}  Failed: {failed}")
 
         return failed == 0
 
@@ -215,6 +277,49 @@ class Command(BaseCommand):
 
         self.stdout.write("")
         return len(issues) == 0
+
+    # ── Pre-restore validation ──────────────────────────────────────
+
+    def _validate_dump_file(self, dump_path):
+        """Validate a pg_dump file before restoring."""
+        self.stdout.write(self.style.MIGRATE_HEADING("\n=== Pre-Restore Validation ===\n"))
+        ok = True
+
+        # Check file exists
+        if not os.path.exists(dump_path):
+            self.stdout.write(self.style.ERROR(f"   FAIL: File not found: {dump_path}"))
+            return False
+        self.stdout.write(self.style.SUCCESS(f"   File exists: {dump_path}"))
+
+        # Check file size > 0
+        file_size = os.path.getsize(dump_path)
+        if file_size == 0:
+            self.stdout.write(self.style.ERROR("   FAIL: File is empty (0 bytes)."))
+            return False
+        size_mb = file_size / (1024 * 1024)
+        self.stdout.write(self.style.SUCCESS(f"   File size: {size_mb:.1f} MB ({file_size:,} bytes)"))
+
+        # Check first line contains pg_dump signature
+        try:
+            with open(dump_path, "r", errors="replace") as f:
+                first_line = f.readline(1024)
+            if "PostgreSQL" in first_line or "pg_dump" in first_line:
+                self.stdout.write(self.style.SUCCESS("   File header looks like a pg_dump output."))
+            else:
+                self.stdout.write(self.style.ERROR(
+                    "   FAIL: First line does not contain 'PostgreSQL' or 'pg_dump'. "
+                    "This may not be a valid database dump."
+                ))
+                self.stdout.write(f"   First line: {first_line.strip()[:120]}")
+                ok = False
+        except Exception as exc:
+            self.stdout.write(self.style.ERROR(f"   FAIL: Could not read file: {exc}"))
+            ok = False
+
+        self.stdout.write("")
+        if ok:
+            self.stdout.write(self.style.SUCCESS("Pre-restore validation passed. Safe to proceed with restore."))
+        return ok
 
     # ── Summary ────────────────────────────────────────────────────
 

--- a/apps/tenants/management/commands/provision_tenant.py
+++ b/apps/tenants/management/commands/provision_tenant.py
@@ -26,12 +26,28 @@ class Command(BaseCommand):
         parser.add_argument("--admin-username", default="admin", help="Admin username (default: admin)")
         parser.add_argument("--admin-password", help="Admin password (prompted if not given)")
         parser.add_argument("--no-demo-data", action="store_true", help="Skip loading demo/seed data")
+        parser.add_argument(
+            "--skip-to",
+            choices=["schema", "key", "admin", "config"],
+            default=None,
+            help="Resume provisioning from a specific phase after a failure. "
+                 "Phases: schema (agency + domain), key (encryption key), "
+                 "admin (admin user), config (default config).",
+        )
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Report what would be done without making any changes.",
+        )
+
+    # Phase ordering for --skip-to
+    PHASES = ["schema", "key", "admin", "config"]
 
     def handle(self, *args, **options):
         import getpass
 
         from django.conf import settings
-        from django.db import connection
+        from django.db import connection, transaction
 
         from apps.tenants.models import Agency, AgencyDomain, TenantKey
 
@@ -41,76 +57,138 @@ class Command(BaseCommand):
         admin_username = options["admin_username"]
         admin_password = options.get("admin_password")
         schema_name = short_code.replace("-", "_")
+        skip_to = options["skip_to"]
+        dry_run = options["dry_run"]
 
-        if not admin_password:
+        # Determine which phases to run
+        if skip_to:
+            skip_index = self.PHASES.index(skip_to)
+            phases_to_run = set(self.PHASES[skip_index:])
+            skipped = self.PHASES[:skip_index]
+            if skipped:
+                self.stdout.write(
+                    self.style.WARNING(f"Resuming from '{skip_to}' — skipping: {', '.join(skipped)}")
+                )
+        else:
+            phases_to_run = set(self.PHASES)
+
+        if dry_run:
+            self.stdout.write(self.style.WARNING("[DRY RUN] No changes will be made.\n"))
+            self.stdout.write(f"Would provision agency '{name}' (schema: {schema_name})")
+            self.stdout.write(f"Phases to run: {', '.join(p for p in self.PHASES if p in phases_to_run)}")
+            if "schema" in phases_to_run:
+                self.stdout.write(f"  [schema] Create/reuse agency '{short_code}' and domain '{domain}'")
+            if "key" in phases_to_run:
+                self.stdout.write(f"  [key]    Generate encryption key for tenant")
+            if "admin" in phases_to_run:
+                self.stdout.write(f"  [admin]  Create/update admin user '{admin_username}'")
+            if "config" in phases_to_run:
+                self.stdout.write(f"  [config] Load default terminology and feature toggles")
+            return
+
+        if not admin_password and "admin" in phases_to_run:
             admin_password = getpass.getpass("Admin password: ")
             if not admin_password:
                 raise CommandError("Admin password is required.")
 
         self.stdout.write(f"Provisioning agency '{name}' (schema: {schema_name})...")
 
-        # Step 1: Create or reuse the tenant row.
-        agency, created = Agency.objects.get_or_create(
-            short_code=short_code,
-            defaults={"name": name, "schema_name": schema_name},
-        )
-        if agency.schema_name != schema_name:
-            raise CommandError(
-                f"Agency '{short_code}' already exists with schema '{agency.schema_name}', "
-                f"expected '{schema_name}'. Resolve the mismatch before rerunning.",
-            )
-        if created:
-            self.stdout.write(self.style.SUCCESS(f"  Schema '{agency.schema_name}' created."))
-        else:
-            updated_fields = []
-            if agency.name != name:
-                agency.name = name
-                updated_fields.append("name")
-            if updated_fields:
-                agency.save(update_fields=updated_fields)
-            self.stdout.write(self.style.WARNING(f"  Schema '{agency.schema_name}' already exists; reusing tenant."))
+        # Steps 1-3 (schema, domain, key) are wrapped in a transaction so they
+        # either all succeed or all roll back, preventing partial state.
+        agency = None
+        with transaction.atomic():
+            # Step 1-2: Create or reuse the tenant row and domain routing.
+            if "schema" in phases_to_run:
+                self.stdout.write(self.style.MIGRATE_HEADING("[phase: schema] Creating agency and domain..."))
+                agency, created = Agency.objects.get_or_create(
+                    short_code=short_code,
+                    defaults={"name": name, "schema_name": schema_name},
+                )
+                if agency.schema_name != schema_name:
+                    raise CommandError(
+                        f"Agency '{short_code}' already exists with schema '{agency.schema_name}', "
+                        f"expected '{schema_name}'. Resolve the mismatch before rerunning.",
+                    )
+                if created:
+                    self.stdout.write(self.style.SUCCESS(f"  Schema '{agency.schema_name}' created."))
+                else:
+                    updated_fields = []
+                    if agency.name != name:
+                        agency.name = name
+                        updated_fields.append("name")
+                    if updated_fields:
+                        agency.save(update_fields=updated_fields)
+                    self.stdout.write(self.style.WARNING(f"  Schema '{agency.schema_name}' already exists; reusing tenant."))
 
-        # Step 2: Create or reuse domain routing.
-        domain_record, domain_created = AgencyDomain.objects.get_or_create(
-            domain=domain,
-            defaults={"tenant": agency, "is_primary": True},
-        )
-        if domain_record.tenant_id != agency.pk:
-            raise CommandError(
-                f"Domain '{domain}' already belongs to tenant '{domain_record.tenant.short_code}'. "
-                "Resolve the domain conflict before rerunning.",
-            )
-        if not domain_record.is_primary:
-            domain_record.is_primary = True
-            domain_record.save(update_fields=["is_primary"])
-        if domain_created:
-            self.stdout.write(self.style.SUCCESS(f"  Domain '{domain}' configured."))
-        else:
-            self.stdout.write(self.style.WARNING(f"  Domain '{domain}' already exists; keeping it attached to this tenant."))
+                # Step 2: Create or reuse domain routing.
+                domain_record, domain_created = AgencyDomain.objects.get_or_create(
+                    domain=domain,
+                    defaults={"tenant": agency, "is_primary": True},
+                )
+                if domain_record.tenant_id != agency.pk:
+                    raise CommandError(
+                        f"Domain '{domain}' already belongs to tenant '{domain_record.tenant.short_code}'. "
+                        "Resolve the domain conflict before rerunning.",
+                    )
+                if not domain_record.is_primary:
+                    domain_record.is_primary = True
+                    domain_record.save(update_fields=["is_primary"])
+                if domain_created:
+                    self.stdout.write(self.style.SUCCESS(f"  Domain '{domain}' configured."))
+                else:
+                    self.stdout.write(self.style.WARNING(f"  Domain '{domain}' already exists; keeping it attached to this tenant."))
+                self.stdout.write(self.style.SUCCESS("[phase: schema] DONE"))
+            else:
+                # Resuming — look up the existing agency
+                agency = Agency.objects.filter(short_code=short_code).first()
+                if not agency:
+                    raise CommandError(
+                        f"Cannot resume: agency '{short_code}' not found. "
+                        "Run without --skip-to first to create the agency."
+                    )
 
-        # Step 3: Create or reuse the tenant encryption key.
-        tenant_key, key_created = TenantKey.objects.get_or_create(
-            tenant=agency,
-            defaults={"encrypted_key": self._generate_encrypted_tenant_key(settings.FIELD_ENCRYPTION_KEY)},
-        )
-        if key_created:
-            self.stdout.write(self.style.SUCCESS("  Encryption key generated and stored."))
-        else:
-            self.stdout.write(self.style.WARNING("  Encryption key already exists; reusing existing key."))
+            # Step 3: Create or reuse the tenant encryption key.
+            if "key" in phases_to_run:
+                self.stdout.write(self.style.MIGRATE_HEADING("[phase: key] Generating encryption key..."))
+                tenant_key, key_created = TenantKey.objects.get_or_create(
+                    tenant=agency,
+                    defaults={"encrypted_key": self._generate_encrypted_tenant_key(settings.FIELD_ENCRYPTION_KEY)},
+                )
+                if key_created:
+                    self.stdout.write(self.style.SUCCESS("  Encryption key generated and stored."))
+                else:
+                    self.stdout.write(self.style.WARNING("  Encryption key already exists; reusing existing key."))
+                self.stdout.write(self.style.SUCCESS("[phase: key] DONE"))
+
+        # If agency wasn't set in the transaction block (skipping schema + key),
+        # look it up now for steps 4-5.
+        if agency is None:
+            agency = Agency.objects.filter(short_code=short_code).first()
+            if not agency:
+                raise CommandError(
+                    f"Cannot resume: agency '{short_code}' not found. "
+                    "Run without --skip-to first to create the agency."
+                )
 
         # Step 4: Create or update the admin user within the tenant schema.
-        self._run_tenant_phase(
-            agency,
-            "admin user creation",
-            lambda: self._ensure_admin_user(admin_username, admin_password, name),
-        )
+        if "admin" in phases_to_run:
+            self.stdout.write(self.style.MIGRATE_HEADING("[phase: admin] Creating admin user..."))
+            self._run_tenant_phase(
+                agency,
+                "admin user creation",
+                lambda: self._ensure_admin_user(admin_username, admin_password, name),
+            )
+            self.stdout.write(self.style.SUCCESS("[phase: admin] DONE"))
 
         # Step 5: Load default configuration.
-        self._run_tenant_phase(
-            agency,
-            "default configuration",
-            lambda: self._load_defaults(),
-        )
+        if "config" in phases_to_run:
+            self.stdout.write(self.style.MIGRATE_HEADING("[phase: config] Loading default configuration..."))
+            self._run_tenant_phase(
+                agency,
+                "default configuration",
+                lambda: self._load_defaults(),
+            )
+            self.stdout.write(self.style.SUCCESS("[phase: config] DONE"))
 
         # Output summary
         self.stdout.write("")

--- a/apps/tenants/management/commands/setup_public_tenant.py
+++ b/apps/tenants/management/commands/setup_public_tenant.py
@@ -67,6 +67,8 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
+        from django.db import transaction
+
         from apps.tenants.models import Agency, AgencyDomain
 
         domain = options["domain"]
@@ -87,49 +89,52 @@ class Command(BaseCommand):
             )
             return
 
-        # Check whether a 'public' agency already exists (rare edge case where
-        # the agency was created but the domain insert failed).
-        agency = Agency.objects.filter(schema_name=schema_name).first()
-        if not agency:
-            self.stdout.write(
-                f"Creating agency '{name}' (schema: {schema_name})..."
-            )
-            agency = Agency(
-                name=name,
-                short_code=short_code,
-                schema_name=schema_name,
-            )
-            # Disable auto-create: the 'public' schema already exists.
-            agency.auto_create_schema = False
-            agency.save()
-            self.stdout.write(self.style.SUCCESS(f"  Agency '{name}' created."))
-        else:
-            self.stdout.write(
-                f"Reusing existing agency '{agency.name}' (schema: {schema_name})."
-            )
+        # Wrap agency creation + domain registration + localhost registration
+        # in a single transaction so partial state can't happen.
+        with transaction.atomic():
+            # Check whether a 'public' agency already exists (rare edge case where
+            # the agency was created but the domain insert failed).
+            agency = Agency.objects.filter(schema_name=schema_name).first()
+            if not agency:
+                self.stdout.write(
+                    f"Creating agency '{name}' (schema: {schema_name})..."
+                )
+                agency = Agency(
+                    name=name,
+                    short_code=short_code,
+                    schema_name=schema_name,
+                )
+                # Disable auto-create: the 'public' schema already exists.
+                agency.auto_create_schema = False
+                agency.save()
+                self.stdout.write(self.style.SUCCESS(f"  Agency '{name}' created."))
+            else:
+                self.stdout.write(
+                    f"Reusing existing agency '{agency.name}' (schema: {schema_name})."
+                )
 
-        AgencyDomain.objects.create(
-            domain=domain,
-            tenant=agency,
-            is_primary=True,
-        )
-        self.stdout.write(
-            self.style.SUCCESS(f"  Domain '{domain}' registered.")
-        )
-
-        # Register 'localhost' as a secondary domain so Docker health checks
-        # (curl http://localhost:8000/auth/login/) can resolve to a tenant.
-        if domain != "localhost" and not AgencyDomain.objects.filter(
-            domain="localhost"
-        ).exists():
             AgencyDomain.objects.create(
-                domain="localhost",
+                domain=domain,
                 tenant=agency,
-                is_primary=False,
+                is_primary=True,
             )
             self.stdout.write(
-                "  Secondary domain 'localhost' registered (for health checks)."
+                self.style.SUCCESS(f"  Domain '{domain}' registered.")
             )
+
+            # Register 'localhost' as a secondary domain so Docker health checks
+            # (curl http://localhost:8000/auth/login/) can resolve to a tenant.
+            if domain != "localhost" and not AgencyDomain.objects.filter(
+                domain="localhost"
+            ).exists():
+                AgencyDomain.objects.create(
+                    domain="localhost",
+                    tenant=agency,
+                    is_primary=False,
+                )
+                self.stdout.write(
+                    "  Secondary domain 'localhost' registered (for health checks)."
+                )
 
         self.stdout.write(
             self.style.SUCCESS(

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -84,6 +84,12 @@ python manage.py startup_check
 echo ""
 echo "Verifying encrypted field integrity..."
 python manage.py shell -c "
+import sys
+
+bad_total = 0
+checked_total = 0
+
+# Check SurveyResponse.respondent_name
 from apps.surveys.models import SurveyResponse
 bad = 0
 checked = 0
@@ -92,11 +98,32 @@ for r in SurveyResponse.objects.exclude(_respondent_name_encrypted=b'').iterator
     if r.respondent_name_display == '[DECRYPTION ERROR]':
         bad += 1
 if bad:
-    import sys
     print(f'FAIL: {bad}/{checked} survey respondent names cannot be decrypted.')
+else:
+    print(f'OK: {checked} encrypted respondent name(s) verified.' if checked else 'OK: No encrypted respondent names to verify.')
+bad_total += bad
+checked_total += checked
+
+# Check ClientFile.first_name and last_name
+from apps.clients.models import ClientFile
+bad = 0
+checked = 0
+for c in ClientFile.objects.exclude(_first_name_encrypted=b'').iterator():
+    checked += 1
+    if c.first_name == '[DECRYPTION ERROR]' or c.last_name == '[DECRYPTION ERROR]':
+        bad += 1
+if bad:
+    print(f'FAIL: {bad}/{checked} client names cannot be decrypted.')
+else:
+    print(f'OK: {checked} encrypted client name(s) verified.' if checked else 'OK: No encrypted client names to verify.')
+bad_total += bad
+checked_total += checked
+
+if bad_total:
+    print(f'TOTAL: {bad_total}/{checked_total} encrypted fields failed decryption.')
     print('The FIELD_ENCRYPTION_KEY may not match the key used during migration.')
     sys.exit(1)
-print(f'OK: {checked} encrypted respondent name(s) verified.' if checked else 'OK: No encrypted respondent names to verify.')
+print(f'All {checked_total} encrypted field(s) verified successfully.' if checked_total else 'No encrypted fields to verify.')
 " 2>&1 || {
     if [ "${KONOTE_MODE:-production}" = "production" ]; then
         echo "ERROR: Encryption verification failed. Refusing to start."

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -21141,59 +21141,71 @@ msgstr ""
 "puis approuvez pour générer le fichier d'exportation."
 
 msgid "AI-suggested draft"
-msgstr ""
+msgstr "Ébauche suggérée par l'IA"
 
 msgid "Choose a Primary Metric"
-msgstr ""
+msgstr "Choisir une métrique principale"
 
 msgid ""
 "Choose one primary metric for this target. Start with the section-relevant "
 "options below, then browse the full library only if you need something else."
 msgstr ""
+"Choisissez une métrique principale pour cet objectif. Commencez par les "
+"options pertinentes pour cette section ci-dessous, puis parcourez la "
+"bibliothèque complète seulement si vous avez besoin d'autre chose."
 
 msgid ""
 "Choose the faster Log Contact flow for brief updates, or Detailed Note for a"
 " full session note."
 msgstr ""
+"Choisissez le flux rapide Journal de contact pour les mises à jour brèves, "
+"ou Note détaillée pour une note de séance complète."
 
 msgid "Create a note"
-msgstr ""
+msgstr "Créer une note"
 
 msgid "Filter metrics"
-msgstr ""
+msgstr "Filtrer les métriques"
 
 msgid ""
 "Here's a draft based on what they shared. Adjust it to fit what you know "
 "about them."
 msgstr ""
+"Voici une ébauche basée sur ce qu'ils ont partagé. Ajustez-la selon ce que "
+"vous savez d'eux."
 
 msgid ""
 "Optional overall reflections after you have captured the target-specific "
 "details you need."
 msgstr ""
+"Réflexions générales facultatives après avoir saisi les détails spécifiques "
+"à l'objectif dont vous avez besoin."
 
 msgid "Recommended for this section"
-msgstr ""
+msgstr "Recommandé pour cette section"
 
 msgid "Review in the form"
-msgstr ""
+msgstr "Réviser dans le formulaire"
 
 msgid "Select a target to begin"
-msgstr ""
+msgstr "Sélectionnez un objectif pour commencer"
 
 msgid "Session reflections and follow-up"
-msgstr ""
+msgstr "Réflexions de séance et suivi"
 
 msgid "Suggest a draft"
-msgstr ""
+msgstr "Suggérer une ébauche"
 
 msgid "Suggested name"
-msgstr ""
+msgstr "Nom suggéré"
 
 msgid "The full library is grouped by category below."
-msgstr ""
+msgstr "La bibliothèque complète est regroupée par catégorie ci-dessous."
 
 msgid ""
 "Use Log Contact for a fast update, or Detailed Note when you need target-by-"
 "target progress and session reflections."
 msgstr ""
+"Utilisez Journal de contact pour une mise à jour rapide, ou Note détaillée "
+"lorsque vous avez besoin du progrès objectif par objectif et des réflexions "
+"de séance."


### PR DESCRIPTION
## Summary

- **REV26-I18N2**: Fill 16 remaining empty French translations in django.po (all 5,661 entries now translated)
- **REV26-DEP3**: Make tenant provisioning and backup recovery paths more resumable and consistent
- Mark REFACTOR1 and CHORE-RPT-TEST1 as done in TODO.md (both were completed in earlier PRs)

### Deployment improvements (REV26-DEP3)

- `provision_tenant`: `--skip-to` flag for resuming from a specific phase, `--dry-run` preview, `transaction.atomic()` around steps 1-3
- `setup_public_tenant`: Transaction wrapping to prevent partial domain state
- `verify_backup_restore`: `--pre-restore` dump file validation, `--full` flag for complete encryption check, expanded to cover ProgressNote + ClientFile
- `entrypoint.sh`: Startup encryption check now covers both SurveyResponse and ClientFile

## Test plan

- [x] 35 translation tests pass
- [x] All Python files compile cleanly
- [x] Shell script syntax verified
- [ ] Deploy to dev VPS and verify startup sequence

🤖 Generated with [Claude Code](https://claude.com/claude-code)