### PR TITLE
fix: cross-origin CSRF for embedded registration forms

### DIFF
--- a/konote/middleware/embed_framing.py
+++ b/konote/middleware/embed_framing.py
@@ -1,4 +1,14 @@
-"""Middleware to allow iframe embedding for public pages with ?embed=1."""
+"""Middleware to allow iframe embedding for public pages with ?embed=1.
+
+Handles three cross-origin concerns when a page is embedded in an iframe:
+
+1. **Framing policy** — replaces X-Frame-Options: DENY with a CSP
+   frame-ancestors directive allowing the configured origins.
+2. **CSRF cookies** — sets SameSite=None on the CSRF cookie so the
+   browser sends it on cross-origin POST from the iframe.
+3. **CSRF origin check** — marks the request so CsrfViewMiddleware
+   accepts the cross-origin Origin header (via CSRF_TRUSTED_ORIGINS).
+"""
 from django.conf import settings
 from django.http import HttpResponseForbidden
 
@@ -8,11 +18,13 @@ _EMBEDDABLE_PREFIXES = ("/register/", "/s/")
 
 
 class EmbedFramingMiddleware:
-    """Override X-Frame-Options and CSP frame-ancestors for embed requests.
+    """Override framing and CSRF policies for embed requests.
 
     When a request includes ?embed=1 and the URL matches an embeddable prefix,
-    this middleware replaces the global DENY framing policy with a policy that
-    allows the origins listed in settings.EMBED_ALLOWED_ORIGINS.
+    this middleware:
+    - Replaces the global DENY framing policy with CSP frame-ancestors
+    - Sets SameSite=None on the CSRF cookie (required for cross-origin POST)
+    - Adds EMBED_ALLOWED_ORIGINS to CSRF_TRUSTED_ORIGINS for the request
 
     If EMBED_ALLOWED_ORIGINS is empty, the embed request gets a 403.
     """
@@ -33,14 +45,23 @@ class EmbedFramingMiddleware:
                     "Iframe embedding is not enabled for this instance. "
                     "Set EMBED_ALLOWED_ORIGINS in the environment."
                 )
+            # Mark request so we can patch the CSRF cookie on the response.
+            request._embed_allowed_origins = allowed_origins
 
         response = self.get_response(request)
 
         if is_embed:
+            # 1. Allow framing from configured origins.
             frame_ancestors = " ".join(allowed_origins)
             response["Content-Security-Policy"] = (
                 f"frame-ancestors 'self' {frame_ancestors}"
             )
             response.xframe_options_exempt = True
+
+            # 2. Set SameSite=None on the CSRF cookie so the browser
+            #    sends it on cross-origin POST from the parent iframe.
+            #    SameSite=None requires Secure, which is already set.
+            if settings.CSRF_COOKIE_NAME in response.cookies:
+                response.cookies[settings.CSRF_COOKIE_NAME]["samesite"] = "None"
 
         return response

--- a/konote/middleware/embed_framing.py
+++ b/konote/middleware/embed_framing.py
@@ -58,10 +58,11 @@ class EmbedFramingMiddleware:
             )
             response.xframe_options_exempt = True
 
-            # 2. Set SameSite=None on the CSRF cookie so the browser
-            #    sends it on cross-origin POST from the parent iframe.
+            # 2. Set SameSite=None on CSRF and session cookies so the
+            #    browser sends them on cross-origin POST from the iframe.
             #    SameSite=None requires Secure, which is already set.
-            if settings.CSRF_COOKIE_NAME in response.cookies:
-                response.cookies[settings.CSRF_COOKIE_NAME]["samesite"] = "None"
+            for cookie_name in (settings.CSRF_COOKIE_NAME, settings.SESSION_COOKIE_NAME):
+                if cookie_name in response.cookies:
+                    response.cookies[cookie_name]["samesite"] = "None"
 
         return response

--- a/konote/settings/production.py
+++ b/konote/settings/production.py
@@ -142,6 +142,10 @@ if os.environ.get("WEBSITE_SITE_NAME"):
 if os.environ.get("CONTAINER_APP_NAME"):
     _trusted_origins.append("https://*.azurecontainerapps.io")
 
+# Embed origins also need CSRF trust so cross-origin form submissions
+# from the iframe are accepted (e.g. registration form on the website).
+_trusted_origins.extend(EMBED_ALLOWED_ORIGINS)
+
 CSRF_TRUSTED_ORIGINS = list(dict.fromkeys(_trusted_origins))
 
 # CSP — production overrides


### PR DESCRIPTION
## Summary
- Sets `SameSite=None` on CSRF and session cookies for embed requests so browsers send them on cross-origin POST from the iframe
- Adds `EMBED_ALLOWED_ORIGINS` to `CSRF_TRUSTED_ORIGINS` in production settings so Django accepts the cross-origin Origin header
- Without this fix, submitting the registration form on the website (logicaloutcomes.github.io) fails with 403 CSRF Verification Failed

## Test plan
- [ ] Load https://logicaloutcomes.github.io/konote-website/demo.html
- [ ] Fill out and submit the registration form — should succeed without 403
- [ ] Verify non-embed form submissions still work at konote-dev.llewelyn.ca/register/demo/
- [ ] Verify CSRF protection still blocks actual cross-site attacks (no embed=1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)