### PR TITLE
docs: three-tier AI architecture documentation

### DIFF
--- a/tasks/cids-evaluation-planning-prompt.md
+++ b/tasks/cids-evaluation-planning-prompt.md
@@ -2,7 +2,7 @@
 
 ## About This Document
 
-This is the system prompt for an LLM-assisted evaluation planning session. An evaluator uses this prompt with a frontier LLM to work through the CIDS Full Tier metadata fields for a nonprofit program.
+This is the system prompt for an LLM-assisted evaluation planning session. An evaluator uses this prompt with a a more capable LLM to work through the CIDS Full Tier metadata fields for a nonprofit program.
 
 **When to use:** During Phase 1-4 of the [CIDS Evaluation Protocol](cids-evaluation-protocol.md).
 
@@ -318,10 +318,10 @@ When drafting content, follow these rules:
 When the Evaluation Framework editor is built, this prompt will be integrated into KoNote's AI assistant, pre-loaded with the program's existing data (metrics, observation counts, program description). The evaluator will work through it inside the application.
 
 ### Standalone (current)
-Until the editor is built, evaluators can use this prompt with any frontier LLM platform. Load it as system instructions (not pasted into the chat window — the prompt is long and works best as persistent context). Upload program documents as attachments. The structured summary output can be manually entered into KoNote or provided to an administrator.
+Until the editor is built, evaluators can use this prompt with any a more capable LLM platform. Load it as system instructions (not pasted into the chat window — the prompt is long and works best as persistent context). Upload program documents as attachments. The structured summary output can be manually entered into KoNote or provided to an administrator.
 
 ### Model selection
-This prompt requires a frontier-class LLM. The tasks require:
+This prompt requires a more capable LLM. The tasks require:
 - Synthesis across multiple documents
 - Evaluation methodology knowledge
 - Literature-informed risk assessment

--- a/tasks/cids-evaluation-protocol.md
+++ b/tasks/cids-evaluation-protocol.md
@@ -12,7 +12,19 @@ The output is a complete evaluation framework that maps directly to CIDS Full Ti
 |------|--------|---------------|
 | **Evaluator** | Professional evaluator (internal or contracted) | Leads the process, makes judgement calls, signs attestation |
 | **Program lead** | Program manager or coordinator | Provides program knowledge, validates descriptions, confirms stakeholder groups |
-| **LLM assistant** | Frontier LLM (via KoNote or external platform) | Drafts descriptions, suggests risks, synthesises literature, checks completeness |
+| **LLM assistant** | A more capable LLM (via external platform) | Drafts descriptions, suggests risks, synthesises literature, checks completeness |
+
+## Where this fits in KoNote's AI architecture
+
+This protocol uses **Tier 3 (Evaluation AI)** — one of three tiers in KoNote's AI architecture. See the [AI Feature Toggles DRR](design-rationale/ai-feature-toggles.md#three-tier-ai-architecture-added-2026-03-07) for the full picture.
+
+| Tier | What it does | Provider | Data it sees |
+|------|-------------|----------|-------------|
+| **1 — Operational** | Theme summarisation, suggestion categorisation | Self-hosted model on Canadian VPS | Scrubbed participant content (never leaves the VPS) |
+| **2 — Tools** | Metric suggestions, goal builder, CIDS code mapping | Cloud AI API | Program metadata only (zero participant data) |
+| **3 — Evaluation** (this protocol) | Evaluation framework planning, literature review, Full Tier metadata | A more capable model via external platform | Non-PII program documentation (evaluator-controlled) |
+
+Tier 3 operates outside KoNote's toggle system. The evaluator manages the LLM session directly, uploading only program-level documentation. No participant data is involved.
 
 ## What gets filled in
 

