### PR TITLE
fix: preserve embed parameter across survey redirects

### DIFF
--- a/apps/surveys/public_views.py
+++ b/apps/surveys/public_views.py
@@ -28,6 +28,19 @@ from .models import (
 logger = logging.getLogger(__name__)
 
 
+def _is_embed(request):
+    """Check if request is in embed mode (?embed=1)."""
+    return request.GET.get("embed") == "1"
+
+
+def _redirect_preserving_embed(request, url_name, **kwargs):
+    """Redirect while preserving ?embed=1 if present."""
+    resp = redirect(url_name, **kwargs)
+    if _is_embed(request):
+        resp["Location"] += "?embed=1"
+    return resp
+
+
 def _survey_rate_limited_response():
     """Return a 429 response for rate-limited survey requests."""
     resp = HttpResponse(
@@ -115,7 +128,7 @@ def public_survey_form(request, token):
         if request.method == "POST" and "consent_agree" in request.POST:
             # Respondent is agreeing to consent — store in session and redirect
             request.session[consent_key] = timezone.now().isoformat()
-            return redirect("public_survey_form", token=token)
+            return _redirect_preserving_embed(request, "public_survey_form", token=token)
 
         if not request.session.get(consent_key):
             # Consent not yet given — show consent page
@@ -142,7 +155,7 @@ def public_survey_form(request, token):
         # Honeypot anti-spam check
         if request.POST.get("website"):
             # Bots fill in hidden fields; real users won't see it
-            return redirect("public_survey_thank_you", token=link.token)
+            return _redirect_preserving_embed(request, "public_survey_thank_you", token=link.token)
 
         # 1. Collect all submitted answers
         all_answers = {}
@@ -261,7 +274,7 @@ def public_survey_form(request, token):
             if scores:
                 request.session[f"survey_scores_{link.token}"] = scores
 
-        resp = redirect("public_survey_thank_you", token=link.token)
+        resp = _redirect_preserving_embed(request, "public_survey_thank_you", token=link.token)
 
         # Set signed cookie to discourage repeat submissions
         if link.single_response:


### PR DESCRIPTION
## Summary
- Survey consent and submission redirects now preserve `?embed=1`
- Without this, clicking Continue on the consent page in the iframe showed a blank page because the redirect lost the embed parameter, triggering X-Frame-Options: DENY

## Test plan
- [ ] On demo page, click consent checkbox and Continue — survey questions should appear (not blank)
- [ ] Submit the survey — thank-you page should appear in the iframe
- [ ] Non-embed surveys should still work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)