### PR TITLE
feat: survey CSV template + source/citation fields + metric unification DRR

### DIFF
--- a/apps/surveys/forms.py
+++ b/apps/surveys/forms.py
@@ -11,7 +11,7 @@ class SurveyForm(forms.ModelForm):
     class Meta:
         model = Survey
         fields = [
-            "name", "name_fr", "description", "description_fr",
+            "name", "name_fr", "description", "description_fr", "source",
             "consent_text", "consent_text_fr",
             "is_anonymous", "show_scores_to_participant", "portal_visible",
         ]
@@ -26,6 +26,7 @@ class SurveyForm(forms.ModelForm):
             "name_fr": _("Survey name (French)"),
             "description": _("Description"),
             "description_fr": _("Description (French)"),
+            "source": _("Source or citation (optional)"),
             "consent_text": _("Consent text (shown before the survey begins)"),
             "consent_text_fr": _("Consent text — French"),
             "is_anonymous": _("Anonymous survey"),
@@ -42,8 +43,13 @@ class SurveyForm(forms.ModelForm):
             "portal_visible": _(
                 "Uncheck to hide this survey from the participant portal."
             ),
+            "source": _(
+                "If this entire survey comes from a single validated instrument, "
+                "note it here. E.g., PHQ-9 (Kroenke et al., 2001). "
+                "For composite surveys, add citations per section instead."
+            ),
             "consent_text": _(
-                "If provided, respondents must agree to this text before "
+                "If provided, respondents must agree to this text before"
                 "they can see the survey questions. Leave blank to skip "
                 "the consent step. Good consent text explains: what data "
                 "is collected, how it will be used, and whether responses "
@@ -62,7 +68,7 @@ class SurveySectionForm(forms.ModelForm):
     class Meta:
         model = SurveySection
         fields = [
-            "title", "title_fr", "instructions", "instructions_fr",
+            "title", "title_fr", "instructions", "instructions_fr", "source",
             "sort_order", "page_break", "skip_for_identified",
             "scoring_method", "max_score",
             "condition_question", "condition_value",
@@ -76,6 +82,7 @@ class SurveySectionForm(forms.ModelForm):
             "title_fr": _("Section title (French)"),
             "instructions": _("Instructions"),
             "instructions_fr": _("Instructions (French)"),
+            "source": _("Source or citation"),
             "sort_order": _("Display order"),
             "page_break": _("Start new page"),
             "skip_for_identified": _("Skip for identified participants"),
@@ -89,6 +96,10 @@ class SurveySectionForm(forms.ModelForm):
                 "Check this for demographics sections. When the survey is "
                 "assigned to a participant or entered by staff, this section "
                 "will be hidden — that data is already on file."
+            ),
+            "source": _(
+                "Where these questions come from, if adapted from a published "
+                "instrument. E.g., WHO-5 (WHO, 1998)."
             ),
             "condition_question": _("Leave blank to always show this section."),
             "condition_value": _("The answer value that makes this section visible."),
@@ -228,4 +239,11 @@ class CSVImportForm(forms.Form):
     survey_name = forms.CharField(max_length=255, label=_("Survey name"))
     survey_name_fr = forms.CharField(
         max_length=255, required=False, label=_("Survey name (French)"),
+    )
+    survey_source = forms.CharField(
+        max_length=500, required=False, label=_("Source or citation (optional)"),
+        help_text=_(
+            "If this entire survey comes from a single instrument, "
+            "note it here. E.g., PHQ-9 (Kroenke et al., 2001)."
+        ),
     )

--- a/apps/surveys/manage_urls.py
+++ b/apps/surveys/manage_urls.py
@@ -31,4 +31,5 @@ urlpatterns = [
         name="survey_rule_deactivate",
     ),
     path("import/", views.csv_import, name="csv_import"),
+    path("import/template/", views.csv_template, name="csv_template"),
 ]

--- a/apps/surveys/migrations/0011_survey_source_surveysection_source.py
+++ b/apps/surveys/migrations/0011_survey_source_surveysection_source.py
@@ -1,0 +1,31 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("surveys", "0010_encrypt_respondent_name"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="survey",
+            name="source",
+            field=models.CharField(
+                blank=True,
+                default="",
+                help_text="Source or citation for the whole survey, e.g. 'PHQ-9 (Kroenke et al., 2001)'.",
+                max_length=500,
+            ),
+        ),
+        migrations.AddField(
+            model_name="surveysection",
+            name="source",
+            field=models.CharField(
+                blank=True,
+                default="",
+                help_text="Source or citation for this section's questions, e.g. 'WHO-5 (WHO, 1998)'.",
+                max_length=500,
+            ),
+        ),
+    ]

