### PR TITLE
🎨 Palette: Global Loading State for Async Buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Global Loading State for Async Submit Buttons
+**Learning:** In a vanilla HTML/HTMX app using PicoCSS, buttons triggering async actions often lack immediate visual feedback and screen reader announcements, which can lead to double submissions and confusion. Setting `aria-busy="true"` dynamically hooks into PicoCSS's built-in loading spinner and announces the busy state, significantly improving perceived performance and accessibility globally.
+**Action:** Implemented global HTMX event listeners (`htmx:beforeRequest` and `htmx:afterRequest`) in `app.js` to automatically toggle `aria-busy="true"` on submit buttons. This provides a universal, accessible loading state for all async operations without adding custom CSS.

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -2131,3 +2131,43 @@ document.body.addEventListener("htmx:afterSettle", function (event) {
     // Run after HTMX swaps in new content (e.g. tab navigation, insights load)
     document.body.addEventListener('htmx:afterSettle', initAllCharts);
 })();
+
+// --- Global loading state for async buttons (UX/A11Y) ---
+// Automatically sets aria-busy="true" on submit buttons during HTMX requests.
+// This triggers Pico CSS's built-in loading spinner and communicates busy state to screen readers.
+(function () {
+    document.body.addEventListener('htmx:beforeRequest', function (event) {
+        var elt = event.detail.elt;
+        if (!elt) return;
+
+        var btn = null;
+        if (elt.tagName === 'FORM') {
+            btn = elt.querySelector('button[type="submit"]');
+        } else if (elt.tagName === 'BUTTON' || elt.tagName === 'A') {
+            btn = elt;
+        }
+
+        if (btn && !btn.hasAttribute('aria-busy')) {
+            btn.setAttribute('aria-busy', 'true');
+            // Store a flag so we only remove it if we added it
+            btn.setAttribute('data-htmx-busy', 'true');
+        }
+    });
+
+    document.body.addEventListener('htmx:afterRequest', function (event) {
+        var elt = event.detail.elt;
+        if (!elt) return;
+
+        var btn = null;
+        if (elt.tagName === 'FORM') {
+            btn = elt.querySelector('button[type="submit"]');
+        } else if (elt.tagName === 'BUTTON' || elt.tagName === 'A') {
+            btn = elt;
+        }
+
+        if (btn && btn.getAttribute('data-htmx-busy') === 'true') {
+            btn.removeAttribute('aria-busy');
+            btn.removeAttribute('data-htmx-busy');
+        }
+    });
+})();


### PR DESCRIPTION
🎨 Palette: Global Loading State for Async Buttons

💡 **What:** Added global JS listeners to automatically apply `aria-busy="true"` on buttons that trigger HTMX requests. 
🎯 **Why:** Provide immediate visual feedback when an action is processing, preventing double submissions and user confusion during slow network requests.
📸 **Before/After:** Automatically utilizes PicoCSS's built-in spinner without custom CSS. See `verification/verification4.png` from testing phase.
♿ **Accessibility:** Dynamically sets `aria-busy="true"`, ensuring screen readers announce the loading state correctly during async operations.

---
*PR created automatically by Jules for task [6112828487386877837](https://jules.google.com/task/6112828487386877837) started by @pboachie*