### PR TITLE
fix: prevent Caddy DNS conflict in multi-instance deploys

### DIFF
--- a/.claude/commands/deploy-to-vps.md
+++ b/.claude/commands/deploy-to-vps.md
@@ -34,7 +34,20 @@ If the wrapper script is unavailable, fall back to the direct SSH commands below
    - Timeout: 5 minutes (build ~30s, migrations can take longer).
    - For dev: if migrations fail, the script auto-resets the database (drop, recreate, re-migrate, re-seed demo data). This is safe because dev only has demo data.
 
-4. If the script exits `0` and prints `Deploy complete`, tell the user the deploy succeeded.
+4. If the script exits `0` and prints `Deploy complete`, verify the site is reachable:
+
+   ```
+   curl -sI --max-time 10 https://konote.llewelyn.ca/auth/login/ 2>&1 | head -1
+   ```
+
+   For dev:
+   ```
+   curl -sI --max-time 10 https://konote-dev.llewelyn.ca/auth/login/ 2>&1 | head -1
+   ```
+
+   If curl returns `HTTP/1.1 200 OK` or a `302` redirect, the deploy succeeded. Tell the user.
+
+   If curl returns `404 Not Found` despite healthy containers, **Caddy is routing to the wrong container** (Docker DNS conflict). Check that the Caddyfile uses explicit container names (`konote-web-1`, `konote-dev-web-1`), not bare service names (`web`). See the troubleshooting section of `docs/deploy-ovhcloud.md` for the fix.
 
 5. Only if the deploy fails or prints a warning, inspect logs.
 

