### PR TITLE
fix: address CIDS review findings 1-5

### DIFF
--- a/apps/admin_settings/management/commands/export_cids_full_tier.py
+++ b/apps/admin_settings/management/commands/export_cids_full_tier.py
@@ -50,6 +50,9 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
+        from django.utils import timezone
+
+        from apps.audit.models import AuditLog
         from apps.programs.models import Program
 
         program_filter = {}
@@ -66,6 +69,18 @@ class Command(BaseCommand):
         )
 
         output = json.dumps(document, indent=options["indent"], ensure_ascii=False)
+
+        program_names = ", ".join(p.name for p in programs[:10])
+        AuditLog.objects.using("audit").create(
+            event_timestamp=timezone.now(),
+            user_id=0,
+            user_display="system (manage.py)",
+            ip_address="127.0.0.1",
+            action="export",
+            object_type="CIDSFullTierExport",
+            object_id=0,
+            description=f"CIDS Full Tier export via management command: {program_names}",
+        )
 
         if options["output"]:
             with open(options["output"], "w", encoding="utf-8") as f:

--- a/apps/admin_settings/management/commands/export_cids_jsonld.py
+++ b/apps/admin_settings/management/commands/export_cids_jsonld.py
@@ -50,6 +50,9 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
+        from django.utils import timezone
+
+        from apps.audit.models import AuditLog
         from apps.programs.models import Program
 
         program_filter = {}
@@ -66,6 +69,18 @@ class Command(BaseCommand):
         )
 
         output = json.dumps(document, indent=options["indent"], ensure_ascii=False)
+
+        program_names = ", ".join(p.name for p in programs[:10])
+        AuditLog.objects.using("audit").create(
+            event_timestamp=timezone.now(),
+            user_id=0,
+            user_display="system (manage.py)",
+            ip_address="127.0.0.1",
+            action="export",
+            object_type="CIDSBasicTierExport",
+            object_id=0,
+            description=f"CIDS Basic Tier export via management command: {program_names}",
+        )
 
         if options["output"]:
             with open(options["output"], "w", encoding="utf-8") as f:

--- a/apps/admin_settings/management/commands/validate_cids_jsonld.py
+++ b/apps/admin_settings/management/commands/validate_cids_jsonld.py
@@ -59,7 +59,10 @@ class Command(BaseCommand):
             ) from exc
 
         if options["input"]:
-            data_graph = Graph().parse(options["input"], format="json-ld")
+            try:
+                data_graph = Graph().parse(options["input"], format="json-ld")
+            except Exception as exc:
+                raise CommandError(f"Failed to parse JSON-LD file: {exc}") from exc
         else:
             program_filter = {}
             if options["program_id"]:
@@ -78,7 +81,12 @@ class Command(BaseCommand):
                 format="json-ld",
             )
 
-        shapes_graph = Graph().parse(options["shapes_url"], format="turtle")
+        try:
+            shapes_graph = Graph().parse(options["shapes_url"], format="turtle")
+        except Exception as exc:
+            raise CommandError(
+                f"Failed to fetch SHACL shapes from {options['shapes_url']}: {exc}"
+            ) from exc
         conforms, _results_graph, results_text = validate(
             data_graph,
             shacl_graph=shapes_graph,

--- a/apps/admin_settings/migrations/0011_taxonomy_exactly_one_fk_constraint.py
+++ b/apps/admin_settings/migrations/0011_taxonomy_exactly_one_fk_constraint.py
@@ -1,0 +1,24 @@
+"""Add database constraint ensuring exactly one FK is set on TaxonomyMapping."""
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("admin_settings", "0010_taxonomymapping_taxonomy_system_labels"),
+    ]
+
+    operations = [
+        migrations.AddConstraint(
+            model_name="taxonomymapping",
+            constraint=models.CheckConstraint(
+                check=(
+                    models.Q(metric_definition__isnull=False, program__isnull=True, plan_target__isnull=True)
+                    | models.Q(metric_definition__isnull=True, program__isnull=False, plan_target__isnull=True)
+                    | models.Q(metric_definition__isnull=True, program__isnull=True, plan_target__isnull=False)
+                ),
+                name="taxonomy_exactly_one_fk",
+            ),
+        ),
+    ]

--- a/apps/admin_settings/models.py
+++ b/apps/admin_settings/models.py
@@ -387,6 +387,16 @@ class TaxonomyMapping(models.Model):
         db_table = "taxonomy_mappings"
         ordering = ["taxonomy_system", "taxonomy_code"]
         verbose_name = "Taxonomy Mapping"
