### PR TITLE
fix: address taxonomy-on-template review findings

### DIFF
--- a/apps/admin_settings/report_template_views.py
+++ b/apps/admin_settings/report_template_views.py
@@ -135,6 +135,19 @@ def report_template_detail(request, profile_id):
         ),
         pk=profile_id,
     )
+
+    # Handle inline taxonomy_system update
+    if request.method == "POST" and "taxonomy_system" in request.POST:
+        new_value = request.POST.get("taxonomy_system", "")
+        valid_values = {v for v, _ in ReportTemplate.TAXONOMY_SYSTEMS}
+        if new_value == "" or new_value in valid_values:
+            profile.taxonomy_system = new_value
+            profile.save(update_fields=["taxonomy_system"])
+            messages.success(request, _("Taxonomy system updated."))
+        else:
+            messages.error(request, _("Invalid taxonomy system."))
+        return redirect("admin_settings:report_template_detail", profile_id=profile.pk)
+
     return render(request, "admin_settings/funder_profiles/detail.html", {
         "profile": profile,
     })

--- a/apps/reports/cids_enrichment.py
+++ b/apps/reports/cids_enrichment.py
@@ -17,8 +17,6 @@ References CIDS v3.2 (not v2.0).
 """
 import logging
 
-from django.utils.translation import gettext_lazy as _lazy
-
 logger = logging.getLogger(__name__)
 
 

--- a/apps/reports/migrations/0020_reporttemplate_taxonomy_system.py
+++ b/apps/reports/migrations/0020_reporttemplate_taxonomy_system.py
@@ -3,6 +3,12 @@
 from django.db import migrations, models
 
 
+def set_existing_templates_iris_plus(apps, schema_editor):
+    """Set taxonomy_system='iris_plus' for existing templates that default to ''."""
+    ReportTemplate = apps.get_model("reports", "ReportTemplate")
+    ReportTemplate.objects.filter(taxonomy_system="").update(taxonomy_system="iris_plus")
+
+
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -33,5 +39,9 @@ class Migration(migrations.Migration):
                 ),
                 max_length=50,
             ),
+        ),
+        migrations.RunPython(
+            set_existing_templates_iris_plus,
+            migrations.RunPython.noop,
         ),
     ]

--- a/apps/reports/models.py
+++ b/apps/reports/models.py
@@ -209,6 +209,7 @@ class ReportTemplate(models.Model):
             "When blank, the default HTML report template is used."
         ),
     )
+    # Keep in sync with TaxonomyMapping.TAXONOMY_SYSTEMS (excludes common_approach)
     TAXONOMY_SYSTEMS = [
         ("iris_plus", _("IRIS+")),
         ("sdg", _("SDG")),

--- a/templates/admin_settings/funder_profiles/detail.html
+++ b/templates/admin_settings/funder_profiles/detail.html
@@ -19,6 +19,18 @@
             <dd>{{ profile.breakdowns.count }}</dd>
             <dt>{% trans "Outcome Metrics" %}</dt>
             <dd>{{ profile.report_metrics.count }}</dd>
+            <dt>{% trans "Standards Taxonomy" %}</dt>
+            <dd>
+                <form method="post" style="display: inline;">
+                    {% csrf_token %}
+                    <select name="taxonomy_system" aria-label="{% trans 'Standards taxonomy system' %}" onchange="this.form.submit()" style="display: inline-block; width: auto; margin-bottom: 0;">
+                        <option value="">{% trans "None (no appendix)" %}</option>
+                        {% for value, label in profile.TAXONOMY_SYSTEMS %}
+                        <option value="{{ value }}"{% if profile.taxonomy_system == value %} selected{% endif %}>{{ label }}</option>
+                        {% endfor %}
+                    </select>
+                </form>
+            </dd>
             <dt>{% trans "Partner" %}</dt>
             <dd>
                 {% if profile.partner %}

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -1708,6 +1708,17 @@ class FunderReportViewTests(TestCase):
             label="Sustainable Cities and Communities",
             specification_uri="https://metadata.un.org/sdg/11",
         )
+        # Create a report template with SDG taxonomy for CIDS export tests
+        partner = Partner.objects.create(
+            name="SDG Test Partner", partner_type="funder", is_active=True,
+        )
+        partner.programs.add(self.program)
+        self.report_template = ReportTemplate.objects.create(
+            partner=partner,
+            name="SDG Test Template",
+            taxonomy_system="sdg",
+            created_by=self.admin,
+        )
         section = PlanSection.objects.create(client_file=client_file, program=self.program)
         target = PlanTarget(plan_section=section, client_file=client_file)
         target.name = "Stable housing"
@@ -1949,16 +1960,13 @@ class FunderReportViewTests(TestCase):
 
     def test_funder_report_cids_json_export_uses_selected_taxonomy(self):
         self._seed_cids_export_data()
-        # Set the template's taxonomy_system so the report uses SDG
-        if hasattr(self, "report_template") and self.report_template:
-            self.report_template.taxonomy_system = "sdg"
-            self.report_template.save()
         self.client.login(username="admin", password="testpass123")
         resp = self._submit_funder_report_through_approval(
             {
                 "program": self.program.pk,
                 "fiscal_year": "2025",
                 "format": "cids_json",
+                "report_template": self.report_template.pk,
                 "recipient": "self",
                 "recipient_reason": "Standards export",
             },
@@ -1969,6 +1977,27 @@ class FunderReportViewTests(TestCase):
         payload = json.loads(self._get_download_content(download_resp))
         indicator = next(node for node in payload["@graph"] if node.get("@type") == "cids:Indicator")
         self.assertEqual(indicator["hasCode"][0]["@id"], "https://metadata.un.org/sdg/11")
+
+    def test_funder_report_csv_export_without_taxonomy(self):
+        """Reports with no taxonomy_system (blank) should export without error."""
+        self._seed_cids_export_data()
+        self.report_template.taxonomy_system = ""
+        self.report_template.save()
+        self.client.login(username="admin", password="testpass123")
+        resp = self._submit_funder_report_through_approval(
+            {
+                "program": self.program.pk,
+                "fiscal_year": "2025",
+                "format": "csv",
+                "report_template": self.report_template.pk,
+                "recipient": "self",
+                "recipient_reason": "No taxonomy export",
+            },
+        )
+        self.assertEqual(resp.status_code, 200)
+        link = SecureExportLink.objects.latest("created_at")
+        download_resp = self.client.get(f"/reports/download/{link.id}/")
+        self.assertEqual(download_resp.status_code, 200)
 
     def test_funder_report_all_programs_html_export(self):
         """All-programs mode with HTML format produces styled HTML, not CSV."""


### PR DESCRIPTION
## Summary
- **Fix test bug**: `_seed_cids_export_data()` now creates a `ReportTemplate` with `taxonomy_system="sdg"` and the test passes it in form data, so the SDG taxonomy is actually applied during the CIDS JSON export test
- **Data migration**: Existing templates get `taxonomy_system="iris_plus"` (prevents regression where reports lose their standards appendix)
- **Remove dead import**: `_lazy` was unused in `cids_enrichment.py`
- **Admin UI**: Inline `<select>` on the report template detail page lets admins set/change the taxonomy system
- **Blank taxonomy test**: Confirms reports export cleanly when `taxonomy_system=""` (no appendix)
- **Sync comment**: Documents that `ReportTemplate.TAXONOMY_SYSTEMS` mirrors `TaxonomyMapping.TAXONOMY_SYSTEMS` minus `common_approach`

## Note
Fix #6 (run `translate_strings` for new model field strings) requires VPS access and will be done at next deploy.

## Test plan
- [ ] Verify `test_funder_report_cids_json_export_uses_selected_taxonomy` passes with the SDG template
- [ ] Verify `test_funder_report_csv_export_without_taxonomy` passes with blank taxonomy
- [ ] Verify admin template detail page shows taxonomy dropdown and saves changes
- [ ] Run `translate_strings` on VPS after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)