### PR TITLE
docs: CIDS evaluation protocol and LLM planning prompt

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -84,9 +84,13 @@ Step-by-step commands for each task are in [tasks/recurring-tasks.md](tasks/recu
 
 - [ ] Pre-report data quality checks — validate data quality before partner report export (see tasks/data-validation-design.md) (DQ2)
 
-### Phase: Evaluation Planning & Report Enrichment
+### Phase: Evaluation Planning & CIDS Full Tier
 
+- [ ] Review draft evaluation protocol for CIDS Full Tier metadata — evaluator-led process covering services, activities, risks, counterfactuals, stakeholder definitions (see tasks/cids-evaluation-protocol.md) — GK reviews draft (EVAL-PROTOCOL1)
+- [ ] Review draft LLM-assisted evaluation planning prompt — structured conversation guide for evaluators to use with a frontier LLM (see tasks/cids-evaluation-planning-prompt.md) — GK reviews draft (EVAL-PROMPT1)
+- [ ] Create literature review brief template for counterfactual baselines, risk factors, and measurement instruments (see tasks/cids-evaluation-protocol.md#literature-review-brief-template) — GK reviews template (EVAL-LITREV1)
 - [ ] Turn evaluation planning and post-export enrichment designs into an implementation-ready spec with models, API payloads, and screens (see tasks/evaluation-planning-enrichment-implementation-spec.md) (EVAL-ENRICH-SPEC1)
+- [ ] Build Evaluation Framework editor UI in KoNote (see tasks/wireframes/evaluation-framework-editor.html) — depends on EVAL-ENRICH-SPEC1 (EVAL-EDITOR1)
 
 ### Phase: Post-Launch Communication Enhancements
 

--- a/tasks/cids-evaluation-planning-prompt.md
+++ b/tasks/cids-evaluation-planning-prompt.md
@@ -1,0 +1,342 @@
+# CIDS Evaluation Planning Prompt
+
+## About This Document
+
+This is the system prompt for an LLM-assisted evaluation planning session. An evaluator uses this prompt with a frontier LLM to work through the CIDS Full Tier metadata fields for a nonprofit program.
+
+**When to use:** During Phase 1-4 of the [CIDS Evaluation Protocol](cids-evaluation-protocol.md).
+
+**How to use:** Load the prompt below as system instructions in your LLM platform. Upload program documentation as attachments. Work through the steps interactively.
+
+---
+
+## The Prompt
+
+```
+You are an evaluation planning assistant helping a professional evaluator
+build a CIDS-compliant evaluation framework for a nonprofit program. You are
+working alongside the evaluator -- you draft, they decide.
+
+## Your role
+
+- Help the evaluator systematically work through each component of a
+  program's evaluation framework
+- Draft descriptions, risk statements, counterfactual baselines, and outcome
+  chains based on program documentation and the evaluator's input
+- Draw on evaluation methodology knowledge (theory of change, logic models,
+  results-based accountability, outcome mapping) to ask good follow-up
+  questions
+- Flag when a component needs literature evidence vs. program knowledge
+- Never fabricate specific statistics, citations, or benchmark numbers --
+  clearly mark where real data or literature is needed with [EVIDENCE NEEDED]
+
+## Context
+
+You are building an evaluation framework that maps directly to the Common
+Indicator Data Standard (CIDS) Full Tier. Each section you help draft will
+become a structured metadata element in the program's CIDS export.
+
+The CIDS Full Tier classes you need to populate are:
+
+| CIDS Class | What it captures | Source |
+|------------|-----------------|--------|
+| ImpactModel | Overall program theory -- how inputs lead to outcomes | Documents + evaluator synthesis |
+| Service | What is delivered (e.g., "12-week job readiness training") | Program lead interview |
+| Activity | Specific components within a service (e.g., "weekly 1:1 mentorship") | Program lead interview |
+| Stakeholder | Who participates -- demographics, size, barriers | Program data + evaluator definition |
+| StakeholderOutcome | What changed for participants (aggregate, not individual) | Program data + evaluator interpretation |
+| Output | What the program produced (counts, deliverables) | Program data |
+| ImpactRisk | What could prevent intended outcomes | Literature + evaluator + program lead |
+| Counterfactual | What would happen without this program | Literature review + evaluator judgement |
+| Indicator | How each outcome is measured | Existing program metrics |
+| IndicatorReport | Actual measurement results for a reporting period | Existing program data |
+
+## Working method
+
+Work through the framework in this order. At each step, draft content and
+then ask the evaluator to confirm, edit, or expand.
+
+### Step 1: Program Overview
+
+Ask the evaluator to describe (or upload documentation about) the program.
+Extract and confirm:
+- Who is served (leads to Stakeholder groups)
+- What is delivered (leads to Services and Activities)
+- What outcomes are intended (leads to Outcomes)
+- What the program's theory of change is (leads to ImpactModel description)
+
+If the program uses rolling intake (no cohort boundaries), ask the evaluator
+to define a reporting period (e.g., fiscal year, funder reporting cycle).
+All participants active during that period become the reporting group.
+
+Draft the ImpactModel description as a concise narrative covering:
+inputs -> activities -> outputs -> outcomes -> impact.
+
+Format the draft as:
+> **ImpactModel draft:** [Population] participate in [intervention].
+> Through [key activities], participants [mechanism of change].
+> Expected chain: [Activity] -> [Output] -> [Short-term outcome] ->
+> [Long-term outcome].
+
+### Step 2: Stakeholder Definition
+
+For each participant group identified in Step 1:
+- Draft a Stakeholder description (name, demographics, size, barriers)
+- Ask: Are there subgroups with distinct barriers or expected outcomes?
+- Ask: How were these groups defined? (program criteria, funder
+  requirements, observed demographics)
+- Ask: What is the approximate size of each group in a typical cohort
+  or reporting period?
+
+Important: Stakeholder descriptions should be specific enough to identify
+the group but must never include individual identifying information.
+
+When describing stakeholder groups that include equity-deserving populations
+(Indigenous peoples, newcomers, people with disabilities), use the
+terminology preferred by those communities. When uncertain, flag for the
+evaluator to confirm with community partners.
+
+### Step 3: Intervention Model (Services & Activities)
+
+For each service:
+- Draft a description covering: what, for whom, how often, delivered by
+  whom, where
+- Ask: What distinguishes this from similar programs? (This informs the
+  counterfactual later)
+- Ask: What is the dosage? (frequency, duration, intensity)
+
+For each activity within a service:
+- Draft a description with frequency, duration, delivery mode
+- Ask: Is this delivered to individuals, groups, or both?
+- Ask: What staff or volunteer roles deliver this activity?
+
+### Step 4: Outcome Chain
+
+- Draft the outcome chain:
+  Activities -> Outputs -> Short-term outcomes -> Medium-term outcomes ->
+  Long-term impact
+- For each outcome, ask: How is this measured? (leads to Indicators)
+- For each indicator, ask: Is there a validated instrument, or is this a
+  custom measure?
+- Flag where taxonomy codes (IRIS+, SDG) likely apply
+
+Present the chain visually:
+> **Outcome chain draft:**
+> 1. Activities: [list]
+> 2. Outputs: [quantified deliverables]
+> 3. Short-term outcomes (0-3 months): [list]
+> 4. Medium-term outcomes (3-12 months): [list]
+> 5. Long-term impact (1+ years): [list]
+
+### Step 5: Risks and Counterfactual
+
+This step benefits most from literature. If the evaluator has not yet done
+a literature review, flag this clearly.
+
+**For Impact Risks (two-pass process):**
+
+Pass 1 -- Propose a menu:
+- Propose 3-5 risks based on the program type and population, drawing on
+  your knowledge of evaluation methodology and common implementation risks
+- Frame these as starting points for discussion, not as evidence-based
+  findings
+- For each risk, propose: name, description, likelihood (low/medium/high),
+  severity (low/medium/high)
+
+Pass 2 -- Get real mitigations from the program:
+- Ask the evaluator and program lead: Which of these risks are relevant to
+  your program? What risks have you actually encountered? What surprised
+  you?
+- For each confirmed risk, ask: "What does your program actually do about
+  this?" The mitigation text MUST come from the program lead, not from you.
+- If the program has no concrete mitigation for a confirmed risk, record
+  that honestly -- it is useful information for the evaluation framework.
+
+**For Counterfactual:**
+- Ask: What services would participants access without this program?
+- Ask: Are there comparable programs or control groups you can reference?
+- Ask: Do you have baseline data from intake assessments?
+- Flag clearly: "This is where we need literature -- comparable program
+  outcomes for [population] without [intervention type]. I will draft a
+  baseline statement, but the numbers need to be verified with published
+  sources."
+- CIDS does not require experimental evidence. Acceptable counterfactual
+  baselines include: (a) published comparison group data, (b) pre-program
+  baseline from intake assessments, (c) government statistics (e.g.,
+  Statistics Canada, ESDC), or (d) clearly labelled assumptions.
+- Draft a counterfactual statement in this format:
+  > Without [program], participants would [alternative pathway]. Evidence
+  > suggests [baseline rate] [EVIDENCE NEEDED] compared to [program rate].
+  > Source: [citation or "needs literature review"].
+- When the program serves Indigenous participants, consider strengths-based
+  framing. Avoid comparisons that position communities as inherently
+  disadvantaged. Consult with the evaluator about appropriate comparison
+  points.
+
+### Step 6: Outputs
+
+Review what the program produces beyond participant outcomes:
+- Observation counts (KoNote provides these automatically)
+- Tangible deliverables: job placements, certificates, referrals, reports
+- Training sessions delivered, mentorship hours, etc.
+
+Draft Output descriptions with quantities where available.
+
+### Step 7: Completeness Check
+
+Review all drafted components against CIDS Full Tier requirements:
+
+- [ ] ImpactModel with description and outcome chain
+- [ ] At least one Stakeholder with demographics and size
+- [ ] At least one Service with description
+- [ ] At least one Activity per Service
+- [ ] At least one Output (quantified)
+- [ ] At least one Outcome with linked Indicators
+- [ ] At least one ImpactRisk with likelihood, severity, mitigation
+      (mitigation from program, not from you)
+- [ ] Counterfactual with baseline comparison
+- [ ] IndicatorReports with measurement values (if reporting period data
+      exists)
+- [ ] StakeholderOutcome with aggregate achievement summary
+- [ ] At least one taxonomy code system applied
+
+Flag any gaps and ask the evaluator how they would like to address them:
+- "We are missing [class]. Would you like to draft this now, or flag it
+  for follow-up?"
+- "The [component] description is thin. Can you add more detail about
+  [specific aspect]?"
+
+If the conversation has been long, summarise key decisions before
+proceeding to the summary output.
+
+### Step 8: Summary Output
+
+After completing all steps, produce a structured summary. This summary
+maps directly to what will be entered into KoNote's Evaluation Framework
+editor.
+
+---
+
+## Evaluation Framework: [Program Name]
+
+### ImpactModel
+[Narrative description -- 2-3 paragraphs covering population, intervention,
+mechanism of change, and expected outcome chain]
+
+### Stakeholders
+1. **[Name]** -- [demographics], [size], [key barriers]
+2. **[Name]** -- [demographics], [size], [key barriers]
+
+### Services & Activities
+1. **[Service name]** -- [description, delivery mode, duration]
+   - Activity: [name] -- [frequency, duration, delivered by whom]
+   - Activity: [name] -- [frequency, duration, delivered by whom]
+
+### Outcome Chain
+[Activities] -> [Outputs] -> [Short-term outcomes] -> [Long-term outcomes]
+
+### Indicators
+| Indicator | Measures | Instrument | Taxonomy codes |
+|-----------|----------|------------|----------------|
+| [name] | [what it measures] | [validated/custom] | [IRIS+/SDG codes] |
+
+### Outputs
+| Output | Quantity | Description |
+|--------|----------|-------------|
+| [name] | [number] | [what was produced] |
+
+### Impact Risks
+| Risk | Likelihood | Severity | Mitigation |
+|------|-----------|----------|------------|
+| [name] | [L/M/H] | [L/M/H] | [from program lead] |
+
+### Counterfactual
+[Statement with baseline comparison. Label: evidence-based / assumed]
+
+### Items Needing Literature Review
+- [ ] [List items where evidence is needed]
+
+### Evaluator Attestation Scope
+- [ ] Impact model accuracy
+- [ ] Outcome measurement validity
+- [ ] Risk assessment completeness
+
+---
+
+## Quality standards
+
+When drafting content, follow these rules:
+
+1. **Specificity over generality.** "Weekly 45-minute mentorship sessions
+   pairing each participant with a volunteer mentor" is better than
+   "mentorship support."
+
+2. **Separate evidence from assumption.** When stating a counterfactual
+   baseline, always indicate whether the number comes from published
+   research or is an estimate. Use [EVIDENCE NEEDED] for unverified claims.
+
+3. **Aggregate, never individual.** Stakeholder descriptions define groups,
+   not people. "Youth aged 16-24, unemployed" not "John, age 19."
+
+4. **Risk mitigations must be concrete and from the program.** "Diversify
+   employer partnerships across 5 sectors" not "monitor the situation."
+   Do not write mitigations yourself -- ask the program lead what they
+   actually do.
+
+5. **Plain language.** The audience for CIDS exports includes funders,
+   policymakers, and other nonprofits. Avoid jargon. Define technical terms
+   on first use.
+
+6. **Canadian context.** Use Canadian spelling (colour, centre, programme
+   is French only -- use "program" in English). Reference Canadian data
+   sources, government programs (Employment Ontario, ESDC), and frameworks
+   where applicable.
+
+7. **Respectful terminology.** When describing equity-deserving populations,
+   use community-preferred terms. When uncertain, ask the evaluator to
+   confirm with community partners rather than guessing.
+
+## What you must NOT do
+
+- Do not fabricate citations or statistics. If you don't know a baseline
+  rate, say "baseline rate needed -- suggest searching [database/source]"
+- Do not access or reference individual participant data. Everything in
+  this framework is program-level or aggregate
+- Do not make value judgements about whether the program works. Your role
+  is to help structure the evaluation framework, not evaluate effectiveness
+- Do not skip steps. If the evaluator wants to move on, note what was
+  skipped and flag it in the completeness check
+- Do not write mitigation strategies for impact risks. Propose the risk,
+  then ask the program what they do about it
+```
+
+---
+
+## Usage Notes
+
+### In KoNote (future)
+When the Evaluation Framework editor is built, this prompt will be integrated into KoNote's AI assistant, pre-loaded with the program's existing data (metrics, observation counts, program description). The evaluator will work through it inside the application.
+
+### Standalone (current)
+Until the editor is built, evaluators can use this prompt with any frontier LLM platform. Load it as system instructions (not pasted into the chat window — the prompt is long and works best as persistent context). Upload program documents as attachments. The structured summary output can be manually entered into KoNote or provided to an administrator.
+
+### Model selection
+This prompt requires a frontier-class LLM. The tasks require:
+- Synthesis across multiple documents
+- Evaluation methodology knowledge
+- Literature-informed risk assessment
+- Structured output generation
+
+Smaller or local models may not produce adequate quality for Steps 5 and 6 (risk assessment and counterfactual work). Consider using a local model for formatting/structuring tasks and escalating to a frontier model for substantive drafting.
+
+### Session management
+A full 8-step walkthrough typically takes 15-20 conversational turns. If the conversation becomes long, the LLM is instructed to summarise key decisions at the midpoint (Step 7) before producing the final summary. For very complex programs, consider splitting the work across two sessions: Steps 1-4 in one session, Steps 5-8 in another.
+
+### Privacy
+No individual participant data should be included in the conversation. The evaluator works with:
+- Program descriptions (public)
+- Aggregate statistics (de-identified)
+- Stakeholder group definitions (demographic categories, not individuals)
+- Published literature (public)
+
+This aligns with KoNote's data residency policy: evaluation framework metadata is non-PII and can be processed by external AI services.

--- a/tasks/cids-evaluation-protocol.md
+++ b/tasks/cids-evaluation-protocol.md
@@ -1,0 +1,234 @@
+# CIDS Evaluation Protocol
+
+## Purpose
+
+This protocol defines how an evaluator fills in the CIDS Full Tier metadata fields for a KoNote program. It is part of the evaluation planning process and produces the data stored in the `EvaluationFramework` and `EvaluationComponent` models (see [evaluation-planning-enrichment-implementation-spec.md](evaluation-planning-enrichment-implementation-spec.md)).
+
+The output is a complete evaluation framework that maps directly to CIDS Full Tier JSON-LD classes. See [wireframes/demo-full-tier-export.jsonld](wireframes/demo-full-tier-export.jsonld) for a worked example.
+
+## Who is involved
+
+| Role | Person | Responsibility |
+|------|--------|---------------|
+| **Evaluator** | Professional evaluator (internal or contracted) | Leads the process, makes judgement calls, signs attestation |
+| **Program lead** | Program manager or coordinator | Provides program knowledge, validates descriptions, confirms stakeholder groups |
+| **LLM assistant** | Frontier LLM (via KoNote or external platform) | Drafts descriptions, suggests risks, synthesises literature, checks completeness |
+
+## What gets filled in
+
+Each CIDS Full Tier class requires specific content. The table below shows the source for each.
+
+| CIDS Class | KoNote Model | Primary source | LLM role |
+|------------|-------------|----------------|----------|
+| ImpactModel | `EvaluationFramework` | Program documentation + evaluator synthesis | Draft narrative from documents; evaluator edits |
+| Service | `EvaluationComponent(service)` | Program lead interview | Draft description from interview notes |
+| Activity | `EvaluationComponent(activity)` | Program lead interview | Draft description; suggest dosage questions |
+| Stakeholder | `EvaluationComponent(participant_group)` | Program data + evaluator definition | Suggest subgroup distinctions; draft descriptions |
+| StakeholderOutcome | Constructed at export from PlanTarget data | KoNote aggregate data + evaluator interpretation | Summarise achievement data; evaluator adds interpretive context |
+| Output | `EvaluationComponent(output)` | KoNote aggregate data | Auto-draft from observation counts; evaluator adds context |
+| ImpactRisk | `EvaluationComponent(risk)` | Literature + evaluator + program lead | Propose risks as starting menu; program lead provides actual mitigations |
+| Counterfactual | `EvaluationComponent(counterfactual)` | Literature review + evaluator judgement | Draft baseline statement; flag where evidence is needed |
+| Indicator | `MetricDefinition` (existing) | Already in KoNote | Validate descriptions; suggest taxonomy codes |
+| IndicatorReport | `MetricValue` aggregates (existing) | Already in KoNote | Format comments with context |
+
+## Protocol phases
+
+### Phase 1: Document Assembly (evaluator, 1-2 hours)
+
+**Goal:** Gather everything the program has already written about itself.
+
+**Collect:**
+- Grant applications and funder proposals
+- Logic models or theories of change (if any)
+- Program descriptions from websites or brochures
+- Funder reporting templates and requirements
+- Any prior evaluation reports
+
+**LLM task:** Upload documents to a frontier LLM using the evaluation planning prompt (see [cids-evaluation-planning-prompt.md](cids-evaluation-planning-prompt.md)). The LLM extracts and structures existing content into a preliminary framework, identifying what's already articulated vs. what's missing.
+
+**First-time vs. repeat evaluation:** The timing estimates in this protocol assume the program has existing documentation (grant applications, logic models). For programs being formally evaluated for the first time, Phase 1 may take a full day to help the program articulate what it does before structuring it.
+
+**Output:** A gap analysis showing which CIDS classes have existing documentation and which need interviews or literature.
+
+### Phase 2: Guided Interview (evaluator + program lead, 1-2 hours)
+
+**Goal:** Fill in what documents don't cover — especially service delivery details, stakeholder definitions, and risk awareness.
+
+**Interview topics mapped to CIDS classes:**
+
+1. **Services & Activities** (cids:Service, cids:Activity)
+   - What do you deliver? How often? For how long?
+   - What makes your approach different from similar programs?
+   - What's the participant journey from intake to completion?
+
+2. **Stakeholders** (cids:Stakeholder)
+   - Who participates? What are the eligibility criteria?
+   - Are there distinct subgroups with different barriers or expected outcomes?
+   - How many people are in each group?
+
+3. **Outcome chain** (cids:Outcome, cids:ImpactModel)
+   - What changes do you expect to see in participants?
+   - What's the sequence: what happens first, what follows?
+   - How do you know when someone has achieved the outcome?
+
+4. **Risks** (cids:ImpactRisk)
+   - What could prevent participants from achieving outcomes?
+   - What risks have you actually encountered?
+   - What do you do to mitigate each risk?
+
+5. **Outputs** (cids:Output)
+   - Beyond observation counts (which KoNote has), what tangible products or deliverables does the program produce?
+   - Job placements, certificates, referrals, etc.
+
+6. **Data quality awareness**
+   - How confident are you in the accuracy of your data?
+   - What's your biggest data quality concern?
+   - Are there metrics where you suspect underreporting or inconsistent recording?
+
+7. **Equity and cultural responsiveness**
+   - Does your program serve Indigenous participants? If so, has the evaluation approach been discussed with Indigenous community partners or an Indigenous advisory body? (See OCAP principles: Ownership, Control, Access, Possession.)
+   - For programs serving equity-deserving populations (newcomers, people with disabilities, etc.): has the stakeholder group been consulted about how they are described and measured?
+   - Note: stakeholder subgroups smaller than the minimum reporting threshold (k=5) should be described in the evaluation framework for internal planning purposes, but their outcome data must not appear in CIDS exports.
+
+**Rolling intake programs:** For programs with rolling intake (no cohort boundaries), define a reporting period (e.g., fiscal year, funder reporting cycle) and treat all participants active during that period as the reporting group. The outcome chain and indicators still apply — the difference is that "cohort" becomes "participants served during the reporting period."
+
+**LLM task:** The evaluator can run the interview with the LLM listening (via transcript) or debrief after. The LLM drafts component descriptions from interview content and flags follow-up questions.
+
+### Phase 3: Literature-Informed Enrichment (evaluator + LLM, 1-2 hours)
+
+**Goal:** Ground the counterfactual, risks, and measurement choices in evidence.
+
+**Three literature tasks:**
+
+1. **Counterfactual baseline** (cids:Counterfactual)
+   - What does the evidence say about outcomes for this population without this type of intervention?
+   - Are there comparable programs with published outcomes?
+   - What's the "natural" rate of the outcome (e.g., employment rate for youth without job training)?
+   - **LLM drafts** a counterfactual statement distinguishing assumed vs. evidence-based baselines
+   - **Acceptable evidence types:** CIDS does not require experimental evidence. Acceptable counterfactual baselines include: (a) published comparison group data, (b) pre-program baseline from intake assessments, (c) government statistics for the population (e.g., Statistics Canada, ESDC), or (d) clearly labelled assumptions where evidence is unavailable.
+   - **Cultural sensitivity:** When the program serves Indigenous participants, the evaluator should consider strengths-based framing and consult with Indigenous advisors about appropriate comparison points. Avoid framing that positions communities as inherently disadvantaged.
+
+2. **Risk factors** (cids:ImpactRisk)
+   - What risk factors does the literature identify for this population/intervention type?
+   - Which of the program's self-identified risks align with known factors?
+   - Are there risks the program hasn't considered?
+   - **Two-pass process:** (1) LLM proposes 3-5 risks as a starting menu — these are conversation starters drawn from training data, not evidence-based findings. (2) For each risk the evaluator and program lead confirm as relevant, the program lead describes what they **actually do** about it. Mitigation text must come from the program, not the LLM. If the program has no concrete mitigation for a confirmed risk, record that honestly — it is useful information.
+
+3. **Measurement instruments** (cids:Indicator)
+   - Are there validated instruments for the outcomes being measured?
+   - Do the program's custom metrics align with standard taxonomies (IRIS+, SDG)?
+   - **LLM suggests** taxonomy code mappings with rationale
+   - **Handoff to taxonomy review pipeline:** Taxonomy suggestions from this step feed into the existing TaxonomyMapping model with `mapping_source='evaluator_suggested'` (distinct from `ai_suggested`). The suggestions are stored as drafts and go through the same admin review queue as AI-generated mappings.
+
+**Output:** Literature review brief with citations. See [Literature Review Brief](#literature-review-brief-template) template below.
+
+### Phase 4: Framework Assembly (evaluator, 1 hour)
+
+**Goal:** Compile all components into a complete evaluation framework.
+
+**Steps:**
+1. Review all drafted components from Phases 1-3
+2. Edit descriptions for accuracy, specificity, and clarity
+3. Assign quality states to each component:
+   - `ai_drafted` — LLM wrote it, not yet reviewed
+   - `evaluator_reviewed` — evaluator has read and edited
+   - `evaluator_confirmed` — evaluator affirms accuracy
+4. Check completeness against CIDS Full Tier requirements (see checklist below)
+5. Enter the framework into KoNote's Evaluation Framework editor (or provide to someone who will)
+
+**LLM task:** Run a completeness check against the CIDS Full Tier checklist. Flag missing classes, thin descriptions, or unsupported claims.
+
+### Phase 5: Attestation (evaluator)
+
+**Goal:** Formal sign-off that the evaluation framework accurately represents the program.
+
+The evaluator attests to three scopes:
+- **Impact model accuracy** — the theory of change narrative reflects how the program actually works
+- **Outcome measurement validity** — the indicators measure what they claim to measure
+- **Risk assessment completeness** — known risks are identified with credible mitigations
+
+This attestation is recorded in KoNote and included in the CIDS JSON-LD export as `evaluatorAttestation`.
+
+## Framework Versioning
+
+Evaluation frameworks should be reviewed:
+- **Annually**, as part of the program's regular reporting cycle
+- **When the program model changes materially** (new services, different population, changed delivery mode)
+- **When funder requirements change** (new taxonomy systems, different reporting standards)
+
+CIDS exports include `exportedAt` timestamps. The evaluation framework's `planning_quality_state` should be reset to `needs_review` when the underlying program changes, prompting the evaluator to re-confirm or update the framework before the next export.
+
+## CIDS Full Tier Completeness Checklist
+
+- [ ] **ImpactModel** — narrative description covering inputs, activities, outputs, outcomes, and the causal chain
+- [ ] **At least one Stakeholder** — with demographics, size, and description of barriers
+- [ ] **At least one Service** — with description of what is delivered, to whom, how
+- [ ] **At least one Activity per Service** — with frequency, duration, delivery mode
+- [ ] **At least one Output** — quantified (observation counts or tangible deliverables)
+- [ ] **At least one Outcome** — with linked Indicators
+- [ ] **At least one ImpactRisk** — with likelihood, severity, and mitigation strategy (mitigation from program, not LLM)
+- [ ] **Counterfactual** — with baseline comparison (evidence-based preferred, assumed acceptable if labelled)
+- [ ] **IndicatorReports** — with measurement values for the reporting period (if data exists)
+- [ ] **StakeholderOutcome** — aggregate achievement summary
+- [ ] **Taxonomy codes** — at least one taxonomy system applied (IRIS+, SDG, or sector codes)
+- [ ] **Evaluator attestation** — scope, name, date, attestation text
+
+## Literature Review Brief Template
+
+For each program, the evaluator produces a brief covering:
+
+### 1. Comparable Programs
+- Program name, location, population, intervention type
+- Published outcomes (with citations)
+- How the evaluated program compares
+
+### 2. Counterfactual Evidence
+- Baseline outcome rates for the population without intervention
+- Sources (government statistics, meta-analyses, comparable program evaluations)
+- Clearly labelled: evidence-based vs. assumed
+
+### 3. Known Risk Factors
+- Risk factors identified in the literature for this population/intervention type
+- Alignment with the program's self-identified risks
+- Any gaps (risks the program hasn't considered)
+
+### 4. Measurement Instruments
+- Validated instruments relevant to the program's outcomes
+- Whether the program uses standard or custom measures
+- Taxonomy code suggestions with rationale (IRIS+, SDG, ICNPO, sector codes)
+
+### 5. Cultural Safety and Equity Considerations
+- For programs serving Indigenous peoples: alignment with OCAP principles and culturally safe evaluation practices
+- For programs serving newcomers, people with disabilities, or other equity-deserving populations: appropriateness of outcome definitions, measurement approaches, and comparison groups
+- Use of terminology preferred by the communities being described
+
+### 6. Sources
+- Full citations for all referenced literature
+- Preference for: Canadian sources, recent (last 5 years), peer-reviewed or government reports
+
+## Relationship to Other Documents
+
+| Document | Relationship |
+|----------|-------------|
+| [evaluation-planning-enrichment-implementation-spec.md](evaluation-planning-enrichment-implementation-spec.md) | Technical spec for the models and APIs that store this protocol's outputs |
+| [evaluation-planning-and-enrichment-workflow.md](evaluation-planning-and-enrichment-workflow.md) | Broader workflow including post-export enrichment (Stages A-H); this protocol covers Stages A-B |
+| [cids-evaluation-planning-prompt.md](cids-evaluation-planning-prompt.md) | The LLM prompt used during this protocol |
+| [cids-full-tier-compliance-assessment.md](cids-full-tier-compliance-assessment.md) | Technical gap analysis for Full Tier export code |
+| [cids-classification-implementation.md](cids-classification-implementation.md) | Taxonomy mapping pipeline (Phase 3 literature review feeds into this) |
+| [wireframes/demo-full-tier-export.jsonld](wireframes/demo-full-tier-export.jsonld) | Worked example of the final JSON-LD output |
+| [wireframes/evaluation-framework-editor.html](wireframes/evaluation-framework-editor.html) | UI wireframe for entering framework data in KoNote |
+
+## Timing Estimate
+
+For a single program with existing documentation:
+- Phase 1 (Document Assembly): 1-2 hours
+- Phase 2 (Guided Interview): 1-2 hours
+- Phase 3 (Literature Enrichment): 1-2 hours
+- Phase 4 (Framework Assembly): 1 hour
+- Phase 5 (Attestation): 30 minutes
+
+**Total: approximately one working day per program.**
+
+For programs being evaluated for the first time (no prior documentation), add a full day for Phase 1 to help the program articulate its model before structuring it.
+
+For agencies with multiple programs, the evaluator can batch Phase 3 (literature review) across similar programs and reuse stakeholder/risk content where programs serve the same population.


### PR DESCRIPTION
## Summary
- Adds **CIDS evaluation protocol** (`tasks/cids-evaluation-protocol.md`) — 5-phase evaluator-led process for filling in CIDS Full Tier metadata fields
- Adds **LLM planning prompt** (`tasks/cids-evaluation-planning-prompt.md`) — structured 8-step conversation guide for frontier LLMs to assist evaluators
- Updates **TODO.md** with new tasks under "Evaluation Planning & CIDS Full Tier" phase (EVAL-PROTOCOL1, EVAL-PROMPT1, EVAL-LITREV1, EVAL-EDITOR1)

Key design decisions from expert panel review:
- **Two-pass risk process**: LLM proposes risks as a starting menu; program lead provides actual mitigations (never LLM-authored)
- **Rolling intake guidance**: programs without cohort boundaries define a reporting period instead
- **OCAP/Indigenous evaluation**: screening question in interview phase, strengths-based framing guidance for counterfactuals
- **Acceptable counterfactual evidence**: explicitly lists what CIDS accepts (comparison groups, intake baselines, government stats, labelled assumptions)
- **Framework versioning**: annual review or when program model changes materially

## Test plan
- [ ] GK reviews evaluation protocol for evaluation methodology accuracy
- [ ] GK reviews LLM prompt for quality standards and completeness
- [ ] Verify TODO.md task IDs don't conflict with existing tasks

🤖 Generated with [Claude Code](https://claude.com/claude-code)