### PR TITLE
fix: remove main content focus outline

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -85,8 +85,7 @@
     border: 0;
 }
 #main-content:focus {
-    outline: 3px solid var(--kn-primary);
-    outline-offset: 4px;
+    outline: none;
 }
 
 /* ---- Demo mode banner ---- */


### PR DESCRIPTION
## Summary
- remove the shared #main-content focus outline that rendered as a blue frame around whole pages
- keep automatic focus on main content without the full-page visual border

## Testing
- checked CSS diagnostics for static/css/main.css