### PR TITLE
feat: add W3C DQV data quality signals to CIDS export

### DIFF
--- a/apps/plans/migrations/0026_metricdefinition_dqv_fields.py
+++ b/apps/plans/migrations/0026_metricdefinition_dqv_fields.py
@@ -1,0 +1,66 @@
+"""Add data quality descriptor fields for CIDS DQV export.
+
+Three descriptive fields on MetricDefinition that tell funders *how*
+data is generated, without creating a quality hierarchy.
+"""
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("plans", "0025_metricdefinition_instrument_name"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="metricdefinition",
+            name="evidence_type",
+            field=models.CharField(
+                blank=True,
+                choices=[
+                    ("self_report", "Self-report (participant completes)"),
+                    ("staff_observed", "Staff-observed (recorded by worker)"),
+                    ("administrative_record", "Administrative record (system data)"),
+                    ("third_party_assessed", "Third-party assessed (external evaluator)"),
+                    ("coded_qualitative", "Coded qualitative (open responses coded to scale)"),
+                ],
+                default="",
+                help_text="How the data is generated. Describes the source, not quality.",
+                max_length=30,
+            ),
+        ),
+        migrations.AddField(
+            model_name="metricdefinition",
+            name="measure_basis",
+            field=models.CharField(
+                blank=True,
+                choices=[
+                    ("published_validated", "Published, validated for this population"),
+                    ("published_adapted", "Published, adapted for local context"),
+                    ("custom_participatory", "Custom, developed with participant input"),
+                    ("custom_staff_designed", "Custom, designed by staff"),
+                    ("administrative", "Administrative or system-generated"),
+                ],
+                default="",
+                help_text="How the measure was developed. Not a quality ranking.",
+                max_length=30,
+            ),
+        ),
+        migrations.AddField(
+            model_name="metricdefinition",
+            name="derivation_method",
+            field=models.CharField(
+                blank=True,
+                choices=[
+                    ("direct_response", "Direct participant response"),
+                    ("coded_from_qualitative", "Coded from qualitative responses"),
+                    ("calculated_composite", "Calculated composite score"),
+                    ("staff_rating", "Staff rating or judgment"),
+                ],
+                default="",
+                help_text="How the recorded value was produced. Only needed when the value isn't a direct participant response.",
+                max_length=30,
+            ),
+        ),
+    ]

--- a/apps/plans/models.py
+++ b/apps/plans/models.py
@@ -196,6 +196,46 @@ class MetricDefinition(models.Model):
         default=False,
         help_text=_("True for published validated instruments (PHQ-9, GAD-7, K10, etc.)."),
     )
+
+    # ── Data quality descriptors (for CIDS DQV export) ────────────────
+    EVIDENCE_TYPE_CHOICES = [
+        ("self_report", _("Self-report (participant completes)")),
+        ("staff_observed", _("Staff-observed (recorded by worker)")),
+        ("administrative_record", _("Administrative record (system data)")),
+        ("third_party_assessed", _("Third-party assessed (external evaluator)")),
+        ("coded_qualitative", _("Coded qualitative (open responses coded to scale)")),
+    ]
+    evidence_type = models.CharField(
+        max_length=30, blank=True, default="",
+        choices=EVIDENCE_TYPE_CHOICES,
+        help_text=_("How the data is generated. Describes the source, not quality."),
+    )
+
+    MEASURE_BASIS_CHOICES = [
+        ("published_validated", _("Published, validated for this population")),
+        ("published_adapted", _("Published, adapted for local context")),
+        ("custom_participatory", _("Custom, developed with participant input")),
+        ("custom_staff_designed", _("Custom, designed by staff")),
+        ("administrative", _("Administrative or system-generated")),
+    ]
+    measure_basis = models.CharField(
+        max_length=30, blank=True, default="",
+        choices=MEASURE_BASIS_CHOICES,
+        help_text=_("How the measure was developed. Not a quality ranking."),
+    )
+
+    DERIVATION_METHOD_CHOICES = [
+        ("direct_response", _("Direct participant response")),
+        ("coded_from_qualitative", _("Coded from qualitative responses")),
+        ("calculated_composite", _("Calculated composite score")),
+        ("staff_rating", _("Staff rating or judgment")),
+    ]
+    derivation_method = models.CharField(
+        max_length=30, blank=True, default="",
+        choices=DERIVATION_METHOD_CHOICES,
+        help_text=_("How the recorded value was produced. Only needed when "
+                    "the value isn't a direct participant response."),
+    )
     scoring_bands = models.JSONField(
         null=True, blank=True,
         help_text=_('Published severity cutoffs, e.g. [{"label": "Minimal", "min": 0, "max": 4}]. Display-only.'),

--- a/apps/reports/cids_jsonld.py
+++ b/apps/reports/cids_jsonld.py
@@ -325,6 +325,125 @@ def _compute_indicator_report(metric, values_qs, observation_count, program):
         )
 
 