--- a/docs/deploy-ovhcloud.md
+++ b/docs/deploy-ovhcloud.md
@@ -799,7 +799,7 @@ konote.yourdomain.ca {
 }
 
 konote-dev.yourdomain.ca {
-    reverse_proxy konote-dev-web:8000
+    reverse_proxy konote-dev-web-1:8000
 
     header {
         Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
@@ -812,7 +812,7 @@ konote-dev.yourdomain.ca {
 }
 ```
 
-> **Important:** Use `konote-web-1` (the container name), not `web` (the service name). Both instances define a `web` service, so Docker's DNS would resolve `web` ambiguously. Container names are unique.
+> **CRITICAL: Use explicit container names, never bare service names.** Both instances define a `web` service. When Caddy is connected to both frontend networks, Docker DNS can resolve the bare name `web` to either container unpredictably. If it resolves to the wrong one, the production site returns 404 on every page (because django-tenants doesn't recognise the domain). Use `konote-web-1` and `konote-dev-web-1` (the container names) to avoid this.
 
 ### Step 5: Clone and configure the dev instance
 
@@ -1083,6 +1083,40 @@ Django is rejecting the request because the domain is not in `ALLOWED_HOSTS`. Co
 - You're running two instances and the wrong one is receiving traffic (check Caddyfile uses explicit container names)
 
 Fix: edit `.env`, update `ALLOWED_HOSTS`, then run `sudo docker compose up -d`.
+
+### "404 Not Found" on production but dev works (multi-instance)
+
+If all URLs on the production domain return 404 but the dev domain works fine, **Caddy is routing production traffic to the dev web container**. This happens because of a Docker DNS conflict:
+
+- Both instances define a `web` service
+- When Caddy is connected to both frontend networks, Docker DNS can resolve `web` to the dev container instead of production
+- The dev container doesn't recognise the production domain, so django-tenants returns 404
+
+**Fix:**
+
+1. Check the Caddyfile uses explicit container names (not bare service names):
+
+```
+# Wrong — ambiguous when multiple instances share a network
+reverse_proxy web:8000
+
+# Correct — unambiguous container name
+reverse_proxy konote-web-1:8000
+```
+
+2. Edit the Caddyfile on the VPS:
+
+```bash
+sudo nano /opt/konote/Caddyfile
+```
+
+3. Restart Caddy to pick up the change:
+
+```bash
+sudo docker restart konote-caddy-1
+```
+
+> **Note:** The deploy script preserves the Caddyfile across deploys (it backs up and restores custom Caddyfiles that differ from the repo template). You can also protect it manually with `git update-index --skip-worktree Caddyfile`.
 
 ### "502 Bad Gateway" from Caddy
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -11,7 +11,7 @@
 # The /deploy-to-vps skill runs this via: ssh konote-vps /opt/konote/deploy.sh [flags]
 #
 # What it does:
-#   1. Pulls latest develop branch
+#   1. Pulls latest code (main for production, develop for dev)
 #   2. Rebuilds the web container
 #   3. Restarts containers
 #   4. Waits for health check
@@ -107,22 +107,48 @@ deploy_instance() {
 
     # --- Pull latest code ---
     echo "=== Pulling latest code ==="
+
+    # Preserve the Caddyfile — multi-instance setups use a custom Caddyfile
+    # that differs from the single-instance template in the repo. Without
+    # this, `git checkout -- .` overwrites it and Caddy routes break.
+    local caddyfile_backup=""
+    if [ -f "Caddyfile" ]; then
+        caddyfile_backup=$(cat Caddyfile)
+    fi
+
     git checkout -- . 2>/dev/null || true  # Reset any local modifications (e.g. CRLF fixes)
 
-    # Ensure dev instance is on the develop branch (not main).
-    # Production stays on whatever branch it's on (typically main).
+    # Restore the Caddyfile if it was customised (differs from repo version)
+    if [ -n "$caddyfile_backup" ]; then
+        echo "$caddyfile_backup" > Caddyfile
+    fi
+
+    # Determine the correct branch for this instance
+    local target_branch="main"
     if [ "$is_dev" = "true" ]; then
-        local current_branch
-        current_branch=$(git branch --show-current 2>/dev/null || echo "unknown")
-        if [ "$current_branch" != "develop" ]; then
-            echo -e "  ${YELLOW}Dev instance on '${current_branch}' — switching to 'develop'${NC}"
-            git fetch origin develop
-            git checkout develop
-            git reset --hard origin/develop
+        target_branch="develop"
+    fi
+
+    # Ensure the instance is on the correct branch
+    local current_branch
+    current_branch=$(git branch --show-current 2>/dev/null || echo "unknown")
+    if [ "$current_branch" != "$target_branch" ]; then
+        echo -e "  ${YELLOW}Instance on '${current_branch}' — switching to '${target_branch}'${NC}"
+        git fetch origin "$target_branch"
+        git checkout "$target_branch"
+        git reset --hard "origin/${target_branch}"
+        # Re-restore Caddyfile after branch switch
+        if [ -n "$caddyfile_backup" ]; then
+            echo "$caddyfile_backup" > Caddyfile
         fi
     fi
 
-    git pull origin develop
+    git pull origin "$target_branch"
+
+    # Re-restore Caddyfile after pull (pull can overwrite tracked files)
+    if [ -n "$caddyfile_backup" ]; then
+        echo "$caddyfile_backup" > Caddyfile
+    fi
 
     # --- Record after-commit ---
     local after_commit
@@ -158,6 +184,24 @@ deploy_instance() {
             if ! docker inspect "$caddy_container" --format '{{json .NetworkSettings.Networks}}' | grep -q "$dev_network"; then
                 echo "=== Connecting Caddy to dev frontend network ==="
                 docker network connect "$dev_network" "$caddy_container" 2>/dev/null || true
+            fi
+        fi
+    fi
+
+    # --- Verify Caddy routing (multi-instance DNS conflict prevention) ---
+    # When Caddy is connected to multiple frontend networks, the bare service
+    # name "web" can resolve to the wrong container. Verify that the Caddyfile
+    # uses explicit container names, not bare service names.
+    if [ "$is_dev" = "true" ]; then
+        local caddy_container="konote-caddy-1"
+        if docker ps --format '{{.Names}}' | grep -q "^${caddy_container}$"; then
+            local caddyfile_content
+            caddyfile_content=$(docker exec "$caddy_container" cat /etc/caddy/Caddyfile 2>/dev/null || true)
+            if echo "$caddyfile_content" | grep -q "reverse_proxy web:"; then
+                echo -e "${YELLOW}  WARNING: Caddyfile uses bare 'web' service name instead of explicit${NC}"
+                echo -e "${YELLOW}  container name. This causes DNS conflicts in multi-instance setups.${NC}"
+                echo -e "${YELLOW}  Fix: use 'konote-web-1:8000' instead of 'web:8000' in the Caddyfile.${NC}"
+                log_event "DEPLOY WARNING: Caddyfile uses bare 'web' — DNS conflict risk"
             fi
         fi
     fi


### PR DESCRIPTION
## Summary

- **deploy.sh** preserves the custom Caddyfile across `git checkout -- .`, branch switches, and pulls — prevents the single-instance repo template from overwriting the multi-domain Caddyfile on the VPS
- **deploy.sh** warns at deploy time if the Caddyfile uses bare service names (`web`) instead of explicit container names (`konote-web-1`)
- **deploy.sh** uses the correct branch per instance (`main` for production, `develop` for dev) — incorporates the fix from #476
- **deploy-to-vps skill** now verifies site reachability with `curl` after deploy, with guidance on diagnosing the DNS conflict if it returns 404
- **deploy-ovhcloud.md** adds a troubleshooting entry explaining the DNS conflict and fix, and upgrades the Section 14 container name warning to CRITICAL

## Context

Production site (`konote.llewelyn.ca`) went down with 404 on all pages. Root cause: Docker DNS resolved the bare name `web` in the Caddyfile to the dev container instead of production, because Caddy was connected to both frontend networks.

## Test plan

- [ ] Deploy dev instance (`--dev`) and verify Caddyfile is preserved
- [ ] Deploy production and verify Caddyfile is not overwritten
- [ ] Verify both `konote.llewelyn.ca` and `konote-dev.llewelyn.ca` return 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)