### PR TITLE
fix: show correct label for JSON-LD reports on download page

### DIFF
--- a/apps/reports/views.py
+++ b/apps/reports/views.py
@@ -1000,6 +1000,7 @@ def export_form(request):
         "program_name": str(program_display_name),
         "is_pdf": export_format == "pdf",
         "is_html": export_format == "html",
+        "is_json": export_format == "cids_json",
     })
 
 
@@ -1642,6 +1643,7 @@ def funder_report_approve(request):
         "program_name": str(program_display_name),
         "is_pdf": export_format == "pdf",
         "is_html": export_format == "html",
+        "is_json": export_format == "cids_json",
         "agency_notes": agency_notes,
     })
 
@@ -1785,6 +1787,7 @@ def generate_report_form(request):
         "program_name": template.partner.translated_name,
         "is_pdf": export_format == "pdf",
         "is_html": export_format == "html",
+        "is_json": export_format == "cids_json",
     })
 
 

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -5600,6 +5600,9 @@ msgstr ""
 "Votre rapport HTML est prêt à télécharger. Vous pouvez l'ouvrir dans "
 "n'importe quel navigateur web ou le partager directement."
 
+msgid "Your JSON-LD file is ready to download."
+msgstr "Votre fichier JSON-LD est prêt à télécharger."
+
 msgid ""
 "Your CSV file is ready to download. You can open it in Excel or Google "
 "Sheets."
@@ -5612,6 +5615,9 @@ msgstr "Télécharger le rapport PDF"
 
 msgid "Download HTML Report"
 msgstr "Télécharger le rapport HTML"
+
+msgid "Download JSON-LD File"
+msgstr "Télécharger le fichier JSON-LD"
 
 msgid "Download CSV File"
 msgstr "Télécharger le fichier CSV"

--- a/templates/reports/export_link_created.html
+++ b/templates/reports/export_link_created.html
@@ -36,6 +36,8 @@
         {% trans "Your PDF report is ready to download." %}
         {% elif is_html %}
         {% trans "Your HTML report is ready to download. You can open it in any web browser or share it directly." %}
+        {% elif is_json %}
+        {% trans "Your JSON-LD file is ready to download." %}
         {% else %}
         {% trans "Your CSV file is ready to download. You can open it in Excel or Google Sheets." %}
         {% endif %}
@@ -48,6 +50,8 @@
     <span aria-hidden="true">&#x1F4C4;</span> {% trans "Download PDF Report" %}
     {% elif is_html %}
     <span aria-hidden="true">&#x1F4C4;</span> {% trans "Download HTML Report" %}
+    {% elif is_json %}
+    <span aria-hidden="true">&#x1F4C4;</span> {% trans "Download JSON-LD File" %}
     {% else %}
     <span aria-hidden="true">&#x1F4CA;</span> {% trans "Download CSV File" %}
     {% endif %}


### PR DESCRIPTION
## Summary
- The download confirmation page (`export_link_created.html`) only checked for PDF and HTML formats — JSON-LD exports fell through to the `else` branch and showed "Download CSV File" with CSV-specific help text
- Added `is_json` context variable to all three render calls in `views.py` and a new `{% elif is_json %}` branch in the template
- Added French translations for the two new strings

## Test plan
- [ ] Generate a CIDS JSON-LD report and verify the download page says "Download JSON-LD File" (not CSV)
- [ ] Generate a CSV report and verify it still says "Download CSV File"
- [ ] Generate a PDF report and verify it still says "Download PDF Report"

🤖 Generated with [Claude Code](https://claude.com/claude-code)