### PR TITLE
fix: correct migration dependency for programs.0010

### DIFF
--- a/apps/programs/migrations/0010_evaluation_framework_models.py
+++ b/apps/programs/migrations/0010_evaluation_framework_models.py
@@ -10,7 +10,7 @@ class Migration(migrations.Migration):
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
         ("programs", "0009_program_cids_sector_code_program_description_fr_and_more"),
-        ("reports", "0006_reporttemplate_layout_preset"),
+        ("reports", "0006_rename_funder_profile_to_report_template"),
     ]
 
     operations = [


### PR DESCRIPTION
## Summary
- Fixed broken migration dependency in `programs.0010_evaluation_framework_models`
- Referenced nonexistent `('reports', '0006_reporttemplate_layout_preset')` — corrected to `('reports', '0006_rename_funder_profile_to_report_template')`
- This was blocking container startup on the dev VPS (crash loop)

## Test plan
- [ ] Dev VPS container starts without crash loop
- [ ] `migrate_default` runs successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)