### PR TITLE
Remove PHQ-9 and GAD-7 from metric library seeds

### DIFF
--- a/seeds/metric_library.json
+++ b/seeds/metric_library.json
@@ -1,46 +1,5 @@
 [
   {
-    "name": "PHQ-9 (Depression)",
-    "name_fr": "PHQ-9 (Dépression)",
-    "definition": "Patient Health Questionnaire-9. Scores 0-27. Measures depression severity: 0-4 minimal, 5-9 mild, 10-14 moderate, 15-19 moderately severe, 20-27 severe.",
-    "definition_fr": "Questionnaire sur la santé du patient-9. Scores 0-27. Mesure la sévérité de la dépression : 0-4 minimale, 5-9 légère, 10-14 modérée, 15-19 modérément sévère, 20-27 sévère.",
-    "category": "mental_health",
-    "min_value": 0,
-    "max_value": 27,
-    "unit": "score",
-    "unit_fr": "pointage",
-    "instrument_name": "PHQ-9",
-    "is_standardized_instrument": true,
-    "higher_is_better": false,
-    "scoring_bands": [
-      {"min": 0, "max": 4, "label": "Minimal", "label_fr": "Minimale"},
-      {"min": 5, "max": 9, "label": "Mild", "label_fr": "Légère"},
-      {"min": 10, "max": 14, "label": "Moderate", "label_fr": "Modérée"},
-      {"min": 15, "max": 19, "label": "Moderately severe", "label_fr": "Modérément sévère"},
-      {"min": 20, "max": 27, "label": "Severe", "label_fr": "Sévère"}
-    ]
-  },
-  {
-    "name": "GAD-7 (Anxiety)",
-    "name_fr": "GAD-7 (Anxiété)",
-    "definition": "Generalized Anxiety Disorder-7. Scores 0-21. Measures anxiety severity: 0-4 minimal, 5-9 mild, 10-14 moderate, 15-21 severe.",
-    "definition_fr": "Trouble d'anxiété généralisée-7. Scores 0-21. Mesure la sévérité de l'anxiété : 0-4 minimale, 5-9 légère, 10-14 modérée, 15-21 sévère.",
-    "category": "mental_health",
-    "min_value": 0,
-    "max_value": 21,
-    "unit": "score",
-    "unit_fr": "pointage",
-    "instrument_name": "GAD-7",
-    "is_standardized_instrument": true,
-    "higher_is_better": false,
-    "scoring_bands": [
-      {"min": 0, "max": 4, "label": "Minimal", "label_fr": "Minimale"},
-      {"min": 5, "max": 9, "label": "Mild", "label_fr": "Légère"},
-      {"min": 10, "max": 14, "label": "Moderate", "label_fr": "Modérée"},
-      {"min": 15, "max": 21, "label": "Severe", "label_fr": "Sévère"}
-    ]
-  },
-  {
     "name": "K10 (Psychological Distress)",
     "name_fr": "K10 (Détresse psychologique)",
     "definition": "Kessler Psychological Distress Scale. Scores 10-50. 10-19 likely well, 20-24 mild, 25-29 moderate, 30-50 severe distress.",
@@ -58,6 +17,14 @@
       {"min": 20, "max": 24, "label": "Mild", "label_fr": "Légère"},
       {"min": 25, "max": 29, "label": "Moderate", "label_fr": "Modérée"},
       {"min": 30, "max": 50, "label": "Severe", "label_fr": "Sévère"}
+    ],
+    "rationale_log": [
+      {
+        "date": "2026-03-04",
+        "note": "Kessler Psychological Distress Scale (Kessler et al., 2002). Validated screening tool for non-specific psychological distress. Scores 10-50 with published severity bands. Widely used in Canadian community services and population health surveys.",
+        "note_fr": "Échelle de détresse psychologique de Kessler (Kessler et al., 2002). Outil de dépistage validé pour la détresse psychologique non spécifique. Scores de 10 à 50 avec bandes de sévérité publiées. Largement utilisé dans les services communautaires canadiens et les enquêtes de santé publique.",
+        "author": "System"
+      }
     ]
   },
   {


### PR DESCRIPTION
This pull request updates the `seeds/metric_library.json` file by removing the PHQ-9 and GAD-7 mental health metrics and adding additional rationale documentation for the K10 metric. The changes focus on streamlining the metric library and improving documentation for the K10 instrument.

**Metric removals:**

* Removed the PHQ-9 (Depression) metric, including all associated metadata, scoring bands, and French translations.
* Removed the GAD-7 (Anxiety) metric, including all associated metadata, scoring bands, and French translations.

**Documentation improvements:**

* Added a `rationale_log` entry to the K10 (Psychological Distress) metric, providing context and references for its use and validation, in both English and French.