--- a/apps/surveys/models.py
+++ b/apps/surveys/models.py
@@ -27,6 +27,10 @@ class Survey(models.Model):
     name_fr = models.CharField(max_length=255, blank=True, default="")
     description = models.TextField(default="", blank=True)
     description_fr = models.TextField(default="", blank=True)
+    source = models.CharField(
+        max_length=500, blank=True, default="",
+        help_text=_("Source or citation for the whole survey, e.g. 'PHQ-9 (Kroenke et al., 2001)'."),
+    )
     status = models.CharField(max_length=20, choices=STATUS_CHOICES, default="draft")
     is_anonymous = models.BooleanField(
         default=False,
@@ -110,6 +114,10 @@ class SurveySection(models.Model):
         help_text=_("Section only shows when this question has the condition value."),
     )
     condition_value = models.CharField(max_length=255, blank=True, default="")
+    source = models.CharField(
+        max_length=500, blank=True, default="",
+        help_text=_("Source or citation for this section's questions, e.g. 'WHO-5 (WHO, 1998)'."),
+    )
     is_active = models.BooleanField(default=True)
     skip_for_identified = models.BooleanField(
         default=False,

--- a/apps/surveys/views.py
+++ b/apps/surveys/views.py
@@ -431,6 +431,43 @@ def csv_import(request):
     return render(request, "surveys/admin/csv_import.html", {"form": form})
 
 
+@login_required
+@admin_required
+def csv_template(request):
+    """Download a template CSV for survey import with example rows."""
+    _surveys_or_404()
+    response = HttpResponse(content_type="text/csv")
+    response["Content-Disposition"] = 'attachment; filename="survey-template.csv"'
+    writer = csv.writer(response)
+    writer.writerow([
+        "section", "question", "type", "required", "options",
+        "score_values", "instructions", "page_break",
+        "section_fr", "question_fr", "options_fr",
+    ])
+    writer.writerow([
+        "Demographics", "What is your age range?", "single_choice", "yes",
+        "Under 18;18-30;31-50;Over 50", "", "Answer the following about yourself.",
+        "yes", "Démographie", "Quelle est votre tranche d'âge?",
+        "Moins de 18 ans;18-30;31-50;Plus de 50 ans",
+    ])
+    writer.writerow([
+        "Demographics", "What is your postal code?", "short_text", "no",
+        "", "", "", "", "Démographie", "Quel est votre code postal?", "",
+    ])
+    writer.writerow([
+        "Satisfaction", "How satisfied are you with the program?", "rating_scale",
+        "yes", "Very dissatisfied;Dissatisfied;Neutral;Satisfied;Very satisfied",
+        "1;2;3;4;5", "Rate your experience below.", "",
+        "Satisfaction", "Quel est votre niveau de satisfaction avec le programme?",
+        "Très insatisfait;Insatisfait;Neutre;Satisfait;Très satisfait",
+    ])
+    writer.writerow([
+        "Satisfaction", "What could we improve?", "long_text", "no",
+        "", "", "", "", "Satisfaction", "Que pourrions-nous améliorer?", "",
+    ])
+    return response
+
+
 # ---------------------------------------------------------------------------
 # Participant-level views — staff viewing/managing surveys on a client file
 # ---------------------------------------------------------------------------

--- a/apps/surveys/views.py
+++ b/apps/surveys/views.py
@@ -320,6 +320,7 @@ def csv_import(request):
                     survey = Survey.objects.create(
                         name=form.cleaned_data["survey_name"],
                         name_fr=form.cleaned_data.get("survey_name_fr", ""),
+                        source=form.cleaned_data.get("survey_source", ""),
                         status="draft",
                         created_by=request.user,
                     )
@@ -347,8 +348,16 @@ def csv_import(request):
                                 page_break=row.get(
                                     "page_break", "",
                                 ).strip().lower() == "yes",
+                                source=row.get("source", "").strip(),
                             )
                             sections[section_title] = section
+                        else:
+                            # Apply first non-blank source to existing section
+                            row_source = row.get("source", "").strip()
+                            section_obj = sections[section_title]
+                            if row_source and not section_obj.source:
+                                section_obj.source = row_source
+                                section_obj.save(update_fields=["source"])
 
                         section = sections[section_title]
 
