### PR TITLE
feat: implement feature toggle management for demo circles and enhanc…

### DIFF
--- a/apps/admin_settings/demo_engine.py
+++ b/apps/admin_settings/demo_engine.py
@@ -25,6 +25,7 @@ from django.contrib.auth import get_user_model
 from django.db import transaction
 from django.utils import timezone
 
+from apps.admin_settings.models import FeatureToggle
 from apps.clients.models import ClientFile, ClientProgramEnrolment
 from apps.events.models import Alert, Event, EventType
 from apps.notes.models import (
@@ -496,7 +497,10 @@ class DemoDataEngine:
         return profile
 
     # Known keys for each profile section (used for typo detection)
-    _VALID_TOP_KEYS = {"description", "defaults", "programs", "portal"}
+    _VALID_TOP_KEYS = {
+        "description", "defaults", "programs", "portal",
+        "demo_group", "users", "feature_toggles",
+    }
     _VALID_PORTAL_KEYS = {
         "journal_pools", "staff_notes_pool", "messages_pool",
         "program_resources", "client_resources", "survey_definitions",
@@ -518,6 +522,29 @@ class DemoDataEngine:
                     f"  Warning: unknown portal key '{key}' — will be ignored. "
                     f"Valid keys: {', '.join(sorted(self._VALID_PORTAL_KEYS))}"
                 )
+
+    def apply_feature_toggles(self, profile):
+        """Apply optional feature toggle overrides from the demo profile."""
+        feature_toggles = profile.get("feature_toggles", {})
+        if not feature_toggles:
+            return
+
+        applied = 0
+        for feature_key, is_enabled in feature_toggles.items():
+            if not isinstance(is_enabled, bool):
+                self.log_warning(
+                    f"  Warning: feature_toggles['{feature_key}'] must be true/false. Ignoring."
+                )
+                continue
+
+            FeatureToggle.objects.update_or_create(
+                feature_key=feature_key,
+                defaults={"is_enabled": is_enabled},
+            )
+            applied += 1
+
+        if applied:
+            self.log(f"  Applied {applied} feature toggle override(s) from the demo profile.")
 
     # ----- Cleanup -----
 
@@ -1790,6 +1817,7 @@ class DemoDataEngine:
         random.seed(42)  # Reproducible demo data
 
         profile = self.load_profile(profile_path)
+        self.apply_feature_toggles(profile)
 
         # Apply profile defaults
         profile_defaults = profile.get("defaults", {})

--- a/apps/admin_settings/management/commands/disable_circles_feature.py
+++ b/apps/admin_settings/management/commands/disable_circles_feature.py
@@ -1,0 +1,30 @@
+from django.core.management.base import BaseCommand
+
+
+class Command(BaseCommand):
+    help = "Disable the circles feature toggle and remove demo circles."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--keep-demo-circles",
+            action="store_true",
+            help="Disable the feature toggle but leave demo circles in the database.",
+        )
+
+    def handle(self, *args, **options):
+        from apps.admin_settings.models import FeatureToggle
+        from apps.circles.models import Circle
+
+        toggle, _ = FeatureToggle.objects.get_or_create(feature_key="circles")
+        toggle.is_enabled = False
+        toggle.save(update_fields=["is_enabled"])
+
+        deleted_count = 0
+        if not options["keep_demo_circles"]:
+            deleted_count = Circle.objects.filter(is_demo=True).delete()[0]
+
+        self.stdout.write(
+            self.style.SUCCESS(
+                f"Circles disabled. Demo circles removed: {deleted_count}."
+            )
+        )

--- a/apps/admin_settings/management/commands/seed_demo_data.py
+++ b/apps/admin_settings/management/commands/seed_demo_data.py
@@ -31,6 +31,7 @@ from django.contrib.auth import get_user_model
 from django.core.management.base import BaseCommand
 from django.utils import timezone
 
