### PR TITLE
fix: embed CSRF cookie SameSite ordering

### DIFF
--- a/konote/middleware/embed_framing.py
+++ b/konote/middleware/embed_framing.py
@@ -52,11 +52,17 @@ class EmbedFramingMiddleware:
 
         if is_embed:
             # 1. Allow framing from configured origins.
+            #    Override both CSP and X-Frame-Options headers directly
+            #    (runs after XFrameOptionsMiddleware and CSPMiddleware).
             frame_ancestors = " ".join(allowed_origins)
             response["Content-Security-Policy"] = (
                 f"frame-ancestors 'self' {frame_ancestors}"
             )
-            response.xframe_options_exempt = True
+            # Remove X-Frame-Options: DENY set by XFrameOptionsMiddleware.
+            # CSP frame-ancestors is the authoritative directive; we delete
+            # the legacy header to avoid conflicts.
+            if "X-Frame-Options" in response:
+                del response["X-Frame-Options"]
 
             # 2. Set SameSite=None on CSRF and session cookies so the
             #    browser sends them on cross-origin POST from the iframe.

--- a/konote/settings/base.py
+++ b/konote/settings/base.py
@@ -101,6 +101,10 @@ MIDDLEWARE = [
     "konote.middleware.health_check.HealthCheckMiddleware",
     # SecurityMiddleware MUST be second for security headers
     "django.middleware.security.SecurityMiddleware",
+    # EmbedFramingMiddleware MUST be early (before Session/CSRF) so its
+    # response handler runs AFTER those middlewares set their cookies,
+    # allowing it to patch SameSite=None for cross-origin embeds.
+    "konote.middleware.embed_framing.EmbedFramingMiddleware",
     # WhiteNoiseMiddleware serves static files directly, before tenant resolution
     "whitenoise.middleware.WhiteNoiseMiddleware",
     # TenantMainMiddleware sets the PostgreSQL schema based on subdomain
@@ -120,9 +124,6 @@ MIDDLEWARE = [
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "csp.middleware.CSPMiddleware",
-    # EmbedFramingMiddleware MUST be after XFrameOptions and CSP so it can
-    # override their headers for ?embed=1 requests on public pages.
-    "konote.middleware.embed_framing.EmbedFramingMiddleware",
 ]
 
 ROOT_URLCONF = "konote.urls"


### PR DESCRIPTION
## Summary
- Moves `EmbedFramingMiddleware` earlier in the middleware list (before SessionMiddleware/CsrfViewMiddleware) so its response handler runs after cookies are set, allowing it to patch `SameSite=None`
- Deletes `X-Frame-Options` header directly instead of using `xframe_options_exempt` (which doesn't work from the new position)
- Without this, the embedded registration form on the website cannot submit because the browser won't send the CSRF cookie cross-origin

## Test plan
- [ ] Deploy to dev VPS and verify `SameSite=None` on CSRF/session cookies for embed requests
- [ ] Verify form submission works from the iframe on the website
- [ ] Verify non-embed requests still have `SameSite=Lax` and `X-Frame-Options: DENY`

🤖 Generated with [Claude Code](https://claude.com/claude-code)