### PR TITLE
fix: address PR #414 review findings

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -23,8 +23,6 @@
 
 ### Phase: Deep Review Fixes (2026-03-06)
 
-- [ ] 🔨 Clean up translation catalog health: remove duplicate `msgid`s, fill missing and empty French strings, and rebuild `django.mo` (REV26-I18N2)
-- [ ] 🔨 Make tenant provisioning and backup recovery paths more resumable and consistent (REV26-DEP3)
 - [ ] Expand automated accessibility coverage across one public survey flow, one portal flow, and one report/chart flow — PB (REV26-A11Y1)
 - [ ] Document the active participant-data AI provider mode and data residency expectations for operators — SG (REV26-AI4)
 - [ ] Complete organization-specific privacy policy, retention schedule, and breach workflow documentation — SG (REV26-PRIV1)
@@ -120,6 +118,8 @@ Not yet clear we should build these, or the design isn't settled. May be too com
 
 ## Recently Done
 
+- [x] Translation catalog cleanup — filled 16 remaining empty French entries, 0 empty remain — PR #414 — 2026-03-07 (REV26-I18N2)
+- [x] Tenant provisioning + backup recovery resumability — --skip-to, --dry-run, --pre-restore, --full, transaction wrapping, expanded encryption checks — PR #414 — 2026-03-07 (REV26-DEP3)
 - [x] Extract role string constants into auth_app/constants.py — 5 PRs merged, 107 files updated — 2026-03-07 (REFACTOR1)
 - [x] Add smoke test for all-programs HTML export path — PR #340 — 2026-03-07 (CHORE-RPT-TEST1)
 - [x] Deep review follow-up hardening pass — AI scrubber expanded, focused analysis and note-structure flows scrubbed, insecure remote insights HTTP blocked, Docker build inputs tightened, tenant-key rotation disabled, `/health/` healthcheck wired, production startup fails closed on public-tenant bootstrap, French survey/export fixes landed, public survey page-step validation improved, registration intake/review audit coverage added — 2026-03-06 (REV26-SEC1, REV26-DEP1, REV26-DEP2, REV26-AI1, REV26-AI2, REV26-AI3, REV26-I18N1)

--- a/apps/audit/management/commands/verify_backup_restore.py
+++ b/apps/audit/management/commands/verify_backup_restore.py
@@ -80,7 +80,11 @@ class Command(BaseCommand):
         if check_default:
             results["table_counts"] = self._check_table_counts()
 
-        # ── 2. Encryption health ───────────────────────────────────
+        # ── 2a. Encryption key round-trip ────────────────────────────
+        if check_default:
+            results["encryption_key"] = self._check_encryption_roundtrip()
+
+        # ── 2b. Encryption health ───────────────────────────────────
         if check_default:
             results["encryption"] = self._check_encryption(sample_size, full_check)
 
@@ -114,6 +118,29 @@ class Command(BaseCommand):
             self.stdout.write(f"   {label}: {count:,}")
         self.stdout.write("")
         return True
+
+    def _check_encryption_roundtrip(self):
+        """Verify FIELD_ENCRYPTION_KEY can round-trip encrypt and decrypt."""
+        self.stdout.write(self.style.MIGRATE_HEADING("2a. Encryption Key Round-Trip"))
+        try:
+            from apps.clients.encryption import encrypt_field, decrypt_field
+            test_value = "verify-backup-restore-test"
+            encrypted = encrypt_field(test_value)
+            decrypted = decrypt_field(encrypted)
+            if decrypted == test_value:
+                self.stdout.write(self.style.SUCCESS("   FIELD_ENCRYPTION_KEY round-trip OK."))
+                self.stdout.write("")
+                return True
+            else:
+                self.stdout.write(self.style.ERROR(
+                    f"   FAIL: Round-trip mismatch. Expected '{test_value}', got '{decrypted}'."
+                ))
+                self.stdout.write("")
+                return False
+        except Exception as exc:
+            self.stdout.write(self.style.ERROR(f"   FAIL: Encryption round-trip error: {exc}"))
+            self.stdout.write("")
+            return False
 
     def _check_encryption(self, sample_size, full_check=False):
         self.stdout.write(self.style.MIGRATE_HEADING("2. Encryption Health"))
@@ -304,11 +331,15 @@ class Command(BaseCommand):
             with open(dump_path, "r", errors="replace") as f:
                 first_line = f.readline(1024)
             if "PostgreSQL" in first_line or "pg_dump" in first_line:
-                self.stdout.write(self.style.SUCCESS("   File header looks like a pg_dump output."))
+                self.stdout.write(self.style.SUCCESS(
+                    "   Text-format pg_dump detected (header contains PostgreSQL/pg_dump signature)."
+                ))
             else:
                 self.stdout.write(self.style.ERROR(
                     "   FAIL: First line does not contain 'PostgreSQL' or 'pg_dump'. "
-                    "This may not be a valid database dump."
+                    "This may not be a valid text-format database dump. "
+                    "Note: binary/custom-format dumps are not supported by this check — "
+                    "use 'pg_restore --list <file>' to validate those."
                 ))
                 self.stdout.write(f"   First line: {first_line.strip()[:120]}")
                 ok = False

--- a/apps/tenants/management/commands/provision_tenant.py
+++ b/apps/tenants/management/commands/provision_tenant.py
@@ -10,6 +10,16 @@ Usage:
         --domain youth-services.konote.ca \\
         --admin-username admin \\
         --admin-password <secure-password>
+
+Recovery:
+    If provisioning fails, rerun with --skip-to <phase> where <phase> is
+    the phase that failed. All phases use get_or_create and are idempotent.
+
+    Note: transaction.atomic() wraps steps 1-3 (schema, domain, key) but
+    django-tenants may issue CREATE SCHEMA as DDL, which causes an implicit
+    commit in PostgreSQL. This means the transaction cannot truly roll back
+    schema creation. However, since all operations are idempotent, re-running
+    the command safely reuses existing objects.
 """
 from django.core.management.base import BaseCommand, CommandError
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -108,7 +108,7 @@ checked_total += checked
 from apps.clients.models import ClientFile
 bad = 0
 checked = 0
-for c in ClientFile.objects.exclude(_first_name_encrypted=b'').iterator():
+for c in ClientFile.objects.exclude(_first_name_encrypted=b'').exclude(_first_name_encrypted__isnull=True).iterator():
     checked += 1
     if c.first_name == '[DECRYPTION ERROR]' or c.last_name == '[DECRYPTION ERROR]':
         bad += 1


### PR DESCRIPTION
## Summary

Addresses all 5 findings from the expert panel review of PR #414.

1. **NULL exclusion in entrypoint.sh** — ClientFile filter now excludes both empty bytes and NULL `_first_name_encrypted` values
2. **TODO.md housekeeping** — REV26-I18N2 and REV26-DEP3 marked done
3. **Recovery docstring** — `provision_tenant.py` documents `--skip-to` usage and DDL/transaction caveat
4. **Format detection messaging** — `--pre-restore` error now explains text-format-only limitation and suggests `pg_restore --list` for binary dumps
5. **Encryption round-trip test** — New check 2a in `verify_backup_restore` verifies FIELD_ENCRYPTION_KEY can encrypt+decrypt, catching key mismatches even with no data

## Test plan

- [x] All Python files compile cleanly
- [x] Shell script syntax verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)