@@ -441,29 +450,40 @@ def csv_template(request):
     writer = csv.writer(response)
     writer.writerow([
         "section", "question", "type", "required", "options",
-        "score_values", "instructions", "page_break",
+        "score_values", "instructions", "page_break", "source",
         "section_fr", "question_fr", "options_fr",
     ])
     writer.writerow([
         "Demographics", "What is your age range?", "single_choice", "yes",
         "Under 18;18-30;31-50;Over 50", "", "Answer the following about yourself.",
-        "yes", "Démographie", "Quelle est votre tranche d'âge?",
+        "yes", "",
+        "Démographie", "Quelle est votre tranche d'âge?",
         "Moins de 18 ans;18-30;31-50;Plus de 50 ans",
     ])
     writer.writerow([
         "Demographics", "What is your postal code?", "short_text", "no",
-        "", "", "", "", "Démographie", "Quel est votre code postal?", "",
+        "", "", "", "", "",
+        "Démographie", "Quel est votre code postal?", "",
+    ])
+    writer.writerow([
+        "Wellbeing", "I have felt cheerful and in good spirits", "rating_scale",
+        "yes", "At no time;Some of the time;Less than half the time;More than half the time;Most of the time;All of the time",
+        "0;1;2;3;4;5", "Over the last two weeks...", "",
+        "WHO-5 (WHO, 1998)",
+        "Bien-être", "Je me suis senti(e) gai(e) et de bonne humeur",
+        "Jamais;Parfois;Moins de la moitié du temps;Plus de la moitié du temps;La plupart du temps;Tout le temps",
     ])
     writer.writerow([
         "Satisfaction", "How satisfied are you with the program?", "rating_scale",
         "yes", "Very dissatisfied;Dissatisfied;Neutral;Satisfied;Very satisfied",
-        "1;2;3;4;5", "Rate your experience below.", "",
+        "1;2;3;4;5", "Rate your experience below.", "", "",
         "Satisfaction", "Quel est votre niveau de satisfaction avec le programme?",
         "Très insatisfait;Insatisfait;Neutre;Satisfait;Très satisfait",
     ])
     writer.writerow([
         "Satisfaction", "What could we improve?", "long_text", "no",
-        "", "", "", "", "Satisfaction", "Que pourrions-nous améliorer?", "",
+        "", "", "", "", "",
+        "Satisfaction", "Que pourrions-nous améliorer?", "",
     ])
     return response
 

