### PR TITLE
Add ARIA labels to improve accessibility of copy buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-03-08 - Added `.badge-danger` to form error linking logic
 **Learning:** Django often renders form validation errors using custom classes (like `badge badge-danger`) instead of generic `.error` classes. The `linkErrorMessages()` function in `static/js/app.js` was missing these dynamic form errors, causing screen reader users to miss context when a form field failed validation. I updated the script to target both `.error` and `.badge-danger`.
 **Action:** Always check the codebase for the actual class names used for error messages before assuming `.error` is sufficient for a11y linking scripts.
+
+## 2025-03-10 - Add ARIA Labels to Copy Buttons
+**Learning:** Many "Copy" buttons in the app use the `copy-btn` class but lack `aria-label`s. Screen readers might just read "Copy" out of context, which can be confusing (e.g., "Copy what?").
+**Action:** Add descriptive `aria-label` attributes to these buttons (e.g., `aria-label="{% trans 'Copy calendar link' %}"`) to improve accessibility.

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -22873,3 +22873,27 @@ msgstr ""
 
 msgid "Why we're asking"
 msgstr ""
+
+msgid "Copy AI draft to clipboard"
+msgstr ""
+
+msgid "Copy Outlook link"
+msgstr ""
+
+msgid "Copy calendar link"
+msgstr ""
+
+msgid "Copy direct link"
+msgstr ""
+
+msgid "Copy embed code"
+msgstr ""
+
+msgid "Copy export link"
+msgstr ""
+
+msgid "Copy registration link"
+msgstr ""
+
+msgid "Copy survey link"
+msgstr ""

--- a/templates/events/calendar_feed_settings.html
+++ b/templates/events/calendar_feed_settings.html
@@ -16,7 +16,7 @@
     <p>{% trans "Copy this link and paste it into your calendar app using the steps below." %}</p>
     <div role="group">
         <input type="text" id="feed-url" value="{{ feed_url }}" readonly aria-label="{% trans 'Calendar link' %}">
-        <button type="button" class="outline copy-btn" data-clipboard-target="feed-url">{% trans "Copy" %}</button>
+        <button type="button" class="outline copy-btn" data-clipboard-target="feed-url" aria-label="{% trans 'Copy calendar link' %}">{% trans "Copy" %}</button>
     </div>
 
     {% if outlook_subscribe_url %}
@@ -24,7 +24,7 @@
     <p>{% trans "Outlook sometimes needs a different format. If the link above doesn't work in Outlook, try this one instead." %}</p>
     <div role="group">
         <input type="text" id="outlook-url" value="{{ outlook_subscribe_url }}" readonly aria-label="{% trans 'Outlook calendar link' %}">
-        <button type="button" class="outline copy-btn" data-clipboard-target="outlook-url">{% trans "Copy" %}</button>
+        <button type="button" class="outline copy-btn" data-clipboard-target="outlook-url" aria-label="{% trans 'Copy Outlook link' %}">{% trans "Copy" %}</button>
     </div>
     {% endif %}
 </section>

--- a/templates/registration/admin/link_embed.html
+++ b/templates/registration/admin/link_embed.html
@@ -37,6 +37,7 @@
             <button type="button"
                     class="copy-btn"
                     data-clipboard-target="#embed-code"
+                    aria-label="{% trans 'Copy embed code' %}"
                     style="position: absolute; top: 0.5rem; right: 0.5rem;">
                 {% trans "Copy" %}
             </button>
@@ -58,6 +59,7 @@
             <button type="button"
                     class="copy-btn"
                     data-clipboard-target="#direct-url"
+                    aria-label="{% trans 'Copy direct link' %}"
                     style="position: absolute; top: 0.25rem; right: 0.25rem;">
                 {% trans "Copy" %}
             </button>

--- a/templates/registration/admin/link_form.html
+++ b/templates/registration/admin/link_form.html
@@ -16,7 +16,7 @@
     <p>
         <strong>{% trans "Registration URL:" %}</strong><br>
         <code id="registration-url">{{ request.scheme }}://{{ request.get_host }}{{ link.get_absolute_url }}</code>
-        <button type="button" class="outline secondary copy-btn" data-clipboard-target="#registration-url" style="margin-left: 0.5rem; padding: 0.25rem 0.5rem;">{% trans "Copy" %}</button>
+        <button type="button" class="outline secondary copy-btn" data-clipboard-target="#registration-url" aria-label="{% trans 'Copy registration link' %}" style="margin-left: 0.5rem; padding: 0.25rem 0.5rem;">{% trans "Copy" %}</button>
     </p>
 </article>
 {% endif %}

