### PR TITLE
feat: enhance demo participant retrieval and add PHQ-9 and GAD-7 metr…

### DIFF
--- a/apps/portal/models.py
+++ b/apps/portal/models.py
@@ -231,15 +231,26 @@ DEMO_PORTAL_LOGIN_PREVIEW_LIMIT = 3
 
 
 def get_demo_portal_participants(limit=DEMO_PORTAL_LOGIN_PREVIEW_LIMIT):
-    """Return a small, stable set of demo participants for login shortcuts."""
-    return list(
+    """Return a small, stable set of demo participants for login shortcuts.
+
+    When instance-specific demo data exists (for example ``PC-*`` records for
+    a client demo), prefer those over the generic ``DEMO-*`` shortcuts so the
+    login page matches the active seeded dataset for the environment.
+    """
+    base_qs = (
         ParticipantUser.objects.filter(
             is_active=True,
             mfa_method="exempt",
+            client_file__is_demo=True,
         )
         .select_related("client_file")
-        .order_by("client_file__record_id")[:limit]
+        .order_by("client_file__record_id")
     )
+    instance_specific_qs = base_qs.exclude(
+        client_file__record_id__startswith="DEMO-"
+    )
+    qs = instance_specific_qs if instance_specific_qs.exists() else base_qs
+    return list(qs[:limit])
 
 
 # ---------------------------------------------------------------------------

--- a/seeds/metric_library.json
+++ b/seeds/metric_library.json
@@ -1,5 +1,62 @@
 [
   {
+    "name": "PHQ-9 (Depression)",
+    "name_fr": "PHQ-9 (Dépression)",
+    "definition": "Patient Health Questionnaire-9. Scores 0-27. 0-4 minimal, 5-9 mild, 10-14 moderate, 15-19 moderately severe, 20-27 severe depression.",
+    "definition_fr": "Questionnaire de santé du patient-9. Scores de 0 à 27. 0-4 minimale, 5-9 légère, 10-14 modérée, 15-19 modérément sévère, 20-27 sévère.",
+    "category": "mental_health",
+    "min_value": 0,
+    "max_value": 27,
+    "unit": "score",
+    "unit_fr": "pointage",
+    "instrument_name": "PHQ-9",
+    "is_standardized_instrument": true,
+    "higher_is_better": false,
+    "scoring_bands": [
+      {"min": 0, "max": 4, "label": "Minimal", "label_fr": "Minimale"},
+      {"min": 5, "max": 9, "label": "Mild", "label_fr": "Légère"},
+      {"min": 10, "max": 14, "label": "Moderate", "label_fr": "Modérée"},
+      {"min": 15, "max": 19, "label": "Moderately Severe", "label_fr": "Modérément sévère"},
+      {"min": 20, "max": 27, "label": "Severe", "label_fr": "Sévère"}
+    ],
+    "rationale_log": [
+      {
+        "date": "2026-03-04",
+        "note": "Patient Health Questionnaire-9 (Kroenke et al., 2001). Validated screening and monitoring tool for depression severity with widely used published cut-points. Common in community mental health, primary care, and nonprofit counselling settings.",
+        "note_fr": "Questionnaire de santé du patient-9 (Kroenke et al., 2001). Outil validé de dépistage et de suivi de la sévérité de la dépression avec seuils publiés largement utilisés. Courant en santé mentale communautaire, en soins primaires et dans les services de counseling communautaires.",
+        "author": "System"
+      }
+    ]
+  },
+  {
+    "name": "GAD-7 (Anxiety)",
+    "name_fr": "GAD-7 (Anxiété)",
+    "definition": "Generalized Anxiety Disorder-7. Scores 0-21. 0-4 minimal, 5-9 mild, 10-14 moderate, 15-21 severe anxiety.",
+    "definition_fr": "Échelle du trouble d'anxiété généralisée-7. Scores de 0 à 21. 0-4 minimale, 5-9 légère, 10-14 modérée, 15-21 sévère.",
+    "category": "mental_health",
+    "min_value": 0,
+    "max_value": 21,
+    "unit": "score",
+    "unit_fr": "pointage",
+    "instrument_name": "GAD-7",
+    "is_standardized_instrument": true,
+    "higher_is_better": false,
+    "scoring_bands": [
+      {"min": 0, "max": 4, "label": "Minimal", "label_fr": "Minimale"},
+      {"min": 5, "max": 9, "label": "Mild", "label_fr": "Légère"},
+      {"min": 10, "max": 14, "label": "Moderate", "label_fr": "Modérée"},
+      {"min": 15, "max": 21, "label": "Severe", "label_fr": "Sévère"}
+    ],
+    "rationale_log": [
+      {
+        "date": "2026-03-04",
+        "note": "Generalized Anxiety Disorder-7 (Spitzer et al., 2006). Validated screening and monitoring tool for generalized anxiety severity with published cut-points. Widely used in community counselling, primary care, and outcome monitoring.",
+        "note_fr": "Échelle du trouble d'anxiété généralisée-7 (Spitzer et al., 2006). Outil validé de dépistage et de suivi de la sévérité de l'anxiété généralisée avec seuils publiés. Largement utilisé en counseling communautaire, en soins primaires et pour le suivi des résultats.",
+        "author": "System"
+      }
+    ]
+  },
+  {
     "name": "K10 (Psychological Distress)",
     "name_fr": "K10 (Détresse psychologique)",
     "definition": "Kessler Psychological Distress Scale. Scores 10-50. 10-19 likely well, 20-24 mild, 25-29 moderate, 30-50 severe distress.",


### PR DESCRIPTION
This pull request introduces improvements to demo participant selection logic and expands the metric library with two widely used mental health instruments. The most important changes are grouped below:

**Demo participant selection logic:**

* Improved the `get_demo_portal_participants` function in `apps/portal/models.py` to prioritize instance-specific demo participants (e.g., `PC-*` records) over generic demo participants (`DEMO-*`) when available, ensuring the login page reflects the active seeded dataset for the environment.

**Metric library expansion:**

* Added the PHQ-9 (Depression) instrument to `seeds/metric_library.json`, including English and French names, definitions, scoring bands, and rationale, supporting standardized depression measurement.
* Added the GAD-7 (Anxiety) instrument to `seeds/metric_library.json`, with bilingual metadata, scoring bands, and rationale, enabling standardized anxiety measurement.