--- a/tasks/design-rationale/survey-metric-unification.md
+++ b/tasks/design-rationale/survey-metric-unification.md
@@ -1,0 +1,105 @@
+# Design Rationale: Survey–Metric Unification
+
+**Status:** Decided (2026-03-07)
+**Decided by:** GK (subject matter expert, evaluation methodology)
+
+## Decision
+
+Survey questions and outcome metrics are the same underlying construct — a measured item that can appear in different contexts (staff progress notes, participant portal forms, anonymous surveys). The system should treat them as one thing, not two parallel systems.
+
+### Core Change
+
+`SurveyQuestion` gets an **optional FK to `MetricDefinition`**. When linked:
+- The question inherits metadata from the metric: source/citation, instrument grouping, scoring rules, directionality, CIDS alignment
+- Survey responses for linked questions can feed into the same outcome tracking that progress notes use
+- One PHQ-9 item definition, surfaced in a staff note, a portal form, or a survey
+
+When unlinked (FK is null):
+- The question works exactly as it does today — standalone, custom, no metric relationship
+- Used for demographics, open-ended feedback, consent questions, etc.
+
+### Metadata Fields That Already Exist on MetricDefinition
+
+These are the fields survey questions should inherit (not duplicate) when linked:
+
+| Field | Purpose |
+|-------|---------|
+| `instrument_name` | Groups items from the same instrument (e.g., "PHQ-9") |
+| `is_standardized_instrument` | Flags published validated tools |
+| `definition` / `definition_fr` | What the item measures and how to score it |
+| `scoring_bands` | Published severity cutoffs (JSON) |
+| `higher_is_better` | Directionality |
+| `min_value` / `max_value` | Valid range |
+| `rationale_log` | Append-only changelog with dates, notes, author |
+| `cids_indicator_uri` | CIDS indicator alignment |
+| `iris_metric_code` | IRIS+ metric code |
+| `sdg_goals` | SDG alignment |
+| `cids_defined_by` | Organisation that defined the indicator |
+
+### Metadata That Stays on SurveySection
+
+`SurveySection` already has `scoring_method` (none/sum/average) and `max_score`. These are section-level (subscale-level) concerns and stay where they are — they describe how to aggregate the items in that section.
+
+A section-level `source` field (free text, optional) can be added for cases where someone wants to cite the instrument at the section level without linking every question to a MetricDefinition. This is the lightweight path for agencies that don't use the metric library.
+
+## Why Not Question-Level Source Fields?
+
+Rejected: adding `source` directly to `SurveyQuestion`.
+
+- Questions from the same instrument share the same citation — per-question sourcing creates duplication
+- The MetricDefinition already has comprehensive metadata; duplicating it on SurveyQuestion creates two sources of truth
+- The natural unit of citation in evaluation is the instrument/subscale (section), not the individual item
+
+## Why Not Survey-Level Only?
+
+Rejected as the sole location: adding `source` only to `Survey`.
+
+- Composite surveys mix questions from multiple instruments — one survey-level field can't capture this
+- Survey-level source is still useful as a shorthand ("This is the PHQ-9"), so keep it as a convenience field
+
+## Implementation Path
+
+### Phase 1 — Lightweight (current session scope)
+1. Add `source` (TextField, optional) to `Survey` — whole-instrument shorthand
+2. Add `source` (TextField, optional) to `SurveySection` — per-section/subscale citation
+3. Update CSV import to accept `source` column (first non-blank value per section applies to the section)
+4. Update CSV template with source examples
+5. No bilingual `source_fr` — citations aren't translated
+
+### Phase 2 — MetricDefinition Link (future session)
+1. Add optional FK `metric_definition` to `SurveyQuestion`
+2. When linked, display inherited metadata (source, scoring, instrument name) from the metric
+3. Survey builder UI: "Link to metric" search/picker when adding questions
+4. CSV import: optional `metric_code` column that matches `MetricDefinition` by name or ID
+5. Response aggregation: linked question responses can appear in outcome tracking charts
+
+### Phase 3 — Unified Measurement Library (future)
+1. Survey sections that correspond to full instruments (all items from PHQ-9) auto-link to MetricDefinition
+2. "Create survey from instrument" workflow — select a MetricDefinition with `is_standardized_instrument=True`, auto-generate survey sections and questions
+3. Cross-context reporting: "Show all PHQ-9 data for this participant" regardless of whether it came from a progress note or a survey
+
+## CIDS Compliance Interaction
+
+This decision directly supports CIDS compliance and metadata tagging:
+
+- **MetricDefinition already carries CIDS fields** (`cids_indicator_uri`, `iris_metric_code`, `sdg_goals`, `cids_defined_by`, `cids_unit_description`, `cids_has_baseline`, `cids_theme_override`). When a survey question links to a metric, all CIDS metadata flows through without re-tagging.
+- **Survey responses linked to CIDS-aligned metrics can be included in JSON-LD exports.** A PHQ-9 administered as a portal survey produces the same CIDS-compliant data as a PHQ-9 score recorded in a progress note.
+- **Avoids duplicate CIDS tagging.** Without unification, someone would need to manually tag survey questions with CIDS URIs separately from metrics — two places to maintain, guaranteed to drift.
+- **Supports the Common Approach reporting requirement.** Funders using Common Approach / CIDS expect standardised indicator data regardless of how it was collected (staff observation, client self-report, survey). Unification means one indicator definition, multiple collection surfaces.
+
+See also: `tasks/design-rationale/cids-metadata-assignment.md` for the CIDS metadata workflow on MetricDefinition.
+
+## Anti-Patterns
+
+- **Do not duplicate MetricDefinition fields on SurveyQuestion.** If a question is linked to a metric, read the metadata from the metric. If it's unlinked, it has no instrument metadata — that's fine.
+- **Do not require linking.** Many survey questions (demographics, feedback, consent) are not metrics. The FK must be nullable.
+- **Do not auto-create MetricDefinitions from survey questions.** Metrics are curated library items. Surveys may have throwaway questions. The link is always intentional.
+- **Do not add `source_fr`.** Citations are language-neutral. One field is enough.
+
+## Scoring Interaction
+
+Different sections already support different scoring rules via `SurveySection.scoring_method`. When a question is linked to a MetricDefinition:
+- The metric's `scoring_bands` provide severity interpretation
+- The section's `scoring_method` (sum/average) determines how items are aggregated
+- The metric's `higher_is_better` determines directionality for display
+- These don't conflict — they describe different levels (item vs. subscale)