+def _build_dqv_quality(metric, values_qs, observation_count, program, measures):
+    """Build DQV quality measurements and annotations for an IndicatorReport.
+
+    Uses W3C Data Quality Vocabulary to signal data reliability:
+    - Response rate (completeness): participants who reported / eligible
+    - Data parsability (completeness): % of values successfully parsed
+    - Observation volume (precision): total observations recorded
+    - Instrument validation (annotation): whether a validated instrument was used
+    - Plausibility review (annotation): outliers reviewed by staff
+    """
+    quality_measurements = []
+    quality_annotations = []
+
+    # ── Response rate (completeness) ────────────────────────────────
+    # Numerator: distinct participants with values
+    participant_measure = next(
+        (m for m in measures if m.get("measureType") == "konote:participant_count"),
+        None,
+    )
+    if participant_measure:
+        reported = int(participant_measure["hasNumericalValue"])
+    else:
+        # Achievement metrics use count_achieved; fall back to counting from queryset
+        reported = (
+            values_qs
+            .values_list(
+                "progress_note_target__plan_target__client_file_id", flat=True,
+            )
+            .distinct()
+            .count()
+        )
+
+    # Denominator: participants with active plan targets for this metric
+    eligible = (
+        PlanTargetMetric.objects.filter(
+            plan_target__plan_section__program=program,
+            metric_def=metric,
+            plan_target__status__in=["default", "completed"],
+        )
+        .values_list("plan_target__client_file_id", flat=True)
+        .distinct()
+        .count()
+    )
+
+    if eligible > 0 and reported > 0:
+        response_rate = round(reported / eligible * 100, 1)
+        quality_measurements.append({
+            "@type": "dqv:QualityMeasurement",
+            "dqv:isMeasurementOf": "completeness",
+            "dqv:value": response_rate,
+            "konote:numerator": reported,
+            "konote:denominator": eligible,
+            "konote:dimensionLabel": "Response rate (participants reported / eligible)",
+        })
+
+    # ── Data parsability (completeness, scale metrics only) ─────────
+    skipped_measure = next(
+        (m for m in measures if m.get("measureType") == "konote:skipped_unparseable"),
+        None,
+    )
+    if skipped_measure and observation_count > 0:
+        skipped = int(skipped_measure["hasNumericalValue"])
+        parseable = observation_count - skipped
+        parsability_rate = round(parseable / observation_count * 100, 1)
+        quality_measurements.append({
+            "@type": "dqv:QualityMeasurement",
+            "dqv:isMeasurementOf": "completeness",
+            "dqv:value": parsability_rate,
+            "konote:dimensionLabel": "Data parsability (% of values successfully parsed)",
+        })
+
+    # ── Observation volume (precision) ──────────────────────────────
+    if observation_count > 0:
+        quality_measurements.append({
+            "@type": "dqv:QualityMeasurement",
+            "dqv:isMeasurementOf": "precision",
+            "dqv:value": observation_count,
+            "konote:dimensionLabel": "Total observations recorded",
+        })
+
+    # ── Instrument validation (annotation) ──────────────────────────
+    if getattr(metric, "is_standardized_instrument", False):
+        instrument = getattr(metric, "instrument_name", None) or metric.name
+        quality_annotations.append({
+            "@type": "dqv:QualityAnnotation",
+            "oa:hasBody": {
+                "@type": "oa:TextualBody",
+                "rdf:value": f"Collected using validated instrument: {instrument}",
+            },
+            "oa:motivatedBy": "dqv:qualityAssessment",
+            "konote:annotationType": "instrument_validation",
+        })
+
+    # ── Plausibility review (annotation) ────────────────────────────
+    confirmed_count = values_qs.filter(plausibility_confirmed=True).count()
+    if confirmed_count > 0 and observation_count > 0:
+        confirmation_rate = round(confirmed_count / observation_count * 100, 1)
+        quality_annotations.append({
+            "@type": "dqv:QualityAnnotation",
+            "oa:hasBody": {
+                "@type": "oa:TextualBody",
+                "rdf:value": (
+                    f"{confirmed_count} of {observation_count} values "
+                    f"({confirmation_rate}%) were flagged as outliers "
+                    f"and confirmed by staff."
+                ),
+            },
+            "oa:motivatedBy": "dqv:qualityAssessment",
+            "konote:annotationType": "plausibility_confirmation",
+            "konote:confirmationRate": confirmation_rate,
+            "konote:confirmedCount": confirmed_count,
+        })
+
+    return {
+        "dqv:hasQualityMeasurement": quality_measurements,
+        "dqv:hasQualityAnnotation": quality_annotations,
+    }
+
+
 def _build_address_node(org, org_id):
     if not all([
         org.street_address,
@@ -675,6 +794,15 @@ def build_cids_jsonld_document(programs, taxonomy_lens="common_approach", date_f
                     "value": measures,
                     "hasComment": comment,
                 }
+                # Add DQV data quality signals
+                dqv = _build_dqv_quality(
+                    metric, values_qs, observation_count, program, measures,
+                )
+                if dqv.get("dqv:hasQualityMeasurement"):
+                    report_node["dqv:hasQualityMeasurement"] = dqv["dqv:hasQualityMeasurement"]
+                if dqv.get("dqv:hasQualityAnnotation"):
+                    report_node["dqv:hasQualityAnnotation"] = dqv["dqv:hasQualityAnnotation"]
+
                 indicator_node["hasIndicatorReport"] = [{"@id": report_id}]
                 add_node(report_node)
 
@@ -742,6 +870,8 @@ def build_cids_jsonld_document(programs, taxonomy_lens="common_approach", date_f
         "@context": [
             CIDS_CONTEXT,
             {
+                "dqv": "http://www.w3.org/ns/dqv#",
+                "oa": "http://www.w3.org/ns/oa#",
                 "konote": "https://konote.ca/cids/extensions#",
                 "konote:mean": {"@id": "konote:mean", "@type": "@id"},
                 "konote:median": {"@id": "konote:median", "@type": "@id"},
@@ -758,6 +888,12 @@ def build_cids_jsonld_document(programs, taxonomy_lens="common_approach", date_f
                 "konote:target_rate": {"@id": "konote:target_rate", "@type": "@id"},
                 "konote:target_high_band_percent": {"@id": "konote:target_high_band_percent", "@type": "@id"},
                 "konote:skipped_unparseable": {"@id": "konote:skipped_unparseable", "@type": "@id"},
+                "konote:numerator": {"@id": "konote:numerator"},
+                "konote:denominator": {"@id": "konote:denominator"},
+                "konote:dimensionLabel": {"@id": "konote:dimensionLabel"},
+                "konote:annotationType": {"@id": "konote:annotationType"},
+                "konote:confirmationRate": {"@id": "konote:confirmationRate"},
+                "konote:confirmedCount": {"@id": "konote:confirmedCount"},
             },
         ],
         "@graph": graph,

--- a/apps/reports/cids_jsonld.py
+++ b/apps/reports/cids_jsonld.py
@@ -328,18 +328,25 @@ def _compute_indicator_report(metric, values_qs, observation_count, program):
 def _build_dqv_quality(metric, values_qs, observation_count, program, measures):
     """Build DQV quality measurements and annotations for an IndicatorReport.
 
-    Uses W3C Data Quality Vocabulary to signal data reliability:
-    - Response rate (completeness): participants who reported / eligible
-    - Data parsability (completeness): % of values successfully parsed
-    - Observation volume (precision): total observations recorded
-    - Instrument validation (annotation): whether a validated instrument was used
-    - Plausibility review (annotation): outliers reviewed by staff
+    Follows the "describe, don't rank" principle: quality signals tell funders
+    *how* the data was generated so they can make contextual judgments.
+
+    Tier 1 — Quantitative measurements (computed automatically):
+      - Reporting rate (completeness): participants who reported / eligible
+      - Data parsability (completeness): % of values successfully parsed
+      - Observation density (precision): observations per participant
+
+    Tier 2 — Structured annotations (from MetricDefinition fields):
+      - Evidence type: how data is generated (self-report, staff-observed, etc.)
+      - Measure basis: how the measure was developed (published, custom, etc.)
+      - Derivation method: how the value was produced (when not a direct response)
     """
     quality_measurements = []
     quality_annotations = []
 
-    # ── Response rate (completeness) ────────────────────────────────
-    # Numerator: distinct participants with values
+    # ── Tier 1: Quantitative measurements ───────────────────────────
+
+    # Reporting rate (completeness)
     participant_measure = next(
         (m for m in measures if m.get("measureType") == "konote:participant_count"),
         None,
@@ -347,7 +354,7 @@ def _build_dqv_quality(metric, values_qs, observation_count, program, measures):
     if participant_measure:
         reported = int(participant_measure["hasNumericalValue"])
     else:
-        # Achievement metrics use count_achieved; fall back to counting from queryset
+        # Achievement metrics don't emit participant_count; count from queryset
         reported = (
             values_qs
             .values_list(
@@ -357,7 +364,6 @@ def _build_dqv_quality(metric, values_qs, observation_count, program, measures):
             .count()
         )
 
-    # Denominator: participants with active plan targets for this metric
     eligible = (
         PlanTargetMetric.objects.filter(
             plan_target__plan_section__program=program,
@@ -377,10 +383,10 @@ def _build_dqv_quality(metric, values_qs, observation_count, program, measures):
             "dqv:value": response_rate,
             "konote:numerator": reported,
             "konote:denominator": eligible,
-            "konote:dimensionLabel": "Response rate (participants reported / eligible)",
+            "konote:dimensionLabel": "Reporting rate (participants reported / eligible)",
         })
 
-    # ── Data parsability (completeness, scale metrics only) ─────────
+    # Data parsability (completeness, scale metrics only)
     skipped_measure = next(
         (m for m in measures if m.get("measureType") == "konote:skipped_unparseable"),
         None,
@@ -396,46 +402,74 @@ def _build_dqv_quality(metric, values_qs, observation_count, program, measures):
             "konote:dimensionLabel": "Data parsability (% of values successfully parsed)",
         })
 
-    # ── Observation volume (precision) ──────────────────────────────
-    if observation_count > 0:
+    # Observation density (precision)
+    if observation_count > 0 and reported > 0:
+        density = round(observation_count / reported, 1)
         quality_measurements.append({
             "@type": "dqv:QualityMeasurement",
             "dqv:isMeasurementOf": "precision",
-            "dqv:value": observation_count,
-            "konote:dimensionLabel": "Total observations recorded",
+            "dqv:value": density,
+            "konote:dimensionLabel": "Observation density (observations per participant)",
+            "konote:totalObservations": observation_count,
+            "konote:totalParticipants": reported,
         })
 
-    # ── Instrument validation (annotation) ──────────────────────────
-    if getattr(metric, "is_standardized_instrument", False):
-        instrument = getattr(metric, "instrument_name", None) or metric.name
+    # ── Tier 2: Structured descriptors ──────────────────────────────
+
+    # Evidence type — how data is generated
+    evidence_type = getattr(metric, "evidence_type", "")
+    if evidence_type:
+        label = dict(getattr(metric, "EVIDENCE_TYPE_CHOICES", [])).get(
+            evidence_type, evidence_type,
+        )
         quality_annotations.append({
             "@type": "dqv:QualityAnnotation",
             "oa:hasBody": {
                 "@type": "oa:TextualBody",
-                "rdf:value": f"Collected using validated instrument: {instrument}",
+                "rdf:value": str(label),
             },
             "oa:motivatedBy": "dqv:qualityAssessment",
-            "konote:annotationType": "instrument_validation",
+            "konote:annotationType": "evidence_type",
+            "konote:annotationCategory": evidence_type,
         })
 
-    # ── Plausibility review (annotation) ────────────────────────────
-    confirmed_count = values_qs.filter(plausibility_confirmed=True).count()
-    if confirmed_count > 0 and observation_count > 0:
-        confirmation_rate = round(confirmed_count / observation_count * 100, 1)
+    # Measure basis — how the measure was developed
+    measure_basis = getattr(metric, "measure_basis", "")
+    if measure_basis:
+        label = dict(getattr(metric, "MEASURE_BASIS_CHOICES", [])).get(
+            measure_basis, measure_basis,
+        )
+        # Include instrument name when applicable
+        instrument = getattr(metric, "instrument_name", "")
+        body = str(label)
+        if instrument and measure_basis in ("published_validated", "published_adapted"):
+            body = f"{label}: {instrument}"
         quality_annotations.append({
             "@type": "dqv:QualityAnnotation",
             "oa:hasBody": {
                 "@type": "oa:TextualBody",
-                "rdf:value": (
-                    f"{confirmed_count} of {observation_count} values "
-                    f"({confirmation_rate}%) were flagged as outliers "
-                    f"and confirmed by staff."
-                ),
+                "rdf:value": body,
             },
             "oa:motivatedBy": "dqv:qualityAssessment",
-            "konote:annotationType": "plausibility_confirmation",
-            "konote:confirmationRate": confirmation_rate,
-            "konote:confirmedCount": confirmed_count,
+            "konote:annotationType": "measure_basis",
+            "konote:annotationCategory": measure_basis,
+        })
+
+    # Derivation method — how the value was produced (when not direct)
+    derivation_method = getattr(metric, "derivation_method", "")
+    if derivation_method:
+        label = dict(getattr(metric, "DERIVATION_METHOD_CHOICES", [])).get(
+            derivation_method, derivation_method,
+        )
+        quality_annotations.append({
+            "@type": "dqv:QualityAnnotation",
+            "oa:hasBody": {
+                "@type": "oa:TextualBody",
+                "rdf:value": str(label),
+            },
+            "oa:motivatedBy": "dqv:qualityAssessment",
+            "konote:annotationType": "derivation_method",
+            "konote:annotationCategory": derivation_method,
         })
 
     return {
@@ -892,8 +926,9 @@ def build_cids_jsonld_document(programs, taxonomy_lens="common_approach", date_f
                 "konote:denominator": {"@id": "konote:denominator"},
                 "konote:dimensionLabel": {"@id": "konote:dimensionLabel"},
                 "konote:annotationType": {"@id": "konote:annotationType"},
-                "konote:confirmationRate": {"@id": "konote:confirmationRate"},
-                "konote:confirmedCount": {"@id": "konote:confirmedCount"},
+                "konote:annotationCategory": {"@id": "konote:annotationCategory"},
+                "konote:totalObservations": {"@id": "konote:totalObservations"},
+                "konote:totalParticipants": {"@id": "konote:totalParticipants"},
             },
         ],
         "@graph": graph,

--- a/apps/reports/cids_jsonld.py
+++ b/apps/reports/cids_jsonld.py
@@ -12,7 +12,7 @@ import json
 import math
 from statistics import mean, median, stdev
 
-from django.db.models import Q
+from django.db.models import Count, Q
 from django.utils import timezone
 
 from apps.admin_settings.models import CidsCodeList, OrganizationProfile, TaxonomyMapping
@@ -325,7 +325,8 @@ def _compute_indicator_report(metric, values_qs, observation_count, program):
         )
 
 
-def _build_dqv_quality(metric, values_qs, observation_count, program, measures):
+def _build_dqv_quality(metric, values_qs, observation_count, program, measures,
+                       eligible_count=None):
     """Build DQV quality measurements and annotations for an IndicatorReport.
 
     Follows the "describe, don't rank" principle: quality signals tell funders
@@ -340,6 +341,10 @@ def _build_dqv_quality(metric, values_qs, observation_count, program, measures):
       - Evidence type: how data is generated (self-report, staff-observed, etc.)
       - Measure basis: how the measure was developed (published, custom, etc.)
       - Derivation method: how the value was produced (when not a direct response)
+
+    Args:
+        eligible_count: Pre-computed eligible participant count for this metric.
+            Pass from a batched query to avoid per-metric DB hits.
     """
     quality_measurements = []
     quality_annotations = []
@@ -347,10 +352,9 @@ def _build_dqv_quality(metric, values_qs, observation_count, program, measures):
     # ── Tier 1: Quantitative measurements ───────────────────────────
 
     # Reporting rate (completeness)
-    participant_measure = next(
-        (m for m in measures if m.get("measureType") == "konote:participant_count"),
-        None,
-    )
+    measures_by_type = {m.get("measureType"): m for m in measures}
+
+    participant_measure = measures_by_type.get("konote:participant_count")
     if participant_measure:
         reported = int(participant_measure["hasNumericalValue"])
     else:
@@ -364,7 +368,7 @@ def _build_dqv_quality(metric, values_qs, observation_count, program, measures):
             .count()
         )
 
-    eligible = (
+    eligible = eligible_count if eligible_count is not None else (
         PlanTargetMetric.objects.filter(
             plan_target__plan_section__program=program,
             metric_def=metric,
@@ -387,10 +391,7 @@ def _build_dqv_quality(metric, values_qs, observation_count, program, measures):
         })
 
     # Data parsability (completeness, scale metrics only)
-    skipped_measure = next(
-        (m for m in measures if m.get("measureType") == "konote:skipped_unparseable"),
-        None,
-    )
+    skipped_measure = measures_by_type.get("konote:skipped_unparseable")
     if skipped_measure and observation_count > 0:
         skipped = int(skipped_measure["hasNumericalValue"])
         parseable = observation_count - skipped
@@ -416,60 +417,32 @@ def _build_dqv_quality(metric, values_qs, observation_count, program, measures):
 
     # ── Tier 2: Structured descriptors ──────────────────────────────
 
-    # Evidence type — how data is generated
-    evidence_type = getattr(metric, "evidence_type", "")
-    if evidence_type:
-        label = dict(getattr(metric, "EVIDENCE_TYPE_CHOICES", [])).get(
-            evidence_type, evidence_type,
-        )
+    _DESCRIPTOR_FIELDS = [
+        ("evidence_type", MetricDefinition.EVIDENCE_TYPE_CHOICES),
+        ("measure_basis", MetricDefinition.MEASURE_BASIS_CHOICES),
+        ("derivation_method", MetricDefinition.DERIVATION_METHOD_CHOICES),
+    ]
+    for field_name, choices in _DESCRIPTOR_FIELDS:
+        value = getattr(metric, field_name, "")
+        if not value:
+            continue
+        label = str(dict(choices).get(value, value))
+        # Include instrument name for published measures
+        if field_name == "measure_basis" and value in (
+            "published_validated", "published_adapted",
+        ):
+            instrument = getattr(metric, "instrument_name", "")
+            if instrument:
+                label = f"{label}: {instrument}"
         quality_annotations.append({
             "@type": "dqv:QualityAnnotation",
             "oa:hasBody": {
                 "@type": "oa:TextualBody",
-                "rdf:value": str(label),
+                "rdf:value": label,
             },
             "oa:motivatedBy": "dqv:qualityAssessment",
-            "konote:annotationType": "evidence_type",
-            "konote:annotationCategory": evidence_type,
-        })
-
-    # Measure basis — how the measure was developed
-    measure_basis = getattr(metric, "measure_basis", "")
-    if measure_basis:
-        label = dict(getattr(metric, "MEASURE_BASIS_CHOICES", [])).get(
-            measure_basis, measure_basis,
-        )
-        # Include instrument name when applicable
-        instrument = getattr(metric, "instrument_name", "")
-        body = str(label)
-        if instrument and measure_basis in ("published_validated", "published_adapted"):
-            body = f"{label}: {instrument}"
-        quality_annotations.append({
-            "@type": "dqv:QualityAnnotation",
-            "oa:hasBody": {
-                "@type": "oa:TextualBody",
-                "rdf:value": body,
-            },
-            "oa:motivatedBy": "dqv:qualityAssessment",
-            "konote:annotationType": "measure_basis",
-            "konote:annotationCategory": measure_basis,
-        })
-
-    # Derivation method — how the value was produced (when not direct)
-    derivation_method = getattr(metric, "derivation_method", "")
-    if derivation_method:
-        label = dict(getattr(metric, "DERIVATION_METHOD_CHOICES", [])).get(
-            derivation_method, derivation_method,
-        )
-        quality_annotations.append({
-            "@type": "dqv:QualityAnnotation",
-            "oa:hasBody": {
-                "@type": "oa:TextualBody",
-                "rdf:value": str(label),
-            },
-            "oa:motivatedBy": "dqv:qualityAssessment",
-            "konote:annotationType": "derivation_method",
-            "konote:annotationCategory": derivation_method,
+            "konote:annotationType": field_name,
+            "konote:annotationCategory": value,
         })
 
     return {
@@ -766,6 +739,19 @@ def build_cids_jsonld_document(programs, taxonomy_lens="common_approach", date_f
         )
 
         program_metrics = list(metric_queryset.filter(pk__in=metric_ids).distinct())
+
+        # Batch eligible participant counts per metric (avoids N+1 in DQV)
+        eligible_by_metric = dict(
+            PlanTargetMetric.objects.filter(
+                plan_target__plan_section__program=program,
+                metric_def__in=program_metrics,
+                plan_target__status__in=["default", "completed"],
+            )
+            .values("metric_def_id")
+            .annotate(eligible=Count("plan_target__client_file_id", distinct=True))
+            .values_list("metric_def_id", "eligible")
+        )
+
         outcome_indicator_refs = []
 
         for metric in program_metrics:
@@ -831,6 +817,7 @@ def build_cids_jsonld_document(programs, taxonomy_lens="common_approach", date_f
                 # Add DQV data quality signals
                 dqv = _build_dqv_quality(
                     metric, values_qs, observation_count, program, measures,
+                    eligible_count=eligible_by_metric.get(metric.pk),
                 )
                 if dqv.get("dqv:hasQualityMeasurement"):
                     report_node["dqv:hasQualityMeasurement"] = dqv["dqv:hasQualityMeasurement"]

--- a/tasks/wireframes/common-approach-working-document.html
+++ b/tasks/wireframes/common-approach-working-document.html
@@ -1,0 +1,783 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>KoNote CIDS Implementation — Working Document for Common Approach</title>
+  <style>
+    :root {
+      --text: #2d3748;
+      --text-light: #4a5568;
+      --text-muted: #718096;
+      --bg: #ffffff;
+      --bg-subtle: #f7fafc;
+      --border: #e2e8f0;
+      --accent: #3176aa;
+      --accent-light: #ebf4ff;
+      --green: #276749;
+      --green-bg: #f0fff4;
+      --amber: #975a16;
+      --amber-bg: #fffff0;
+      --red: #9b2c2c;
+    }
+
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: "Segoe UI", system-ui, -apple-system, sans-serif;
+      color: var(--text);
+      line-height: 1.65;
+      max-width: 820px;
+      margin: 0 auto;
+      padding: 2rem 1.5rem;
+      background: var(--bg);
+    }
+
+    h1 { font-size: 1.6rem; font-weight: 600; margin-bottom: 0.25rem; }
+    h2 {
+      font-size: 1.15rem; font-weight: 600;
+      margin: 2.5rem 0 0.75rem;
+      padding-bottom: 0.4rem;
+      border-bottom: 2px solid var(--border);
+      color: var(--text);
+    }
+    h3 { font-size: 1rem; font-weight: 600; margin: 1.25rem 0 0.5rem; }
+    p { margin-bottom: 0.75rem; }
+
+    .doc-meta {
+      color: var(--text-muted);
+      font-size: 0.9rem;
+      margin-bottom: 2rem;
+      padding-bottom: 1rem;
+      border-bottom: 1px solid var(--border);
+    }
+
+    /* Status labels */
+    .status {
+      display: inline-block;
+      padding: 0.15rem 0.5rem;
+      border-radius: 3px;
+      font-size: 0.8rem;
+      font-weight: 500;
+    }
+    .status-deployed { background: var(--green-bg); color: var(--green); }
+    .status-written { background: var(--amber-bg); color: var(--amber); }
+    .status-designed { background: var(--accent-light); color: var(--accent); }
+
+    /* Lists */
+    ul, ol { margin: 0.5rem 0 0.75rem 1.5rem; }
+    li { margin-bottom: 0.35rem; }
+
+    /* Tables */
+    table {
+      width: 100%; border-collapse: collapse;
+      margin: 0.75rem 0 1rem;
+      font-size: 0.9rem;
+    }
+    th, td {
+      text-align: left;
+      padding: 0.5rem 0.6rem;
+      border: 1px solid var(--border);
+    }
+    th { background: var(--bg-subtle); font-weight: 600; font-size: 0.85rem; }
+
+    /* Callout boxes */
+    .callout {
+      border-left: 3px solid var(--accent);
+      background: var(--bg-subtle);
+      padding: 0.75rem 1rem;
+      margin: 1rem 0;
+      font-size: 0.9rem;
+    }
+    .callout p:last-child { margin-bottom: 0; }
+
+    .question-box {
+      border: 1px solid var(--accent);
+      border-radius: 4px;
+      padding: 0.75rem 1rem;
+      margin: 0.75rem 0;
+      background: var(--accent-light);
+    }
+    .question-box strong { color: var(--accent); }
+
+    /* Collapsible sections */
+    details {
+      margin: 1rem 0;
+      border: 1px solid var(--border);
+      border-radius: 4px;
+    }
+    summary {
+      padding: 0.75rem 1rem;
+      cursor: pointer;
+      font-weight: 600;
+      font-size: 0.95rem;
+      background: var(--bg-subtle);
+      user-select: none;
+    }
+    summary:hover { background: #edf2f7; }
+    details > div, details > pre { padding: 1rem; }
+
+    /* Demo dashboard (embedded) */
+    .demo-section {
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      overflow: hidden;
+      margin: 1rem 0;
+    }
+    .demo-label {
+      background: var(--bg-subtle);
+      padding: 0.5rem 0.75rem;
+      font-size: 0.8rem;
+      color: var(--text-muted);
+      border-bottom: 1px solid var(--border);
+      font-style: italic;
+    }
+    .demo-content { padding: 1.25rem; }
+
+    /* Outcome cards (simplified) */
+    .outcome-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+      gap: 0.75rem;
+      margin: 0.75rem 0;
+    }
+    .outcome-card {
+      border: 1px solid var(--border);
+      border-radius: 4px;
+      padding: 0.75rem;
+      text-align: center;
+    }
+    .outcome-card .value {
+      font-size: 1.8rem;
+      font-weight: 700;
+      line-height: 1.2;
+    }
+    .outcome-card .label {
+      font-size: 0.8rem;
+      color: var(--text-muted);
+      margin-top: 0.25rem;
+    }
+    .outcome-card .context {
+      font-size: 0.75rem;
+      color: var(--text-light);
+      margin-top: 0.35rem;
+    }
+    .val-green { color: var(--green); }
+    .val-blue { color: var(--accent); }
+
+    /* Progress bar */
+    .bar-container {
+      width: 100%; height: 6px;
+      background: #e2e8f0; border-radius: 3px;
+      margin: 0.4rem 0;
+      overflow: hidden;
+    }
+    .bar-fill { height: 100%; border-radius: 3px; }
+
+    /* Chain diagram */
+    .chain {
+      display: flex; align-items: center; gap: 0.3rem;
+      flex-wrap: wrap; margin: 0.5rem 0;
+    }
+    .chain-step {
+      background: var(--accent-light); color: var(--accent);
+      padding: 0.25rem 0.5rem; border-radius: 3px;
+      font-size: 0.8rem; font-weight: 500;
+    }
+    .chain-arrow { color: var(--text-muted); font-size: 0.9rem; }
+
+    /* Component mapping table */
+    .cids-badge {
+      display: inline-block;
+      background: #edf2f7; color: var(--text-light);
+      padding: 0.1rem 0.4rem; border-radius: 3px;
+      font-size: 0.75rem; font-family: monospace;
+    }
+
+    /* Code block */
+    pre {
+      background: #1a202c;
+      color: #e2e8f0;
+      padding: 1rem;
+      border-radius: 4px;
+      overflow-x: auto;
+      font-size: 0.8rem;
+      line-height: 1.5;
+    }
+
+    /* Risk table */
+    .risk-row td:first-child { font-weight: 500; }
+    .severity { font-size: 0.75rem; font-weight: 600; text-transform: uppercase; }
+    .sev-high { color: var(--red); }
+    .sev-medium { color: var(--amber); }
+
+    /* Footer */
+    .footer {
+      margin-top: 3rem; padding-top: 1rem;
+      border-top: 1px solid var(--border);
+      color: var(--text-muted);
+      font-size: 0.8rem;
+    }
+
+    @media print {
+      body { max-width: none; padding: 1rem; font-size: 10pt; }
+      details { border: none; }
+      details > div, details > pre { display: block; }
+      summary { background: none; }
+      .demo-section { break-inside: avoid; }
+    }
+  </style>
+</head>
+<body>
+
+<h1>KoNote &amp; CIDS Full Tier: Where We Are</h1>
+<div class="doc-meta">
+  Working document for Common Approach colleagues &middot; March 2026<br>
+  Prepared by Gillian Kerr, Logical Outcomes
+</div>
+
+<p>KoNote is a participant outcome management system designed for Canadian nonprofits — each agency runs their own instance. We're building toward CIDS Full Tier compliance and wanted to share where we are and what we've learned mapping the standard so far.</p>
+
+<h2>Where we are right now</h2>
+
+<p>The software supports all 14 CIDS Full Tier classes, but we haven't yet tested the full pipeline with real program data. Here's what's built and what still needs work:</p>
+
+<h3><span class="status status-deployed">Built</span></h3>
+<ul>
+  <li>Programs carry CIDS sector codes and population served codes</li>
+  <li>Metrics and outcome targets carry CIDS indicator fields</li>
+  <li>Code list support for ICNPO, PopulationServed, SDG, and IRIS+ (based on 5.3b — not yet populated on our test instance)</li>
+  <li>Taxonomy classification workflow — AI suggests mappings to code lists; an admin reviews and approves them</li>
+  <li>Secure export with approval flow — exports are reviewed before they leave the instance, and any personally identifiable information is flagged</li>
+  <li>Aggregate reports suppress small groups (k&ge;5) to protect privacy</li>
+  <li>Agency profile for organisation-level CIDS metadata</li>
+  <li>Basic Tier JSON-LD export with SHACL validation</li>
+  <li>Full Tier JSON-LD export — assembles all 14 CIDS classes into one document</li>
+  <li>IndicatorReport computes outcome statistics per metric type: success rates, means, medians, distributions, pre/post change, effect sizes</li>
+  <li>Data quality signals on IndicatorReport using W3C DQV — response rates, instrument validation status, plausibility review, observation volume</li>
+  <li>Evaluation framework editor — agencies define their program's services, activities, outputs, risks, and counterfactuals, which map directly to Full Tier classes</li>
+  <li>Enrichment — derives themes and standards alignment from program data</li>
+  <li>Evaluator attestation — optional step where an evaluator reviews the framework before export</li>
+  <li>Coverage dashboard — shows which programs have class coverage and where gaps remain</li>
+</ul>
+
+<h3><span class="status status-designed">Still to do</span></h3>
+<ul>
+  <li>Test the full pipeline with real program data</li>
+  <li>Full Tier SHACL validation (we'd like to use your improved validation tool when it's available)</li>
+</ul>
+
+<h2>Privacy</h2>
+
+<p>KoNote is designed for Canadian nonprofits that handle data subject to PHIPA (Ontario) and comparable provincial health privacy legislation. All personally identifiable information is encrypted locally and does not leave the instance.</p>
+
+<p>Full Tier CIDS classes describe program models and aggregate outcomes, not individual participants. <code>cids:Stakeholder</code> refers to stakeholder groups (e.g., "youth aged 16-24"), not individuals. <code>cids:StakeholderOutcome</code> describes aggregate outcomes for a group. <code>cids:ImpactModel</code> is the theory of change.</p>
+
+<p>Our exports work in three layers:</p>
+
+<table>
+  <thead>
+    <tr><th>Layer</th><th>What's in it</th><th>Privacy</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><strong>1. Program model</strong></td>
+      <td>ImpactModel, Service, Activity, Output, Stakeholder groups, ImpactRisk, Counterfactual</td>
+      <td>No concern — describes programs, not people</td>
+    </tr>
+    <tr>
+      <td><strong>2. Aggregate measurement</strong></td>
+      <td>IndicatorReport with cohort results, suppressed to k&ge;5</td>
+      <td>Statistical disclosure controls</td>
+    </tr>
+    <tr>
+      <td><strong>3. Case trajectories</strong> (optional)</td>
+      <td>De-identified outcome pathways per cohort</td>
+      <td>k-anonymity, dates generalised to quarters, minimum n&ge;15</td>
+    </tr>
+  </tbody>
+</table>
+
+<h2>What the export looks like for funders</h2>
+
+<p>We built a demo using realistic data from a fictional youth employment program. This is what a funder or platform consuming the CIDS export would see — the JSON-LD data rendered as a readable dashboard.</p>
+
+<div class="demo-section">
+  <div class="demo-label">Demo: Funder outcome view rendered from CIDS Full Tier JSON-LD export</div>
+  <div class="demo-content">
+
+    <p style="color: var(--text-muted); font-size: 0.85rem; margin-bottom: 0.5rem;">Bright Futures Community Services &middot; Toronto, ON</p>
+    <h3 style="margin-top: 0;">Bright Futures Youth Employment Services</h3>
+    <p style="font-size: 0.9rem;">12-week job readiness program for youth aged 16-24. September 2025 cohort, 23 participants.</p>
+
+    <div class="outcome-grid">
+      <div class="outcome-card">
+        <div class="value val-green">78%</div>
+        <div class="label">Employment rate</div>
+        <div class="context">18 of 23 employed<br>(target was 65%)</div>
+      </div>
+      <div class="outcome-card">
+        <div class="value val-blue">3.2 &rarr; 7.8</div>
+        <div class="label">Job readiness score</div>
+        <div class="context">Mean, 1-10 scale<br>87% moved to high band</div>
+      </div>
+      <div class="outcome-card">
+        <div class="value val-green">83%</div>
+        <div class="label">90-day retention</div>
+        <div class="context">15 of 18 maintained<br>employment 90+ days</div>
+      </div>
+      <div class="outcome-card">
+        <div class="value val-blue">342</div>
+        <div class="label">Sessions delivered</div>
+        <div class="context">Avg 14.9/participant<br>83% met minimum</div>
+      </div>
+    </div>
+
+    <h3 style="font-size: 0.9rem; margin-top: 1rem;">Theory of change</h3>
+    <div class="chain">
+      <span class="chain-step">Training</span>
+      <span class="chain-arrow">&rarr;</span>
+      <span class="chain-step">Skills</span>
+      <span class="chain-arrow">&rarr;</span>
+      <span class="chain-step">Confidence</span>
+      <span class="chain-arrow">&rarr;</span>
+      <span class="chain-step">Interviews</span>
+      <span class="chain-arrow">&rarr;</span>
+      <span class="chain-step">Employment</span>
+      <span class="chain-arrow">&rarr;</span>
+      <span class="chain-step">Income stability</span>
+    </div>
+
+    <h3 style="font-size: 0.9rem; margin-top: 1rem;">Counterfactual</h3>
+    <p style="font-size: 0.9rem;">Without the program, participants would access basic Employment Ontario services (job boards, resume review) but not structured training or mentorship. Comparable GTA youth programs show <strong>23% placement</strong> without structured support, vs. <strong>78%</strong> with this program.</p>
+
+    <h3 style="font-size: 0.9rem; margin-top: 1rem;">Impact risks</h3>
+    <table style="font-size: 0.85rem;">
+      <tbody class="risk-row">
+        <tr>
+          <td>Economic downturn reduces positions</td>
+          <td><span class="severity sev-medium">Medium</span> likelihood / <span class="severity sev-high">High</span> severity</td>
+          <td>12 employer partners across 5 sectors</td>
+        </tr>
+        <tr>
+          <td>Attrition from housing instability</td>
+          <td><span class="severity sev-medium">Medium</span> / <span class="severity sev-medium">Medium</span></td>
+          <td>Shelter partnerships, hybrid attendance</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h3 style="font-size: 0.9rem; margin-top: 1rem;">Stakeholder groups</h3>
+    <p style="font-size: 0.85rem;">Youth aged 16-24, unemployed (n=20) &middot; Newcomer youth, arrived &lt;5 years (n=8) &middot; Indigenous youth (n=3)</p>
+
+    <h3 style="font-size: 0.9rem; margin-top: 1rem;">Evaluator attestation</h3>
+    <p style="font-size: 0.85rem; color: var(--green);"><strong>Jennifer Martinez</strong>, March 5, 2026 — "I have reviewed the evaluation framework, outcome chain, risk assessment, and component definitions. The framework accurately reflects our program model and evaluation methodology."</p>
+
+  </div>
+</div>
+
+<p>All of that comes from the CIDS JSON-LD export. No individual participant data is included anywhere — it's all program-level and aggregate.</p>
+
+<h2>But can you trust the numbers?</h2>
+
+<p>Completing all 14 CIDS classes tells a funder that a report is <em>structurally</em> complete. It says nothing about whether the underlying data is reliable. A program could populate every class while having a 20% response rate, unvalidated measurement tools, and self-selected respondents. A funder aggregating across a funding stream needs to know which results to weight heavily and which to interpret with caution.</p>
+
+<p>This is a gap most agencies aren't addressing — and it's arguably the most important question for funders: <strong>how much should I trust these outcomes?</strong></p>
+
+<p>CIDS addresses this through the <a href="https://www.w3.org/TR/vocab-dqv/">W3C Data Quality Vocabulary (DQV)</a>, which provides properties on <code>IndicatorReport</code> for signalling the quality of the data behind the numbers. KoNote uses these to emit five concrete data quality signals alongside every outcome report:</p>
+
+<table>
+  <thead>
+    <tr><th>Signal</th><th>What it tells funders</th><th>Example</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><strong>Response rate</strong></td>
+      <td>What proportion of eligible participants actually have data?</td>
+      <td>19 of 23 eligible participants reported (83%)</td>
+    </tr>
+    <tr>
+      <td><strong>Data parsability</strong></td>
+      <td>Were recorded values usable, or were many unparseable?</td>
+      <td>98% of values parsed successfully</td>
+    </tr>
+    <tr>
+      <td><strong>Observation volume</strong></td>
+      <td>How much data underpins these statistics?</td>
+      <td>342 observations across 23 participants</td>
+    </tr>
+    <tr>
+      <td><strong>Instrument validation</strong></td>
+      <td>Was a published, validated measurement tool used?</td>
+      <td>Rosenberg Self-Esteem Scale (validated)</td>
+    </tr>
+    <tr>
+      <td><strong>Plausibility review</strong></td>
+      <td>Were outlier values reviewed by staff?</td>
+      <td>3 flagged values confirmed by clinician</td>
+    </tr>
+  </tbody>
+</table>
+
+<p>These signals use standard DQV properties (<code>dqv:hasQualityMeasurement</code> and <code>dqv:hasQualityAnnotation</code> on <code>cids:IndicatorReport</code>), so any system consuming CIDS exports can read them without custom parsing.</p>
+
+<div class="callout">
+  <p><strong>Why this matters for aggregation:</strong> When a funder rolls up outcomes across 15 funded programs, knowing that Program A has an 83% response rate using a validated instrument and Program B has a 25% response rate using ad hoc questions fundamentally changes how you interpret and weight the results. Without data quality signals, all CIDS exports look equally credible.</p>
+</div>
+
+<div class="demo-section">
+  <div class="demo-label">Demo: Data quality signals rendered from CIDS IndicatorReport</div>
+  <div class="demo-content">
+    <p style="font-size: 0.85rem; color: var(--text-muted); margin-bottom: 0.5rem;">Bright Futures Community Services &middot; Job Readiness Score</p>
+    <div class="outcome-grid">
+      <div class="outcome-card">
+        <div class="value val-green">83%</div>
+        <div class="label">Response rate</div>
+        <div class="context">19 of 23 eligible<br>participants reported</div>
+      </div>
+      <div class="outcome-card">
+        <div class="value val-green">98%</div>
+        <div class="label">Data parsability</div>
+        <div class="context">340 of 342 values<br>parsed successfully</div>
+      </div>
+      <div class="outcome-card">
+        <div class="value val-blue">342</div>
+        <div class="label">Observations</div>
+        <div class="context">Avg 14.9 per<br>participant</div>
+      </div>
+      <div class="outcome-card" style="border-color: var(--green);">
+        <div class="value" style="font-size: 0.85rem; color: var(--green);">&#10003; Validated</div>
+        <div class="label">Instrument</div>
+        <div class="context">Rosenberg Self-Esteem<br>Scale</div>
+      </div>
+    </div>
+    <p style="font-size: 0.8rem; color: var(--text-muted); margin-top: 0.5rem;">3 outlier values were flagged and confirmed by clinical staff.</p>
+  </div>
+</div>
+
+<h2>How funders aggregate across agencies</h2>
+
+<p>A natural question: if each agency defines their own metrics, how does a funder produce a summary across an entire funding stream? The answer is that CIDS doesn't require agencies to use the same measures — it requires them to tag their measures with shared taxonomy codes. Aggregation happens at the taxonomy level, not the metric level.</p>
+
+<h3>How it would work in practice</h3>
+
+<ol>
+  <li><strong>Funder defines a reporting template</strong> — expressed in CIDS vocabulary: "For this funding stream, report on SDG 8 outcomes, IRIS+ OI4060 indicators, stakeholder breakdowns by PopulationServed codes, and an impact model with risks and counterfactuals." The template specifies which taxonomy codes and CIDS classes the funder wants populated — not what specific metrics to use.</li>
+  <li><strong>Agency maps their existing metrics to the template</strong> — they already track employment outcomes in whatever way makes sense for their program. The mapping step is tagging their indicators with the codes the funder asked for (IRIS+ OI4060, SDG 8.5, etc.). KoNote's taxonomy classification workflow supports this.</li>
+  <li><strong>System generates a report against the template</strong> — the export filters to what the funder asked for, structured the way they asked for it.</li>
+  <li><strong>Funder receives structured data they can aggregate</strong> — because every agency reported against the same template (same codes, same classes), the funder can roll up across their funding stream by taxonomy code.</li>
+</ol>
+
+<p>This means the funder can always answer "how many of our funded programs achieved their own employment targets?" without forcing everyone to measure employment the same way. One agency tracks job placement rates, another tracks hours of paid work, another tracks income change — but they're all tagged SDG 8 and IRIS+ OI4060, so the funder can group and compare them thematically.</p>
+
+<div class="demo-section">
+  <div class="demo-label">Demo: Funder funding-stream summary rendered from multiple CIDS Full Tier exports</div>
+  <div class="demo-content">
+
+    <p style="color: var(--text-muted); font-size: 0.85rem; margin-bottom: 0.5rem;">Prosper Canada Foundation &middot; Youth Employment Funding Stream &middot; 2025&ndash;26</p>
+    <h3 style="margin-top: 0;">Funding Stream: Youth Employment Ontario</h3>
+    <p style="font-size: 0.9rem;">15 funded programs across Ontario. Reporting period: September 2025 &ndash; February 2026.</p>
+
+    <div class="outcome-grid">
+      <div class="outcome-card">
+        <div class="value val-blue">15</div>
+        <div class="label">Programs funded</div>
+        <div class="context">13 Full Tier exports<br>2 Basic Tier</div>
+      </div>
+      <div class="outcome-card">
+        <div class="value val-blue">412</div>
+        <div class="label">Total participants</div>
+        <div class="context">Across all programs<br>Avg cohort: 27</div>
+      </div>
+      <div class="outcome-card">
+        <div class="value val-green">80%</div>
+        <div class="label">Met own targets</div>
+        <div class="context">12 of 15 programs<br>met or exceeded</div>
+      </div>
+      <div class="outcome-card">
+        <div class="value val-green">8 of 13</div>
+        <div class="label">Evaluator attested</div>
+        <div class="context">Full Tier programs<br>with attestation</div>
+      </div>
+    </div>
+
+    <h3 style="font-size: 0.9rem; margin-top: 1.25rem;">Outcomes by SDG alignment</h3>
+    <table style="font-size: 0.85rem;">
+      <thead>
+        <tr><th>SDG</th><th>Programs</th><th>Met own targets</th><th>Notes</th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><strong>8 — Decent Work</strong></td>
+          <td>15 of 15</td>
+          <td>12 (80%)</td>
+          <td>All programs report employment outcomes; measures vary (placement rate, hours worked, income change)</td>
+        </tr>
+        <tr>
+          <td><strong>1 — No Poverty</strong></td>
+          <td>9 of 15</td>
+          <td>7 (78%)</td>
+          <td>Income stability, financial literacy, benefits access</td>
+        </tr>
+        <tr>
+          <td><strong>10 — Reduced Inequalities</strong></td>
+          <td>6 of 15</td>
+          <td>5 (83%)</td>
+          <td>Programs specifically serving newcomer or Indigenous youth</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h3 style="font-size: 0.9rem; margin-top: 1.25rem;">Population served</h3>
+    <table style="font-size: 0.85rem;">
+      <thead>
+        <tr><th>Population group</th><th>Programs</th><th>Participants</th><th>Target achievement</th></tr>
+      </thead>
+      <tbody>
+        <tr><td>General youth (16&ndash;24)</td><td>9</td><td>243</td><td>8 of 9 met targets</td></tr>
+        <tr><td>Newcomer youth (&lt;5 years in Canada)</td><td>6</td><td>104</td><td>5 of 6 met targets</td></tr>
+        <tr><td>Indigenous youth</td><td>3</td><td>65</td><td>2 of 3 met targets</td></tr>
+      </tbody>
+    </table>
+
+    <h3 style="font-size: 0.9rem; margin-top: 1.25rem;">Common impact risks across the funding stream</h3>
+    <table style="font-size: 0.85rem;">
+      <tbody class="risk-row">
+        <tr>
+          <td>Economic downturn reduces positions</td>
+          <td>Reported by <strong>9 of 13</strong> programs</td>
+          <td>Most common mitigation: employer sector diversification</td>
+        </tr>
+        <tr>
+          <td>Housing instability &amp; attrition</td>
+          <td>Reported by <strong>7 of 13</strong></td>
+          <td>Mitigations: shelter partnerships, hybrid delivery</td>
+        </tr>
+        <tr>
+          <td>Language barriers limit participation</td>
+          <td>Reported by <strong>5 of 13</strong></td>
+          <td>Mitigations: multilingual facilitators, translated materials</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h3 style="font-size: 0.9rem; margin-top: 1.25rem;">CIDS class coverage</h3>
+    <div style="font-size: 0.85rem;">
+      <div style="display: flex; align-items: center; gap: 0.5rem; margin-bottom: 0.35rem;">
+        <span style="width: 140px;">Full Tier (14/14)</span>
+        <div class="bar-container" style="flex: 1;">
+          <div class="bar-fill" style="width: 87%; background: var(--green);"></div>
+        </div>
+        <span>13 programs</span>
+      </div>
+      <div style="display: flex; align-items: center; gap: 0.5rem; margin-bottom: 0.35rem;">
+        <span style="width: 140px;">Basic Tier (7/14)</span>
+        <div class="bar-container" style="flex: 1;">
+          <div class="bar-fill" style="width: 13%; background: var(--accent);"></div>
+        </div>
+        <span>2 programs</span>
+      </div>
+    </div>
+
+    <h3 style="font-size: 0.9rem; margin-top: 1.25rem;">Data quality across the funding stream</h3>
+    <table style="font-size: 0.85rem;">
+      <thead>
+        <tr><th>Signal</th><th>Funding stream average</th><th>Range</th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Response rate</td>
+          <td><strong>76%</strong> of eligible participants</td>
+          <td>42%–95%</td>
+        </tr>
+        <tr>
+          <td>Using validated instruments</td>
+          <td><strong>11 of 15</strong> programs (73%)</td>
+          <td>&mdash;</td>
+        </tr>
+        <tr>
+          <td>Avg observations per participant</td>
+          <td><strong>12.3</strong></td>
+          <td>3.1–19.8</td>
+        </tr>
+        <tr>
+          <td>Plausibility review done</td>
+          <td><strong>9 of 15</strong> programs (60%)</td>
+          <td>&mdash;</td>
+        </tr>
+      </tbody>
+    </table>
+    <p style="font-size: 0.8rem; color: var(--text-muted);">Data quality signals from <code>dqv:hasQualityMeasurement</code> and <code>dqv:hasQualityAnnotation</code> on each program's IndicatorReport nodes.</p>
+
+  </div>
+</div>
+
+<p>Notice what the funder <em>can</em> see: which programs met their own targets, which populations are being served, which risks are common across the stream, and how complete the reporting is. What the funder <em>doesn't</em> need is for every agency to measure employment the same way — the taxonomy codes make programs comparable thematically without forcing a common metric.</p>
+
+<div class="callout">
+  <p><strong>Open question for Common Approach:</strong> Does the standard envision funders publishing reporting templates as CIDS documents — a set of required Indicators, Themes, and Codes without values filled in? This would be the contract between funder and grantee: the funder defines <em>what</em> to report on (taxonomy codes, CIDS classes), and the agency returns it with their data. That "reporting template" concept is the missing bridge between individual agency exports and funder aggregation.</p>
+</div>
+
+<h2>How the data maps to CIDS classes</h2>
+
+<p>Our planned Evaluation Framework editor maps directly to Full Tier classes. When an agency defines their program's components, they're also populating the CIDS export:</p>
+
+<table>
+  <thead>
+    <tr><th>What the agency enters</th><th>CIDS class it becomes</th><th>Source</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>Who we serve</td><td><span class="cids-badge">cids:Stakeholder</span></td><td>Population served codes on program</td></tr>
+    <tr><td>What we do (service)</td><td><span class="cids-badge">cids:Service</span></td><td>Evaluation component</td></tr>
+    <tr><td>Specific activities</td><td><span class="cids-badge">cids:Activity</span></td><td>Evaluation component</td></tr>
+    <tr><td>What we produce</td><td><span class="cids-badge">cids:Output</span></td><td>Metric observation counts</td></tr>
+    <tr><td>What changes for people</td><td><span class="cids-badge">cids:StakeholderOutcome</span></td><td>Aggregate PlanTarget achievement</td></tr>
+    <tr><td>Our theory of change</td><td><span class="cids-badge">cids:ImpactModel</span></td><td>Program description + framework</td></tr>
+    <tr><td>What could go wrong</td><td><span class="cids-badge">cids:ImpactRisk</span></td><td>Evaluation component</td></tr>
+    <tr><td>What would happen without us</td><td><span class="cids-badge">cids:Counterfactual</span></td><td>Evaluation component</td></tr>
+    <tr><td>How we measure</td><td><span class="cids-badge">cids:Indicator</span></td><td>MetricDefinition</td></tr>
+    <tr><td>What the numbers say</td><td><span class="cids-badge">cids:IndicatorReport</span></td><td>Aggregate MetricValue data</td></tr>
+  </tbody>
+</table>
+
+<h2>CIDS class coverage</h2>
+
+<table>
+  <thead>
+    <tr><th>How we get there</th><th>CIDS classes</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>Basic Tier export with SHACL validation</td>
+      <td>7 of 14: Organization, Outcome, Indicator, IndicatorReport, Theme, Code, Address</td>
+    </tr>
+    <tr>
+      <td>Generated from existing program data</td>
+      <td>+4: ImpactModel, Stakeholder, StakeholderOutcome, Output</td>
+    </tr>
+    <tr>
+      <td>Evaluation framework editor</td>
+      <td>+3: Service, Activity, ImpactRisk, Counterfactual</td>
+    </tr>
+    <tr>
+      <td>Full Tier JSON-LD assembly</td>
+      <td>All 14 classes in one document</td>
+    </tr>
+  </tbody>
+</table>
+
+<h2>Our mapping and modelling experience</h2>
+
+<p>You asked for detail on our experience mapping the CIDS classes and properties. Here's what we found:</p>
+
+<ul>
+  <li><strong>Organization, Outcome, Indicator, IndicatorReport</strong> — mapped directly to our existing data (agency profile, outcome targets, metric definitions, aggregated observations)</li>
+  <li><strong>Theme and Code</strong> — we can import the ICNPO, SDG, IRIS+, and PopulationServed code lists and link metrics and programs to specific codes</li>
+  <li><strong>Stakeholder</strong> — maps to population served codes on our programs, which already describe the groups served (e.g., "youth aged 16-24")</li>
+  <li><strong>ImpactModel, Service, Activity, ImpactRisk, Counterfactual</strong> — these don't exist as standalone entities in a case management system, so we built an evaluation framework editor where agencies define structured components that map to these classes. An agency creating their evaluation framework is simultaneously populating their CIDS export.</li>
+  <li><strong>StakeholderOutcome</strong> — derived from group-level outcome statistics (success rates, means, distributions, percentiles) rather than individual records</li>
+  <li><strong>IndicatorReport values</strong> — we store individual observations in a flexible format (to handle scales, achievement status, and open text), so we compute aggregates per metric type: success rates for achievement metrics, means for scale metrics</li>
+</ul>
+
+<h2>Next steps</h2>
+
+<ul>
+  <li>Test the full pipeline with real program data, including data quality signals</li>
+  <li>Validate our JSON-LD output against your improved validation tool when it's available</li>
+  <li>Explore funder-side aggregation of data quality signals across a funding stream (e.g., average response rate, % of programs using validated instruments)</li>
+</ul>
+
+<details>
+  <summary>Technical detail: sample CIDS JSON-LD export (click to expand)</summary>
+  <div>
+    <p style="font-size: 0.85rem; color: var(--text-muted); margin-bottom: 0.75rem;">This is what the machine-readable export looks like — a JSON-LD document containing all 14 CIDS classes. The funder dashboard above is rendered from this data.</p>
+    <pre>{
+  "@context": "https://ontology.commonapproach.org/contexts/cidsContext.jsonld",
+  "@graph": [
+    {
+      "@type": "cids:Organization",
+      "hasLegalName": "Bright Futures Community Services",
+      "hasOutcome": [{"@id": "urn:konote:program-outcome:5"}],
+      "hasIndicator": [...]
+    },
+    {
+      "@type": "cids:IndicatorReport",
+      "hasName": "Employment Status report",
+      "value": {
+        "@type": "i72:Measure",
+        "hasNumericalValue": "18",
+        "hasUnit": {"@value": "of 23 participants"}
+      },
+      "hasComment": "18 of 23 participants achieved employment (78%)",
+      "dqv:hasQualityMeasurement": [
+        {
+          "@type": "dqv:QualityMeasurement",
+          "dqv:isMeasurementOf": "completeness",
+          "dqv:value": 82.6,
+          "konote:numerator": 19,
+          "konote:denominator": 23,
+          "konote:dimensionLabel": "Response rate"
+        },
+        {
+          "@type": "dqv:QualityMeasurement",
+          "dqv:isMeasurementOf": "precision",
+          "dqv:value": 342,
+          "konote:dimensionLabel": "Total observations"
+        }
+      ],
+      "dqv:hasQualityAnnotation": [
+        {
+          "@type": "dqv:QualityAnnotation",
+          "oa:hasBody": {
+            "rdf:value": "Collected using validated instrument: Rosenberg Self-Esteem Scale"
+          },
+          "konote:annotationType": "instrument_validation"
+        }
+      ]
+    },
+    {
+      "@type": "cids:ImpactModel",
+      "hasName": "Impact Model: Youth Employment Services",
+      "hasDescription": "Youth aged 16-24 participate in a 12-week program...",
+      "hasStakeholder": [...],
+      "hasService": [...],
+      "hasActivity": [...],
+      "hasImpactRisk": [...],
+      "hasCounterfactual": [...]
+    },
+    {
+      "@type": "cids:Stakeholder",
+      "hasName": "Youth aged 16-24, unemployed",
+      "hasDescription": "Stakeholder group, not individuals"
+    },
+    {
+      "@type": "cids:ImpactRisk",
+      "hasName": "Economic downturn reduces available positions",
+      "hasLikelihood": "medium",
+      "hasSeverity": "high",
+      "hasMitigation": "Diversify employer partnerships across sectors..."
+    },
+    {
+      "@type": "cids:Counterfactual",
+      "hasName": "Baseline: Employment Ontario services only",
+      "hasDescription": "23% placement without structured support vs. 78%..."
+    }
+  ],
+  "cids:complianceTier": "Full",
+  "cids:evaluatorAttestation": {
+    "attestedBy": "Jennifer Martinez",
+    "attestedAt": "2026-03-05T14:30:00-05:00",
+    "attestationNote": "I have reviewed the evaluation framework..."
+  }
+}</pre>
+    <p style="font-size: 0.8rem; color: var(--text-muted); margin-top: 0.5rem;">Abbreviated for readability. The full demo export contains 30 nodes across all 14 CIDS classes.</p>
+  </div>
+</details>
+
+<div class="footer">
+  <p>Prepared by Logical Outcomes / KoNote &middot; March 2026</p>
+  <p>This is a working document shared with Common Approach colleagues. Not for public distribution.</p>
+</div>
+
+</body>
+</html>

--- a/tasks/wireframes/common-approach-working-document.html
+++ b/tasks/wireframes/common-approach-working-document.html
@@ -254,7 +254,7 @@
   <li>Basic Tier JSON-LD export with SHACL validation</li>
   <li>Full Tier JSON-LD export — assembles all 14 CIDS classes into one document</li>
   <li>IndicatorReport computes outcome statistics per metric type: success rates, means, medians, distributions, pre/post change, effect sizes</li>
-  <li>Data quality signals on IndicatorReport using W3C DQV — response rates, instrument validation status, plausibility review, observation volume</li>
+  <li>Data quality signals on IndicatorReport using W3C DQV — reporting rates, observation density, plus structured descriptors for evidence type, measure basis, and derivation method (describe, don't rank)</li>
   <li>Evaluation framework editor — agencies define their program's services, activities, outputs, risks, and counterfactuals, which map directly to Full Tier classes</li>
   <li>Enrichment — derives themes and standards alignment from program data</li>
   <li>Evaluator attestation — optional step where an evaluator reviews the framework before export</li>
@@ -384,7 +384,11 @@
 
 <p>This is a gap most agencies aren't addressing — and it's arguably the most important question for funders: <strong>how much should I trust these outcomes?</strong></p>
 
-<p>CIDS addresses this through the <a href="https://www.w3.org/TR/vocab-dqv/">W3C Data Quality Vocabulary (DQV)</a>, which provides properties on <code>IndicatorReport</code> for signalling the quality of the data behind the numbers. KoNote uses these to emit five concrete data quality signals alongside every outcome report:</p>
+<p>CIDS addresses this through the <a href="https://www.w3.org/TR/vocab-dqv/">W3C Data Quality Vocabulary (DQV)</a>, which provides properties on <code>IndicatorReport</code> for signalling the quality of the data behind the numbers.</p>
+
+<p>Our approach follows a principle from evaluation methodology: <strong>describe, don't rank.</strong> A published instrument isn't inherently better than a custom measure designed with the community it serves. A staff-observed rating isn't inherently more reliable than a self-report. What matters is that funders have enough context to make their own judgment for their specific use case. KoNote emits two types of DQV signals:</p>
+
+<h3>Quantitative measurements (computed automatically)</h3>
 
 <table>
   <thead>
@@ -392,7 +396,7 @@
   </thead>
   <tbody>
     <tr>
-      <td><strong>Response rate</strong></td>
+      <td><strong>Reporting rate</strong></td>
       <td>What proportion of eligible participants actually have data?</td>
       <td>19 of 23 eligible participants reported (83%)</td>
     </tr>
@@ -402,19 +406,36 @@
       <td>98% of values parsed successfully</td>
     </tr>
     <tr>
-      <td><strong>Observation volume</strong></td>
-      <td>How much data underpins these statistics?</td>
-      <td>342 observations across 23 participants</td>
+      <td><strong>Observation density</strong></td>
+      <td>How many data points per participant underpin the statistics?</td>
+      <td>14.9 observations per participant</td>
+    </tr>
+  </tbody>
+</table>
+
+<h3>Structured descriptors (declared by agency)</h3>
+
+<p>These describe <em>how</em> data is generated — they're set once per metric and don't imply a quality ranking:</p>
+
+<table>
+  <thead>
+    <tr><th>Descriptor</th><th>What it describes</th><th>Options</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><strong>Evidence type</strong></td>
+      <td>How is the data generated?</td>
+      <td>Self-report &middot; Staff-observed &middot; Administrative record &middot; Third-party assessed &middot; Coded qualitative</td>
     </tr>
     <tr>
-      <td><strong>Instrument validation</strong></td>
-      <td>Was a published, validated measurement tool used?</td>
-      <td>Rosenberg Self-Esteem Scale (validated)</td>
+      <td><strong>Measure basis</strong></td>
+      <td>How was the measure developed?</td>
+      <td>Published validated &middot; Published adapted &middot; Custom participatory &middot; Custom staff-designed &middot; Administrative</td>
     </tr>
     <tr>
-      <td><strong>Plausibility review</strong></td>
-      <td>Were outlier values reviewed by staff?</td>
-      <td>3 flagged values confirmed by clinician</td>
+      <td><strong>Derivation method</strong></td>
+      <td>How was the value produced?</td>
+      <td>Direct response &middot; Coded from qualitative &middot; Calculated composite &middot; Staff rating</td>
     </tr>
   </tbody>
 </table>
@@ -422,7 +443,7 @@
 <p>These signals use standard DQV properties (<code>dqv:hasQualityMeasurement</code> and <code>dqv:hasQualityAnnotation</code> on <code>cids:IndicatorReport</code>), so any system consuming CIDS exports can read them without custom parsing.</p>
 
 <div class="callout">
-  <p><strong>Why this matters for aggregation:</strong> When a funder rolls up outcomes across 15 funded programs, knowing that Program A has an 83% response rate using a validated instrument and Program B has a 25% response rate using ad hoc questions fundamentally changes how you interpret and weight the results. Without data quality signals, all CIDS exports look equally credible.</p>
+  <p><strong>Why this matters for aggregation:</strong> When a funder rolls up outcomes across 15 funded programs, knowing that Program A has an 83% reporting rate using a staff-observed measure adapted from a published instrument, and Program B has a 25% reporting rate using a custom self-report scale, fundamentally changes how you interpret and weight the results. The signals don't say which is "better" — they give the funder enough context to decide for themselves.</p>
 </div>
 
 <div class="demo-section">
@@ -432,26 +453,25 @@
     <div class="outcome-grid">
       <div class="outcome-card">
         <div class="value val-green">83%</div>
-        <div class="label">Response rate</div>
+        <div class="label">Reporting rate</div>
         <div class="context">19 of 23 eligible<br>participants reported</div>
       </div>
       <div class="outcome-card">
-        <div class="value val-green">98%</div>
-        <div class="label">Data parsability</div>
-        <div class="context">340 of 342 values<br>parsed successfully</div>
+        <div class="value val-blue">14.9</div>
+        <div class="label">Obs. density</div>
+        <div class="context">observations per<br>participant</div>
       </div>
       <div class="outcome-card">
-        <div class="value val-blue">342</div>
-        <div class="label">Observations</div>
-        <div class="context">Avg 14.9 per<br>participant</div>
+        <div class="value" style="font-size: 0.75rem;">Staff-observed</div>
+        <div class="label">Evidence type</div>
+        <div class="context">Recorded by<br>program worker</div>
       </div>
-      <div class="outcome-card" style="border-color: var(--green);">
-        <div class="value" style="font-size: 0.85rem; color: var(--green);">&#10003; Validated</div>
-        <div class="label">Instrument</div>
-        <div class="context">Rosenberg Self-Esteem<br>Scale</div>
+      <div class="outcome-card">
+        <div class="value" style="font-size: 0.7rem;">Published, adapted</div>
+        <div class="label">Measure basis</div>
+        <div class="context">Rosenberg SE Scale<br>adapted for youth</div>
       </div>
     </div>
-    <p style="font-size: 0.8rem; color: var(--text-muted); margin-top: 0.5rem;">3 outlier values were flagged and confirmed by clinical staff.</p>
   </div>
 </div>
 
@@ -582,32 +602,53 @@
     <h3 style="font-size: 0.9rem; margin-top: 1.25rem;">Data quality across the funding stream</h3>
     <table style="font-size: 0.85rem;">
       <thead>
-        <tr><th>Signal</th><th>Funding stream average</th><th>Range</th></tr>
+        <tr><th>Signal</th><th>Funding stream summary</th><th>Range</th></tr>
       </thead>
       <tbody>
         <tr>
-          <td>Response rate</td>
+          <td>Reporting rate</td>
           <td><strong>76%</strong> of eligible participants</td>
           <td>42%–95%</td>
         </tr>
         <tr>
-          <td>Using validated instruments</td>
-          <td><strong>11 of 15</strong> programs (73%)</td>
-          <td>&mdash;</td>
-        </tr>
-        <tr>
-          <td>Avg observations per participant</td>
-          <td><strong>12.3</strong></td>
+          <td>Observation density</td>
+          <td><strong>12.3</strong> per participant</td>
           <td>3.1–19.8</td>
-        </tr>
-        <tr>
-          <td>Plausibility review done</td>
-          <td><strong>9 of 15</strong> programs (60%)</td>
-          <td>&mdash;</td>
         </tr>
       </tbody>
     </table>
-    <p style="font-size: 0.8rem; color: var(--text-muted);">Data quality signals from <code>dqv:hasQualityMeasurement</code> and <code>dqv:hasQualityAnnotation</code> on each program's IndicatorReport nodes.</p>
+    <table style="font-size: 0.85rem; margin-top: 0.5rem;">
+      <thead>
+        <tr><th>Evidence type</th><th>Programs</th><th>Measure basis</th><th>Programs</th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Self-report</td>
+          <td>7</td>
+          <td>Published, validated</td>
+          <td>5</td>
+        </tr>
+        <tr>
+          <td>Staff-observed</td>
+          <td>5</td>
+          <td>Published, adapted</td>
+          <td>4</td>
+        </tr>
+        <tr>
+          <td>Coded qualitative</td>
+          <td>2</td>
+          <td>Custom, participatory</td>
+          <td>3</td>
+        </tr>
+        <tr>
+          <td>Administrative record</td>
+          <td>1</td>
+          <td>Custom, staff-designed</td>
+          <td>3</td>
+        </tr>
+      </tbody>
+    </table>
+    <p style="font-size: 0.8rem; color: var(--text-muted);">Data quality signals from <code>dqv:hasQualityMeasurement</code> and <code>dqv:hasQualityAnnotation</code> on each program's IndicatorReport nodes. These describe how data is generated — not how "good" it is.</p>
 
   </div>
 </div>
@@ -716,22 +757,29 @@
           "dqv:value": 82.6,
           "konote:numerator": 19,
           "konote:denominator": 23,
-          "konote:dimensionLabel": "Response rate"
+          "konote:dimensionLabel": "Reporting rate (participants reported / eligible)"
         },
         {
           "@type": "dqv:QualityMeasurement",
           "dqv:isMeasurementOf": "precision",
-          "dqv:value": 342,
-          "konote:dimensionLabel": "Total observations"
+          "dqv:value": 14.9,
+          "konote:dimensionLabel": "Observation density (observations per participant)",
+          "konote:totalObservations": 342,
+          "konote:totalParticipants": 23
         }
       ],
       "dqv:hasQualityAnnotation": [
         {
           "@type": "dqv:QualityAnnotation",
-          "oa:hasBody": {
-            "rdf:value": "Collected using validated instrument: Rosenberg Self-Esteem Scale"
-          },
-          "konote:annotationType": "instrument_validation"
+          "oa:hasBody": {"rdf:value": "Staff-observed (recorded by worker)"},
+          "konote:annotationType": "evidence_type",
+          "konote:annotationCategory": "staff_observed"
+        },
+        {
+          "@type": "dqv:QualityAnnotation",
+          "oa:hasBody": {"rdf:value": "Published, adapted for local context: Rosenberg Self-Esteem Scale"},
+          "konote:annotationType": "measure_basis",
+          "konote:annotationCategory": "published_adapted"
         }
       ]
     },

--- a/tests/test_cids.py
+++ b/tests/test_cids.py
@@ -1739,16 +1739,16 @@ class CidsJsonLdExportTest(TestCase):
         measurements = report["dqv:hasQualityMeasurement"]
         self.assertIsInstance(measurements, list)
         self.assertTrue(len(measurements) >= 1)
-        # Should include observation volume
-        volume = next(
+        # Should include observation density
+        density = next(
             (m for m in measurements if m.get("dqv:isMeasurementOf") == "precision"),
             None,
         )
-        self.assertIsNotNone(volume)
-        self.assertEqual(volume["dqv:value"], 1)
+        self.assertIsNotNone(density)
+        self.assertEqual(density["dqv:value"], 1.0)  # 1 observation / 1 participant
 
     def test_response_rate_calculation(self):
-        """Response rate = reported / eligible participants."""
+        """Reporting rate = reported / eligible participants."""
         # Add a second eligible participant who did NOT report
         client2 = ClientFile.objects.create()
         client2.first_name = "Second"
@@ -1764,7 +1764,7 @@ class CidsJsonLdExportTest(TestCase):
         target2.name = "Second target"
         target2.save()
         PlanTargetMetric.objects.create(plan_target=target2, metric_def=self.metric)
-        # Now: 2 eligible, 1 reported → 50% response rate
+        # Now: 2 eligible, 1 reported → 50% reporting rate
 
         doc = self._run_export()
         report = next(
@@ -1783,10 +1783,9 @@ class CidsJsonLdExportTest(TestCase):
         self.assertEqual(completeness["konote:numerator"], 1)
         self.assertEqual(completeness["konote:denominator"], 2)
 
-    def test_instrument_annotation_when_standardized(self):
-        """Validated instrument annotation appears when is_standardized_instrument=True."""
-        self.metric.is_standardized_instrument = True
-        self.metric.instrument_name = "PHQ-9"
+    def test_evidence_type_annotation(self):
+        """Evidence type annotation describes how data is generated."""
+        self.metric.evidence_type = "staff_observed"
         self.metric.save()
 
         doc = self._run_export()
@@ -1796,49 +1795,63 @@ class CidsJsonLdExportTest(TestCase):
         )
         self.assertIn("dqv:hasQualityAnnotation", report)
         annotations = report["dqv:hasQualityAnnotation"]
-        instrument_ann = next(
+        ev_ann = next(
             (a for a in annotations
-             if a.get("konote:annotationType") == "instrument_validation"),
+             if a.get("konote:annotationType") == "evidence_type"),
             None,
         )
-        self.assertIsNotNone(instrument_ann)
-        self.assertIn("PHQ-9", instrument_ann["oa:hasBody"]["rdf:value"])
+        self.assertIsNotNone(ev_ann)
+        self.assertEqual(ev_ann["konote:annotationCategory"], "staff_observed")
 
-    def test_no_instrument_annotation_when_not_standardized(self):
-        """No instrument annotation when is_standardized_instrument=False."""
-        doc = self._run_export()
-        report = next(
-            n for n in doc["@graph"]
-            if n.get("@type") == "cids:IndicatorReport"
-        )
-        annotations = report.get("dqv:hasQualityAnnotation", [])
-        instrument_ann = next(
-            (a for a in annotations
-             if a.get("konote:annotationType") == "instrument_validation"),
-            None,
-        )
-        self.assertIsNone(instrument_ann)
-
-    def test_plausibility_confirmation_annotation(self):
-        """Plausibility annotation appears when values have been confirmed."""
-        mv = MetricValue.objects.first()
-        mv.plausibility_confirmed = True
-        mv.save()
+    def test_measure_basis_with_instrument_name(self):
+        """Published validated measure includes instrument name in body."""
+        self.metric.measure_basis = "published_validated"
+        self.metric.instrument_name = "PHQ-9"
+        self.metric.save()
 
         doc = self._run_export()
         report = next(
             n for n in doc["@graph"]
             if n.get("@type") == "cids:IndicatorReport"
         )
-        self.assertIn("dqv:hasQualityAnnotation", report)
         annotations = report["dqv:hasQualityAnnotation"]
-        plaus_ann = next(
+        basis_ann = next(
             (a for a in annotations
-             if a.get("konote:annotationType") == "plausibility_confirmation"),
+             if a.get("konote:annotationType") == "measure_basis"),
             None,
         )
-        self.assertIsNotNone(plaus_ann)
-        self.assertEqual(plaus_ann["konote:confirmedCount"], 1)
+        self.assertIsNotNone(basis_ann)
+        self.assertEqual(basis_ann["konote:annotationCategory"], "published_validated")
+        self.assertIn("PHQ-9", basis_ann["oa:hasBody"]["rdf:value"])
+
+    def test_derivation_method_annotation(self):
+        """Derivation method annotation appears for coded qualitative."""
+        self.metric.derivation_method = "coded_from_qualitative"
+        self.metric.save()
+
+        doc = self._run_export()
+        report = next(
+            n for n in doc["@graph"]
+            if n.get("@type") == "cids:IndicatorReport"
+        )
+        annotations = report["dqv:hasQualityAnnotation"]
+        deriv_ann = next(
+            (a for a in annotations
+             if a.get("konote:annotationType") == "derivation_method"),
+            None,
+        )
+        self.assertIsNotNone(deriv_ann)
+        self.assertEqual(deriv_ann["konote:annotationCategory"], "coded_from_qualitative")
+
+    def test_no_annotations_when_fields_empty(self):
+        """No quality annotations when DQV descriptor fields are blank."""
+        doc = self._run_export()
+        report = next(
+            n for n in doc["@graph"]
+            if n.get("@type") == "cids:IndicatorReport"
+        )
+        # Default metric has no evidence_type, measure_basis, or derivation_method
+        self.assertNotIn("dqv:hasQualityAnnotation", report)
 
     def test_selected_taxonomy_lens_creates_code_nodes(self):
         CidsCodeList.objects.create(
@@ -1899,6 +1912,9 @@ def _make_metric(**kwargs):
         "target_rate": None,
         "is_standardized_instrument": False,
         "instrument_name": "",
+        "evidence_type": "",
+        "measure_basis": "",
+        "derivation_method": "",
     }
     defaults.update(kwargs)
     m = MagicMock(**defaults)

--- a/tests/test_cids.py
+++ b/tests/test_cids.py
@@ -1719,6 +1719,127 @@ class CidsJsonLdExportTest(TestCase):
         self.assertEqual(theme["hasName"], "Education")
         self.assertEqual(theme["@id"], "urn:iris:theme:education")
 
+    # ── DQV data quality tests ────────────────────────────────────
+
+    def test_dqv_namespace_in_context(self):
+        """Export context includes dqv and oa namespaces."""
+        doc = self._run_export()
+        ctx = doc["@context"][1]
+        self.assertEqual(ctx["dqv"], "http://www.w3.org/ns/dqv#")
+        self.assertEqual(ctx["oa"], "http://www.w3.org/ns/oa#")
+
+    def test_indicator_report_has_dqv_quality_measurements(self):
+        """IndicatorReport nodes include dqv:hasQualityMeasurement."""
+        doc = self._run_export()
+        report = next(
+            n for n in doc["@graph"]
+            if n.get("@type") == "cids:IndicatorReport"
+        )
+        self.assertIn("dqv:hasQualityMeasurement", report)
+        measurements = report["dqv:hasQualityMeasurement"]
+        self.assertIsInstance(measurements, list)
+        self.assertTrue(len(measurements) >= 1)
+        # Should include observation volume
+        volume = next(
+            (m for m in measurements if m.get("dqv:isMeasurementOf") == "precision"),
+            None,
+        )
+        self.assertIsNotNone(volume)
+        self.assertEqual(volume["dqv:value"], 1)
+
+    def test_response_rate_calculation(self):
+        """Response rate = reported / eligible participants."""
+        # Add a second eligible participant who did NOT report
+        client2 = ClientFile.objects.create()
+        client2.first_name = "Second"
+        client2.last_name = "Client"
+        client2.save()
+        section2 = PlanSection.objects.create(
+            client_file=client2, program=self.program,
+        )
+        target2 = PlanTarget(
+            plan_section=section2,
+            client_file=client2,
+        )
+        target2.name = "Second target"
+        target2.save()
+        PlanTargetMetric.objects.create(plan_target=target2, metric_def=self.metric)
+        # Now: 2 eligible, 1 reported → 50% response rate
+
+        doc = self._run_export()
+        report = next(
+            n for n in doc["@graph"]
+            if n.get("@type") == "cids:IndicatorReport"
+        )
+        measurements = report["dqv:hasQualityMeasurement"]
+        completeness = next(
+            (m for m in measurements
+             if m.get("dqv:isMeasurementOf") == "completeness"
+             and "numerator" in str(m)),
+            None,
+        )
+        self.assertIsNotNone(completeness)
+        self.assertEqual(completeness["dqv:value"], 50.0)
+        self.assertEqual(completeness["konote:numerator"], 1)
+        self.assertEqual(completeness["konote:denominator"], 2)
+
+    def test_instrument_annotation_when_standardized(self):
+        """Validated instrument annotation appears when is_standardized_instrument=True."""
+        self.metric.is_standardized_instrument = True
+        self.metric.instrument_name = "PHQ-9"
+        self.metric.save()
+
+        doc = self._run_export()
+        report = next(
+            n for n in doc["@graph"]
+            if n.get("@type") == "cids:IndicatorReport"
+        )
+        self.assertIn("dqv:hasQualityAnnotation", report)
+        annotations = report["dqv:hasQualityAnnotation"]
+        instrument_ann = next(
+            (a for a in annotations
+             if a.get("konote:annotationType") == "instrument_validation"),
+            None,
+        )
+        self.assertIsNotNone(instrument_ann)
+        self.assertIn("PHQ-9", instrument_ann["oa:hasBody"]["rdf:value"])
+
+    def test_no_instrument_annotation_when_not_standardized(self):
+        """No instrument annotation when is_standardized_instrument=False."""
+        doc = self._run_export()
+        report = next(
+            n for n in doc["@graph"]
+            if n.get("@type") == "cids:IndicatorReport"
+        )
+        annotations = report.get("dqv:hasQualityAnnotation", [])
+        instrument_ann = next(
+            (a for a in annotations
+             if a.get("konote:annotationType") == "instrument_validation"),
+            None,
+        )
+        self.assertIsNone(instrument_ann)
+
+    def test_plausibility_confirmation_annotation(self):
+        """Plausibility annotation appears when values have been confirmed."""
+        mv = MetricValue.objects.first()
+        mv.plausibility_confirmed = True
+        mv.save()
+
+        doc = self._run_export()
+        report = next(
+            n for n in doc["@graph"]
+            if n.get("@type") == "cids:IndicatorReport"
+        )
+        self.assertIn("dqv:hasQualityAnnotation", report)
+        annotations = report["dqv:hasQualityAnnotation"]
+        plaus_ann = next(
+            (a for a in annotations
+             if a.get("konote:annotationType") == "plausibility_confirmation"),
+            None,
+        )
+        self.assertIsNotNone(plaus_ann)
+        self.assertEqual(plaus_ann["konote:confirmedCount"], 1)
+
     def test_selected_taxonomy_lens_creates_code_nodes(self):
         CidsCodeList.objects.create(
             list_name="SDGImpacts",
@@ -1776,6 +1897,8 @@ def _make_metric(**kwargs):
         "achievement_options": None,
         "achievement_success_values": None,
         "target_rate": None,
+        "is_standardized_instrument": False,
+        "instrument_name": "",
     }
     defaults.update(kwargs)
     m = MagicMock(**defaults)


### PR DESCRIPTION
## Summary
- Add DQV quality measurements (reporting rate, data parsability, observation density) and structured annotations (evidence type, measure basis, derivation method) to CIDS IndicatorReport nodes
- Add three new MetricDefinition fields for agency-declared quality descriptors following "describe, don't rank" principle
- Add data quality section to Common Approach working document
- Batch eligible participant counts to avoid N+1 queries during export

## Test plan
- [ ] 7 new tests in test_cids.py cover DQV namespace, measurements, annotations, and edge cases
- [ ] Verify JSON-LD export includes DQV properties on IndicatorReport nodes
- [ ] Verify migration applies cleanly on dev instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)