### PR TITLE
fix: checkbox layout squished in Pico CSS forms

### DIFF
--- a/apps/auth_app/templatetags/form_tags.py
+++ b/apps/auth_app/templatetags/form_tags.py
@@ -1,0 +1,42 @@
+"""Template tags for form field rendering.
+
+Usage in templates:
+    {% load form_tags %}
+    {% describedby_ids field as desc_ids %}
+    {{ field|aria_describedby:desc_ids }}
+"""
+import re
+
+from django import template
+from django.utils.safestring import mark_safe
+
+register = template.Library()
+
+
+@register.simple_tag
+def describedby_ids(field):
+    """Return space-separated IDs for aria-describedby based on what's present."""
+    ids = []
+    fid = field.id_for_label
+    if field.help_text:
+        ids.append(f"{fid}_helptext")
+    if field.errors:
+        ids.append(f"{fid}_error")
+    return " ".join(ids)
+
+
+@register.filter(name="aria_describedby")
+def aria_describedby(bound_field, describedby_id):
+    """Add aria-describedby attribute to a rendered form widget."""
+    if not describedby_id:
+        return bound_field
+    html = str(bound_field)
+    if "aria-describedby=" in html:
+        return bound_field
+    html = re.sub(
+        r"(<(?:input|select|textarea)\b)",
+        rf'\1 aria-describedby="{describedby_id}"',
+        html,
+        count=1,
+    )
+    return mark_safe(html)

--- a/templates/auth_app/user_form.html
+++ b/templates/auth_app/user_form.html
@@ -19,15 +19,7 @@
     {% csrf_token %}
 
     {% for field in form %}
-    <label for="{{ field.id_for_label }}">
-        {{ field.label }}
-        {% if field.field.required %}<abbr title="{% trans 'required' %}">*</abbr>{% endif %}
-    </label>
-    {{ field }}
-    {% if field.help_text %}<small>{{ field.help_text }}</small>{% endif %}
-    {% if field.errors %}
-    <small class="badge badge-danger">{{ field.errors.0 }}</small>
-    {% endif %}
+    {% include "includes/_form_field.html" with field=field %}
     {% endfor %}
 
     {% if not editing %}

--- a/templates/includes/_form_field.html
+++ b/templates/includes/_form_field.html
@@ -1,0 +1,26 @@
+{% comment %}
+Reusable form field renderer that handles checkbox vs. non-checkbox fields.
+
+Pico CSS requires checkboxes to be INSIDE the <label> tag for proper layout.
+Regular fields need the label ABOVE the input. This include handles both.
+Help text and errors are linked via aria-describedby for screen readers.
+
+Usage:
+    {% include "includes/_form_field.html" with field=field %}
+{% endcomment %}{% load i18n form_tags %}{% describedby_ids field as desc_ids %}
+{% if field.field.widget.input_type == "checkbox" %}
+<label>
+    {% if desc_ids %}{{ field|aria_describedby:desc_ids }}{% else %}{{ field }}{% endif %}
+    {{ field.label }}
+</label>
+{% if field.help_text %}<small id="{{ field.id_for_label }}_helptext">{{ field.help_text }}</small>{% endif %}
+{% if field.errors %}<small class="error" id="{{ field.id_for_label }}_error" role="alert">{{ field.errors.0 }}</small>{% endif %}
+{% else %}
+<label for="{{ field.id_for_label }}">
+    {{ field.label }}
+    {% if field.field.required %}<abbr title="{% trans 'required' %}">*</abbr>{% endif %}
+</label>
+{% if desc_ids %}{{ field|aria_describedby:desc_ids }}{% else %}{{ field }}{% endif %}
+{% if field.help_text %}<small id="{{ field.id_for_label }}_helptext">{{ field.help_text }}</small>{% endif %}
+{% if field.errors %}<small class="error" id="{{ field.id_for_label }}_error" role="alert">{{ field.errors.0 }}</small>{% endif %}
+{% endif %}

--- a/templates/surveys/admin/rule_form.html
+++ b/templates/surveys/admin/rule_form.html
@@ -39,16 +39,7 @@
 
         {% for field in form %}
         <div>
-            {{ field.label_tag }}
-            {{ field }}
-            {% if field.help_text %}
-                <small id="{{ field.id_for_label }}_help">{{ field.help_text }}</small>
-            {% endif %}
-            {% if field.errors %}
-                {% for error in field.errors %}
-                    <small class="error" id="{{ field.id_for_label }}_error" role="alert">{{ error }}</small>
-                {% endfor %}
-            {% endif %}
+            {% include "includes/_form_field.html" with field=field %}
         </div>
         {% endfor %}
 

--- a/templates/surveys/admin/survey_form.html
+++ b/templates/surveys/admin/survey_form.html
@@ -16,10 +16,7 @@
         <legend>{% trans "Survey Details" %}</legend>
         {% for field in form %}
             {% if field.name != "consent_text" and field.name != "consent_text_fr" %}
-            <label for="{{ field.id_for_label }}">{{ field.label }}{% if field.field.required %} <abbr title="{% trans 'required' %}">*</abbr>{% endif %}</label>
-            {{ field }}
-            {% if field.help_text %}<small>{{ field.help_text }}</small>{% endif %}
-            {% if field.errors %}<small class="error" role="alert">{{ field.errors.0 }}</small>{% endif %}
+            {% include "includes/_form_field.html" with field=field %}
             {% endif %}
         {% endfor %}
     </fieldset>
@@ -52,10 +49,7 @@
             {{ section_form.id }}
             {% for field in section_form %}
                 {% if field.name != "id" and field.name != "DELETE" and field.name != "condition_question" and field.name != "condition_value" %}
-                <label for="{{ field.id_for_label }}">{{ field.label }}</label>
-                {{ field }}
-                {% if field.help_text %}<small>{{ field.help_text }}</small>{% endif %}
-                {% if field.errors %}<small class="error" role="alert">{{ field.errors.0 }}</small>{% endif %}
+                {% include "includes/_form_field.html" with field=field %}
                 {% endif %}
             {% endfor %}
 


### PR DESCRIPTION
## Summary
- Pico CSS requires checkboxes **inside** `<label>` tags for proper grid layout. Generic form loops were rendering them as separate sibling elements, causing labels and checkboxes to overlap/squish together.
- Created reusable `_form_field.html` include that detects checkbox fields via `field.field.widget.input_type` and renders the correct Pico CSS pattern
- Added `form_tags.py` template tags with `aria-describedby` support linking help text and error messages to form controls (WCAG 2.2 AA — 1.3.1 Info and Relationships)
- Fixed 3 templates covering 8 BooleanFields: survey form, user form, trigger rule form

## Test plan
- [ ] Visit survey create/edit page — checkboxes (Anonymous, Show scores, Portal visible) should display inline with label text, not squished
- [ ] Visit user create/edit page — is_admin checkbox should display correctly
- [ ] Visit trigger rule create page — auto_assign, include_existing checkboxes should display correctly
- [ ] Screen reader: help text should be announced when focusing form fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)