--- a/tasks/design-rationale/survey-metric-unification.md
+++ b/tasks/design-rationale/survey-metric-unification.md
@@ -2,6 +2,7 @@
 
 **Status:** Decided (2026-03-07)
 **Decided by:** GK (subject matter expert, evaluation methodology)
+**Reviewed by:** Expert panel (2026-03-07) — Evaluation Systems Architect, Django Data Modeller, Nonprofit Capacity Builder, Standards Compliance Specialist
 
 ## Decision
 
@@ -57,30 +58,31 @@ Rejected as the sole location: adding `source` only to `Survey`.
 - Composite surveys mix questions from multiple instruments — one survey-level field can't capture this
 - Survey-level source is still useful as a shorthand ("This is the PHQ-9"), so keep it as a convenience field
 
-## Implementation Path
+## Scoring Pipeline
 
-### Phase 1 — Lightweight (current session scope)
-1. Add `source` (TextField, optional) to `Survey` — whole-instrument shorthand
-2. Add `source` (TextField, optional) to `SurveySection` — per-section/subscale citation
-3. Update CSV import to accept `source` column (first non-blank value per section applies to the section)
-4. Update CSV template with source examples
-5. No bilingual `source_fr` — citations aren't translated
+`SurveySection.scoring_method` and `MetricDefinition.scoring_bands` are **complementary, not conflicting.** They are two steps in the same pipeline:
 
-### Phase 2 — MetricDefinition Link (future session)
-1. Add optional FK `metric_definition` to `SurveyQuestion`
-2. When linked, display inherited metadata (source, scoring, instrument name) from the metric
-3. Survey builder UI: "Link to metric" search/picker when adding questions
-4. CSV import: optional `metric_code` column that matches `MetricDefinition` by name or ID
-5. Response aggregation: linked question responses can appear in outcome tracking charts
+1. **Step 1 — Aggregate items:** `scoring_method` (sum/average) computes the subscale score from individual item scores within the section
+2. **Step 2 — Interpret the total:** `scoring_bands` maps the aggregated score to severity categories (e.g., PHQ-9 total of 15 → "Moderately severe depression")
 
-### Phase 3 — Unified Measurement Library (future)
-1. Survey sections that correspond to full instruments (all items from PHQ-9) auto-link to MetricDefinition
-2. "Create survey from instrument" workflow — select a MetricDefinition with `is_standardized_instrument=True`, auto-generate survey sections and questions
-3. Cross-context reporting: "Show all PHQ-9 data for this participant" regardless of whether it came from a progress note or a survey
+This is exactly how validated instruments work. Do not attempt to "resolve" these as competing systems — they are sequential stages.
 
 ## CIDS Compliance Interaction
 
-This decision directly supports CIDS compliance and metadata tagging:
+This decision directly supports CIDS compliance and metadata tagging.
+
+### CIDS indicators map to sections, not questions
+
+CIDS indicators (`cids:indicatorForOutcome`) are defined at the outcome level — they map to the *subscale score* (PHQ-9 total), not to individual items (PHQ-9 question 3). In this system:
+
+- The **section** (subscale) is what maps to a CIDS indicator
+- The section computes the subscale score via `scoring_method`
+- When all questions in a section are linked to the same `MetricDefinition` (via `instrument_name`), the section inherits that metric's CIDS properties
+- CIDS export should pull: `SurveySection.source` → citation, `MetricDefinition.cids_indicator_uri` → indicator, computed section score → value
+
+Same pattern applies to IRIS+ codes (`iris_metric_code`) — these map to aggregate measures, not individual items.
+
+### What unification enables
 
 - **MetricDefinition already carries CIDS fields** (`cids_indicator_uri`, `iris_metric_code`, `sdg_goals`, `cids_defined_by`, `cids_unit_description`, `cids_has_baseline`, `cids_theme_override`). When a survey question links to a metric, all CIDS metadata flows through without re-tagging.
 - **Survey responses linked to CIDS-aligned metrics can be included in JSON-LD exports.** A PHQ-9 administered as a portal survey produces the same CIDS-compliant data as a PHQ-9 score recorded in a progress note.