+from apps.admin_settings.models import FeatureToggle
 from apps.auth_app.models import AccessGrant, AccessGrantReason
 from apps.clients.models import (
     ClientDetailValue,
@@ -1524,7 +1525,7 @@ class Command(BaseCommand):
         # Always ensure demo circles exist (idempotent via get_or_create)
         try:
             worker1 = User.objects.get(username="demo-worker-1")
-            self._create_demo_circles(worker1)
+            self._sync_demo_circles(worker1)
         except User.DoesNotExist:
             pass
 
@@ -1731,7 +1732,7 @@ class Command(BaseCommand):
         self._ensure_pending_alert_recommendation(workers, programs_by_name)
 
         # --- Create demo circles ---
-        self._create_demo_circles(worker1)
+        self._sync_demo_circles(worker1)
 
         # --- Create demo groups ---
         self._create_demo_groups(workers, programs_by_name, now)
@@ -1824,10 +1825,6 @@ class Command(BaseCommand):
         Circles represent families, households, and support networks.
         Uses get_or_create for idempotency.
         """
-        # Three circles demonstrating different family/network structures:
-        # A: Same-household couple + non-participant child (cross-enrolment)
-        # B: Youth support network with non-participant parent (different households)
-        # C: Newcomer family with participant sibling (same household)
         DEMO_CIRCLES = [
             {
                 "name": "Rivera-Chen Household",
@@ -1857,7 +1854,6 @@ class Command(BaseCommand):
 
         created_count = 0
         for circle_def in DEMO_CIRCLES:
-            # Check if circle already exists by looking for exact name match in demo circles
             existing = [
                 c for c in Circle.objects.demo().filter(status="active")
                 if c.name == circle_def["name"]
@@ -1891,6 +1887,17 @@ class Command(BaseCommand):
 
         if created_count:
             self.stdout.write(f"  Created {created_count} demo circles with members.")
+
+    def _sync_demo_circles(self, created_by):
+        """Create or remove demo circles based on the circles feature toggle."""
+        circles_enabled = FeatureToggle.get_all_flags().get("circles", False)
+        if not circles_enabled:
+            deleted_count = Circle.objects.filter(is_demo=True).delete()[0]
+            if deleted_count:
+                self.stdout.write("  Circles feature is off — removed demo circles.")
+            return
+
+        self._create_demo_circles(created_by)
 
     def _seed_client_data(
         self, record_id, plan_config, workers, programs_by_name,

--- a/tests/test_management_commands.py
+++ b/tests/test_management_commands.py
@@ -298,6 +298,24 @@ class SeedDemoDataTest(TestCase):
             f"Achievement value should be a category string, got '{sample.value}'",
         )
 
+    def test_seed_enables_circles_in_demo_mode(self):
+        """Generic demo seeding should enable circles and create demo circles."""
+        from apps.admin_settings.models import FeatureToggle
+        from apps.circles.models import Circle
+
+        FeatureToggle.objects.update_or_create(
+            feature_key="circles",
+            defaults={"is_enabled": False},
+        )
+
+        out = io.StringIO()
+        call_command("seed", stdout=out)
+
+        self.assertTrue(
+            FeatureToggle.objects.get(feature_key="circles").is_enabled
+        )
+        self.assertTrue(Circle.objects.filter(is_demo=True).exists())
+
 
 @override_settings(FIELD_ENCRYPTION_KEY=TEST_KEY, DEMO_MODE=True)
 class GenerateDemoDataCommandTest(TestCase):
@@ -355,6 +373,23 @@ class GenerateDemoDataCommandTest(TestCase):
             "seeds/custom_profile.json",
         )
         self.assertNotIn("Using default demo profile", out.getvalue())
+
+    def test_demo_engine_applies_feature_toggles_from_profile(self):
+        """Profile feature_toggles should update feature flags before generation."""
+        from apps.admin_settings.demo_engine import DemoDataEngine
+        from apps.admin_settings.models import FeatureToggle
+
+        FeatureToggle.objects.update_or_create(
+            feature_key="circles",
+            defaults={"is_enabled": True},
+        )
+
+        engine = DemoDataEngine(stdout=io.StringIO(), stderr=io.StringIO())
+        engine.apply_feature_toggles({"feature_toggles": {"circles": False}})
+
+        self.assertFalse(
+            FeatureToggle.objects.get(feature_key="circles").is_enabled
+        )
 
 
 @override_settings(FIELD_ENCRYPTION_KEY=TEST_KEY, DEMO_MODE=False)


### PR DESCRIPTION
This pull request adds support for managing feature toggles in demo data workflows, particularly for the "circles" feature. It introduces the ability to apply feature toggles from demo profiles, synchronizes demo circles based on the toggle state, and provides a management command to disable the circles feature and remove demo circles. Tests are updated and added to verify these behaviors.

**Feature toggle management:**
* Added `apply_feature_toggles` method to `DemoDataEngine` to apply feature toggle overrides from a demo profile, allowing toggles like "circles" to be set before generating demo data. The method is called during the main `run` process. (`apps/admin_settings/demo_engine.py`) [[1]](diffhunk://#diff-76f6017f113bb1092c1c6a11a24a89925e9959097abd77a3101365aaa3034e30R526-R548) [[2]](diffhunk://#diff-76f6017f113bb1092c1c6a11a24a89925e9959097abd77a3101365aaa3034e30R1820)
* Updated valid profile keys to include `feature_toggles`, enabling toggles to be specified in demo profiles. (`apps/admin_settings/demo_engine.py`)

**Circles feature synchronization:**
* Replaced `_create_demo_circles` with `_sync_demo_circles` in the demo data seeding process, so demo circles are created or removed depending on the "circles" feature toggle. (`apps/admin_settings/management/commands/seed_demo_data.py`) [[1]](diffhunk://#diff-c7c9a2d254385916e1397696f86719c416e9a70edd9fd8b8e2ea410e0ec759b8L1527-R1528) [[2]](diffhunk://#diff-c7c9a2d254385916e1397696f86719c416e9a70edd9fd8b8e2ea410e0ec759b8L1734-R1735) [[3]](diffhunk://#diff-c7c9a2d254385916e1397696f86719c416e9a70edd9fd8b8e2ea410e0ec759b8R1891-R1901)

**Management command:**
* Added a new management command `disable_circles_feature` to disable the "circles" feature toggle and optionally remove demo circles from the database. (`apps/admin_settings/management/commands/disable_circles_feature.py`)

**Testing:**
* Added and updated tests to verify that seeding enables circles in demo mode and that feature toggles from profiles are correctly applied by the demo engine. (`tests/test_management_commands.py`) [[1]](diffhunk://#diff-41ef344f67aca3307c0c36d976a38852326eb704ddcfb86ba2ed58e3f0440a00R301-R318) [[2]](diffhunk://#diff-41ef344f67aca3307c0c36d976a38852326eb704ddcfb86ba2ed58e3f0440a00R377-R393)