--- a/templates/registration/admin/link_list.html
+++ b/templates/registration/admin/link_list.html
@@ -71,7 +71,7 @@
                         <li><a href="{% url 'registration:registration_link_edit' pk=link.pk %}">{% trans "Edit" %}</a></li>
                         <li><a href="{{ link.get_absolute_url }}" target="_blank">{% trans "View Form" %}</a></li>
                         <li><a href="{% url 'registration:registration_link_embed' pk=link.pk %}"><strong>{% trans "Get Embed Code" %}</strong></a></li>
-                        <li><a href="#" class="copy-btn" data-clipboard-text="{{ request.scheme }}://{{ request.get_host }}{{ link.get_absolute_url }}">{% trans "Copy Direct Link" %}</a></li>
+                        <li><a href="#" class="copy-btn" data-clipboard-text="{{ request.scheme }}://{{ request.get_host }}{{ link.get_absolute_url }}" aria-label="{% trans 'Copy direct link' %}">{% trans "Copy Direct Link" %}</a></li>
                         <li><a href="{% url 'registration:submission_list' %}?link={{ link.pk }}">{% trans "View Submissions" %}</a></li>
                         <li><a href="{% url 'registration:registration_link_delete' pk=link.pk %}" class="secondary">{% trans "Delete" %}</a></li>
                     </ul>

--- a/templates/reports/_insights_ai.html
+++ b/templates/reports/_insights_ai.html
@@ -76,7 +76,7 @@
 
     {# Actions #}
     <div class="ai-actions" style="margin-top: 1rem;">
-        <button class="outline secondary copy-btn" type="button" data-clipboard-closest=".insights-ai-result">
+        <button class="outline secondary copy-btn" type="button" data-clipboard-closest=".insights-ai-result" aria-label="{% trans 'Copy AI draft to clipboard' %}">
             {% trans "Copy to clipboard" %}
         </button>
         <button

--- a/templates/reports/export_link_created.html
+++ b/templates/reports/export_link_created.html
@@ -109,6 +109,7 @@
                 style="max-width: 10rem;"
                 class="secondary copy-btn"
                 data-clipboard-target="export-link"
+                aria-label="{% trans 'Copy export link' %}"
             >
                 <span aria-hidden="true">&#x1F4CB;</span> {% trans "Copy Link" %}
             </button>

--- a/templates/surveys/admin/survey_links.html
+++ b/templates/surveys/admin/survey_links.html
@@ -63,6 +63,7 @@
                                style="margin-bottom:0">
                         <button type="button" class="outline secondary copy-btn"
                                 data-clipboard-text="{{ request.scheme }}://{{ request.get_host }}/s/{{ link.token }}/"
+                                aria-label="{% trans 'Copy survey link' %}"
                                 style="margin-bottom:0; white-space:nowrap">{% trans "Copy" %}</button>
                     </div>
                 {% else %}


### PR DESCRIPTION
This pull request improves accessibility across the app by adding descriptive ARIA labels to all "Copy" buttons. This ensures that screen readers provide more context to users, clarifying what each button copies (e.g., "Copy calendar link" instead of just "Copy"). Additionally, new translation keys have been added for these ARIA labels.

**Accessibility improvements for copy buttons:**

* Added `aria-label` attributes to all buttons and links with the `copy-btn` class in templates, specifying exactly what will be copied (e.g., "Copy calendar link", "Copy Outlook link", "Copy AI draft to clipboard", etc.). This change affects calendar, registration, report, and survey copy actions. [[1]](diffhunk://#diff-ed95ef3de4dd44e1c4df83b5535b57e6d0b8d10a49b201fe2d7bc4be3238180bL19-R27) [[2]](diffhunk://#diff-70b3240cdb7b15eea2058bf7c20563bc83be06cb3e87661ca6d1977b5db23ffaR40) [[3]](diffhunk://#diff-70b3240cdb7b15eea2058bf7c20563bc83be06cb3e87661ca6d1977b5db23ffaR62) [[4]](diffhunk://#diff-2ab3d38b47a5982c82efd04f83976d45945621da9e3a163864279c27fbdce225L19-R19) [[5]](diffhunk://#diff-38b0befdddd870fa0f1ca1c2094e171f890827f135b1a6ba918154b992334188L74-R74) [[6]](diffhunk://#diff-7bb9c0004781a9185030e137d61eec37bee69ac96846970567d293bc3e5a76c8L79-R79) [[7]](diffhunk://#diff-0266f788683ff072deb8a778a27dfb68998970f1bb4f6c4e92ba8ea6f2d3f01aR112) [[8]](diffhunk://#diff-a8a636f6d7c0735dd55747d69a3a9eea0bfbd147c4648242c799deaca64da216R66)

* Updated `.Jules/palette.md` documentation to reflect the new ARIA labeling practice for copy buttons and explain the accessibility rationale.

**Internationalization support:**

* Added new translation keys for all new ARIA label strings in the French translation file (`django.po`).