@@ -89,17 +91,60 @@ This decision directly supports CIDS compliance and metadata tagging:
 
 See also: `tasks/design-rationale/cids-metadata-assignment.md` for the CIDS metadata workflow on MetricDefinition.
 
+## Implementation Path
+
+### Phase 1 — Lightweight (completed 2026-03-07)
+1. Add `source` (CharField, optional) to `Survey` — whole-instrument shorthand
+2. Add `source` (CharField, optional) to `SurveySection` — per-section/subscale citation
+3. Update CSV import to accept `source` column (first non-blank value per section applies to the section)
+4. Update CSV template with source examples (including WHO-5 with citation)
+5. No bilingual `source_fr` — citations aren't translated
+
+### Phase 2 — MetricDefinition Link (future session)
+1. Add optional FK `metric_definition` to `SurveyQuestion` with `on_delete=SET_NULL` — if a metric is deactivated, the survey question survives but loses its link
+2. When linked, display inherited metadata (source, scoring, instrument name) from the metric
+3. Survey builder UI: "Link to metric" picker — **hidden by default** behind an "Advanced" or collapsed section. Show a subtle indicator (icon/badge) on sections whose `source` matches a known `instrument_name` but aren't yet linked (nudge, not gate)
+4. **Post-import linking review** (replaces CSV metric column): after CSV import, check section `source` fields against `MetricDefinition.instrument_name` with fuzzy matching (case-insensitive, hyphen-insensitive). If matches found, present a review screen: "These sections match instruments in your metric library. Link them?" One click per section, confirmed by the evaluation coordinator. No `metric_code` CSV column — keep the CSV workflow simple.
+5. **Aggregation bridge** (required — this is what makes unification real): when a survey response is submitted and the section has linked metrics, compute the section score per `scoring_method` and record it as an outcome data point tagged with:
+   - The MetricDefinition (via the FK)
+   - The collection context: `survey` (vs. `progress_note` or `portal`)
+   - The survey response ID (for traceability)
+   - This data point appears in outcome charts alongside progress-note entries
+
+### Phase 3 — Unified Measurement Library (future)
+1. Survey sections that correspond to full instruments (all items from PHQ-9) auto-link to MetricDefinition
+2. "Create survey from instrument" workflow — select a MetricDefinition with `is_standardized_instrument=True`, auto-generate survey sections and questions
+3. Cross-context reporting: "Show all PHQ-9 data for this participant" regardless of whether it came from a progress note or a survey
+
+## MetricDefinition Versioning
+
+When a MetricDefinition changes after a survey has collected responses:
+
+- **Do not snapshot metadata on every answer.** This is clinical-trial thinking — overkill for nonprofit program evaluation.
+- **Use the existing `rationale_log`** (append-only changelog) to track why changes were made. The current scoring_bands / definition are always the latest version; the rationale_log preserves the audit trail.
+- **For fundamental changes** (metric changes meaning, not just band adjustments): deactivate the old MetricDefinition and create a new one. The FK on old survey questions still points to the old (deactivated) definition with its original interpretation. `on_delete=SET_NULL` means deactivation doesn't cascade-delete survey questions.
+- **The UI must handle null gracefully.** If a metric is deactivated and the FK goes null, the survey question still works — question text, options, and scoring live on SurveyQuestion. The link is additive, not structural.
+
+## Cross-App Dependency
+
+The FK from `apps.surveys.SurveyQuestion` to `apps.plans.MetricDefinition` couples these two Django apps. Surveys can no longer be tested or used without the plans app installed. This is acceptable — both apps always coexist in KoNote — but should be documented in test setup and app configuration.
+
 ## Anti-Patterns
 
 - **Do not duplicate MetricDefinition fields on SurveyQuestion.** If a question is linked to a metric, read the metadata from the metric. If it's unlinked, it has no instrument metadata — that's fine.
 - **Do not require linking.** Many survey questions (demographics, feedback, consent) are not metrics. The FK must be nullable.
 - **Do not auto-create MetricDefinitions from survey questions.** Metrics are curated library items. Surveys may have throwaway questions. The link is always intentional.
 - **Do not add `source_fr`.** Citations are language-neutral. One field is enough.
+- **Do not add a metric linking column to the CSV import.** Use the post-import review screen instead. Keep the CSV workflow simple for program managers.
+- **Do not require metric linking to use surveys.** The FK is additive — surveys work exactly as before without it.
+- **Do not map CIDS indicators to individual survey questions.** CIDS indicators map to sections/instruments (subscale scores). The section is the CIDS unit, not the question.
 
