### PR TITLE
chore: add French translations for taxonomy system strings

### DIFF
--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -22897,3 +22897,39 @@ msgstr ""
 
 msgid "Copy survey link"
 msgstr ""
+
+msgid "CIDS / IRIS+"
+msgstr "CIDS / IRIS+"
+
+msgid "ESDC"
+msgstr "EDSC"
+
+msgid "IRIS+"
+msgstr "IRIS+"
+
+msgid "Invalid taxonomy system."
+msgstr "Système de taxonomie invalide."
+
+msgid "None (no appendix)"
+msgstr "Aucun (pas d'annexe)"
+
+msgid "Provincial"
+msgstr "Provincial"
+
+msgid "Public Health Agency of Canada"
+msgstr "Agence de la santé publique du Canada"
+
+msgid "SDG"
+msgstr "ODD"
+
+msgid "Standards Taxonomy"
+msgstr "Taxonomie de normes"
+
+msgid "Standards taxonomy system"
+msgstr "Système de taxonomie de normes"
+
+msgid "Taxonomy system updated."
+msgstr "Système de taxonomie mis à jour."
+
+msgid "United Way"
+msgstr "Centraide"


### PR DESCRIPTION
## Summary
- Add French translations for 12 new strings from the taxonomy-on-template feature (PRs #481-483)
- Key translations: ESDC→EDSC, SDG→ODD, United Way→Centraide

## Test plan
- [ ] Deploy to dev VPS and run `translate_strings` to compile .mo
- [ ] Verify French labels appear correctly in report template detail page

🤖 Generated with [Claude Code](https://claude.com/claude-code)