### PR TITLE
fix: Demographics group admin_only in seed commands

### DIFF
--- a/apps/admin_settings/management/commands/apply_setup.py
+++ b/apps/admin_settings/management/commands/apply_setup.py
@@ -245,6 +245,7 @@ def _apply_custom_fields(groups_data, stdout):
         group = CustomFieldGroup.objects.create(
             title=grp["title"],
             sort_order=i,
+            admin_only=grp.get("admin_only", False),
         )
         group_count += 1
 

--- a/apps/clients/management/commands/seed_intake_fields.py
+++ b/apps/clients/management/commands/seed_intake_fields.py
@@ -478,12 +478,22 @@ class Command(BaseCommand):
             # Create or get the group
             # Youth/recreation groups are archived by default — agencies can reactivate if needed
             initial_status = "archived" if group_title in ARCHIVED_BY_DEFAULT else "active"
+            defaults = {"sort_order": group_sort_order, "status": initial_status}
+            # Demographics are admin-only: hidden from frontline workers to
+            # prevent bias activation (DEMO-VIS1). Participants self-report
+            # via the portal; admins see values for funder reporting.
+            if group_title == "Demographics":
+                defaults["admin_only"] = True
             group, was_group_created = CustomFieldGroup.objects.get_or_create(
                 title=group_title,
-                defaults={"sort_order": group_sort_order, "status": initial_status},
+                defaults=defaults,
             )
             if was_group_created:
                 groups_created += 1
+            elif group_title == "Demographics" and not group.admin_only:
+                # Existing installs: upgrade to admin_only
+                group.admin_only = True
+                group.save(update_fields=["admin_only"])
 
             # Create fields within the group
             for field_idx, field_data in enumerate(fields):


### PR DESCRIPTION
## Summary
- `seed_intake_fields` now sets `admin_only=True` when creating the Demographics group
- Existing installs get upgraded on next seed run (idempotent)
- `apply_setup` config JSON now supports `admin_only` key on groups

Fixes: After DB reset on dev, the Demographics group lost its `admin_only=True` flag because the data migration ran before the seed command created the groups.

## Test plan
- [ ] Deploy to dev, verify Demographics group has `admin_only=True`
- [ ] Verify About Me card appears on portal dashboard
- [ ] Verify non-admin staff cannot see Demographics fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)