-## Scoring Interaction
+## Risk Register
 
-Different sections already support different scoring rules via `SurveySection.scoring_method`. When a question is linked to a MetricDefinition:
-- The metric's `scoring_bands` provide severity interpretation
-- The section's `scoring_method` (sum/average) determines how items are aggregated
-- The metric's `higher_is_better` determines directionality for display
-- These don't conflict — they describe different levels (item vs. subscale)
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| Staff confusion from metric linking UI | Medium | Medium | Hidden by default, post-import review only, evaluation coordinator confirms |
+| MetricDefinition changes invalidate old survey interpretations | Low | Medium | Append-only rationale_log, deactivate-and-replace for fundamental changes |
+| CIDS export pulls from wrong level (question vs. section) | Medium | High | Enforce section-level CIDS mapping in export code, document in anti-patterns |
+| Cross-app coupling breaks test isolation | Low | Low | Document dependency, both apps always coexist in KoNote |
+| Fuzzy matching on instrument names produces false positives | Low | Low | Review screen requires human confirmation — false matches are caught |

--- a/templates/surveys/admin/csv_import.html
+++ b/templates/surveys/admin/csv_import.html
@@ -19,31 +19,25 @@
     {% if field.errors %}<small class="error" role="alert">{{ field.errors.0 }}</small>{% endif %}
     {% endfor %}
 
+    <p>
+        <a href="{% url 'survey_manage:csv_template' %}" download>{% trans "Download template CSV" %}</a>
+        — {% trans "a ready-to-edit file with example questions you can replace with your own." %}
+    </p>
+
     <details>
-        <summary>{% trans "CSV format guide" %}</summary>
-        <p>{% trans "Your CSV file should have the following columns:" %}</p>
-        <table aria-label="{% trans 'CSV columns' %}">
-            <thead>
-                <tr>
-                    <th scope="col">{% trans "Column" %}</th>
-                    <th scope="col">{% trans "Required" %}</th>
-                    <th scope="col">{% trans "Description" %}</th>
-                </tr>
-            </thead>
-            <tbody>
-                <tr><td>section</td><td>{% trans "Yes" %}</td><td>{% trans "Section name — questions with the same section name are grouped together." %}</td></tr>
-                <tr><td>question</td><td>{% trans "Yes" %}</td><td>{% trans "The question text." %}</td></tr>
-                <tr><td>type</td><td>{% trans "No" %}</td><td>{% trans "Question type: short_text, long_text, single_choice, multiple_choice, rating_scale, yes_no." %}</td></tr>
-                <tr><td>required</td><td>{% trans "No" %}</td><td>{% trans "yes or no — whether the question must be answered." %}</td></tr>
-                <tr><td>options</td><td>{% trans "No" %}</td><td>{% trans "For choice questions — separate options with semicolons: Agree;Neutral;Disagree" %}</td></tr>
-                <tr><td>score_values</td><td>{% trans "No" %}</td><td>{% trans "Numeric scores matching options: 3;2;1" %}</td></tr>
-                <tr><td>instructions</td><td>{% trans "No" %}</td><td>{% trans "Instructions shown at the top of a section." %}</td></tr>
-                <tr><td>page_break</td><td>{% trans "No" %}</td><td>{% trans "yes — to start a new page at this section." %}</td></tr>
-                <tr><td>section_fr</td><td>{% trans "No" %}</td><td>{% trans "French section name." %}</td></tr>
-                <tr><td>question_fr</td><td>{% trans "No" %}</td><td>{% trans "French question text." %}</td></tr>
-                <tr><td>options_fr</td><td>{% trans "No" %}</td><td>{% trans "French option labels, semicolon-separated." %}</td></tr>
-            </tbody>
-        </table>
+        <summary>{% trans "Column reference" %}</summary>
+        <p>{% trans "Only <strong>section</strong> and <strong>question</strong> are required. All other columns are optional." %}</p>
+        <ul>
+            <li><strong>section</strong> — {% trans "Section name. Questions with the same section name are grouped together." %}</li>
+            <li><strong>question</strong> — {% trans "The question text." %}</li>
+            <li><strong>type</strong> — {% trans "short_text, long_text, single_choice, multiple_choice, rating_scale, or yes_no. Defaults to short_text." %}</li>
+            <li><strong>required</strong> — {% trans "yes or no." %}</li>
+            <li><strong>options</strong> — {% trans "For choice/rating questions, separate with semicolons: Agree;Neutral;Disagree" %}</li>
+            <li><strong>score_values</strong> — {% trans "Numeric scores matching options: 3;2;1" %}</li>
+            <li><strong>instructions</strong> — {% trans "Instructions shown at the top of a section." %}</li>
+            <li><strong>page_break</strong> — {% trans "yes to start a new page at this section." %}</li>
+            <li><strong>section_fr</strong>, <strong>question_fr</strong>, <strong>options_fr</strong> — {% trans "French translations (optional)." %}</li>
+        </ul>
     </details>
 
     <div role="group">

