### PR TITLE
fix: hide bulk operation checkboxes from workers

### DIFF
--- a/apps/clients/views.py
+++ b/apps/clients/views.py
@@ -369,10 +369,13 @@ def client_list(request):
     user_role = _get_user_highest_role(request.user)
     can_create = PERMISSIONS.get(user_role, {}).get("client.create", DENY) != DENY
     # Bulk operation permission flags (UX17)
-    can_bulk_status = any(
+    # Only show bulk ops for management roles (PM, executive) and admins —
+    # regular workers find the bulk modal confusing and don't need it.
+    _bulk_eligible = user_role in MANAGEMENT_ROLES or getattr(request.user, "is_admin", False)
+    can_bulk_status = _bulk_eligible and any(
         can_access(upr.role, "client.edit") != DENY for upr in _user_roles
     )
-    can_bulk_transfer = any(
+    can_bulk_transfer = _bulk_eligible and any(
         can_access(upr.role, "client.transfer") != DENY for upr in _user_roles
     )
     show_bulk = can_bulk_status or can_bulk_transfer


### PR DESCRIPTION
## Summary
- Workers (staff role) saw confusing checkboxes on the participant list that opened a bulk operations modal they don't need
- Bulk operations (change status, transfer programs) are now restricted to management roles (program managers, executives) and admins only
- The existing permission checks (`client.edit`, `client.transfer`) still apply — this adds a role gate on top

## Test plan
- [ ] Log in as a **worker** — confirm no checkboxes appear on the participant list
- [ ] Log in as a **program manager** — confirm checkboxes and bulk actions still work
- [ ] Log in as an **admin** — confirm checkboxes and bulk actions still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)