### PR TITLE
feat: add multi-program report support

### DIFF
--- a/apps/reports/export_engine.py
+++ b/apps/reports/export_engine.py
@@ -309,15 +309,7 @@ def generate_template_report(template, date_from, date_to, period_label,
             if not all_demographic_labels:
                 all_demographic_labels = list(demo_groups.keys())
 
-    # Use the first program's data for now (multi-program merge is future work)
-    if len(programs) > 1:
-        logger.warning(
-            "Template %r spans %d programs but only %r is included in report. "
-            "Multi-program aggregation is not yet implemented.",
-            template.name, len(programs), programs[0].name,
-        )
-    _program, report_data = all_report_data[0]
-    metric_results = all_metric_results[0] if all_metric_results else []
+    is_multi_program = len(programs) > 1
 
     safe_partner = sanitise_filename(template.partner.name.replace(" ", "_"))
     safe_period = sanitise_filename(period_label.replace(" ", "_"))
@@ -329,26 +321,177 @@ def generate_template_report(template, date_from, date_to, period_label,
         ).order_by("sort_order")
     )
 
-    if export_format == "pdf":
-        from .pdf_views import generate_funder_report_pdf
-        pdf_response = generate_funder_report_pdf(
-            request, report_data,
-            sections=sections if sections else None,
-            metric_results=metric_results if metric_results else None,
+    if is_multi_program:
+        content, filename = _render_multi_program(
+            template=template,
+            all_report_data=all_report_data,
+            all_metric_results=all_metric_results,
+            all_demographic_labels=all_demographic_labels,
+            sections=sections,
+            has_aggregation=has_aggregation,
+            period_label=period_label,
+            date_from=date_from,
+            date_to=date_to,
+            user=user,
+            request=request,
+            export_format=export_format,
+            taxonomy_lens=taxonomy_lens,
+            report_metrics=report_metrics,
+            safe_partner=safe_partner,
+            safe_period=safe_period,
         )
-        filename = f"Report_{safe_partner}_{safe_period}.pdf"
-        content = pdf_response.content
-    elif export_format == "html":
+    else:
+        _program, report_data = all_report_data[0]
+        metric_results = all_metric_results[0] if all_metric_results else []
+
+        if export_format == "pdf":
+            from .pdf_views import generate_funder_report_pdf
+            pdf_response = generate_funder_report_pdf(
+                request, report_data,
+                sections=sections if sections else None,
+                metric_results=metric_results if metric_results else None,
+            )
+            filename = f"Report_{safe_partner}_{safe_period}.pdf"
+            content = pdf_response.content
+        elif export_format == "html":
+            from .pdf_utils import render_html_string
+            html_template = _get_html_template_name(template)
+            html_context = _build_html_context(
+                report_data, sections, metric_results, template, user,
+            )
+            content = render_html_string(html_template, html_context)
+            filename = f"Report_{safe_partner}_{safe_period}.html"
+        elif export_format == "cids_json":
+            document = build_cids_jsonld_document(
+                programs=[_program],
+                taxonomy_lens=taxonomy_lens,
+                date_from=date_from,
+                date_to=date_to,
+                metric_definitions=[rm.metric_definition for rm in report_metrics] if report_metrics else None,
+            )
+            content = json.dumps(document, indent=2, ensure_ascii=False)
+            filename = f"Report_{safe_partner}_{safe_period}.jsonld"
+        else:
+            csv_buffer = io.StringIO()
+            writer = csv.writer(csv_buffer)
+
+            if has_aggregation and metric_results:
+                csv_rows = generate_template_csv_rows(
+                    template, report_data, metric_results,
+                    all_demographic_labels, period_label, user,
+                )
+            else:
+                csv_rows = generate_funder_report_csv_rows(report_data)
+
+            for row in csv_rows:
+                writer.writerow(sanitise_csv_row(row))
+            filename = f"Report_{safe_partner}_{safe_period}.csv"
+            content = csv_buffer.getvalue()
+
+    return content, filename, total_client_count
+
+
+def _render_multi_program(
+    *,
+    template,
+    all_report_data,
+    all_metric_results,
+    all_demographic_labels,
+    sections,
+    has_aggregation,
+    period_label,
+    date_from,
+    date_to,
+    user,
+    request,
+    export_format,
+    taxonomy_lens,
+    report_metrics,
+    safe_partner,
+    safe_period,
+):
+    """Render a report that spans multiple programs.
+
+    Produces per-program sections with an organisation-level summary.
+    """
+    from .utils import aggregate_all_programs_totals
+
+    display_name = getattr(user, "display_name", str(user)) if user else ""
+    threshold = getattr(template, "suppression_threshold", SMALL_CELL_THRESHOLD)
+
+    # Build programs list with metric_results attached
+    programs_with_data = []
+    for i, (prog, rd) in enumerate(all_report_data):
+        entry = {"name": prog.name, "report_data": rd}
+        if all_metric_results and i < len(all_metric_results):
+            entry["metric_results"] = all_metric_results[i]
+        programs_with_data.append(entry)
+
+    totals = aggregate_all_programs_totals(all_report_data)
+    # Remove 'programs' from totals to avoid overwriting programs_with_data
+    # (which includes metric_results and chart_images)
+    totals.pop("programs", None)
+
+    if sections:
+        logger.info(
+            "Template %r has %d ReportSection(s); multi-program reports "
+            "use a summary layout — section-driven content (narrative, "
+            "standards alignment) is included per program.",
+            template.name, len(sections),
+        )
+
+    if export_format in ("html", "pdf"):
         from .pdf_utils import render_html_string
-        html_template = _get_html_template_name(template)
-        html_context = _build_html_context(
-            report_data, sections, metric_results, template, user,
-        )
-        content = render_html_string(html_template, html_context)
-        filename = f"Report_{safe_partner}_{safe_period}.html"
+        from .chart_utils import generate_metric_charts, is_chart_available
+
+        # Generate charts per program
+        if is_chart_available():
+            for prog_entry in programs_with_data:
+                mr = prog_entry.get("metric_results")
+                if mr:
+                    prog_entry["chart_images"] = generate_metric_charts(mr)
+
+        html_context = {
+            "partner_name": template.partner.translated_name,
+            "template_name": template.name,
+            "period_label": period_label,
+            "generated_at": timezone.now().strftime("%Y-%m-%d"),
+            "generated_by": display_name,
+            "programs": programs_with_data,
+            "sections": sections,
+            "suppression_threshold": threshold,
+            **totals,
+        }
+
+        if export_format == "pdf":
+            from .pdf_utils import is_pdf_available
+            if is_pdf_available():
+                from weasyprint import HTML as WeasyHTML
+                html_str = render_html_string(
+                    "reports/html_report_multi_program.html", html_context,
+                )
+                pdf_bytes = WeasyHTML(string=html_str).write_pdf()
+                content = pdf_bytes
+                filename = f"Report_{safe_partner}_{safe_period}.pdf"
+            else:
+                # WeasyPrint not available — fall back to HTML with correct extension
+                content = render_html_string(
+                    "reports/html_report_multi_program.html", html_context,
+                )
+                filename = f"Report_{safe_partner}_{safe_period}.html"
+                logger.warning(
+                    "WeasyPrint not available; multi-program PDF exported as HTML.",
+                )
+        else:
+            content = render_html_string(
+                "reports/html_report_multi_program.html", html_context,
+            )
+            filename = f"Report_{safe_partner}_{safe_period}.html"
+
     elif export_format == "cids_json":
+        all_programs = [prog for prog, _rd in all_report_data]
         document = build_cids_jsonld_document(
-            programs=[_program],
+            programs=all_programs,
             taxonomy_lens=taxonomy_lens,
             date_from=date_from,
             date_to=date_to,
@@ -356,26 +499,50 @@ def generate_template_report(template, date_from, date_to, period_label,
         )
         content = json.dumps(document, indent=2, ensure_ascii=False)
         filename = f"Report_{safe_partner}_{safe_period}.jsonld"
+
     else:
+        # CSV: per-program sections
         csv_buffer = io.StringIO()
         writer = csv.writer(csv_buffer)
 
-        if has_aggregation and metric_results:
-            # Use DRR-specified metric-rows × demographic-columns format
-            csv_rows = generate_template_csv_rows(
-                template, report_data, metric_results,
-                all_demographic_labels, period_label, user,
-            )
-        else:
-            # Fall back to legacy format when no ReportMetric records
-            csv_rows = generate_funder_report_csv_rows(report_data)
+        # Organisation summary header
+        writer.writerow(sanitise_csv_row([
+            f"{_('Report')}: {template.partner.translated_name} — {template.name}",
+        ]))
+        writer.writerow(sanitise_csv_row([
+            f"{_('Period')}: {period_label}",
+        ]))
+        writer.writerow(sanitise_csv_row([
+            f"{_('Programs')}: {len(all_report_data)}",
+        ]))
+        writer.writerow(sanitise_csv_row([
+            f"{_('Total Individuals Served')}: {totals['total_served']}",
+        ]))
+        writer.writerow([])
 
-        for row in csv_rows:
-            writer.writerow(sanitise_csv_row(row))
+        for i, (prog, rd) in enumerate(all_report_data):
+            metric_results = all_metric_results[i] if all_metric_results and i < len(all_metric_results) else []
+
+            if has_aggregation and metric_results:
+                csv_rows = generate_template_csv_rows(
+                    template, rd, metric_results,
+                    all_demographic_labels, period_label, user,
+                )
+            else:
+                csv_rows = generate_funder_report_csv_rows(rd)
+
+            # Override the program name row
+            writer.writerow(sanitise_csv_row([
+                f"{'=' * 40} {prog.name} {'=' * 40}",
+            ]))
+            for row in csv_rows:
+                writer.writerow(sanitise_csv_row(row))
+            writer.writerow([])
+
         filename = f"Report_{safe_partner}_{safe_period}.csv"
         content = csv_buffer.getvalue()
 
-    return content, filename, total_client_count
+    return content, filename
 
 
 def _get_html_template_name(template):

--- a/apps/reports/utils.py
+++ b/apps/reports/utils.py
@@ -247,6 +247,10 @@ def get_quarter_choices(num_quarters: int = 8) -> List[Tuple[str, str]]:
 def aggregate_all_programs_totals(data_or_sections):
     """Aggregate service metrics across all program reports.
 
+    When any program's value has been suppressed (replaced with a string
+    like ``"< 5"``), the corresponding org-level total is also marked as
+    ``"suppressed"`` to avoid misleading undercounts.
+
     Args:
         data_or_sections: List of (program, report_data) tuples.
 
@@ -256,18 +260,30 @@ def aggregate_all_programs_totals(data_or_sections):
     total_served = 0
     total_new = 0
     total_contacts = 0
+    any_served_suppressed = False
+    any_new_suppressed = False
+    any_contacts_suppressed = False
     programs = []
     for program, rd in data_or_sections:
-        if isinstance(rd.get("total_individuals_served"), int):
-            total_served += rd["total_individuals_served"]
-        if isinstance(rd.get("new_clients_this_period"), int):
-            total_new += rd["new_clients_this_period"]
-        if isinstance(rd.get("total_contacts"), int):
-            total_contacts += rd["total_contacts"]
+        served = rd.get("total_individuals_served")
+        new = rd.get("new_clients_this_period")
+        contacts = rd.get("total_contacts")
+        if isinstance(served, int):
+            total_served += served
+        elif isinstance(served, str):
+            any_served_suppressed = True
+        if isinstance(new, int):
+            total_new += new
+        elif isinstance(new, str):
+            any_new_suppressed = True
+        if isinstance(contacts, int):
+            total_contacts += contacts
+        elif isinstance(contacts, str):
+            any_contacts_suppressed = True
         programs.append({"name": program.name, "report_data": rd})
     return {
-        "total_served": total_served,
-        "total_new_clients": total_new,
-        "total_contacts": total_contacts,
+        "total_served": "suppressed" if any_served_suppressed else total_served,
+        "total_new_clients": "suppressed" if any_new_suppressed else total_new,
+        "total_contacts": "suppressed" if any_contacts_suppressed else total_contacts,
         "programs": programs,
     }

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -21350,3 +21350,25 @@ msgstr "Sélection invalide."
 
 msgid "Please select a program."
 msgstr "Veuillez sélectionner un programme."
+
+#. from reports/html_report_multi_program.html
+msgid "Multi-Program Outcome Report"
+msgstr "Rapport de résultats multiprogramme"
+
+#. blocktrans from reports/html_report_multi_program.html (title)
+#, python-format
+msgid "Multi-Program Outcome Report \u2014 %(name)s"
+msgstr "Rapport de résultats multiprogramme \u2014 %(name)s"
+
+#. from reports/html_report_multi_program.html
+msgid "Metric Charts"
+msgstr "Graphiques des indicateurs"
+
+#. from reports/html_report_multi_program.html
+msgid "This report was generated using KoNote's Multi-Program Outcome Report Template."
+msgstr "Ce rapport a été généré à l'aide du modèle de rapport de résultats multiprogramme de KoNote."
+
+#. blocktrans from reports/html_report_multi_program.html
+#, python-format
+msgid "Bar chart showing %(label)s across demographic groups"
+msgstr "Diagramme à barres montrant %(label)s par groupes démographiques"

--- a/templates/reports/_report_styles.html
+++ b/templates/reports/_report_styles.html
@@ -1,5 +1,5 @@
 {# Shared CSS for standalone HTML report exports (included by
-   html_report.html, html_report_all_programs.html, and html_outcome_report.html). #}
+   html_report.html, html_report_all_programs.html, html_report_multi_program.html, and html_outcome_report.html). #}
 * { box-sizing: border-box; }
 body {
     font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;

--- a/templates/reports/html_report_multi_program.html
+++ b/templates/reports/html_report_multi_program.html
@@ -1,0 +1,420 @@
+{% load i18n %}{% get_current_language as LANGUAGE_CODE %}<!DOCTYPE html>
+<html lang="{{ LANGUAGE_CODE }}">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>{% blocktrans with name=partner_name %}Multi-Program Outcome Report — {{ name }}{% endblocktrans %}</title>
+    <style>
+        {% include "reports/_report_styles.html" %}
+
+        @media print {
+            body { padding: 0; max-width: none; }
+            .no-print { display: none; }
+            details > summary { display: none; }
+            details > *:not(summary) { display: block !important; }
+            .program-section { page-break-before: always; }
+            .program-section:first-of-type { page-break-before: auto; }
+        }
+
+        .stat-box .change {
+            font-size: 0.75rem;
+            color: #4a5568;
+            margin-top: 0.15rem;
+        }
+
+        /* Metrics table */
+        .metrics-table {
+            width: 100%;
+            border-collapse: collapse;
+            margin: 0.8rem 0;
+        }
+        .metrics-table th, .metrics-table td {
+            border: 1px solid #d1d5db;
+            padding: 8px 12px;
+            text-align: right;
+        }
+        .metrics-table th:first-child, .metrics-table td:first-child {
+            text-align: left;
+        }
+        .metrics-table thead th {
+            background-color: #f7f8fa;
+            font-weight: 600;
+        }
+
+        /* Narrative sections */
+        .narrative-section {
+            border-left: 4px solid #3176aa;
+            padding: 0.8rem 1rem;
+            margin: 0.8rem 0;
+            background-color: #f7f8fa;
+        }
+        .narrative-section .placeholder {
+            font-style: italic;
+            color: #718096;
+        }
+
+        /* Chart sections */
+        .chart-section { margin: 0.8rem 0; }
+        .chart-container {
+            margin: 0.6rem 0;
+            text-align: center;
+        }
+        .chart-image {
+            max-width: 100%;
+            height: auto;
+        }
+        .chart-caption {
+            font-size: 0.8rem;
+            color: #718096;
+            margin-top: 0.2rem;
+            font-style: italic;
+        }
+
+        /* Program section dividers */
+        .program-section {
+            margin-top: 2rem;
+            border-top: 3px solid #3176aa;
+            padding-top: 1rem;
+        }
+        .program-section:first-of-type {
+            border-top: none;
+            margin-top: 1rem;
+        }
+        .program-section-title {
+            font-size: 1.2rem;
+            font-weight: 700;
+            color: #3176aa;
+            margin-bottom: 0.5rem;
+            margin-top: 0;
+            border-bottom: none;
+            padding-bottom: 0;
+        }
+    </style>
+</head>
+<body>
+<!-- Report Header -->
+<div class="pdf-header">
+    <h1>{% trans "Multi-Program Outcome Report" %}</h1>
+    <div class="subtitle">{{ partner_name }} — {{ template_name }}</div>
+    <dl class="meta-grid">
+        <dt>{% trans "Partner" %}</dt>
+        <dd>{{ partner_name }}</dd>
+        <dt>{% trans "Period" %}</dt>
+        <dd>{{ period_label }}</dd>
+        <dt>{% trans "Programs Included" %}</dt>
+        <dd>{{ programs|length }}</dd>
+        <dt>{% trans "Generated" %}</dt>
+        <dd>{% blocktrans with date=generated_at author=generated_by %}{{ date }} by {{ author }}{% endblocktrans %}</dd>
+    </dl>
+</div>
+
+<!-- Organisation-wide summary -->
+<div class="report-header-bar">{% trans "Organisation Summary" %}</div>
+<div class="stat-grid">
+    <div class="stat-box">
+        <div class="value">{{ total_served }}</div>
+        <div class="label">{% trans "Total Individuals Served" %}</div>
+    </div>
+    <div class="stat-box">
+        <div class="value">{{ total_new_clients }}</div>
+        <div class="label">{% trans "New Participants This Period" %}</div>
+    </div>
+    <div class="stat-box">
+        <div class="value">{{ total_contacts }}</div>
+        <div class="label">{% trans "Total Service Contacts" %}</div>
+    </div>
+    <div class="stat-box">
+        <div class="value">{{ programs|length }}</div>
+        <div class="label">{% trans "Programs" %}</div>
+    </div>
+</div>
+
+<!-- Table of contents -->
+{% if programs|length >= 3 %}
+<nav class="report-toc no-print" aria-label="{% trans 'Programs in this report' %}">
+    <h2>{% trans "Programs" %}</h2>
+    <ol>
+    {% for prog in programs %}
+        <li><a href="#program-{{ forloop.counter }}">{{ prog.name }}</a></li>
+    {% endfor %}
+    </ol>
+</nav>
+{% endif %}
+
+<!-- Per-program sections -->
+{% for prog in programs %}
+<div class="program-section" id="program-{{ forloop.counter }}">
+    <h2 class="program-section-title">{{ prog.name }}</h2>
+
+    {# ===== Service Statistics ===== #}
+    <div class="stat-grid">
+        <div class="stat-box">
+            <div class="value">{{ prog.report_data.total_individuals_served|default:"0" }}</div>
+            <div class="label">{% trans "Total Individuals Served" %}</div>
+            {% if prog.report_data.prev_total_individuals_served is not None %}
+            <div class="change">
+                {% if prog.report_data.total_individuals_served > prog.report_data.prev_total_individuals_served %}
+                <span aria-hidden="true">&#9650;</span>
+                <span class="sr-only">{% trans "Increased" %}</span>
+                {% elif prog.report_data.total_individuals_served < prog.report_data.prev_total_individuals_served %}
+                <span aria-hidden="true">&#9660;</span>
+                <span class="sr-only">{% trans "Decreased" %}</span>
+                {% endif %}
+                {% trans "from" %} {{ prog.report_data.prev_total_individuals_served }} {% trans "previous period" %}
+            </div>
+            {% endif %}
+        </div>
+        <div class="stat-box">
+            <div class="value">{{ prog.report_data.new_clients_this_period|default:"0" }}</div>
+            <div class="label">{% trans "New Participants This Period" %}</div>
+        </div>
+        <div class="stat-box">
+            <div class="value">{{ prog.report_data.total_contacts|default:"0" }}</div>
+            <div class="label">{% trans "Total Service Contacts" %}</div>
+        </div>
+    </div>
+
+    {# ===== Metrics Table (from ReportMetric aggregation) ===== #}
+    {% if prog.metric_results %}
+    <details open>
+    <summary class="report-header-bar">{% trans "Outcome Metrics" %}</summary>
+    <table class="metrics-table">
+        <thead>
+            <tr>
+                <th scope="col">{% trans "Metric" %}</th>
+                {% for mr in prog.metric_results %}
+                {% if forloop.first %}
+                {% for group_label, group_data in mr.values.items %}
+                <th scope="col">{{ group_label }}</th>
+                {% endfor %}
+                {% endif %}
+                {% endfor %}
+            </tr>
+        </thead>
+        <tbody>
+            {% for mr in prog.metric_results %}
+            <tr>
+                <td>{{ mr.label }}</td>
+                {% for group_label, group_data in mr.values.items %}
+                <td>
+                    {% if group_data.n > 0 and group_data.n < suppression_threshold %}
+                    &lt; {{ suppression_threshold }}
+                    {% elif mr.aggregation == "threshold_percentage" or mr.aggregation == "percentage" %}
+                    {{ group_data.value }}%
+                    <div class="achievement-bar" role="progressbar" aria-valuenow="{{ group_data.value }}" aria-valuemin="0" aria-valuemax="100">
+                        <div class="achievement-bar-fill" style="width: {{ group_data.value }}%;"></div>
+                    </div>
+                    {% else %}
+                    {{ group_data.value }}
+                    {% endif %}
+                </td>
+                {% endfor %}
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    </details>
+
+    {# Charts for this program #}
+    {% if prog.chart_images %}
+    <details open>
+    <summary class="report-header-bar">{% trans "Metric Charts" %}</summary>
+    <div class="chart-section">
+        {% for chart in prog.chart_images %}
+        <div class="chart-container">
+            <img src="{{ chart.chart_data_uri }}" alt="{% blocktrans with label=chart.label %}Bar chart showing {{ label }} across demographic groups{% endblocktrans %}" class="chart-image">
+            <p class="chart-caption">{{ chart.label }}</p>
+        </div>
+        {% endfor %}
+    </div>
+    </details>
+    {% endif %}
+    {% endif %}
+
+    {# ===== Age Demographics ===== #}
+    {% if prog.report_data.age_demographics %}
+    <details open>
+    <summary class="report-header-bar">{% trans "Age Demographics" %} &mdash; {{ prog.report_data.age_demographics_total }} {% trans "participants" %}</summary>
+    <div style="margin: 0.8rem 0;">
+        <div class="demo-row header">
+            <div>{% trans "Age Group" %}</div>
+            <div style="text-align: right;">{% trans "Count" %}</div>
+            <div style="text-align: right;">{% trans "Percentage" %}</div>
+        </div>
+        {% for age_group, count in prog.report_data.age_demographics.items %}
+        <div class="demo-row">
+            <div>
+                {{ age_group }}
+                {% if prog.report_data.age_demographics_total > 0 %}
+                <div class="demo-bar" role="progressbar" aria-valuenow="{% widthratio count prog.report_data.age_demographics_total 100 %}" aria-valuemin="0" aria-valuemax="100" aria-label="{{ age_group }}">
+                    <div class="demo-bar-fill" style="width: {% widthratio count prog.report_data.age_demographics_total 100 %}%;"></div>
+                </div>
+                {% endif %}
+            </div>
+            <div style="text-align: right;">{{ count }}</div>
+            <div style="text-align: right;">
+                {% if prog.report_data.age_demographics_total > 0 %}
+                {% widthratio count prog.report_data.age_demographics_total 100 %}%
+                {% else %}
+                {% trans "N/A" %}
+                {% endif %}
+            </div>
+        </div>
+        {% endfor %}
+        <div class="demo-row header">
+            <div>{% trans "Total" %}</div>
+            <div style="text-align: right;">{{ prog.report_data.age_demographics_total }}</div>
+            <div style="text-align: right;">100%</div>
+        </div>
+    </div>
+    </details>
+    {% endif %}
+
+    {# ===== Outcome Indicators (legacy, when no ReportMetric records) ===== #}
+    {% if not prog.metric_results %}
+    {% if prog.report_data.primary_outcome %}
+    <details open>
+    <summary class="report-header-bar">{% trans "Outcome Indicators" %}</summary>
+    <h4 style="margin-top: 0.5rem;">{% trans "Primary Outcome" %}</h4>
+    <div class="outcome-card">
+        <h4>{{ prog.report_data.primary_outcome.name }}</h4>
+        <div class="rate">{{ prog.report_data.primary_outcome.achievement_rate }}%</div>
+        <div class="achievement-bar" role="progressbar" aria-valuenow="{{ prog.report_data.primary_outcome.achievement_rate }}" aria-valuemin="0" aria-valuemax="100" aria-label="{{ prog.report_data.primary_outcome.name }}">
+            <div class="achievement-bar-fill" style="width: {{ prog.report_data.primary_outcome.achievement_rate }}%;"></div>
+        </div>
+        <div class="details">
+            <strong>{% trans "Target:" %}</strong> {{ prog.report_data.primary_outcome.target_value }}<br>
+            <strong>{% trans "Clients Measured:" %}</strong> {{ prog.report_data.primary_outcome.clients_measured }}<br>
+            <strong>{% trans "Clients Achieving Target:" %}</strong> {% blocktrans with achieved=prog.report_data.primary_outcome.clients_achieved measured=prog.report_data.primary_outcome.clients_measured %}{{ achieved }} of {{ measured }}{% endblocktrans %}
+        </div>
+    </div>
+
+    {% if prog.report_data.secondary_outcomes %}
+    <h4>{% trans "Secondary Outcomes" %}</h4>
+    <table>
+        <thead>
+            <tr>
+                <th scope="col">{% trans "Indicator Name" %}</th>
+                <th scope="col">{% trans "Target" %}</th>
+                <th scope="col">{% trans "Measured" %}</th>
+                <th scope="col">{% trans "Achieved" %}</th>
+                <th scope="col">{% trans "Rate" %}</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for outcome in prog.report_data.secondary_outcomes %}
+            <tr>
+                <td>{{ outcome.name }}</td>
+                <td>{{ outcome.target_value }}</td>
+                <td>{{ outcome.clients_measured }}</td>
+                <td>{{ outcome.clients_achieved }}</td>
+                <td>
+                    {{ outcome.achievement_rate }}%
+                    <div class="achievement-bar" role="progressbar" aria-valuenow="{{ outcome.achievement_rate }}" aria-valuemin="0" aria-valuemax="100">
+                        <div class="achievement-bar-fill" style="width: {{ outcome.achievement_rate }}%;"></div>
+                    </div>
+                </td>
+            </tr>
+            {% endfor %}
+        </tbody>
+    </table>
+    {% endif %}
+    </details>
+    {% endif %}
+    {% endif %}
+
+    {# ===== Narrative Sections (from ReportSection) ===== #}
+    {% for section in sections %}
+    {% if section.section_type == "narrative" %}
+    <details open>
+    <summary class="report-header-bar">{{ section.title }}</summary>
+    <div class="narrative-section">
+        {% if section.instructions %}
+        <p>{{ section.instructions }}</p>
+        {% endif %}
+        <p class="placeholder">{% trans "[To be added during review]" %}</p>
+    </div>
+    </details>
+    {% endif %}
+    {% endfor %}
+
+    {# ===== Standards Alignment (from ReportSection) ===== #}
+    {% for section in sections %}
+    {% if section.section_type == "standards_alignment" %}
+    <details id="program-{{ forloop.parentloop.counter }}-standards">
+    <summary class="report-header-bar">{{ section.title }}</summary>
+    {% if prog.report_data.cids_alignment %}
+    <p style="font-size: 0.85rem; color: #718096; margin-bottom: 0.8rem;">
+        {% blocktrans with version=prog.report_data.cids_alignment.cids_version %}Aligned with Common Impact Data Standard (CIDS) v{{ version }}.{% endblocktrans %}
+    </p>
+    <p><strong>{% trans "Reporting Lens:" %}</strong> {{ prog.report_data.cids_alignment.taxonomy_lens_label }}</p>
+    {% if prog.report_data.cids_alignment.program_cids.sector_code %}
+    <p><strong>{% trans "Sector:" %}</strong> {{ prog.report_data.cids_alignment.program_cids.sector_code }}</p>
+    {% endif %}
+    {% if prog.report_data.cids_alignment.metrics %}
+    <table class="metrics-table">
+        <thead>
+            <tr>
+                <th scope="col">{% trans "Indicator" %}</th>
+                <th scope="col">{% trans "Selected Code" %}</th>
+                <th scope="col">{% trans "Selected Label" %}</th>
+                <th scope="col">{% trans "Code List" %}</th>
+            </tr>
+        </thead>
+        <tbody>
+            {% for m in prog.report_data.cids_alignment.metrics %}
+            {% if m.selected_code %}
+            <tr>
+                <td>{{ m.name }}</td>
+                <td>{{ m.selected_code|default:"—" }}</td>
+                <td>{{ m.selected_label|default:"—" }}</td>
+                <td>{{ m.selected_list_name|default:"—" }}</td>
+            </tr>
+            {% endif %}
+            {% endfor %}
+        </tbody>
+    </table>
+    <p style="font-size: 0.85rem; color: #718096;">
+        {% blocktrans with mapped=prog.report_data.cids_alignment.mapped_count total=prog.report_data.cids_alignment.total_count %}{{ mapped }} of {{ total }} indicators mapped for the selected reporting lens.{% endblocktrans %}
+    </p>
+    {% endif %}
+    {% else %}
+    <div class="narrative-section">
+        <p class="placeholder">{% trans "No CIDS standards alignment data available. Import code lists and tag metrics to populate this section." %}</p>
+    </div>
+    {% endif %}
+    </details>
+    {% endif %}
+    {% endfor %}
+
+    {# ===== Program Summary ===== #}
+    {% if prog.report_data.achievement_summary.total_clients > 0 %}
+    <div class="report-header-bar">{% trans "Program Summary" %}</div>
+    <div class="summary-grid">
+        <div class="summary-card">
+            <div class="number">{{ prog.report_data.achievement_summary.overall_rate }}%</div>
+            <div class="achievement-bar" role="progressbar" aria-valuenow="{{ prog.report_data.achievement_summary.overall_rate }}" aria-valuemin="0" aria-valuemax="100" aria-label="{% trans 'Overall achievement rate' %}">
+                <div class="achievement-bar-fill" style="width: {{ prog.report_data.achievement_summary.overall_rate }}%;"></div>
+            </div>
+            <div class="label">{% trans "Overall Achievement Rate" %}</div>
+        </div>
+        <div class="summary-card">
+            <div class="number">{{ prog.report_data.achievement_summary.clients_met_any_target }} / {{ prog.report_data.achievement_summary.total_clients }}</div>
+            <div class="label">{% trans "Participants Met at Least One Target" %}</div>
+        </div>
+    </div>
+    {% endif %}
+</div>
+{% endfor %}
+
+<div class="footer-note">
+    {% trans "This report was generated using KoNote's Multi-Program Outcome Report Template." %}
+    {% blocktrans with period=period_label %}Data reflects client outcomes recorded during the {{ period }} reporting period.{% endblocktrans %}
+    {% blocktrans with count=programs|length %}Includes data from {{ count }} program(s).{% endblocktrans %}
+</div>
+
+<div class="generated-by">
+    {% trans "Generated by KoNote" %}
+</div>
+</body>
+</html>

--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -1633,3 +1633,221 @@ class ClientInsightsPartialTest(TestCase):
         resp = self.http.get(f"/reports/participant/{empty_cf.pk}/insights/")
         self.assertEqual(resp.status_code, 200)
         self.assertContains(resp, "No notes recorded")
+
+
+# ────────────────────────────────────────────────────────────────────
+# Multi-program report tests
+# ────────────────────────────────────────────────────────────────────
+
+
+class AggregateAllProgramsTotalsTests(SimpleTestCase):
+    """aggregate_all_programs_totals must handle suppressed values."""
+
+    def _make_program(self, name):
+        """Return a simple object with a .name attribute."""
+        class FakeProgram:
+            pass
+        p = FakeProgram()
+        p.name = name
+        return p
+
+    def test_all_numeric(self):
+        from apps.reports.utils import aggregate_all_programs_totals
+        data = [
+            (self._make_program("P1"), _minimal_report_data(
+                total_individuals_served=20, new_clients_this_period=5, total_contacts=40,
+            )),
+            (self._make_program("P2"), _minimal_report_data(
+                total_individuals_served=30, new_clients_this_period=8, total_contacts=60,
+            )),
+        ]
+        totals = aggregate_all_programs_totals(data)
+        self.assertEqual(totals["total_served"], 50)
+        self.assertEqual(totals["total_new_clients"], 13)
+        self.assertEqual(totals["total_contacts"], 100)
+        self.assertEqual(len(totals["programs"]), 2)
+
+    def test_any_suppressed_marks_total_suppressed(self):
+        from apps.reports.utils import aggregate_all_programs_totals
+        data = [
+            (self._make_program("P1"), _minimal_report_data(
+                total_individuals_served="< 5", new_clients_this_period=5, total_contacts=40,
+            )),
+            (self._make_program("P2"), _minimal_report_data(
+                total_individuals_served=30, new_clients_this_period=8, total_contacts=60,
+            )),
+        ]
+        totals = aggregate_all_programs_totals(data)
+        self.assertEqual(totals["total_served"], "suppressed")
+        self.assertEqual(totals["total_new_clients"], 13)
+        self.assertEqual(totals["total_contacts"], 100)
+
+    def test_all_suppressed(self):
+        from apps.reports.utils import aggregate_all_programs_totals
+        data = [
+            (self._make_program("P1"), _minimal_report_data(
+                total_individuals_served="< 5", new_clients_this_period="< 5", total_contacts="< 5",
+            )),
+            (self._make_program("P2"), _minimal_report_data(
+                total_individuals_served="< 5", new_clients_this_period="< 5", total_contacts="< 5",
+            )),
+        ]
+        totals = aggregate_all_programs_totals(data)
+        self.assertEqual(totals["total_served"], "suppressed")
+        self.assertEqual(totals["total_new_clients"], "suppressed")
+        self.assertEqual(totals["total_contacts"], "suppressed")
+
+
+class MultiProgramCSVRenderTests(SimpleTestCase):
+    """_render_multi_program CSV output must include per-program sections."""
+
+    def _make_program(self, name):
+        class FakeProgram:
+            pass
+        p = FakeProgram()
+        p.name = name
+        p.pk = hash(name)
+        return p
+
+    def _make_template(self, name="Test Report"):
+        class FakePartner:
+            translated_name = "Test Partner"
+            name = "Test Partner"
+        class FakeTemplate:
+            pass
+        t = FakeTemplate()
+        t.partner = FakePartner()
+        t.name = name
+        t.suppression_threshold = 5
+        return t
+
+    def test_csv_has_per_program_headers(self):
+        from apps.reports.export_engine import _render_multi_program
+
+        prog1 = self._make_program("Youth Services")
+        prog2 = self._make_program("Adult Programs")
+        rd1 = _minimal_report_data(program_name="Youth Services")
+        rd2 = _minimal_report_data(program_name="Adult Programs")
+
+        content, filename = _render_multi_program(
+            template=self._make_template(),
+            all_report_data=[(prog1, rd1), (prog2, rd2)],
+            all_metric_results=[],
+            all_demographic_labels=[],
+            sections=[],
+            has_aggregation=False,
+            period_label="Q1 2026",
+            date_from=date(2026, 1, 1),
+            date_to=date(2026, 3, 31),
+            user=None,
+            request=None,
+            export_format="csv",
+            taxonomy_lens="iris_plus",
+            report_metrics=[],
+            safe_partner="Test_Partner",
+            safe_period="Q1_2026",
+        )
+
+        self.assertIn("Youth Services", content)
+        self.assertIn("Adult Programs", content)
+        self.assertIn("Test Partner", content)
+        self.assertTrue(filename.endswith(".csv"))
+
+    def test_html_includes_all_programs(self):
+        from apps.reports.export_engine import _render_multi_program
+
+        prog1 = self._make_program("Program A")
+        prog2 = self._make_program("Program B")
+        rd1 = _minimal_report_data(program_name="Program A")
+        rd2 = _minimal_report_data(program_name="Program B")
+
+        content, filename = _render_multi_program(
+            template=self._make_template(),
+            all_report_data=[(prog1, rd1), (prog2, rd2)],
+            all_metric_results=[],
+            all_demographic_labels=[],
+            sections=[],
+            has_aggregation=False,
+            period_label="Q1 2026",
+            date_from=date(2026, 1, 1),
+            date_to=date(2026, 3, 31),
+            user=None,
+            request=None,
+            export_format="html",
+            taxonomy_lens="iris_plus",
+            report_metrics=[],
+            safe_partner="Test_Partner",
+            safe_period="Q1_2026",
+        )
+
+        self.assertIn("Program A", content)
+        self.assertIn("Program B", content)
+        self.assertIn("Multi-Program", content)
+        self.assertTrue(filename.endswith(".html"))
+
+    def test_totals_pop_does_not_lose_metric_results(self):
+        """Regression: **totals must not overwrite programs_with_data."""
+        from apps.reports.export_engine import _render_multi_program
+
+        prog1 = self._make_program("P1")
+        prog2 = self._make_program("P2")
+        rd1 = _minimal_report_data(program_name="P1")
+        rd2 = _minimal_report_data(program_name="P2")
+
+        fake_metrics = [{"label": "Test Metric", "aggregation": "count",
+                         "values": {"All": {"value": 10, "n": 10}}}]
+
+        content, filename = _render_multi_program(
+            template=self._make_template(),
+            all_report_data=[(prog1, rd1), (prog2, rd2)],
+            all_metric_results=[fake_metrics, fake_metrics],
+            all_demographic_labels=["All"],
+            sections=[],
+            has_aggregation=True,
+            period_label="Q1 2026",
+            date_from=date(2026, 1, 1),
+            date_to=date(2026, 3, 31),
+            user=None,
+            request=None,
+            export_format="html",
+            taxonomy_lens="iris_plus",
+            report_metrics=[],
+            safe_partner="Test_Partner",
+            safe_period="Q1_2026",
+        )
+
+        # Verify metric results appear in the HTML output
+        self.assertIn("Test Metric", content)
+
+    def test_pdf_fallback_uses_html_extension(self):
+        """When WeasyPrint is unavailable, filename should be .html not .pdf."""
+        from apps.reports.export_engine import _render_multi_program
+
+        prog1 = self._make_program("P1")
+        prog2 = self._make_program("P2")
+        rd1 = _minimal_report_data(program_name="P1")
+        rd2 = _minimal_report_data(program_name="P2")
+
+        with patch("apps.reports.export_engine.is_pdf_available", return_value=False):
+            content, filename = _render_multi_program(
+                template=self._make_template(),
+                all_report_data=[(prog1, rd1), (prog2, rd2)],
+                all_metric_results=[],
+                all_demographic_labels=[],
+                sections=[],
+                has_aggregation=False,
+                period_label="Q1 2026",
+                date_from=date(2026, 1, 1),
+                date_to=date(2026, 3, 31),
+                user=None,
+                request=None,
+                export_format="pdf",
+                taxonomy_lens="iris_plus",
+                report_metrics=[],
+                safe_partner="Test_Partner",
+                safe_period="Q1_2026",
+            )
+
+        # When WeasyPrint is unavailable, should fall back to .html
+        self.assertTrue(filename.endswith(".html"),
+                        f"Expected .html extension, got: {filename}")


### PR DESCRIPTION
## Summary

- When a report template's partner spans multiple programs, the system now generates a combined report instead of only including the first program's data
- Adds org-level summary with per-program sections (stats, metrics, demographics, narrative, standards alignment, outcomes)
- Supports all export formats: HTML, PDF, CSV, and CIDS JSON-LD
- Fixes org-level totals to show "suppressed" when any program's data was suppressed (prevents misleading undercounts)
- Fixes PDF fallback to use `.html` extension when WeasyPrint is unavailable
- Includes French translations for new template strings

## Test plan

- [ ] Verify multi-program HTML report renders correctly with 2+ programs
- [ ] Verify CSV output has per-program sections with org summary header
- [ ] Verify suppressed org totals display "suppressed" instead of 0
- [ ] Verify single-program reports are unchanged
- [ ] Run `pytest tests/test_exports.py -v` for new unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)