+        constraints = [
+            models.CheckConstraint(
+                check=(
+                    models.Q(metric_definition__isnull=False, program__isnull=True, plan_target__isnull=True)
+                    | models.Q(metric_definition__isnull=True, program__isnull=False, plan_target__isnull=True)
+                    | models.Q(metric_definition__isnull=True, program__isnull=True, plan_target__isnull=False)
+                ),
+                name="taxonomy_exactly_one_fk",
+            ),
+        ]
 
     def __str__(self):
         target = (

--- a/apps/reports/cids_views.py
+++ b/apps/reports/cids_views.py
@@ -7,8 +7,10 @@ from django.http import HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404, render
 from django.utils import timezone
 
+from apps.audit.models import AuditLog
 from apps.auth_app.decorators import admin_required
 from apps.programs.models import EvaluationFramework, Program
+from konote.utils import get_client_ip
 
 from .cids_full_tier import (
     build_full_tier_jsonld,
@@ -85,6 +87,18 @@ def cids_full_tier_export(request):
         programs,
         taxonomy_lens=taxonomy_lens,
         include_layer3=include_layer3,
+    )
+
+    program_names = ", ".join(p.name for p in programs[:10])
+    AuditLog.objects.using("audit").create(
+        event_timestamp=timezone.now(),
+        user_id=request.user.pk,
+        user_display=str(request.user),
+        ip_address=get_client_ip(request),
+        action="export",
+        object_type="CIDSFullTierExport",
+        object_id=0,
+        description=f"CIDS Full Tier export ({taxonomy_lens}): {program_names}",
     )
 
     if request.GET.get("format") == "download":

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -5500,3 +5500,23 @@ article[aria-label="notification"].fading-out {
 .pill-nav a:focus {
     opacity: 0.85;
 }
+
+/* ---- CIDS / classification inline utilities ---- */
+.inline-form {
+    display: inline;
+}
+
+.compact-btn {
+    padding: 0.25rem 0.5rem;
+    font-size: 0.875rem;
+}
+
+.grid-single {
+    grid-template-columns: 1fr;
+}
+
+.flex-between {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}

--- a/templates/admin_settings/classification/detail.html
+++ b/templates/admin_settings/classification/detail.html
@@ -1,44 +1,45 @@
 {% extends "base.html" %}
+{% load i18n %}
 
-{% block title %}Review Mapping — {{ site.product_name|default:"KoNote" }}{% endblock %}
+{% block title %}{% trans "Review Mapping" %} — {{ site.product_name|default:"KoNote" }}{% endblock %}
 
 {% block content %}
 <hgroup>
-    <h1>Review Mapping</h1>
+    <h1>{% trans "Review Mapping" %}</h1>
     <p>{{ mapping.subject_display }} · {{ mapping.subject_type|title }} · {{ mapping.taxonomy_list_name|default:mapping.get_taxonomy_system_display }}</p>
 </hgroup>
 
 <article>
-    <header><strong>Current Suggestion</strong></header>
-    <p><strong>Code:</strong> {{ mapping.taxonomy_code }}</p>
-    <p><strong>Label:</strong> {{ mapping.taxonomy_label|default:"(no label)" }}</p>
-    <p><strong>Status:</strong> {{ mapping.get_mapping_status_display }}</p>
-    <p><strong>Confidence:</strong> {% if mapping.confidence_score is not None %}{{ mapping.confidence_score|floatformat:2 }}{% else %}—{% endif %}</p>
-    <p><strong>Reason:</strong> {{ mapping.rationale|default:"No rationale stored." }}</p>
+    <header><strong>{% trans "Current Suggestion" %}</strong></header>
+    <p><strong>{% trans "Code:" %}</strong> {{ mapping.taxonomy_code }}</p>
+    <p><strong>{% trans "Label:" %}</strong> {{ mapping.taxonomy_label|default:"(no label)" }}</p>
+    <p><strong>{% trans "Status:" %}</strong> {{ mapping.get_mapping_status_display }}</p>
+    <p><strong>{% trans "Confidence:" %}</strong> {% if mapping.confidence_score is not None %}{{ mapping.confidence_score|floatformat:2 }}{% else %}—{% endif %}</p>
+    <p><strong>{% trans "Reason:" %}</strong> {{ mapping.rationale|default_if_none:"" }}</p>
     {% if mapping.mapping_status == 'draft' %}
-    <form method="post" action="{% url 'admin_settings:taxonomy_mapping_approve' mapping.pk %}" style="display:inline;">
+    <form method="post" action="{% url 'admin_settings:taxonomy_mapping_approve' mapping.pk %}" class="inline-form">
         {% csrf_token %}
-        <button type="submit">Approve This Mapping</button>
+        <button type="submit">{% trans "Approve This Mapping" %}</button>
     </form>
-    <form method="post" action="{% url 'admin_settings:taxonomy_mapping_reject' mapping.pk %}" style="display:inline;">
+    <form method="post" action="{% url 'admin_settings:taxonomy_mapping_reject' mapping.pk %}" class="inline-form">
         {% csrf_token %}
-        <button type="submit" class="secondary">Reject This Mapping</button>
+        <button type="submit" class="secondary">{% trans "Reject This Mapping" %}</button>
     </form>
     {% endif %}
 </article>
 
 <section>
-    <h2>Other Suggestions for This Item</h2>
+    <h2>{% trans "Other Suggestions for This Item" %}</h2>
     {% if related_mappings %}
     <div class="overflow-auto">
         <table>
             <thead>
                 <tr>
-                    <th>Code</th>
-                    <th>Label</th>
-                    <th>Status</th>
-                    <th>Confidence</th>
-                    <th>Reason</th>
+                    <th>{% trans "Code" %}</th>
+                    <th>{% trans "Label" %}</th>
+                    <th>{% trans "Status" %}</th>
+                    <th>{% trans "Confidence" %}</th>
+                    <th>{% trans "Reason" %}</th>
                 </tr>
             </thead>
             <tbody>
@@ -55,24 +56,24 @@
         </table>
     </div>
     {% else %}
-    <p>No sibling suggestions yet.</p>
+    <p>{% trans "No sibling suggestions yet." %}</p>
     {% endif %}
 </section>
 
 <section>
-    <h2>Rerun Using Another Code List</h2>
+    <h2>{% trans "Rerun Using Another Code List" %}</h2>
     <form method="post" action="{% url 'admin_settings:taxonomy_mapping_reclassify' mapping.pk %}">
         {% csrf_token %}
         {{ reclassify_form.as_p }}
-        <button type="submit" class="secondary">Rerun Suggestions</button>
+        <button type="submit" class="secondary">{% trans "Rerun Suggestions" %}</button>
     </form>
 </section>
 
 <section>
-    <h2>Manual Code Search</h2>
+    <h2>{% trans "Manual Code Search" %}</h2>
     <form method="get">
         {{ manual_search_form.as_p }}
-        <button type="submit" class="secondary">Search This Code List</button>
+        <button type="submit" class="secondary">{% trans "Search This Code List" %}</button>
     </form>
 
     {% if manual_search_results %}
@@ -80,10 +81,10 @@
         <table>
             <thead>
                 <tr>
-                    <th>Code</th>
-                    <th>Label</th>
-                    <th>Description</th>
-                    <th>Action</th>
+                    <th>{% trans "Code" %}</th>
+                    <th>{% trans "Label" %}</th>
+                    <th>{% trans "Description" %}</th>
+                    <th>{% trans "Action" %}</th>
                 </tr>
             </thead>
             <tbody>
@@ -96,7 +97,7 @@
                         <form method="post" action="{% url 'admin_settings:taxonomy_mapping_manual_pick' mapping.pk %}">
                             {% csrf_token %}
                             <input type="hidden" name="code" value="{{ entry.code }}">
-                            <button type="submit">Use This Code</button>
+                            <button type="submit">{% trans "Use This Code" %}</button>
                         </form>
                     </td>
                 </tr>
@@ -105,16 +106,16 @@
         </table>
     </div>
     {% elif manual_search_form.is_bound %}
-    <p>No matching codes were found in {{ mapping.taxonomy_list_name }}.</p>
+    <p>{% trans "No matching codes were found." %}</p>
     {% endif %}
 </section>
 
 <section>
-    <h2>Ask the Review Assistant</h2>
+    <h2>{% trans "Ask the Review Assistant" %}</h2>
     <form method="post" action="{% url 'admin_settings:taxonomy_mapping_ask' mapping.pk %}">
         {% csrf_token %}
         {{ question_form.as_p }}
-        <button type="submit" class="secondary">Ask</button>
+        <button type="submit" class="secondary">{% trans "Ask" %}</button>
     </form>
 
     {% if conversation %}
@@ -127,5 +128,5 @@
     {% endif %}
 </section>
 
-<p><a href="{% url 'admin_settings:taxonomy_review_queue' %}">← Back to Classification Review</a></p>
+<p><a href="{% url 'admin_settings:taxonomy_review_queue' %}">{% trans "← Back to Classification Review" %}</a></p>
 {% endblock %}

--- a/templates/admin_settings/classification/queue.html
+++ b/templates/admin_settings/classification/queue.html
@@ -1,27 +1,28 @@
 {% extends "base.html" %}
+{% load i18n %}
 
-{% block title %}Classification Review — {{ site.product_name|default:"KoNote" }}{% endblock %}
+{% block title %}{% trans "Classification Review" %} — {{ site.product_name|default:"KoNote" }}{% endblock %}
 
 {% block content %}
 <hgroup>
-    <h1>Classification Review</h1>
-    <p>Generate draft mappings from imported code lists, then review and approve them for reporting.</p>
+    <h1>{% trans "Classification Review" %}</h1>
+    <p>{% trans "Generate draft mappings from imported code lists, then review and approve them for reporting." %}</p>
 </hgroup>
 
 <section>
-    <h2>Generate Draft Suggestions</h2>
+    <h2>{% trans "Generate Draft Suggestions" %}</h2>
     <form method="post" action="{% url 'admin_settings:taxonomy_generate_suggestions' %}">
         {% csrf_token %}
         {{ generate_form.as_p }}
-        <button type="submit">Generate Draft Suggestions</button>
+        <button type="submit">{% trans "Generate Draft Suggestions" %}</button>
     </form>
 </section>
 
 <section>
-    <h2>Review Queue</h2>
+    <h2>{% trans "Review Queue" %}</h2>
     <form method="get">
         {{ filter_form.as_p }}
-        <button type="submit" class="secondary">Filter Queue</button>
+        <button type="submit" class="secondary">{% trans "Filter Queue" %}</button>
     </form>
 
     {% if mappings %}
@@ -29,27 +30,27 @@
         {% csrf_token %}
         {{ bulk_form.action }}
         {{ bulk_form.mapping_ids }}
-        <button type="submit" class="secondary">Apply to Selected</button>
+        <button type="submit" class="secondary">{% trans "Apply to Selected" %}</button>
     </form>
     <div class="overflow-auto">
         <table>
             <thead>
                 <tr>
-                    <th>Select</th>
-                    <th>Item</th>
-                    <th>Type</th>
-                    <th>Taxonomy</th>
-                    <th>Code List</th>
-                    <th>Suggestion</th>
-                    <th>Status</th>
-                    <th>Confidence</th>
-                    <th>Actions</th>
+                    <th>{% trans "Select" %}</th>
+                    <th>{% trans "Item" %}</th>
+                    <th>{% trans "Type" %}</th>
+                    <th>{% trans "Taxonomy" %}</th>
+                    <th>{% trans "Code List" %}</th>
+                    <th>{% trans "Suggestion" %}</th>
+                    <th>{% trans "Status" %}</th>
+                    <th>{% trans "Confidence" %}</th>
+                    <th>{% trans "Actions" %}</th>
                 </tr>
             </thead>
             <tbody>
                 {% for mapping in mappings %}
                 <tr>
-                    <td><input type="checkbox" class="bulk-mapping-checkbox" value="{{ mapping.pk }}" form="bulk-review-form" aria-label="Select {{ mapping.subject_display }}"></td>
+                    <td><input type="checkbox" class="bulk-mapping-checkbox" value="{{ mapping.pk }}" form="bulk-review-form" aria-label="{% trans "Select" %} {{ mapping.subject_display }}"></td>
                     <td><a href="{% url 'admin_settings:taxonomy_mapping_detail' mapping.pk %}"><strong>{{ mapping.subject_display }}</strong></a></td>
                     <td>{{ mapping.subject_type|title }}</td>
                     <td>{{ mapping.get_taxonomy_system_display }}</td>
@@ -58,15 +59,15 @@
                     <td>{{ mapping.get_mapping_status_display }}</td>
                     <td>{% if mapping.confidence_score is not None %}{{ mapping.confidence_score|floatformat:2 }}{% else %}—{% endif %}</td>
                     <td>
-                        <a href="{% url 'admin_settings:taxonomy_mapping_detail' mapping.pk %}" class="secondary">Review</a>
+                        <a href="{% url 'admin_settings:taxonomy_mapping_detail' mapping.pk %}" class="secondary">{% trans "Review" %}</a>
                         {% if mapping.mapping_status == 'draft' %}
-                        <form method="post" action="{% url 'admin_settings:taxonomy_mapping_approve' mapping.pk %}" style="display:inline;">
+                        <form method="post" action="{% url 'admin_settings:taxonomy_mapping_approve' mapping.pk %}" class="inline-form">
                             {% csrf_token %}
-                            <button type="submit">Approve</button>
+                            <button type="submit">{% trans "Approve" %}</button>
                         </form>
-                        <form method="post" action="{% url 'admin_settings:taxonomy_mapping_reject' mapping.pk %}" style="display:inline;">
+                        <form method="post" action="{% url 'admin_settings:taxonomy_mapping_reject' mapping.pk %}" class="inline-form">
                             {% csrf_token %}
-                            <button type="submit" class="secondary">Reject</button>
+                            <button type="submit" class="secondary">{% trans "Reject" %}</button>
                         </form>
                         {% endif %}
                     </td>
@@ -90,10 +91,10 @@
     </script>
     {% else %}
     <article>
-        <p>No mappings match the current filters.</p>
+        <p>{% trans "No mappings match the current filters." %}</p>
     </article>
     {% endif %}
 </section>
 
-<p><a href="{% url 'admin_settings:dashboard' %}">← Back to Settings</a></p>
+<p><a href="{% url 'admin_settings:dashboard' %}">{% trans "← Back to Settings" %}</a></p>
 {% endblock %}

--- a/templates/programs/evaluation/framework_detail.html
+++ b/templates/programs/evaluation/framework_detail.html
@@ -71,9 +71,9 @@
                 <td>{{ comp.get_quality_state_display }}</td>
                 <td>
                     <a href="{% url 'programs:component_edit' framework_id=framework.pk component_id=comp.pk %}">{% trans "Edit" %}</a>
-                    <form method="post" action="{% url 'programs:component_deactivate' framework_id=framework.pk component_id=comp.pk %}" style="display:inline">
+                    <form method="post" action="{% url 'programs:component_deactivate' framework_id=framework.pk component_id=comp.pk %}" class="inline-form">
                         {% csrf_token %}
-                        <button type="submit" class="outline contrast" style="padding: 0.25rem 0.5rem; font-size: 0.875rem;">{% trans "Remove" %}</button>
+                        <button type="submit" class="outline contrast" class="compact-btn">{% trans "Remove" %}</button>
                     </form>
                 </td>
             </tr>
@@ -110,9 +110,9 @@
                 <td>{{ link.get_source_type_display }}</td>
                 <td>{% if link.contains_pii %}{% trans "Yes" %}{% else %}{% trans "No" %}{% endif %}</td>
                 <td>
-                    <form method="post" action="{% url 'programs:evidence_delete' framework_id=framework.pk evidence_id=link.pk %}" style="display:inline">
+                    <form method="post" action="{% url 'programs:evidence_delete' framework_id=framework.pk evidence_id=link.pk %}" class="inline-form">
                         {% csrf_token %}
-                        <button type="submit" class="outline contrast" style="padding: 0.25rem 0.5rem; font-size: 0.875rem;">{% trans "Remove" %}</button>
+                        <button type="submit" class="outline contrast" class="compact-btn">{% trans "Remove" %}</button>
                     </form>
                 </td>
             </tr>

--- a/templates/reports/cids_coverage_dashboard.html
+++ b/templates/reports/cids_coverage_dashboard.html
@@ -27,11 +27,11 @@
 
 <section>
     <h2>{% trans "Coverage by Program" %}</h2>
-    <div class="grid" style="grid-template-columns: 1fr;">
+    <div class="grid grid-single">
     {% for summary in summaries %}
     <article>
         <header>
-            <div style="display: flex; justify-content: space-between; align-items: center;">
+            <div class="flex-between">
                 <strong>{{ summary.program.name }}</strong>
                 <span>{{ summary.present }} / {{ summary.total }} ({{ summary.pct }}%)</span>
             </div>


### PR DESCRIPTION
## Summary
Fixes 5 issues identified during the CIDS deployment review session:

1. **Missing translations** — classification `queue.html` and `detail.html` had zero `{% trans %}` tags; now fully wrapped for bilingual support
2. **Missing audit logging** — CIDS export views and management commands now log to the audit database
3. **TaxonomyMapping CheckConstraint** — DB-level constraint ensures exactly one FK (metric_definition, program, or plan_target) is set per row
4. **SHACL validator error handling** — `validate_cids_jsonld` now catches JSON-LD parse errors and network failures with user-friendly messages
5. **Inline styles → CSS classes** — replaced `style=` attributes with `.inline-form`, `.compact-btn`, `.grid-single`, `.flex-between` in main.css

## Test plan
- [ ] `migrate_default` applies new migration (0011_taxonomy_exactly_one_fk_constraint)
- [ ] Classification review pages render correctly with translations
- [ ] CIDS Full Tier export creates audit log entry
- [ ] Coverage dashboard layout unchanged after CSS class swap

🤖 Generated with [Claude Code](https://claude.com/claude-code)