### PR TITLE
fix: page help terminology placeholders and French translations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,9 @@ konote-credentials-*
 *.swp
 *.code-workspace
 
+# Jules (Google AI agent)
+.Jules/
+
 # Claude Code — track shared skills/commands, ignore personal config
 .claude/*
 !.claude/commands/

--- a/konote/context_processors.py
+++ b/konote/context_processors.py
@@ -511,8 +511,13 @@ def active_program_context(request):
 
 
 def page_help(request):
-    """Inject contextual help content for the current page."""
+    """Inject contextual help content for the current page.
+
+    Passes terminology so help text uses the agency's configured terms
+    (e.g. "client" instead of "participant" if customised).
+    """
     from konote.page_help import get_page_help
 
-    help_content = get_page_help(request)
+    terms = terminology(request).get("term")
+    help_content = get_page_help(request, terms=terms)
     return {"page_help": help_content}

--- a/konote/page_help.py
+++ b/konote/page_help.py
@@ -6,60 +6,67 @@ Each entry has:
 - description: one sentence explaining what this page is for
 - tips: list of practical tips (what you can do here)
 - help_section: anchor on /help/ for more detail (optional)
+
+Terminology placeholders ({client}, {client_plural}, {file}, {plan},
+{progress_note}, etc.) are substituted at request time with the agency's
+configured terms. This keeps help text consistent with the rest of the UI.
 """
+from collections import defaultdict
+
 from django.utils.translation import gettext_lazy as _
 
 
 # Keys are Django URL names (from urls.py).
-# Use tuples for tips so they're immutable and translatable.
+# Use {client}, {client_plural}, {file}, {plan}, {progress_note}, etc.
+# for any term the agency can customise. These are replaced at request time.
 PAGE_HELP = {
     # --- Home / Client list ---
     "client_list": {
         "title": _("Home"),
-        "description": _("Your dashboard showing active participants, alerts, and recent activity."),
+        "description": _("Your dashboard showing active {client_plural}, alerts, and recent activity."),
         "tips": [
-            _("Use the search bar to find a participant by name or record ID."),
-            _("Priority items show participants who need attention — overdue notes or active alerts."),
-            _("Recently viewed gives you quick links to participants you've been working with."),
+            _("Use the search bar to find a {client} by name or record ID."),
+            _("Priority items show {client_plural} who need attention — overdue notes or active alerts."),
+            _("Recently viewed gives you quick links to {client_plural} you've been working with."),
         ],
         "help_section": "getting-started",
     },
     # --- Client detail ---
     "client_detail": {
-        "title": _("Participant File"),
-        "description": _("Everything about this participant in one place — their plan, notes, events, and documents."),
+        "title": _("{client} {file}"),
+        "description": _("Everything about this {client} in one place — their {plan}, notes, events, and documents."),
         "tips": [
-            _("Use the tabs to switch between notes, plans, events, and documents."),
-            _("Click 'Quick note' to add a short progress note without leaving this page."),
+            _("Use the tabs to switch between notes, {plan}s, events, and documents."),
+            _("Click 'Quick note' to add a short {progress_note} without leaving this page."),
             _("The status banner shows their current program enrolment and any active alerts."),
         ],
         "help_section": "files",
     },
     # --- Progress notes ---
     "note_list": {
-        "title": _("Progress Notes"),
-        "description": _("All progress notes for this participant, newest first."),
+        "title": _("{progress_note_plural}"),
+        "description": _("All {progress_note_plural} for this {client}, newest first."),
         "tips": [
             _("Click 'New note' to record a session or interaction."),
-            _("Each note has two parts — your clinical observations and the participant's perspective."),
+            _("Each note has two parts — your clinical observations and the {client}'s perspective."),
             _("Notes are linked to program enrolments, so they stay with the right program."),
         ],
         "help_section": "notes",
     },
     "note_create": {
-        "title": _("New Progress Note"),
-        "description": _("Record a session or interaction with this participant."),
+        "title": _("New {progress_note}"),
+        "description": _("Record a session or interaction with this {client}."),
         "tips": [
-            _("Fill in the practitioner lens (your observations) and the participant lens (their perspective)."),
+            _("Fill in the practitioner lens (your observations) and the {client} lens (their perspective)."),
             _("Rate the working alliance if your agency uses alliance tracking."),
-            _("You can record metric scores at the bottom to update outcome tracking."),
+            _("You can record {metric} scores at the bottom to update outcome tracking."),
             _("Ctrl+S saves the form."),
         ],
         "help_section": "notes",
     },
     "note_detail": {
-        "title": _("Progress Note"),
-        "description": _("Viewing a completed progress note."),
+        "title": _("{progress_note}"),
+        "description": _("Viewing a completed {progress_note}."),
         "tips": [
             _("If AI summaries are enabled, you can generate a summary of this note."),
             _("You can cancel (retract) a note if it was entered in error."),
@@ -67,78 +74,96 @@ PAGE_HELP = {
         "help_section": "notes",
     },
     "quick_note_create": {
-        "title": _("Quick Note"),
+        "title": _("{quick_note}"),
         "description": _("A short note for brief interactions — phone calls, check-ins, or quick updates."),
         "tips": [
-            _("Quick notes are shorter than full progress notes — just a description and optional metrics."),
+            _("{quick_note_plural} are shorter than full {progress_note_plural} — just a description and optional {metric_plural}."),
             _("Ctrl+S saves the form."),
         ],
         "help_section": "notes",
     },
     # --- Plans ---
     "plan_view": {
-        "title": _("Outcome Plan"),
-        "description": _("This participant's goals and the metrics tracking their progress."),
+        "title": _("Outcome {plan}"),
+        "description": _("This {client}'s goals and the {metric_plural} tracking their progress."),
         "tips": [
-            _("Goals are grouped into sections (life areas or themes)."),
-            _("Click a metric to see the progress chart over time."),
+            _("Goals are grouped into {section_plural} (life areas or themes)."),
+            _("Click a {metric} to see the progress chart over time."),
             _("Add new goals using the button at the top — AI suggestions are available if enabled."),
         ],
         "help_section": "plans",
     },
     "goal_create": {
         "title": _("New Goal"),
-        "description": _("Add a new goal to this participant's outcome plan."),
+        "description": _("Add a new goal to this {client}'s outcome {plan}."),
         "tips": [
             _("If AI suggestions are enabled, start typing and suggestions will appear."),
-            _("Each goal gets one or more metrics to track progress over time."),
+            _("Each goal gets one or more {metric_plural} to track progress over time."),
         ],
         "help_section": "plans",
     },
     "target_create": {
-        "title": _("New Metric"),
-        "description": _("Add a metric to track progress on a goal."),
+        "title": _("New {metric}"),
+        "description": _("Add a {metric} to track progress on a goal."),
         "tips": [
-            _("Choose from your agency's metric library, or create a custom one."),
-            _("Metrics are scored during progress notes — you don't need to enter scores separately."),
+            _("Choose from your agency's {metric} library, or create a custom one."),
+            _("{metric_plural} are scored during {progress_note_plural} — you don't need to enter scores separately."),
         ],
         "help_section": "plans",
     },
     # --- Events ---
     "event_list": {
-        "title": _("Events"),
-        "description": _("Significant events and alerts for this participant."),
+        "title": _("{event_plural}"),
+        "description": _("Significant {event_plural} and alerts for this {client}."),
         "tips": [
-            _("Events record things that happened — incidents, milestones, referrals."),
+            _("{event_plural} record things that happened — incidents, milestones, referrals."),
             _("Alerts flag things that need follow-up — they stay visible until resolved."),
+        ],
+        "help_section": "events",
+    },
+    "event_create": {
+        "title": _("New {event}"),
+        "description": _("Record a significant {event} for this {client}."),
+        "tips": [
+            _("Choose a category that best describes what happened."),
+            _("Add details in the description — this becomes part of the {client}'s record."),
         ],
         "help_section": "events",
     },
     "meeting_list": {
         "title": _("Meetings"),
-        "description": _("Upcoming and past meetings across all your participants."),
+        "description": _("Upcoming and past meetings across all your {client_plural}."),
         "tips": [
-            _("Meetings can be linked to participants or stand alone (like team meetings)."),
+            _("Meetings can be linked to {client_plural} or stand alone (like team meetings)."),
             _("Overdue meetings (past date, not completed) appear at the top."),
+        ],
+        "help_section": "events",
+    },
+    "alert_create": {
+        "title": _("New Alert"),
+        "description": _("Create an alert that flags something needing follow-up for this {client}."),
+        "tips": [
+            _("Alerts stay visible on the {client}'s {file} and in priority lists until resolved."),
+            _("Choose a severity level — high-severity alerts appear in the executive dashboard."),
         ],
         "help_section": "events",
     },
     # --- Reports ---
     "client_analysis": {
         "title": _("Progress Analysis"),
-        "description": _("Charts and summaries showing how this participant's metrics have changed over time."),
+        "description": _("Charts and summaries showing how this {client}'s {metric_plural} have changed over time."),
         "tips": [
-            _("Each chart shows one metric — look for trends, not single data points."),
-            _("You can export this as a PDF to share with the participant or their team."),
+            _("Each chart shows one {metric} — look for trends, not single data points."),
+            _("You can export this as a PDF to share with the {client} or their team."),
         ],
         "help_section": "reports",
     },
     "program_insights": {
         "title": _("Outcome Insights"),
-        "description": _("Program-level view of how outcomes are tracking across all participants."),
+        "description": _("Program-level view of how outcomes are tracking across all {client_plural}."),
         "tips": [
             _("Use the program filter to compare outcomes across different programs."),
-            _("Distribution charts show how participants are spread across score ranges."),
+            _("Distribution charts show how {client_plural} are spread across score ranges."),
         ],
         "help_section": "insights",
     },
@@ -153,17 +178,26 @@ PAGE_HELP = {
     },
     "executive_dashboard": {
         "title": _("Executive Dashboard"),
-        "description": _("High-level summary of agency activity — participant counts, note volumes, and alerts."),
+        "description": _("High-level summary of agency activity — {client} counts, note volumes, and alerts."),
         "tips": [
             _("Use the date range and program filters to focus on specific time periods or programs."),
             _("You can export the dashboard data for board reports or funder updates."),
         ],
         "help_section": "reports",
     },
+    "session_report": {
+        "title": _("Sessions Report"),
+        "description": _("See session counts and dates by {client} across your programs."),
+        "tips": [
+            _("Filter by program and date range to focus on a specific period."),
+            _("Use this to check which {client_plural} haven't had recent sessions."),
+        ],
+        "help_section": "reports",
+    },
     # --- Communications ---
     "communication_log": {
         "title": _("Communication Log"),
-        "description": _("Email and communication history for this participant."),
+        "description": _("Email and communication history for this {client}."),
         "tips": [
             _("Use 'Quick log' to record a phone call or in-person conversation."),
             _("Emails sent through KoNote are automatically logged here."),
@@ -175,23 +209,23 @@ PAGE_HELP = {
         "description": _("Staff messages assigned to you or your team."),
         "tips": [
             _("Unread messages show a badge in the navigation bar."),
-            _("You can leave messages for other staff on any participant's file."),
+            _("You can leave messages for other staff on any {client}'s {file}."),
         ],
         "help_section": "files",
     },
     # --- Client management ---
     "client_create": {
-        "title": _("New Participant"),
-        "description": _("Register a new participant in the system."),
+        "title": _("New {client}"),
+        "description": _("Register a new {client} in the system."),
         "tips": [
             _("Required fields are marked with an asterisk (*)."),
-            _("After creating, you'll be taken to their file to set up their plan."),
+            _("After creating, you'll be taken to their {file} to set up their {plan}."),
         ],
         "help_section": "files",
     },
     "client_edit": {
-        "title": _("Edit Participant"),
-        "description": _("Update this participant's personal information."),
+        "title": _("Edit {client}"),
+        "description": _("Update this {client}'s personal information."),
         "tips": [
             _("Changes are logged in the audit trail."),
             _("Ctrl+S saves the form."),
@@ -200,12 +234,31 @@ PAGE_HELP = {
     },
     "client_discharge": {
         "title": _("Discharge"),
-        "description": _("End this participant's active enrolment."),
+        "description": _("End this {client}'s active enrolment."),
         "tips": [
             _("You can add a discharge reason and closing notes."),
-            _("Discharged participants can be re-enrolled later if needed."),
+            _("Discharged {client_plural} can be re-enrolled later if needed."),
         ],
         "help_section": "files",
+    },
+    "client_transfer": {
+        "title": _("Transfer"),
+        "description": _("Move this {client} to a different program."),
+        "tips": [
+            _("Select the destination program — the {client}'s {file} and history stay intact."),
+            _("The {client}'s {worker} assignment will be updated to match the new program."),
+        ],
+        "help_section": "files",
+    },
+    # --- Groups ---
+    "group_list": {
+        "title": _("{group_plural}"),
+        "description": _("All active {group_plural} in your programs."),
+        "tips": [
+            _("Click a {group} to see its {member_plural}, {session_plural}, and attendance."),
+            _("Use the program filter to see {group_plural} for a specific program."),
+        ],
+        "help_section": "groups-circles",
     },
     # --- Admin pages ---
     "settings_view": {
@@ -221,8 +274,17 @@ PAGE_HELP = {
         "title": _("User Management"),
         "description": _("Manage staff accounts, roles, and program assignments."),
         "tips": [
-            _("Each user needs at least one program role to access participant files."),
+            _("Each user needs at least one program role to access {client} {file_plural}."),
             _("Admins can see all programs; other roles only see their assigned programs."),
+        ],
+        "help_section": "admin",
+    },
+    "audit_log_list": {
+        "title": _("Audit Log"),
+        "description": _("Record of all significant actions taken in the system."),
+        "tips": [
+            _("Use the filters to narrow by user, action type, or date range."),
+            _("Audit logs are stored in a separate database and cannot be edited."),
         ],
         "help_section": "admin",
     },
@@ -238,12 +300,69 @@ PAGE_HELP = {
     },
 }
 
+# Default fallback tips shown on pages without specific help content.
+DEFAULT_TIPS = [
+    _("Use the search bar at the top to find a {client} by name or ID."),
+    _("Press the Help link in the footer to open the full Help Guide."),
+    _("Use your browser's back button or the navigation menu to return to the home page."),
+]
 
-def get_page_help(request):
-    """Return help content for the current page, or None."""
+
+def get_page_help(request, terms=None):
+    """Return help content for the current page, with terminology substituted.
+
+    Args:
+        request: The current HttpRequest.
+        terms: A dict-like object with terminology keys (client, plan, etc.).
+               If None, no substitution is performed.
+
+    Returns:
+        A dict with title, description, tips, help_section — or a default
+        fallback dict if no page-specific help exists.
+    """
     match = getattr(request, "resolver_match", None)
-    if not match:
-        return None
+    url_name = match.url_name if match else ""
 
-    url_name = match.url_name or ""
-    return PAGE_HELP.get(url_name)
+    entry = PAGE_HELP.get(url_name)
+
+    # Build substitution dict from terminology, with safe fallback
+    subs = defaultdict(lambda: "???")
+    if terms:
+        # terms is a dict-like (AttrDict from terminology context processor)
+        for key in (
+            "client", "client_plural", "file", "file_plural",
+            "plan", "plan_plural", "worker", "worker_plural",
+            "section", "section_plural", "target", "target_plural",
+            "metric", "metric_plural",
+            "progress_note", "progress_note_plural",
+            "quick_note", "quick_note_plural",
+            "event", "event_plural",
+            "group", "group_plural", "member", "member_plural",
+            "session", "session_plural",
+            "circle", "circle_plural",
+            "resource", "resource_plural",
+        ):
+            val = terms.get(key) if hasattr(terms, "get") else getattr(terms, key, None)
+            if val:
+                subs[key] = str(val)
+
+    def sub(text):
+        """Apply terminology substitution to a translated string."""
+        return str(text).format_map(subs)
+
+    if entry:
+        return {
+            "title": sub(entry["title"]),
+            "description": sub(entry["description"]),
+            "tips": [sub(t) for t in entry["tips"]],
+            "help_section": entry.get("help_section", ""),
+        }
+
+    # Default fallback for pages without specific help
+    return {
+        "title": "",
+        "description": "",
+        "tips": [sub(t) for t in DEFAULT_TIPS],
+        "help_section": "",
+        "is_default": True,
+    }

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -21372,3 +21372,499 @@ msgstr "Ce rapport a été généré à l'aide du modèle de rapport de résulta
 #, python-format
 msgid "Bar chart showing %(label)s across demographic groups"
 msgstr "Diagramme à barres montrant %(label)s par groupes démographiques"
+
+#. Page help — contextual tips (from konote/page_help.py and base.html)
+#. Terminology placeholders like {client} are replaced at runtime.
+
+#. from base.html
+msgid "Page help"
+msgstr "Aide de la page"
+
+#. from base.html
+msgid "Here are a few things you can do from anywhere in KoNote:"
+msgstr "Voici quelques actions possibles depuis n’importe quelle page de KoNote :"
+
+#. from base.html
+msgid "Read more in the Help Guide"
+msgstr "En savoir plus dans le guide d’aide"
+
+#. from base.html
+msgid "Open Help Guide"
+msgstr "Ouvrir le guide d’aide"
+
+#. page_help.py
+msgid "Your dashboard showing active {client_plural}, alerts, and recent activity."
+msgstr "Votre tableau de bord affichant les {client_plural} actifs, les alertes et l’activité récente."
+
+#. page_help.py
+msgid "Use the search bar to find a {client} by name or record ID."
+msgstr "Utilisez la barre de recherche pour trouver un(e) {client} par nom ou numéro de dossier."
+
+#. page_help.py
+msgid "Priority items show {client_plural} who need attention — overdue notes or active alerts."
+msgstr "Les éléments prioritaires montrent les {client_plural} qui nécessitent une attention — notes en retard ou alertes actives."
+
+#. page_help.py
+msgid "Recently viewed gives you quick links to {client_plural} you've been working with."
+msgstr "Consultés récemment vous donne un accès rapide aux {client_plural} avec lesquels vous avez travaillé."
+
+#. page_help.py
+msgid "{client} {file}"
+msgstr "{client} — {file}"
+
+#. page_help.py
+msgid "Everything about this {client} in one place — their {plan}, notes, events, and documents."
+msgstr "Tout sur ce(tte) {client} au même endroit — {plan}, notes, événements et documents."
+
+#. page_help.py
+msgid "Use the tabs to switch between notes, {plan}s, events, and documents."
+msgstr "Utilisez les onglets pour naviguer entre les notes, les {plan}s, les événements et les documents."
+
+#. page_help.py
+msgid "Click 'Quick note' to add a short {progress_note} without leaving this page."
+msgstr "Cliquez sur « Note rapide » pour ajouter une courte {progress_note} sans quitter cette page."
+
+#. page_help.py
+msgid "The status banner shows their current program enrolment and any active alerts."
+msgstr "La bannière d’état affiche leur inscription au programme actuel et les alertes actives."
+
+#. page_help.py
+msgid "{progress_note_plural}"
+msgstr "{progress_note_plural}"
+
+#. page_help.py
+msgid "All {progress_note_plural} for this {client}, newest first."
+msgstr "Toutes les {progress_note_plural} pour ce(tte) {client}, les plus récentes en premier."
+
+#. page_help.py
+msgid "Click 'New note' to record a session or interaction."
+msgstr "Cliquez sur « Nouvelle note » pour enregistrer une séance ou une interaction."
+
+#. page_help.py
+msgid "Each note has two parts — your clinical observations and the {client}'s perspective."
+msgstr "Chaque note a deux volets — vos observations cliniques et la perspective du/de la {client}."
+
+#. page_help.py
+msgid "Notes are linked to program enrolments, so they stay with the right program."
+msgstr "Les notes sont liées aux inscriptions de programme et restent dans le bon programme."
+
+#. page_help.py
+msgid "New {progress_note}"
+msgstr "Nouvelle {progress_note}"
+
+#. page_help.py
+msgid "Record a session or interaction with this {client}."
+msgstr "Enregistrer une séance ou une interaction avec ce(tte) {client}."
+
+#. page_help.py
+msgid "Fill in the practitioner lens (your observations) and the {client} lens (their perspective)."
+msgstr "Remplissez le volet intervenant (vos observations) et le volet {client} (leur perspective)."
+
+#. page_help.py
+msgid "Rate the working alliance if your agency uses alliance tracking."
+msgstr "Évaluez l’alliance de travail si votre organisme utilise le suivi d’alliance."
+
+#. page_help.py
+msgid "You can record {metric} scores at the bottom to update outcome tracking."
+msgstr "Vous pouvez enregistrer les scores d’{metric} au bas pour mettre à jour le suivi des résultats."
+
+#. page_help.py
+msgid "Ctrl+S saves the form."
+msgstr "Ctrl+S enregistre le formulaire."
+
+#. page_help.py
+msgid "{progress_note}"
+msgstr "{progress_note}"
+
+#. page_help.py
+msgid "Viewing a completed {progress_note}."
+msgstr "Consultation d’une {progress_note} complétée."
+
+#. page_help.py
+msgid "If AI summaries are enabled, you can generate a summary of this note."
+msgstr "Si les résumés IA sont activés, vous pouvez générer un résumé de cette note."
+
+#. page_help.py
+msgid "You can cancel (retract) a note if it was entered in error."
+msgstr "Vous pouvez annuler (rétracter) une note si elle a été entrée par erreur."
+
+#. page_help.py
+msgid "{quick_note}"
+msgstr "{quick_note}"
+
+#. page_help.py
+msgid "A short note for brief interactions — phone calls, check-ins, or quick updates."
+msgstr "Une note courte pour les interactions brèves — appels, suivis rapides ou mises à jour."
+
+#. page_help.py
+msgid "{quick_note_plural} are shorter than full {progress_note_plural} — just a description and optional {metric_plural}."
+msgstr "Les {quick_note_plural} sont plus courtes que les {progress_note_plural} complètes — juste une description et des {metric_plural} optionnels."
+
+#. page_help.py
+msgid "Outcome {plan}"
+msgstr "{plan} de résultats"
+
+#. page_help.py
+msgid "This {client}'s goals and the {metric_plural} tracking their progress."
+msgstr "Les objectifs de ce(tte) {client} et les {metric_plural} qui suivent leur progrès."
+
+#. page_help.py
+msgid "Goals are grouped into {section_plural} (life areas or themes)."
+msgstr "Les objectifs sont regroupés en {section_plural} (domaines de vie ou thèmes)."
+
+#. page_help.py
+msgid "Click a {metric} to see the progress chart over time."
+msgstr "Cliquez sur un(e) {metric} pour voir le graphique de progrès au fil du temps."
+
+#. page_help.py
+msgid "Add new goals using the button at the top — AI suggestions are available if enabled."
+msgstr "Ajoutez de nouveaux objectifs avec le bouton en haut — des suggestions IA sont disponibles si activées."
+
+#. page_help.py
+msgid "New Goal"
+msgstr "Nouvel objectif"
+
+#. page_help.py
+msgid "Add a new goal to this {client}'s outcome {plan}."
+msgstr "Ajouter un nouvel objectif au {plan} de résultats de ce(tte) {client}."
+
+#. page_help.py
+msgid "If AI suggestions are enabled, start typing and suggestions will appear."
+msgstr "Si les suggestions IA sont activées, commencez à taper et des suggestions apparaîtront."
+
+#. page_help.py
+msgid "Each goal gets one or more {metric_plural} to track progress over time."
+msgstr "Chaque objectif reçoit un ou plusieurs {metric_plural} pour suivre le progrès au fil du temps."
+
+#. page_help.py
+msgid "New {metric}"
+msgstr "Nouvel(le) {metric}"
+
+#. page_help.py
+msgid "Add a {metric} to track progress on a goal."
+msgstr "Ajouter un(e) {metric} pour suivre le progrès d’un objectif."
+
+#. page_help.py
+msgid "Choose from your agency's {metric} library, or create a custom one."
+msgstr "Choisissez dans la bibliothèque d’{metric} de votre organisme, ou créez-en un(e) personnalisé(e)."
+
+#. page_help.py
+msgid "{metric_plural} are scored during {progress_note_plural} — you don't need to enter scores separately."
+msgstr "Les {metric_plural} sont évalués pendant les {progress_note_plural} — pas besoin d’entrer les scores séparément."
+
+#. page_help.py
+msgid "{event_plural}"
+msgstr "{event_plural}"
+
+#. page_help.py
+msgid "Significant {event_plural} and alerts for this {client}."
+msgstr "{event_plural} significatifs et alertes pour ce(tte) {client}."
+
+#. page_help.py
+msgid "{event_plural} record things that happened — incidents, milestones, referrals."
+msgstr "Les {event_plural} consignent ce qui s’est passé — incidents, jalons, références."
+
+#. page_help.py
+msgid "Alerts flag things that need follow-up — they stay visible until resolved."
+msgstr "Les alertes signalent ce qui nécessite un suivi — elles restent visibles jusqu’à leur résolution."
+
+#. page_help.py
+msgid "New {event}"
+msgstr "Nouvel {event}"
+
+#. page_help.py
+msgid "Record a significant {event} for this {client}."
+msgstr "Enregistrer un {event} significatif pour ce(tte) {client}."
+
+#. page_help.py
+msgid "Choose a category that best describes what happened."
+msgstr "Choisissez une catégorie qui décrit le mieux ce qui s’est passé."
+
+#. page_help.py
+msgid "Add details in the description — this becomes part of the {client}'s record."
+msgstr "Ajoutez des détails dans la description — ceci fait partie du dossier du/de la {client}."
+
+#. page_help.py
+msgid "Upcoming and past meetings across all your {client_plural}."
+msgstr "Rencontres à venir et passées pour tous vos {client_plural}."
+
+#. page_help.py
+msgid "Meetings can be linked to {client_plural} or stand alone (like team meetings)."
+msgstr "Les rencontres peuvent être liées à des {client_plural} ou être indépendantes (comme les réunions d’équipe)."
+
+#. page_help.py
+msgid "Overdue meetings (past date, not completed) appear at the top."
+msgstr "Les rencontres en retard (date passée, non complétées) apparaissent en haut."
+
+#. page_help.py
+msgid "New Alert"
+msgstr "Nouvelle alerte"
+
+#. page_help.py
+msgid "Create an alert that flags something needing follow-up for this {client}."
+msgstr "Créer une alerte signalant quelque chose qui nécessite un suivi pour ce(tte) {client}."
+
+#. page_help.py
+msgid "Alerts stay visible on the {client}'s {file} and in priority lists until resolved."
+msgstr "Les alertes restent visibles dans le {file} du/de la {client} et dans les listes prioritaires jusqu’à leur résolution."
+
+#. page_help.py
+msgid "Choose a severity level — high-severity alerts appear in the executive dashboard."
+msgstr "Choisissez un niveau de gravité — les alertes de haute gravité apparaissent dans le tableau de bord exécutif."
+
+#. page_help.py
+msgid "Progress Analysis"
+msgstr "Analyse des progrès"
+
+#. page_help.py
+msgid "Charts and summaries showing how this {client}'s {metric_plural} have changed over time."
+msgstr "Graphiques et résumés montrant comment les {metric_plural} de ce(tte) {client} ont évolué au fil du temps."
+
+#. page_help.py
+msgid "Each chart shows one {metric} — look for trends, not single data points."
+msgstr "Chaque graphique montre un(e) {metric} — cherchez les tendances, pas les points isolés."
+
+#. page_help.py
+msgid "You can export this as a PDF to share with the {client} or their team."
+msgstr "Vous pouvez l’exporter en PDF pour le partager avec le/la {client} ou son équipe."
+
+#. page_help.py
+msgid "Outcome Insights"
+msgstr "Aperçu des résultats"
+
+#. page_help.py
+msgid "Program-level view of how outcomes are tracking across all {client_plural}."
+msgstr "Vue au niveau du programme montrant comment les résultats évoluent pour tous les {client_plural}."
+
+#. page_help.py
+msgid "Use the program filter to compare outcomes across different programs."
+msgstr "Utilisez le filtre de programme pour comparer les résultats entre différents programmes."
+
+#. page_help.py
+msgid "Distribution charts show how {client_plural} are spread across score ranges."
+msgstr "Les graphiques de distribution montrent comment les {client_plural} sont répartis dans les plages de scores."
+
+#. page_help.py
+msgid "Generate Report"
+msgstr "Générer un rapport"
+
+#. page_help.py
+msgid "Create a formatted report using one of your agency's report templates."
+msgstr "Créez un rapport formaté en utilisant l’un des modèles de rapport de votre organisme."
+
+#. page_help.py
+msgid "Choose a template, select the date range and programs, then preview before exporting."
+msgstr "Choisissez un modèle, sélectionnez la période et les programmes, puis prévisualisez avant d’exporter."
+
+#. page_help.py
+msgid "Reports can be exported as Word documents or PDFs."
+msgstr "Les rapports peuvent être exportés en documents Word ou PDF."
+
+#. page_help.py
+msgid "Executive Dashboard"
+msgstr "Tableau de bord exécutif"
+
+#. page_help.py
+msgid "High-level summary of agency activity — {client} counts, note volumes, and alerts."
+msgstr "Résumé de haut niveau de l’activité de l’organisme — nombre de {client}, volume de notes et alertes."
+
+#. page_help.py
+msgid "Use the date range and program filters to focus on specific time periods or programs."
+msgstr "Utilisez les filtres de période et de programme pour cibler des périodes ou programmes spécifiques."
+
+#. page_help.py
+msgid "You can export the dashboard data for board reports or funder updates."
+msgstr "Vous pouvez exporter les données du tableau de bord pour les rapports au conseil ou les mises à jour aux bailleurs de fonds."
+
+#. page_help.py
+msgid "Sessions Report"
+msgstr "Rapport des séances"
+
+#. page_help.py
+msgid "See session counts and dates by {client} across your programs."
+msgstr "Consultez le nombre de séances et les dates par {client} dans vos programmes."
+
+#. page_help.py
+msgid "Filter by program and date range to focus on a specific period."
+msgstr "Filtrez par programme et période pour cibler une période spécifique."
+
+#. page_help.py
+msgid "Use this to check which {client_plural} haven't had recent sessions."
+msgstr "Utilisez ceci pour vérifier quels {client_plural} n’ont pas eu de séances récentes."
+
+#. page_help.py
+msgid "Communication Log"
+msgstr "Journal des communications"
+
+#. page_help.py
+msgid "Email and communication history for this {client}."
+msgstr "Historique des courriels et communications pour ce(tte) {client}."
+
+#. page_help.py
+msgid "Use 'Quick log' to record a phone call or in-person conversation."
+msgstr "Utilisez « Entrée rapide » pour enregistrer un appel téléphonique ou une conversation en personne."
+
+#. page_help.py
+msgid "Emails sent through KoNote are automatically logged here."
+msgstr "Les courriels envoyés par KoNote sont automatiquement consignés ici."
+
+#. page_help.py
+msgid "Staff messages assigned to you or your team."
+msgstr "Messages du personnel qui vous sont assignés ou assignés à votre équipe."
+
+#. page_help.py
+msgid "Unread messages show a badge in the navigation bar."
+msgstr "Les messages non lus affichent un badge dans la barre de navigation."
+
+#. page_help.py
+msgid "You can leave messages for other staff on any {client}'s {file}."
+msgstr "Vous pouvez laisser des messages pour d’autres membres du personnel dans le {file} de n’importe quel(le) {client}."
+
+#. page_help.py
+msgid "New {client}"
+msgstr "Nouveau/Nouvelle {client}"
+
+#. page_help.py
+msgid "Register a new {client} in the system."
+msgstr "Inscrire un(e) nouveau/nouvelle {client} dans le système."
+
+#. page_help.py
+msgid "Required fields are marked with an asterisk (*)."
+msgstr "Les champs obligatoires sont marqués d’un astérisque (*)."
+
+#. page_help.py
+msgid "After creating, you'll be taken to their {file} to set up their {plan}."
+msgstr "Après la création, vous serez dirigé(e) vers leur {file} pour configurer leur {plan}."
+
+#. page_help.py
+msgid "Edit {client}"
+msgstr "Modifier {client}"
+
+#. page_help.py
+msgid "Update this {client}'s personal information."
+msgstr "Mettre à jour les renseignements personnels de ce(tte) {client}."
+
+#. page_help.py
+msgid "Changes are logged in the audit trail."
+msgstr "Les modifications sont consignées dans le journal de vérification."
+
+#. page_help.py
+msgid "Discharge"
+msgstr "Congé"
+
+#. page_help.py
+msgid "End this {client}'s active enrolment."
+msgstr "Mettre fin à l’inscription active de ce(tte) {client}."
+
+#. page_help.py
+msgid "You can add a discharge reason and closing notes."
+msgstr "Vous pouvez ajouter une raison de congé et des notes de clôture."
+
+#. page_help.py
+msgid "Discharged {client_plural} can be re-enrolled later if needed."
+msgstr "Les {client_plural} ayant reçu leur congé peuvent être réinscrits ultérieurement si nécessaire."
+
+#. page_help.py
+msgid "Transfer"
+msgstr "Transfert"
+
+#. page_help.py
+msgid "Move this {client} to a different program."
+msgstr "Transférer ce(tte) {client} vers un programme différent."
+
+#. page_help.py
+msgid "Select the destination program — the {client}'s {file} and history stay intact."
+msgstr "Sélectionnez le programme de destination — le {file} et l’historique du/de la {client} restent intacts."
+
+#. page_help.py
+msgid "The {client}'s {worker} assignment will be updated to match the new program."
+msgstr "L’affectation du/de la {worker} du/de la {client} sera mise à jour selon le nouveau programme."
+
+#. page_help.py
+msgid "{group_plural}"
+msgstr "{group_plural}"
+
+#. page_help.py
+msgid "All active {group_plural} in your programs."
+msgstr "Tous les {group_plural} actifs dans vos programmes."
+
+#. page_help.py
+msgid "Click a {group} to see its {member_plural}, {session_plural}, and attendance."
+msgstr "Cliquez sur un {group} pour voir ses {member_plural}, {session_plural} et la présence."
+
+#. page_help.py
+msgid "Use the program filter to see {group_plural} for a specific program."
+msgstr "Utilisez le filtre de programme pour voir les {group_plural} d’un programme spécifique."
+
+#. page_help.py
+msgid "Agency-wide settings — terminology, features, branding, and system configuration."
+msgstr "Paramètres à l’échelle de l’organisme — terminologie, fonctionnalités, image de marque et configuration du système."
+
+#. page_help.py
+msgid "Changes to terminology update labels across the entire system."
+msgstr "Les changements de terminologie mettent à jour les libellés dans tout le système."
+
+#. page_help.py
+msgid "Feature toggles let you enable or disable optional features like AI suggestions."
+msgstr "Les bascules de fonctionnalités vous permettent d’activer ou de désactiver des fonctions optionnelles comme les suggestions IA."
+
+#. page_help.py
+msgid "User Management"
+msgstr "Gestion des utilisateurs"
+
+#. page_help.py
+msgid "Manage staff accounts, roles, and program assignments."
+msgstr "Gérer les comptes du personnel, les rôles et les affectations de programme."
+
+#. page_help.py
+msgid "Each user needs at least one program role to access {client} {file_plural}."
+msgstr "Chaque utilisateur a besoin d’au moins un rôle de programme pour accéder aux {file_plural} des {client}."
+
+#. page_help.py
+msgid "Admins can see all programs; other roles only see their assigned programs."
+msgstr "Les administrateurs peuvent voir tous les programmes; les autres rôles ne voient que leurs programmes assignés."
+
+#. page_help.py
+msgid "Audit Log"
+msgstr "Journal de vérification"
+
+#. page_help.py
+msgid "Record of all significant actions taken in the system."
+msgstr "Registre de toutes les actions significatives effectuées dans le système."
+
+#. page_help.py
+msgid "Use the filters to narrow by user, action type, or date range."
+msgstr "Utilisez les filtres pour affiner par utilisateur, type d’action ou période."
+
+#. page_help.py
+msgid "Audit logs are stored in a separate database and cannot be edited."
+msgstr "Les journaux de vérification sont stockés dans une base de données séparée et ne peuvent pas être modifiés."
+
+#. page_help.py
+msgid "CIDS Dashboard"
+msgstr "Tableau de bord CIDS"
+
+#. page_help.py
+msgid "Common Impact Data Standard compliance — see how your data maps to CIDS fields."
+msgstr "Conformité à la Norme commune de données d’impact — voyez comment vos données correspondent aux champs CIDS."
+
+#. page_help.py
+msgid "Green items are complete; yellow items need attention."
+msgstr "Les éléments verts sont complétés; les éléments jaunes nécessitent une attention."
+
+#. page_help.py
+msgid "Click a section to see which fields need to be filled in."
+msgstr "Cliquez sur une section pour voir quels champs doivent être remplis."
+
+#. page_help.py — fallback
+msgid "Use the search bar at the top to find a {client} by name or ID."
+msgstr "Utilisez la barre de recherche en haut pour trouver un(e) {client} par nom ou numéro."
+
+#. page_help.py — fallback
+msgid "Press the Help link in the footer to open the full Help Guide."
+msgstr "Appuyez sur le lien Aide dans le pied de page pour ouvrir le guide d’aide complet."
+
+#. page_help.py — fallback
+msgid "Use your browser's back button or the navigation menu to return to the home page."
+msgstr "Utilisez le bouton retour de votre navigateur ou le menu de navigation pour revenir à la page d’accueil."
+

--- a/templates/base.html
+++ b/templates/base.html
@@ -333,9 +333,13 @@
     <div class="modal-backdrop" id="page-help-backdrop" hidden></div>
     <div class="page-help-modal" id="page-help-modal" hidden role="dialog" aria-labelledby="page-help-title" aria-modal="true" tabindex="-1">
         <button type="button" class="modal-close" id="close-page-help" aria-label="{% trans 'Close' %}">&times;</button>
-        {% if page_help %}
+        {% if page_help.is_default %}
+        <h2 id="page-help-title">{% trans "Help" %}</h2>
+        <p class="page-help-description">{% trans "Here are a few things you can do from anywhere in KoNote:" %}</p>
+        {% else %}
         <h2 id="page-help-title">{{ page_help.title }}</h2>
         <p class="page-help-description">{{ page_help.description }}</p>
+        {% endif %}
         <ul class="page-help-tips">
             {% for tip in page_help.tips %}
             <li>{{ tip }}</li>
@@ -343,10 +347,7 @@
         </ul>
         {% if page_help.help_section %}
         <p class="page-help-more"><a href="{% url 'help' %}#{{ page_help.help_section }}">{% trans "Read more in the Help Guide" %} &rarr;</a></p>
-        {% endif %}
         {% else %}
-        <h2 id="page-help-title">{% trans "Help" %}</h2>
-        <p class="page-help-description">{% trans "Visit the Help Guide for detailed information about using KoNote." %}</p>
         <p class="page-help-more"><a href="{% url 'help' %}">{% trans "Open Help Guide" %} &rarr;</a></p>
         {% endif %}
     </div>


### PR DESCRIPTION
## Summary
- Replace hardcoded "participant" with terminology placeholders ({client}, {file}, {plan}, {metric}, etc.) — substituted at runtime with agency's configured terms
- Add French translations for all ~123 page help strings
- Improve fallback: pages without specific help now show 3 universal tips (search, help link, navigation) instead of just a link
- Add help content for more pages: events, alerts, groups, transfers, sessions report, audit log

Fixes review findings from PR #440.

## Test plan
- [ ] Open ? on home page — verify it says the agency's configured term (not hardcoded "participant")
- [ ] Switch to French — verify help modal shows French text
- [ ] Open ? on a page without specific help (e.g. privacy) — verify 3 fallback tips appear
- [ ] Open ? on new pages (events, groups, audit log) — verify content appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)