--- a/templates/surveys/admin/csv_import.html
+++ b/templates/surveys/admin/csv_import.html
@@ -26,7 +26,7 @@
 
     <details>
         <summary>{% trans "Column reference" %}</summary>
-        <p>{% trans "Only <strong>section</strong> and <strong>question</strong> are required. All other columns are optional." %}</p>
+        <p>{% trans "Only section and question are required. All other columns are optional." %}</p>
         <ul>
             <li><strong>section</strong> — {% trans "Section name. Questions with the same section name are grouped together." %}</li>
             <li><strong>question</strong> — {% trans "The question text." %}</li>
@@ -36,6 +36,7 @@
             <li><strong>score_values</strong> — {% trans "Numeric scores matching options: 3;2;1" %}</li>
             <li><strong>instructions</strong> — {% trans "Instructions shown at the top of a section." %}</li>
             <li><strong>page_break</strong> — {% trans "yes to start a new page at this section." %}</li>
+            <li><strong>source</strong> — {% trans "Citation for this section's questions. Only needed on the first row of each section." %}</li>
             <li><strong>section_fr</strong>, <strong>question_fr</strong>, <strong>options_fr</strong> — {% trans "French translations (optional)." %}</li>
         </ul>
     </details>

--- a/templates/surveys/admin/survey_detail.html
+++ b/templates/surveys/admin/survey_detail.html
@@ -23,6 +23,9 @@
 {% if survey.description %}
 <p>{{ survey.description }}</p>
 {% endif %}
+{% if survey.source %}
+<p><small>{% trans "Source:" %} {{ survey.source }}</small></p>
+{% endif %}
 
 {# Status actions #}
 <div role="group">

--- a/templates/surveys/admin/survey_questions.html
+++ b/templates/surveys/admin/survey_questions.html
@@ -35,6 +35,9 @@
         {% if section.instructions %}
         <br><small>{{ section.instructions }}</small>
         {% endif %}
+        {% if section.source %}
+        <br><small>{% trans "Source:" %} {{ section.source }}</small>
+        {% endif %}
     </header>
 
     {# Existing questions in this section #}


### PR DESCRIPTION
## Summary

- **Downloadable CSV template** for survey imports — realistic bilingual example rows (demographics, WHO-5, satisfaction) that users can open in Excel and edit
- **Source/citation fields** on Survey and SurveySection models — free text, optional, displayed on admin pages
- **CSV import** reads `source` column and applies first non-blank value per section
- **Design Rationale Record** for survey-metric unification — documents the 3-phase plan to unify surveys and outcome metrics (Phase 1 shipped here, Phase 2-3 documented)

## Context

GK confirmed the architectural decision: "Survey questions are just metrics." A PHQ-9 item should be the same construct whether it appears in a staff progress note, a participant portal form, or an anonymous survey. The DRR documents the full unification plan with expert panel review, including CIDS compliance interaction, scoring pipeline, versioning strategy, and risk register.

## Changes

- `Survey.source` — whole-instrument citation (e.g., "PHQ-9, Kroenke et al., 2001")
- `SurveySection.source` — per-section citation for composite surveys
- `csv_template` view — generates downloadable template CSV with headers + 5 example rows
- Updated `csv_import.html` — download link replaces dense format table, column reference simplified
- Migration `0011_survey_source_surveysection_source`
- `tasks/design-rationale/survey-metric-unification.md` — full DRR with expert panel findings

## Test plan

- [ ] Import a CSV using the template — verify source field populates on the section
- [ ] Create a survey via UI — verify source field appears on form and detail page
- [ ] Download template CSV — verify it opens in Excel with correct columns and examples

Generated with [Claude Code](https://claude.com/claude-code)