### PR TITLE
fix: hide Collapse button on standalone note page

### DIFF
--- a/templates/notes/_note_detail.html
+++ b/templates/notes/_note_detail.html
@@ -92,10 +92,12 @@
     {% if note.status != "cancelled" %}
     <a href="{% url 'notes:note_cancel' note_id=note.pk %}" class="secondary">{% trans "Cancel this note" %}</a>
     {% endif %}
+    {% if not standalone_page %}
     <a href="#"
        hx-get="{% url 'notes:note_summary' note_id=note.pk %}"
        hx-target="#note-{{ note.pk }}"
        hx-swap="innerHTML focus-scroll:false"
        class="secondary">{% trans "Collapse" %}</a>
+    {% endif %}
 </footer>
 </div>

--- a/templates/notes/note_detail_page.html
+++ b/templates/notes/note_detail_page.html
@@ -7,6 +7,8 @@
 {% include "_breadcrumbs.html" %}
 <h1>{% trans "Progress Note" %}</h1>
 <article>
+    {% with standalone_page=True %}
     {% include "notes/_note_detail.html" %}
+    {% endwith %}
 </article>
 {% endblock %}


### PR DESCRIPTION
## Summary
- When visiting a note directly at `/notes/<id>/`, the **Collapse** button did nothing because HTMX targeted `#note-<id>` which didn't exist on the standalone page
- Collapse only makes sense in the notes list (client profile), where it shrinks the expanded note back to a summary card
- Now hidden on the standalone page via a `standalone_page` template flag

## Test plan
- [ ] Visit a note directly at `/notes/<id>/` — Collapse button should not appear
- [ ] View notes in a client's notes tab — Collapse should still appear and work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)