--- a/tasks/design-rationale/ai-feature-toggles.md
+++ b/tasks/design-rationale/ai-feature-toggles.md
@@ -256,6 +256,73 @@ The N=5 threshold **only applies when `INSIGHTS_API_BASE` is configured** (self-
 
 **Focused analysis** (top-down question-based search) follows the same graduated model and always returns synthesised content, never verbatim quotes, regardless of program size.
 
+## Three-Tier AI Architecture (Added 2026-03-07)
+
+KoNote uses AI at three distinct tiers, each with different data access, provider routing, and privacy controls. The two-toggle system (`ai_assist_tools_only` and `ai_assist_participant_data`) governs Tiers 1 and 2. Tier 3 operates outside KoNote's toggle system because it runs in an external LLM session controlled by the evaluator.
+
+### Tier 1: Operational AI (self-hosted)
+
+**Provider:** Self-hosted open-source model on the KoNote VPS (Ollama). Configured via `INSIGHTS_API_BASE` and `INSIGHTS_API_KEY`.
+
+**Toggle:** `ai_assist_participant_data` (disabled by default).
+
+**Data it sees:** De-identified participant content — survey responses, open-ended feedback, suggestion themes. PII-scrubbed. Stays on Canadian infrastructure.
+
+| Task | Data sent | Privacy gate |
+|------|-----------|-------------|
+| Outcome insights (theme summarisation) | Scrubbed participant quotes | N>=5 self-hosted, N>=15 external; PII scrub; quote verification |
+| Suggestion categorisation (nightly batch) | Scrubbed suggestion text | Same thresholds; self-hosted only |
+| Focused analysis (question-based search) | Scrubbed participant content | Synthesised output only, never verbatim quotes |
+
+### Tier 2: Tools AI (cloud API)
+
+**Provider:** Cloud AI API. Configured via `OPENROUTER_API_KEY` and `OPENROUTER_MODEL`.
+
+**Toggle:** `ai_assist_tools_only` (enabled by default).
+
+**Data it sees:** Program-level metadata only — metric names, goal text, program descriptions, aggregate statistics. Zero participant data.
+
+| Task | Data sent | Privacy gate |
+|------|-----------|-------------|
+| Metric suggestions | Target description + metric catalogue | No participant data — institutional metadata only |
+| Goal builder | Staff-written outcome text (PII-scrubbed) | Staff controls input; PII scrub as safety net |
+| Narrative generation | Program name + date range + aggregate numbers | Aggregate only |
+| Note structure suggestions | Target name + description + metric names | No participant data |
+| CIDS code suggestions (batch) | Field names + metric definitions | Taxonomy metadata only |
+
+### Tier 3: Evaluation AI (external, evaluator-controlled)
+
+**Provider:** A more capable LLM accessed via an external platform. Not configured in KoNote's `.env` — the evaluator manages the session directly.
+
+**Toggle:** None. This tier operates outside KoNote entirely. No KoNote data is sent automatically.
+
+**Data it sees:** Non-PII program documentation uploaded by the evaluator — grant applications, logic models, program descriptions, aggregate statistics, published literature.
+
+| Task | Data sent | Privacy gate |
+|------|-----------|-------------|
+| Evaluation framework planning | Program documentation (uploaded by evaluator) | Evaluator controls what is shared; no participant data |
+| CIDS Full Tier metadata drafting | Service/activity/risk/counterfactual descriptions | Program-level metadata only |
+| Literature-informed enrichment | Published literature + aggregate program stats | Public and de-identified data only |
+| Taxonomy classification review | Metric definitions + taxonomy code lists | Institutional metadata only |
+
+**Why a separate tier?** The evaluation planning tasks require synthesis across multiple documents, evaluation methodology knowledge, and literature-informed judgement. These exceed the capabilities of the self-hosted model (Tier 1) and involve a different interaction pattern — a structured multi-step conversation rather than single API calls. The evaluator works with a more capable model directly, uploading only non-PII program documentation.
+
+**See also:**
+- [CIDS Evaluation Protocol](../cids-evaluation-protocol.md) — the 5-phase process that uses Tier 3
+- [CIDS Evaluation Planning Prompt](../cids-evaluation-planning-prompt.md) — the structured prompt for Tier 3 sessions
+- [Self-hosted LLM Infrastructure DRR](self-hosted-llm-infrastructure.md) — Tier 1 infrastructure details
+
+### Summary: What goes where
+
+| Data type | Tier | Provider | Leaves VPS? |
+|-----------|------|----------|-------------|
+| Participant quotes (scrubbed) | 1 — Operational | Self-hosted | No |
+| Open-ended suggestions (scrubbed) | 1 — Operational | Self-hosted | No |
+| Metric/goal/program metadata | 2 — Tools | Cloud API | Yes (no PII) |
+| CIDS taxonomy suggestions | 2 — Tools | Cloud API | Yes (no PII) |
+| Evaluation framework content | 3 — Evaluation | External LLM platform | Yes (no PII, evaluator-controlled) |
+| Translation strings | Outside toggle system | Cloud API | Yes (no PII — static UI strings) |
+
 ## GK Review Items
 
 - [ ] Participant-facing transparency wording (portal statement)

--- a/tasks/design-rationale/data-access-residency-policy.md
+++ b/tasks/design-rationale/data-access-residency-policy.md
@@ -96,6 +96,21 @@ These questions were raised as risk-mitigation considerations. After review, GK 
 - [ ] Add to the deployment runbook: access tier classification for each credential
 - [ ] Include standard data-processing terms in contractor and MSP agreements (confidentiality, privacy compliance, incident notification)
 
+## AI Data Flow and Residency
+
+KoNote's three-tier AI architecture (see [AI Feature Toggles DRR](ai-feature-toggles.md#three-tier-ai-architecture-added-2026-03-07)) has different residency implications for each tier:
+
+| AI Tier | Data type | Where processed | Residency implication |
+|---------|-----------|----------------|----------------------|
+| **Tier 1 — Operational** (self-hosted) | Scrubbed participant content | Canadian VPS (Ollama) | No cross-border transfer |
+| **Tier 2 — Tools** (cloud API) | Program metadata only | Cloud API provider | No participant data crosses the border |
+| **Tier 3 — Evaluation** (external LLM) | Program documentation, aggregate stats | External LLM platform | Evaluator-controlled; non-PII only |
+| **Translation** | Static UI strings | Cloud API provider | No personal information |
+
+**Key principle:** Participant data (even scrubbed) never leaves the Canadian VPS. Only institutional metadata and non-PII program documentation are processed by external AI services.
+
+For agencies with heightened data sovereignty concerns (Indigenous communities under OCAP principles), Tier 2 tools can be disabled via `ai_assist_tools_only`, and Tier 3 is entirely optional.
+
 ## Anti-Patterns
 
 **Do not:**


### PR DESCRIPTION
## Summary

- Documents KoNote's three-tier AI architecture (Operational/self-hosted, Tools/cloud API, Evaluation/external) across four planning and policy files
- Adds architecture sections to ai-feature-toggles and data-access-residency-policy DRRs
- Adds "Where this fits" context to cids-evaluation-protocol
- Replaces "frontier LLM" with "a more capable LLM" in cids-evaluation-planning-prompt (vendor-neutral language)

## Related commits in other repos

- `konote-ops`: env-template expanded with all three AI tiers and INSIGHTS_* env vars
- `konote-prosper-canada`: agency-facing "How AI Is Used" section added to evaluation planning protocol

## Test plan

- [ ] Review ai-feature-toggles.md new section for accuracy against implementation
- [ ] Review data-access-residency-policy.md AI flow table
- [ ] Confirm no "frontier" references remain in planning docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)