### PR TITLE
Suppress org-level total when any program value is suppressed

### DIFF
--- a/apps/reports/utils.py
+++ b/apps/reports/utils.py
@@ -248,9 +248,9 @@ def aggregate_all_programs_totals(data_or_sections):
     """Aggregate service metrics across all program reports.
 
     When any program's value has been suppressed (replaced with a string
-    like ``"< 5"``), that program's contribution is skipped so the
-    org-level total still reflects the available data without including
-    suppressed estimates.
+    like ``"< 5"``), the org-level total for that field is also marked
+    ``"suppressed"``. Showing the sum would reveal the suppressed program's
+    approximate count, which defeats the purpose of suppression.
 
     Args:
         data_or_sections: List of (program, report_data) tuples.

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -2035,7 +2035,7 @@ class AggregateAllProgramsTotalsTest(TestCase):
         self.assertEqual(len(result['programs']), 2)
         self.assertEqual(result['programs'][0]['name'], 'Program A')
 
-    def test_skips_suppressed_string_values(self):
+    def test_suppressed_string_values_propagate_to_total(self):
         from apps.reports.utils import aggregate_all_programs_totals
         from unittest.mock import Mock
         p1 = Mock(name='Program A')
@@ -2047,9 +2047,11 @@ class AggregateAllProgramsTotalsTest(TestCase):
             (p2, {'total_individuals_served': 7, 'new_clients_this_period': '< 5', 'total_contacts': 5}),
         ]
         result = aggregate_all_programs_totals(data)
-        self.assertEqual(result['total_served'], 7)  # skips suppressed '< 5'
-        self.assertEqual(result['total_new_clients'], 3)  # skips suppressed '< 5'
-        self.assertEqual(result['total_contacts'], 15)
+        # If any program's value is suppressed, the org total is also suppressed
+        # (showing the sum would reveal the suppressed program's approximate count)
+        self.assertEqual(result['total_served'], 'suppressed')
+        self.assertEqual(result['total_new_clients'], 'suppressed')
+        self.assertEqual(result['total_contacts'], 15)  # no suppressed values
 
     def test_empty_input(self):
         from apps.reports.utils import aggregate_all_programs_totals


### PR DESCRIPTION
This pull request updates the logic for aggregating service metrics across program reports to enhance data privacy. Now, if any program's value for a metric is suppressed (e.g., shown as "< 5"), the organization-level total for that metric is also marked as "suppressed" instead of showing a sum. This prevents revealing approximate counts for suppressed data. Corresponding tests have been updated to reflect this new behavior.

**Data aggregation logic changes:**

* Updated `aggregate_all_programs_totals` in `apps/reports/utils.py` so that if any program's value is suppressed, the org-level total for that field is also marked as "suppressed" rather than calculating a sum. This ensures suppressed program data cannot be inferred from totals.

**Test updates:**

* Renamed and updated the test in `tests/test_reports.py` to `test_suppressed_string_values_propagate_to_total` and changed assertions to expect "suppressed" in org-level totals when any program's value is suppressed, ensuring tests match the new aggregation behavior. [[1]](diffhunk://#diff-fe0d58921d4edabc511863f1859e054acf53f3017f6abeec7560b6e8e5ab1b71L2038-R2038) [[2]](diffhunk://#diff-fe0d58921d4edabc511863f1859e054acf53f3017f6abeec7560b6e8e5ab1b71L2050-R2054)…suppressed when any program value is suppressed