### PR TITLE
🎨 Palette: Add ARIA labels to copy buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-03-08 - Added `.badge-danger` to form error linking logic
 **Learning:** Django often renders form validation errors using custom classes (like `badge badge-danger`) instead of generic `.error` classes. The `linkErrorMessages()` function in `static/js/app.js` was missing these dynamic form errors, causing screen reader users to miss context when a form field failed validation. I updated the script to target both `.error` and `.badge-danger`.
 **Action:** Always check the codebase for the actual class names used for error messages before assuming `.error` is sufficient for a11y linking scripts.
+
+## 2025-03-10 - Add ARIA Labels to Copy Buttons
+**Learning:** Many "Copy" buttons in the app use the `copy-btn` class but lack `aria-label`s. Screen readers might just read "Copy" out of context, which can be confusing (e.g., "Copy what?").
+**Action:** Add descriptive `aria-label` attributes to these buttons (e.g., `aria-label="{% trans 'Copy calendar link' %}"`) to improve accessibility.

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -22873,3 +22873,27 @@ msgstr ""
 
 msgid "Why we're asking"
 msgstr ""
+
+msgid "Copy AI draft to clipboard"
+msgstr ""
+
+msgid "Copy Outlook link"
+msgstr ""
+
+msgid "Copy calendar link"
+msgstr ""
+
+msgid "Copy direct link"
+msgstr ""
+
+msgid "Copy embed code"
+msgstr ""
+
+msgid "Copy export link"
+msgstr ""
+
+msgid "Copy registration link"
+msgstr ""
+
+msgid "Copy survey link"
+msgstr ""

--- a/templates/events/calendar_feed_settings.html
+++ b/templates/events/calendar_feed_settings.html
@@ -16,7 +16,7 @@
     <p>{% trans "Copy this link and paste it into your calendar app using the steps below." %}</p>
     <div role="group">
         <input type="text" id="feed-url" value="{{ feed_url }}" readonly aria-label="{% trans 'Calendar link' %}">
-        <button type="button" class="outline copy-btn" data-clipboard-target="feed-url">{% trans "Copy" %}</button>
+        <button type="button" class="outline copy-btn" data-clipboard-target="feed-url" aria-label="{% trans 'Copy calendar link' %}">{% trans "Copy" %}</button>
     </div>
 
     {% if outlook_subscribe_url %}
@@ -24,7 +24,7 @@
     <p>{% trans "Outlook sometimes needs a different format. If the link above doesn't work in Outlook, try this one instead." %}</p>
     <div role="group">
         <input type="text" id="outlook-url" value="{{ outlook_subscribe_url }}" readonly aria-label="{% trans 'Outlook calendar link' %}">
-        <button type="button" class="outline copy-btn" data-clipboard-target="outlook-url">{% trans "Copy" %}</button>
+        <button type="button" class="outline copy-btn" data-clipboard-target="outlook-url" aria-label="{% trans 'Copy Outlook link' %}">{% trans "Copy" %}</button>
     </div>
     {% endif %}
 </section>

--- a/templates/registration/admin/link_embed.html
+++ b/templates/registration/admin/link_embed.html
@@ -37,6 +37,7 @@
             <button type="button"
                     class="copy-btn"
                     data-clipboard-target="#embed-code"
+                    aria-label="{% trans 'Copy embed code' %}"
                     style="position: absolute; top: 0.5rem; right: 0.5rem;">
                 {% trans "Copy" %}
             </button>
@@ -58,6 +59,7 @@
             <button type="button"
                     class="copy-btn"
                     data-clipboard-target="#direct-url"
+                    aria-label="{% trans 'Copy direct link' %}"
                     style="position: absolute; top: 0.25rem; right: 0.25rem;">
                 {% trans "Copy" %}
             </button>

--- a/templates/registration/admin/link_form.html
+++ b/templates/registration/admin/link_form.html
@@ -16,7 +16,7 @@
     <p>
         <strong>{% trans "Registration URL:" %}</strong><br>
         <code id="registration-url">{{ request.scheme }}://{{ request.get_host }}{{ link.get_absolute_url }}</code>
