### PR TITLE
fix: remove leaking template comment from survey embed

### DIFF
--- a/templates/_lang_toggle_styles.html
+++ b/templates/_lang_toggle_styles.html
@@ -1,5 +1,3 @@
-{# Shared styles for the FLSA language toggle on standalone pages (surveys, etc.).
-   Include this in the <head> of any page that uses _lang_toggle.html outside base.html. #}
 <style>
     .lang-nav { display:flex; justify-content:flex-end; padding:0.75rem 1.25rem 0 }
     .lang-nav form { margin:0 }


### PR DESCRIPTION
## Summary
- Removed Django template comment from `_lang_toggle_styles.html` that was rendering as visible text in the browser on survey pages
- Also fixed "Programme" → "Program" (Canadian spelling) in the demo survey database entries

## Test plan
- [ ] Visit https://logicaloutcomes.github.io/konote-website/demo.html — survey iframe should not show raw template comment text
- [ ] Survey title should read "Program Feedback Survey" not "Programme"

🤖 Generated with [Claude Code](https://claude.com/claude-code)