### PR TITLE
feat: hide demographics from workers, add portal self-ID survey

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -253,6 +253,8 @@ Current DRRs (read the file before modifying related features — all in `tasks/
 - `no-live-api-individual-data.md` — No live API for individual PII
 - `self-hosted-llm-infrastructure.md` — Self-hosted LLM (Ollama/OVHcloud)
 - `encryption-key-rotation.md` — Encryption key rotation procedures
+- `access-tiers.md` — Access tiers, PERM-P5/P6/P8, and demographic visibility (DEMO-VIS1)
+- `funder-reporting-profiles.md` — Funder reporting profiles (CIDS template-based reporting)
 
 ### How Claude Manages Tasks
 

--- a/apps/clients/migrations/0040_customfieldgroup_admin_only.py
+++ b/apps/clients/migrations/0040_customfieldgroup_admin_only.py
@@ -1,0 +1,29 @@
+"""Add admin_only field to CustomFieldGroup.
+
+Groups marked admin_only are only visible to administrators. Used for
+demographic data collected for funder reporting that frontline workers
+do not need to see (DEMO-VIS1).
+"""
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("clients", "0039_set_demographics_collapsed"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="customfieldgroup",
+            name="admin_only",
+            field=models.BooleanField(
+                default=False,
+                help_text=(
+                    "When checked, this group is only visible to administrators. "
+                    "Use for demographic data collected for funder reporting that "
+                    "frontline workers do not need to see."
+                ),
+            ),
+        ),
+    ]

--- a/apps/clients/migrations/0041_set_demographics_admin_only.py
+++ b/apps/clients/migrations/0041_set_demographics_admin_only.py
@@ -1,0 +1,36 @@
+"""Set admin_only=True for the Demographics group.
+
+Demographic data (ethnicity, gender identity, sexual orientation, etc.)
+is collected for funder reporting and equity analysis. It should not be
+visible to frontline workers during routine service delivery.
+
+Rationale (DEMO-VIS1):
+- Prevents implicit bias activation during note-taking
+- Protects small-sample de-identification in aggregate reports
+- Follows PHIPA minimum necessary use principle
+- Cultural safety comes from the relationship, not the database field
+
+See tasks/design-rationale/access-tiers.md for the full expert panel analysis.
+"""
+from django.db import migrations
+
+
+def set_demographics_admin_only(apps, schema_editor):
+    CustomFieldGroup = apps.get_model("clients", "CustomFieldGroup")
+    CustomFieldGroup.objects.filter(title="Demographics").update(admin_only=True)
+
+
+def unset_demographics_admin_only(apps, schema_editor):
+    CustomFieldGroup = apps.get_model("clients", "CustomFieldGroup")
+    CustomFieldGroup.objects.filter(title="Demographics").update(admin_only=False)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("clients", "0040_customfieldgroup_admin_only"),
+    ]
+
+    operations = [
+        migrations.RunPython(set_demographics_admin_only, unset_demographics_admin_only),
+    ]

--- a/apps/clients/models.py
+++ b/apps/clients/models.py
@@ -716,6 +716,14 @@ class CustomFieldGroup(models.Model):
             "This is a display preference — it does not restrict access to the data."
         ),
     )
+    admin_only = models.BooleanField(
+        default=False,
+        help_text=_(
+            "When checked, this group is only visible to administrators. "
+            "Use for demographic data collected for funder reporting that "
+            "frontline workers do not need to see."
+        ),
+    )
     status = models.CharField(
         max_length=20, default="active",
         choices=[("active", "Active"), ("archived", "Archived")],

--- a/apps/clients/views.py
+++ b/apps/clients/views.py
@@ -434,7 +434,10 @@ def client_list(request):
 
 
 def _get_create_field_defs(user):
-    """Return CustomFieldDefinitions marked show_on_create, respecting role access."""
+    """Return CustomFieldDefinitions marked show_on_create, respecting role access.
+
+    Admin-only groups (DEMO-VIS1) are excluded for non-admin users.
+    """
     qs = CustomFieldDefinition.objects.filter(
         status="active",
         group__status="active",
@@ -443,6 +446,9 @@ def _get_create_field_defs(user):
     user_role = getattr(user, "_program_role", None) or _get_user_highest_role(user)
     if user_role == ROLE_RECEPTIONIST:
         qs = qs.filter(front_desk_access="edit")
+    # Admin-only groups: exclude from non-admin users (DEMO-VIS1)
+    if not getattr(user, "is_admin", False):
+        qs = qs.exclude(group__admin_only=True)
     return list(qs)
 
 
@@ -1110,7 +1116,10 @@ def client_detail(request, client_id):
     has_hidden_programs = all_enrolled_count > visible_count
 
     # Custom fields for Info tab — uses shared helper with hide_empty=True (display mode)
-    custom_fields_ctx = _get_custom_fields_context(client, user_role, hide_empty=True)
+    custom_fields_ctx = _get_custom_fields_context(
+        client, user_role, hide_empty=True,
+        is_admin_user=getattr(request.user, "is_admin", False),
+    )
     custom_data = custom_fields_ctx["custom_data"]
     has_editable_fields = custom_fields_ctx["has_editable_fields"]
     # Breadcrumbs: Participants > [Name]
@@ -1257,7 +1266,7 @@ def assessment_due_banner(request, client_id):
     })
 
 
-def _get_custom_fields_context(client, user_role, hide_empty=False):
+def _get_custom_fields_context(client, user_role, hide_empty=False, is_admin_user=False):
     """Build custom fields context for display/edit templates.
 
     Args:
@@ -1265,8 +1274,14 @@ def _get_custom_fields_context(client, user_role, hide_empty=False):
         user_role: User's role (front desk, direct service, etc.)
         hide_empty: If True, exclude fields without values (for display mode).
                    If False, include all fields (for edit mode).
+        is_admin_user: If True, user is an administrator (can see admin-only groups).
 
     Returns a dict with custom_data, has_editable_fields, client, and is_receptionist (front desk flag).
+
+    Admin-only groups (DEMO-VIS1): groups marked admin_only are only visible
+    to administrators. Demographic data collected for funder reporting is not
+    displayed to frontline workers to prevent implicit bias and protect
+    small-sample de-identification in aggregate reports.
 
     DV-safe enforcement (PERM-P5): when client.is_dv_safe is True and user
     is a receptionist, fields marked is_dv_sensitive are excluded regardless
@@ -1282,6 +1297,9 @@ def _get_custom_fields_context(client, user_role, hide_empty=False):
         except Exception:
             dv_hide = True  # Fail closed
     groups = CustomFieldGroup.objects.filter(status="active").prefetch_related("fields")
+    # Admin-only groups: hide from non-admin users (DEMO-VIS1)
+    if not is_admin_user:
+        groups = groups.filter(admin_only=False)
     custom_data = []
     has_editable_fields = False
 
@@ -1349,7 +1367,10 @@ def client_custom_fields_display(request, client_id):
     base_queryset = get_client_queryset(request.user)
     client = get_object_or_404(base_queryset, pk=client_id)
     user_role = getattr(request, "user_program_role", None)
-    context = _get_custom_fields_context(client, user_role, hide_empty=True)
+    context = _get_custom_fields_context(
+        client, user_role, hide_empty=True,
+        is_admin_user=getattr(request.user, "is_admin", False),
+    )
     return render(request, "clients/_custom_fields_display.html", context)
 
 
@@ -1359,7 +1380,10 @@ def client_custom_fields_edit(request, client_id):
     base_queryset = get_client_queryset(request.user)
     client = get_object_or_404(base_queryset, pk=client_id)
     user_role = getattr(request, "user_program_role", None)
-    context = _get_custom_fields_context(client, user_role)
+    context = _get_custom_fields_context(
+        client, user_role,
+        is_admin_user=getattr(request.user, "is_admin", False),
+    )
 
     # Only allow edit mode if user has editable fields
     if not context["has_editable_fields"]:
@@ -1388,9 +1412,13 @@ def client_save_custom_fields(request, client_id):
 
     user_role = getattr(request, "user_program_role", None)
     is_receptionist = user_role == ROLE_RECEPTIONIST
+    is_admin_user = getattr(request.user, "is_admin", False)
 
     if request.method == "POST":
         groups = CustomFieldGroup.objects.filter(status="active").prefetch_related("fields")
+        # Admin-only groups: exclude from non-admin users (DEMO-VIS1)
+        if not is_admin_user:
+            groups = groups.filter(admin_only=False)
 
         # Get field definitions the user can edit
         if is_receptionist:
@@ -1462,7 +1490,10 @@ def client_save_custom_fields(request, client_id):
 
     # For HTMX requests, return the read-only display partial
     if request.headers.get("HX-Request"):
-        context = _get_custom_fields_context(client, user_role, hide_empty=True)
+        context = _get_custom_fields_context(
+            client, user_role, hide_empty=True,
+            is_admin_user=is_admin_user,
+        )
         return render(request, "clients/_custom_fields_display.html", context)
 
     return redirect("clients:client_detail", client_id=client.pk)

--- a/apps/portal/migrations/0008_participantuser_selfid_consent_shown.py
+++ b/apps/portal/migrations/0008_participantuser_selfid_consent_shown.py
@@ -1,0 +1,24 @@
+"""Add selfid_consent_shown field to ParticipantUser.
+
+Tracks whether the participant has seen the self-identification
+consent disclosure before filling in their demographic data (DEMO-VIS1).
+"""
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("portal", "0007_portalresourcelink_url_fr"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="participantuser",
+            name="selfid_consent_shown",
+            field=models.BooleanField(
+                default=False,
+                help_text="True after the participant has seen the self-identification consent notice.",
+            ),
+        ),
+    ]

--- a/apps/portal/models.py
+++ b/apps/portal/models.py
@@ -126,6 +126,12 @@ class ParticipantUser(AbstractBaseUser):
         help_text="True after the participant has seen the journal privacy notice.",
     )
 
+    # One-time self-identification consent disclosure (DEMO-VIS1)
+    selfid_consent_shown = models.BooleanField(
+        default=False,
+        help_text="True after the participant has seen the self-identification consent notice.",
+    )
+
     # Password reset
     password_reset_token_hash = models.CharField(
         max_length=128, blank=True, default="",

--- a/apps/portal/templates/portal/dashboard.html
+++ b/apps/portal/templates/portal/dashboard.html
@@ -102,6 +102,16 @@
         </a>
         {% endif %}
 
+        {% if show_selfid %}
+        <a href="{% url 'portal:selfid_disclosure' %}" class="portal-card">
+            <article>
+                <svg aria-hidden="true" width="28" height="28" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"/><circle cx="12" cy="7" r="4"/></svg>
+                <h2>{% trans "About Me" %}</h2>
+                <p>{% trans "Share information about yourself (optional)." %}</p>
+            </article>
+        </a>
+        {% endif %}
+
     </div>
 </section>
 {% endblock %}

--- a/apps/portal/templates/portal/selfid_disclosure.html
+++ b/apps/portal/templates/portal/selfid_disclosure.html
@@ -1,0 +1,43 @@
+{% extends "portal/base_portal.html" %}
+{% load i18n %}
+
+{% block title %}{% trans "About This Survey" %}{% endblock %}
+
+{% block content %}
+<article class="portal-disclosure">
+    <header>
+        <h1>{% trans "Self-Identification Survey" %}</h1>
+    </header>
+
+    <p>{% trans "We'd like to invite you to share some information about yourself. This is completely voluntary." %}</p>
+
+    <h2>{% trans "What we're asking" %}</h2>
+    <p>{% trans "Questions about your identity, background, and experiences. These may include ethnicity, gender identity, Indigenous identity, and similar topics." %}</p>
+
+    <h2>{% trans "Why we're asking" %}</h2>
+    <p>{% trans "This information helps the agency understand who they're serving and whether their programs are reaching and working for everyone. It's used in summary reports to funders — for example, 'X% of participants identified as Indigenous.' Your individual answers are never shared in these reports." %}</p>
+
+    <h2>{% trans "Who can see your answers" %}</h2>
+    <ul>
+        <li>{% trans "An administrator at the agency can see your individual responses for data quality purposes." %}</li>
+        <li>{% blocktrans with worker_term=term.worker %}<strong>Your {{ worker_term }} cannot see your answers.</strong> This information is kept separate from your file so it doesn't influence your services.{% endblocktrans %}</li>
+        <li>{% trans "Funders and external parties only see summary numbers, never individual responses." %}</li>
+    </ul>
+
+    <h2>{% trans "Your choices" %}</h2>
+    <ul>
+        <li>{% trans "Every question is optional. You can skip any question or choose 'Prefer not to answer.'" %}</li>
+        <li>{% trans "You can change your answers at any time by coming back to this page." %}</li>
+        <li>{% trans "Choosing not to answer will not affect the services you receive." %}</li>
+    </ul>
+
+    <div class="portal-disclosure-actions">
+        <form method="post" action="{% url 'portal:selfid_disclosure' %}">
+            {% csrf_token %}
+            <button type="submit">{% trans "I understand, continue" %}</button>
+        </form>
+
+        <a href="{% url 'portal:dashboard' %}" role="button" class="secondary">{% trans "Maybe later" %}</a>
+    </div>
+</article>
+{% endblock %}

--- a/apps/portal/templates/portal/selfid_form.html
+++ b/apps/portal/templates/portal/selfid_form.html
@@ -1,0 +1,138 @@
+{% extends "portal/base_portal.html" %}
+{% load i18n %}
+
+{% block title %}{% trans "Self-Identification Survey" %}{% endblock %}
+
+{% block content %}
+<article>
+    <header>
+        <h1>{% trans "Self-Identification Survey" %}</h1>
+        <p class="secondary">{% trans "All questions are optional. Choose 'Prefer not to answer' or leave blank for any question you'd rather skip." %}</p>
+    </header>
+
+    {% if success %}
+    <div role="alert" class="portal-alert success">
+        <p>{% trans "Your responses have been saved. Thank you!" %}</p>
+        <p><a href="{% url 'portal:dashboard' %}">{% trans "Return to home" %}</a></p>
+    </div>
+    {% endif %}
+
+    {% if custom_data %}
+    <form method="post" action="{% url 'portal:selfid_form' %}">
+        {% csrf_token %}
+
+        {% for group in custom_data %}
+        <fieldset>
+            <legend>{{ group.group.title }}</legend>
+
+            {% for item in group.fields %}
+            <div class="form-row">
+                <label for="custom_{{ item.field_def.pk }}">{{ item.field_def.name }}</label>
+
+                {% if item.field_def.input_type == "select" %}
+                    <select name="custom_{{ item.field_def.pk }}"
+                            id="custom_{{ item.field_def.pk }}">
+                        <option value="">{% trans "Select…" %}</option>
+                        {% for opt in item.field_def.options_json %}
+                        <option value="{{ opt }}" {% if item.value == opt %}selected{% endif %}>{{ opt }}</option>
+                        {% endfor %}
+                    </select>
+
+                {% elif item.field_def.input_type == "select_other" %}
+                    <select name="custom_{{ item.field_def.pk }}"
+                            id="custom_{{ item.field_def.pk }}"
+                            data-toggle-display-target="other_wrap_{{ item.field_def.pk }}"
+                            data-toggle-display-value="__other__">
+                        <option value="">{% trans "Select…" %}</option>
+                        {% for opt in item.field_def.options_json %}
+                        <option value="{{ opt }}" {% if item.value == opt %}selected{% endif %}>{{ opt }}</option>
+                        {% endfor %}
+                        <option value="__other__" {% if item.value and item.is_other_value %}selected{% endif %}>{% trans "Other" %}</option>
+                    </select>
+                    <div id="other_wrap_{{ item.field_def.pk }}"
+                         style="margin-top: 0.5rem;{% if not item.is_other_value %} display: none;{% endif %}">
+                        <label for="custom_{{ item.field_def.pk }}_other" class="sr-only">{% trans "Other (please specify)" %}</label>
+                        <input type="text"
+                               name="custom_{{ item.field_def.pk }}_other"
+                               id="custom_{{ item.field_def.pk }}_other"
+                               value="{% if item.is_other_value %}{{ item.value }}{% endif %}"
+                               placeholder="{% trans 'Please specify…' %}">
+                    </div>
+
+                {% elif item.field_def.input_type == "multi_select" %}
+                    <fieldset role="group" aria-labelledby="label_{{ item.field_def.pk }}">
+                        {% for opt in item.field_def.options_json %}
+                        <label>
+                            <input type="checkbox"
+                                   name="custom_{{ item.field_def.pk }}"
+                                   value="{{ opt }}"
+                                   {% if opt in item.selected_values %}checked{% endif %}>
+                            {{ opt }}
+                        </label>
+                        {% endfor %}
+                    </fieldset>
+
+                {% elif item.field_def.input_type == "multi_select_other" %}
+                    <fieldset role="group" aria-labelledby="label_{{ item.field_def.pk }}">
+                        {% for opt in item.field_def.options_json %}
+                        <label>
+                            <input type="checkbox"
+                                   name="custom_{{ item.field_def.pk }}"
+                                   value="{{ opt }}"
+                                   {% if opt in item.selected_values %}checked{% endif %}>
+                            {{ opt }}
+                        </label>
+                        {% endfor %}
+                    </fieldset>
+                    <div style="margin-top: 0.5rem;">
+                        <label for="custom_{{ item.field_def.pk }}_other">{% trans "Other (please specify)" %}</label>
+                        <input type="text"
+                               name="custom_{{ item.field_def.pk }}_other"
+                               id="custom_{{ item.field_def.pk }}_other"
+                               value="{{ item.other_text|default:'' }}"
+                               placeholder="{% trans 'Please specify…' %}">
+                    </div>
+
+                {% elif item.field_def.input_type == "textarea" %}
+                    <textarea name="custom_{{ item.field_def.pk }}"
+                              id="custom_{{ item.field_def.pk }}"
+                              rows="3"
+                              placeholder="{{ item.field_def.placeholder }}">{{ item.value }}</textarea>
+
+                {% elif item.field_def.input_type == "date" %}
+                    <input type="date"
+                           name="custom_{{ item.field_def.pk }}"
+                           id="custom_{{ item.field_def.pk }}"
+                           value="{{ item.value }}">
+
+                {% elif item.field_def.input_type == "number" %}
+                    <input type="number"
+                           name="custom_{{ item.field_def.pk }}"
+                           id="custom_{{ item.field_def.pk }}"
+                           value="{{ item.value }}"
+                           placeholder="{{ item.field_def.placeholder }}">
+
+                {% else %}
+                    <input type="text"
+                           name="custom_{{ item.field_def.pk }}"
+                           id="custom_{{ item.field_def.pk }}"
+                           value="{{ item.value }}"
+                           placeholder="{{ item.field_def.placeholder }}">
+                {% endif %}
+            </div>
+            {% endfor %}
+        </fieldset>
+        {% endfor %}
+
+        <div role="group">
+            <button type="submit">{% trans "Save my responses" %}</button>
+            <a href="{% url 'portal:dashboard' %}" role="button" class="secondary">{% trans "Cancel" %}</a>
+        </div>
+    </form>
+
+    {% else %}
+    <p>{% trans "There are no self-identification questions available at this time." %}</p>
+    <a href="{% url 'portal:dashboard' %}" role="button">{% trans "Return to home" %}</a>
+    {% endif %}
+</article>
+{% endblock %}

--- a/apps/portal/templates/portal/selfid_form.html
+++ b/apps/portal/templates/portal/selfid_form.html
@@ -27,7 +27,7 @@
 
             {% for item in group.fields %}
             <div class="form-row">
-                <label for="custom_{{ item.field_def.pk }}">{{ item.field_def.name }}</label>
+                <label for="custom_{{ item.field_def.pk }}" id="label_{{ item.field_def.pk }}">{{ item.field_def.name }}</label>
 
                 {% if item.field_def.input_type == "select" %}
                     <select name="custom_{{ item.field_def.pk }}"

--- a/apps/portal/urls.py
+++ b/apps/portal/urls.py
@@ -52,4 +52,7 @@ urlpatterns = [
     path("surveys/<int:assignment_id>/thanks/", views.portal_survey_thank_you, name="survey_thank_you"),
     # Alliance rating (PORTAL-ALLIANCE1)
     path("alliance/<uuid:request_id>/", views.portal_alliance_rating, name="alliance_rating"),
+    # Self-identification (DEMO-VIS1)
+    path("self-id/", views.selfid_disclosure, name="selfid_disclosure"),
+    path("self-id/form/", views.selfid_form, name="selfid_form"),
 ]

--- a/apps/portal/views.py
+++ b/apps/portal/views.py
@@ -713,6 +713,16 @@ def dashboard(request):
     except Exception:
         pass
 
+    # Self-identification survey: show card if admin-only groups exist (DEMO-VIS1)
+    show_selfid = False
+    try:
+        from apps.clients.models import CustomFieldGroup
+        show_selfid = CustomFieldGroup.objects.filter(
+            status="active", admin_only=True,
+        ).filter(fields__status="active").distinct().exists()
+    except Exception:
+        pass
+
     return render(request, "portal/dashboard.html", {
         "participant": participant,
         "latest_note_date": latest_note,
@@ -723,6 +733,7 @@ def dashboard(request):
         "pending_surveys": pending_surveys,
         "single_survey_url": single_survey_url,
         "pending_alliance": pending_alliance,
+        "show_selfid": show_selfid,
     })
 
 
@@ -2146,4 +2157,146 @@ def portal_alliance_rating(request, request_id):
         "alliance_choices": alliance_choices,
         "alliance_req": alliance_req,
         "rating_error": rating_error,
+    })
+
+
+# ---------------------------------------------------------------------------
+# Self-Identification Survey (DEMO-VIS1)
+# ---------------------------------------------------------------------------
+
+
+@portal_login_required
+def selfid_disclosure(request):
+    """One-time consent disclosure before the self-identification form.
+
+    Explains what demographic data is collected, why, who can see it,
+    and that all questions are optional. Marks selfid_consent_shown=True
+    on acknowledgement.
+    """
+    participant = request.participant_user
+
+    # Already acknowledged — go straight to the form
+    if participant.selfid_consent_shown:
+        return redirect("portal:selfid_form")
+
+    if request.method == "POST":
+        participant.selfid_consent_shown = True
+        participant.save(update_fields=["selfid_consent_shown"])
+        _audit_portal_event(request, "selfid_consent_acknowledged", metadata={
+            "participant_id": str(participant.pk),
+        })
+        return redirect("portal:selfid_form")
+
+    return render(request, "portal/selfid_disclosure.html", {
+        "participant": participant,
+    })
+
+
+@portal_login_required
+def selfid_form(request):
+    """Self-identification form for participants to enter their own demographics.
+
+    Loads admin-only CustomFieldGroups (demographic fields) and lets the
+    participant fill them in directly. Data is saved to the same
+    ClientDetailValue records that admins see, ensuring a single source
+    of truth.
+
+    All fields are optional. The participant can update their responses
+    at any time by revisiting this page.
+    """
+    import json as json_mod
+    from apps.clients.models import (
+        ClientDetailValue, CustomFieldDefinition, CustomFieldGroup,
+    )
+
+    participant = request.participant_user
+    client_file = _get_client_file(request)
+
+    # Require consent disclosure first
+    if not participant.selfid_consent_shown:
+        return redirect("portal:selfid_disclosure")
+
+    # Load admin-only groups (demographics) — these are the fields
+    # that workers cannot see but participants can self-identify
+    groups = CustomFieldGroup.objects.filter(
+        status="active", admin_only=True,
+    ).prefetch_related("fields")
+
+    success = False
+
+    if request.method == "POST":
+        for group in groups:
+            for field_def in group.fields.filter(status="active"):
+                key = f"custom_{field_def.pk}"
+
+                # Parse value based on input type
+                if field_def.input_type in ("multi_select", "multi_select_other"):
+                    selected = request.POST.getlist(key)
+                    if field_def.input_type == "multi_select_other":
+                        other_text = request.POST.get(f"{key}_other", "").strip()
+                        if other_text:
+                            selected = list(selected) + [other_text]
+                    raw_value = json_mod.dumps(selected) if selected else ""
+                elif field_def.input_type == "select_other":
+                    raw_value = request.POST.get(key, "").strip()
+                    if raw_value == "__other__":
+                        raw_value = request.POST.get(f"{key}_other", "").strip()
+                else:
+                    raw_value = request.POST.get(key, "").strip()
+
+                # Save or update
+                cdv, _created = ClientDetailValue.objects.get_or_create(
+                    client_file=client_file, field_def=field_def,
+                )
+                cdv.set_value(raw_value)
+                cdv.save()
+
+        _audit_portal_event(request, "selfid_submitted", metadata={
+            "participant_id": str(participant.pk),
+        })
+        success = True
+
+    # Build form context (similar to _get_custom_fields_context but for portal)
+    custom_data = []
+    for group in groups:
+        field_values = []
+        for field_def in group.fields.filter(status="active"):
+            try:
+                cdv = ClientDetailValue.objects.get(
+                    client_file=client_file, field_def=field_def,
+                )
+                value = cdv.get_value()
+            except ClientDetailValue.DoesNotExist:
+                value = ""
+
+            # Parse multi-select for template
+            selected_values = []
+            other_text = ""
+            is_other_value = False
+            if field_def.input_type in ("multi_select", "multi_select_other") and value:
+                try:
+                    selected_values = json_mod.loads(value)
+                except (json_mod.JSONDecodeError, TypeError):
+                    pass
+                if field_def.input_type == "multi_select_other" and field_def.options_json:
+                    known = set(field_def.options_json)
+                    custom_vals = [v for v in selected_values if v not in known]
+                    other_text = custom_vals[0] if custom_vals else ""
+            elif field_def.input_type == "select_other" and value and field_def.options_json:
+                is_other_value = value not in field_def.options_json
+
+            field_values.append({
+                "field_def": field_def,
+                "value": value,
+                "selected_values": selected_values,
+                "other_text": other_text,
+                "is_other_value": is_other_value,
+            })
+        if field_values:
+            custom_data.append({"group": group, "fields": field_values})
+
+    return render(request, "portal/selfid_form.html", {
+        "participant": participant,
+        "custom_data": custom_data,
+        "success": success,
     })

--- a/apps/portal/views.py
+++ b/apps/portal/views.py
@@ -2206,7 +2206,7 @@ def selfid_form(request):
     """
     import json as json_mod
     from apps.clients.models import (
-        ClientDetailValue, CustomFieldDefinition, CustomFieldGroup,
+        ClientDetailValue, CustomFieldGroup,
     )
 
     participant = request.participant_user

--- a/static/js/portal.js
+++ b/static/js/portal.js
@@ -141,3 +141,16 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     }
 });
+
+// Toggle display of "Other" text fields for select_other inputs (DEMO-VIS1)
+// Mirrors the data-toggle-display handler from app.js for the portal context.
+document.addEventListener('change', function(event) {
+    var target = event.target;
+    if (target.matches('[data-toggle-display-target]')) {
+        var toggleTarget = document.getElementById(target.getAttribute('data-toggle-display-target'));
+        var expectedValue = target.getAttribute('data-toggle-display-value') || '';
+        if (toggleTarget) {
+            toggleTarget.style.display = target.value === expectedValue ? '' : 'none';
+        }
+    }
+});

--- a/tasks/design-rationale/access-tiers.md
+++ b/tasks/design-rationale/access-tiers.md
@@ -1,9 +1,9 @@
 # Access Tiers — Design Rationale Record
 
-Task ID: PERM-TIER1 | Date: 2026-02-25 | Status: Draft — GK reviews PERM-P5 and PERM-P6 before implementation
-Expert panel: Privacy & Health Law Specialist (PHIPA/PIPEDA), Nonprofit Operations Director, Security Architect, Clinical Social Worker (RSW), Nonprofit Technology Consultant, Program Evaluator, UX/Onboarding Specialist, Privacy & Risk Analyst (three rounds across two panels)
+Task ID: PERM-TIER1 | Date: 2026-02-25 | Updated: 2026-03-08 | Status: Draft — GK reviews PERM-P5 and PERM-P6 before implementation
+Expert panel: Privacy & Health Law Specialist (PHIPA/PIPEDA), Nonprofit Operations Director, Security Architect, Clinical Social Worker (RSW), Nonprofit Technology Consultant, Program Evaluator, UX/Onboarding Specialist, Privacy & Risk Analyst, Statistical Disclosure Specialist, Trauma-Informed UX Designer, Anti-Oppression Practice Consultant, Evaluation & Funder Reporting Specialist (five rounds across four panels)
 
-Keyword Index: access tier, permission complexity, Open Access, Role-Based, Clinical Safeguards, GATED, PER_FIELD, DV-safe, per-field front desk, proportional privacy, configuration interview, agency sensitivity, PERM-P5, PERM-P6, PERM-P8
+Keyword Index: access tier, permission complexity, Open Access, Role-Based, Clinical Safeguards, GATED, PER_FIELD, DV-safe, per-field front desk, proportional privacy, configuration interview, agency sensitivity, PERM-P5, PERM-P6, PERM-P8, DEMO-VIS1, demographic visibility, admin-only, implicit bias, de-identification, small-sample, re-identification
 
 ---
 
@@ -194,6 +194,92 @@ The agency confirms or overrides. The override and reasoning are recorded in the
 | 5th | Integration (translations, CLAUDE.md, TODO.md) | All above | No |
 
 PERM-P5 depends on PERM-P8 because DV-safe mode overrides per-field access — it needs the per-field infrastructure to exist. PERM-P6 is independent of PERM-P5 and PERM-P8 (it only needs the tier check) but is built last because it's the most complex.
+
+---
+
+## Demographic Visibility Restriction (DEMO-VIS1)
+
+*Added: 2026-03-08 | Status: Implemented*
+
+### The Decision
+
+**Demographics (ethnicity, gender identity, sexual orientation, Indigenous identity, immigration status, disability, caregiver status) are hidden from all non-admin roles.** The fields do not appear in the worker interface — not collapsed, not locked, absent. Only administrators can view and edit individual demographic records.
+
+This applies at all access tiers. It is not a tier-specific feature — it is a baseline restriction like "front desk never sees clinical notes."
+
+### Why (Three Independent Arguments)
+
+**1. Implicit bias prevention.** Visible identity markers activate unconscious bias during service delivery. A worker who sees "Indigenous, Two-Spirit" before reading a progress note filters that note through those categories. The demographic field tells you a CIDS reporting category, not what the person's identity means to them.
+
+**2. Small-sample de-identification.** In programs with 5–15 participants, a worker who knows individual demographics can reverse-engineer aggregate reports. If a worker knows "only Maria and James are Indigenous" and the report says "1 Indigenous participant showed declining outcomes," the report is no longer anonymous. Hiding demographics from workers breaks the re-identification chain regardless of report format.
+
+**3. PHIPA minimum necessary use (s. 30(2)).** Demographics are collected for funder reporting. A worker's duties are service delivery, not reporting. The information is not reasonably necessary for their role.
+
+### Expert Panel Findings (Two Rounds)
+
+**Panel 1:** Privacy & Health Information Specialist, Trauma-Informed UX Designer, Nonprofit Program Director, Anti-Oppression Practice Consultant
+
+- Unanimous: demographics should not appear on the notes page
+- Spatial separation required — a collapsible section on the same page gets opened by habit
+- Pronouns are practice data (Tier 1, always visible); gender identity *category* is reporting data (admin-only)
+- The "shoulder test": if a participant were standing behind the worker, would they be comfortable with what's on screen?
+
+**Panel 2:** Statistical Disclosure Specialist, Health Information Privacy Officer, Frontline Practice Lead, Evaluation & Funder Reporting Specialist
+
+- Unanimous: demographics should be hidden from workers entirely, not just moved to a separate tab
+- The re-identification arithmetic makes the case conclusive for small programs
+- Every practice scenario examined (cultural safety, referrals, incident documentation) is better served by *not* showing demographics
+- Worker-edited demographics create data integrity violations (workers "correcting" self-identification based on perception)
+
+### The Cultural Safety Counter-Argument (Evaluated and Rejected)
+
+**Argument:** "Workers need demographic data for culturally responsive service."
+
+**Why it doesn't hold:**
+1. Cultural safety comes from the relationship, not the database. A CIDS dropdown category tells you nothing about what matters to *this person*.
+2. Demographic fields are often incomplete or approximate (broad categories, "Prefer not to answer").
+3. Best practice (First Nations Health Authority, OCASI) says: ask, don't assume. Hiding the field supports this.
+4. Identity-specific referrals are driven by participant's expressed needs, not worker's knowledge of their category.
+
+### Role-Based Access Model
+
+| Capability | Front Desk | Worker | Program Lead | Admin | Executive |
+|---|---|---|---|---|---|
+| View individual demographics | No | No | No | **Yes** | No |
+| Edit individual demographics | No | No | No | **Yes** | No |
+| View aggregate demographic reports | No | Yes (own program) | Yes | Yes | Yes |
+| Enter demographics at intake | No | No | No | **Yes** | No |
+
+### What Workers Retain (Unchanged)
+
+- Name, preferred name, pronouns (practice data, always visible)
+- Language/communication preferences (practice data)
+- Active programs, goals, plan summary
+- Alert flags (safety, accessibility needs)
+- All non-demographic custom field groups
+
+### Implementation
+
+- `CustomFieldGroup.admin_only` boolean field (migration 0040)
+- Data migration sets Demographics group to `admin_only=True` (migration 0041)
+- `_get_custom_fields_context()` filters out admin-only groups for non-admin users
+- `client_save_custom_fields()` excludes admin-only groups from non-admin saves
+- `_get_create_field_defs()` excludes admin-only groups from non-admin create forms
+- No "Access Restricted" indicators shown — the fields simply don't render for non-admin roles
+
+### Intake Workflow Implication
+
+Demographics are entered by an **administrator** after intake, not by the frontline intake worker. This is intentional:
+- The intake worker focuses on the person, not the reporting categories
+- An admin entering demographics from a self-identification form reduces the risk of worker-observed (rather than self-identified) data
+- Agencies may collect demographics via a separate self-identification survey rather than during the intake conversation
+
+### Anti-Patterns
+
+- **DO NOT add demographics back to the worker view** as a collapsible, toggled, or "click to reveal" section. The expert panels concluded that any presence on the same page gets opened by habit.
+- **DO NOT create "Access Restricted" labels** where demographic fields would be. This signals that restricted information exists and invites curiosity or workarounds.
+- **DO NOT conflate pronouns with demographic data.** Pronouns are communication/practice data (always visible). Gender identity *category* is reporting data (admin-only).
+- **DO NOT allow workers to edit demographics** even if they can't see them in the display view. The save endpoint must enforce the same restriction.
 
 ---
 

--- a/templates/clients/_custom_fields_edit.html
+++ b/templates/clients/_custom_fields_edit.html
@@ -25,7 +25,7 @@
         <legend id="edit-group-{{ group.group.pk }}">{{ group.group.title }}</legend>
         {% for item in group.fields %}
         <div class="form-row">
-            <label for="custom_{{ item.field_def.pk }}">
+            <label for="custom_{{ item.field_def.pk }}" id="label_{{ item.field_def.pk }}">
                 {{ item.field_def.name }}
                 {% if item.is_editable and item.field_def.is_required %}<abbr title="{% trans 'required' %}">*</abbr>{% endif %}
                 {% if not item.is_editable %}<small class="secondary">({% trans "view only" %})</small>{% endif %}


### PR DESCRIPTION
## Summary

- **Demographics hidden from non-admin workers (DEMO-VIS1):** Added `admin_only` field to `CustomFieldGroup`. The Demographics group is set to `admin_only=True`, making it invisible to frontline workers (Direct Service, Front Desk, Program Managers, Executives). Only administrators can view and edit individual demographic records. Workers never see these fields — no "Access Restricted" indicators, the section simply doesn't render.

- **Portal self-identification survey:** Participants can now enter their own demographics via the portal (`/my/self-id/`). Includes a consent disclosure explaining what's collected, why, who can see it, and that everything is optional. Data saves to the same `ClientDetailValue` records admins see. Dashboard shows an "About Me" nav card when demographic fields exist.

- **DRR updated:** Added DEMO-VIS1 section to `tasks/design-rationale/access-tiers.md` documenting the expert panel decision (two rounds, 8 experts), the cultural safety counter-argument evaluation, and anti-patterns.

## Rationale (from expert panels)

1. **Implicit bias prevention** — visible identity markers activate unconscious bias during service delivery
2. **Small-sample de-identification** — workers who know individual demographics can reverse-engineer aggregate reports (critical in programs with 5-15 participants)
3. **PHIPA minimum necessary use** — demographics are for funder reporting, not service delivery
4. **Self-identified > worker-observed** — portal entry ensures data reflects participant's own identity, not worker perception

## Test plan

- [ ] Verify non-admin workers cannot see the Demographics section on participant Info tab
- [ ] Verify admin users CAN see and edit Demographics on participant Info tab
- [ ] Verify portal self-ID disclosure page appears on first visit to `/my/self-id/`
- [ ] Verify portal self-ID form renders all demographic fields (dropdowns, multi-select, etc.)
- [ ] Verify saving responses creates/updates ClientDetailValue records
- [ ] Verify consent acknowledgement is tracked (`selfid_consent_shown`)
- [ ] Verify "About Me" card appears on portal dashboard
- [ ] Verify returning to self-ID form shows previously saved values
- [ ] Verify audit log entries for consent and submission events

🤖 Generated with [Claude Code](https://claude.com/claude-code)