### PR TITLE
feat: enhance demo participant filtering in portal login and update t…

### DIFF
--- a/apps/portal/models.py
+++ b/apps/portal/models.py
@@ -15,6 +15,7 @@ from django.conf import settings
 from django.contrib.auth.hashers import make_password
 from django.contrib.auth.models import AbstractBaseUser, BaseUserManager
 from django.db import models
+from django.db.models import Q
 from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 
@@ -236,12 +237,21 @@ def get_demo_portal_participants(limit=DEMO_PORTAL_LOGIN_PREVIEW_LIMIT):
     When instance-specific demo data exists (for example ``PC-*`` records for
     a client demo), prefer those over the generic ``DEMO-*`` shortcuts so the
     login page matches the active seeded dataset for the environment.
+
+    We support both the explicit ``client_file.is_demo`` flag and the legacy
+    record-id conventions used by the quick-login route (``DEMO-*``/``PC-*``),
+    because tests and older seeded data still rely on those record IDs even
+    when the boolean flag was not set at creation time.
     """
     base_qs = (
         ParticipantUser.objects.filter(
             is_active=True,
             mfa_method="exempt",
-            client_file__is_demo=True,
+        )
+        .filter(
+            Q(client_file__is_demo=True)
+            | Q(client_file__record_id__startswith="DEMO-")
+            | Q(client_file__record_id__startswith="PC-")
         )
         .select_related("client_file")
         .order_by("client_file__record_id")

--- a/apps/portal/tests/test_auth.py
+++ b/apps/portal/tests/test_auth.py
@@ -205,10 +205,15 @@ class PortalAuthTests(TestCase):
     @override_settings(DEMO_MODE=True)
     def test_portal_login_caps_demo_participants_to_three(self):
         """The portal login page should only preview three demo participants."""
+        self.client_file.record_id = "DEMO-001"
+        self.client_file.is_demo = True
+        self.client_file.save(update_fields=["record_id", "is_demo"])
+
         for index in range(2, 6):
             client_file = ClientFile.objects.create(
-                record_id=f"TEST-{index:03d}",
+                record_id=f"DEMO-{index:03d}",
                 status="active",
+                is_demo=True,
             )
             client_file.first_name = f"Demo {index}"
             client_file.last_name = "Participant"


### PR DESCRIPTION
This pull request updates the logic for selecting demo participants in the portal, ensuring both the new `is_demo` flag and legacy record ID conventions are supported. This improves compatibility with older seeded data and tests, and updates the test suite to reflect these changes.

**Demo participant selection improvements:**

* Updated `get_demo_portal_participants` to select demo participants using both the `client_file.is_demo` flag and legacy record ID patterns (`DEMO-*`, `PC-*`), ensuring broader compatibility with existing data and tests.
* Added import of `Q` from `django.db.models` to support more complex query filtering.

**Test updates:**

* Modified `test_portal_login_caps_demo_participants_to_three` to use `DEMO-*` record IDs and set the `is_demo` flag, aligning the test data with the updated selection logic.