-        <button type="button" class="outline secondary copy-btn" data-clipboard-target="#registration-url" style="margin-left: 0.5rem; padding: 0.25rem 0.5rem;">{% trans "Copy" %}</button>
+        <button type="button" class="outline secondary copy-btn" data-clipboard-target="#registration-url" aria-label="{% trans 'Copy registration link' %}" style="margin-left: 0.5rem; padding: 0.25rem 0.5rem;">{% trans "Copy" %}</button>
     </p>
 </article>
 {% endif %}

--- a/templates/registration/admin/link_list.html
+++ b/templates/registration/admin/link_list.html
@@ -71,7 +71,7 @@
                         <li><a href="{% url 'registration:registration_link_edit' pk=link.pk %}">{% trans "Edit" %}</a></li>
                         <li><a href="{{ link.get_absolute_url }}" target="_blank">{% trans "View Form" %}</a></li>
                         <li><a href="{% url 'registration:registration_link_embed' pk=link.pk %}"><strong>{% trans "Get Embed Code" %}</strong></a></li>
-                        <li><a href="#" class="copy-btn" data-clipboard-text="{{ request.scheme }}://{{ request.get_host }}{{ link.get_absolute_url }}">{% trans "Copy Direct Link" %}</a></li>
+                        <li><a href="#" class="copy-btn" data-clipboard-text="{{ request.scheme }}://{{ request.get_host }}{{ link.get_absolute_url }}" aria-label="{% trans 'Copy direct link' %}">{% trans "Copy Direct Link" %}</a></li>
                         <li><a href="{% url 'registration:submission_list' %}?link={{ link.pk }}">{% trans "View Submissions" %}</a></li>
                         <li><a href="{% url 'registration:registration_link_delete' pk=link.pk %}" class="secondary">{% trans "Delete" %}</a></li>
                     </ul>

--- a/templates/reports/_insights_ai.html
+++ b/templates/reports/_insights_ai.html
@@ -76,7 +76,7 @@
 
     {# Actions #}
     <div class="ai-actions" style="margin-top: 1rem;">
-        <button class="outline secondary copy-btn" type="button" data-clipboard-closest=".insights-ai-result">
+        <button class="outline secondary copy-btn" type="button" data-clipboard-closest=".insights-ai-result" aria-label="{% trans 'Copy AI draft to clipboard' %}">
             {% trans "Copy to clipboard" %}
         </button>
         <button

--- a/templates/reports/export_link_created.html
+++ b/templates/reports/export_link_created.html
@@ -109,6 +109,7 @@
                 style="max-width: 10rem;"
                 class="secondary copy-btn"
                 data-clipboard-target="export-link"
+                aria-label="{% trans 'Copy export link' %}"
             >
                 <span aria-hidden="true">&#x1F4CB;</span> {% trans "Copy Link" %}
             </button>

--- a/templates/surveys/admin/survey_links.html
+++ b/templates/surveys/admin/survey_links.html
@@ -63,6 +63,7 @@
                                style="margin-bottom:0">
                         <button type="button" class="outline secondary copy-btn"
                                 data-clipboard-text="{{ request.scheme }}://{{ request.get_host }}/s/{{ link.token }}/"
+                                aria-label="{% trans 'Copy survey link' %}"
                                 style="margin-bottom:0; white-space:nowrap">{% trans "Copy" %}</button>
                     </div>
                 {% else %}


### PR DESCRIPTION
💡 **What:** Added descriptive `aria-label` attributes (e.g., `aria-label="{% trans 'Copy calendar link' %}"`) to multiple copy-to-clipboard buttons across various templates. Also logged this pattern to the `.Jules/palette.md` journal.

🎯 **Why:** Many buttons using the `copy-btn` class just displayed the text "Copy". For screen reader users tabbing through the page, hearing only "Copy" provides insufficient context about what is being copied. Adding descriptive `aria-label`s makes these actions significantly clearer and improves overall accessibility.

♿ **Accessibility:**
- Improved screen reader context for multiple interactive elements.
- Ensured all added labels are properly wrapped in `{% trans %}` tags for internationalization support.

---
*PR created automatically by Jules for task [13976799306488720994](https://jules.google.com/task/13976799306488720994) started by @pboachie*