### PR TITLE
fix registration redirect and CIDS alignment regressions

### DIFF
--- a/apps/registration/views.py
+++ b/apps/registration/views.py
@@ -250,7 +250,11 @@ def public_registration_form(request, slug):
     request.session["last_submission_auto_approved"] = registration_link.auto_approve
 
     # Redirect - preserve embed mode
-    return redirect_preserving_embed(request, "registration_submitted", slug=slug)
+    return redirect_preserving_embed(
+        request,
+        "registration:registration_submitted",
+        slug=slug,
+    )
 
 
 def registration_submitted(request, slug):

--- a/apps/reports/cids_enrichment.py
+++ b/apps/reports/cids_enrichment.py
@@ -20,6 +20,15 @@ import logging
 logger = logging.getLogger(__name__)
 
 
+def _is_local_indicator_uri(uri):
+    """Return True for auto-generated local indicator URIs.
+
+    These URIs keep local exports internally consistent, but they are not an
+    external standards alignment and should not count as one.
+    """
+    return bool(uri) and uri.startswith("urn:konote:indicator-definition:")
+
+
 def get_taxonomy_lens_label(taxonomy_lens):
     """Return a human-readable label for a taxonomy system key.
 
@@ -100,6 +109,23 @@ def _get_metric_lens_values(metric_definition, taxonomy_lens):
     }
 
 
+def _metric_has_any_standards_reference(metric_definition):
+    """Return True when a metric has any standards-alignment data at all.
+
+    This is broader than a selected taxonomy lens. It is used for default
+    summaries where the caller wants to know whether the metric is linked to
+    any recognised standards metadata, even before a specific reporting lens
+    is chosen.
+    """
+    if metric_definition.iris_metric_code:
+        return True
+    if metric_definition.sdg_goals:
+        return True
+    if metric_definition.cids_indicator_uri and not _is_local_indicator_uri(metric_definition.cids_indicator_uri):
+        return True
+    return False
+
+
 def derive_cids_theme(metric_definition):
     """Derive the CIDS impact theme for a MetricDefinition.
 
@@ -140,7 +166,10 @@ def get_standards_alignment_data(program, metric_definitions=None, taxonomy_lens
             metrics: list of dicts with metric CIDS data
             sdg_summary: dict of SDG goal number → count of metrics
             theme_summary: dict of theme → count of metrics
-                mapped_count: int (metrics with at least one reference for the selected lens)
+                mapped_count: int (metrics with any standards reference when no
+                    lens is selected, or with a mapping for the selected lens)
+                selected_mapped_count: int (metrics with a mapping for the
+                    selected lens)
             total_count: int (total metrics)
     """
     from apps.plans.models import MetricDefinition, PlanTargetMetric
@@ -167,16 +196,21 @@ def get_standards_alignment_data(program, metric_definitions=None, taxonomy_lens
     theme_counter = {}
     lens_counter = {}
     mapped_count = 0
+    selected_mapped_count = 0
 
     for metric in metric_definitions:
         theme, theme_source = derive_cids_theme(metric)
         lens_values = _get_metric_lens_values(metric, taxonomy_lens)
 
-        has_mapping = bool(lens_values["code"])
-        if has_mapping:
-            mapped_count += 1
+        has_selected_mapping = bool(lens_values["code"])
+        if has_selected_mapping:
+            selected_mapped_count += 1
             key = lens_values["label"] or lens_values["code"]
             lens_counter[key] = lens_counter.get(key, 0) + 1
+
+        has_any_mapping = has_selected_mapping or _metric_has_any_standards_reference(metric)
+        if has_any_mapping:
+            mapped_count += 1
 
         # Count SDG goals
         for goal in (metric.sdg_goals or []):
@@ -216,6 +250,7 @@ def get_standards_alignment_data(program, metric_definitions=None, taxonomy_lens
         "lens_summary": dict(sorted(lens_counter.items())),
         "sdg_summary": dict(sorted(sdg_counter.items())),
         "theme_summary": dict(sorted(theme_counter.items())),
-        "mapped_count": mapped_count,
+        "mapped_count": selected_mapped_count if taxonomy_lens else mapped_count,
+        "selected_mapped_count": selected_mapped_count,
         "total_count": len(metrics_data),
     }

--- a/apps/reports/cids_jsonld.py
+++ b/apps/reports/cids_jsonld.py
@@ -539,6 +539,7 @@ def _build_code_node_from_metric(metric_definition, taxonomy_lens):
     if (
         taxonomy_lens == "common_approach"
         and metric_definition.cids_indicator_uri
+        and not metric_definition.cids_indicator_uri.startswith("urn:konote:indicator-definition:")
         and metric_definition.cids_indicator_uri.startswith(("http://", "https://", "urn:"))
     ):
         code_id = metric_definition.cids_indicator_uri

--- a/apps/reports/funder_report.py
+++ b/apps/reports/funder_report.py
@@ -593,7 +593,8 @@ def generate_funder_report_csv_rows(report_data: dict[str, Any]) -> list[list[st
 
     # CIDS Standards Alignment appendix
     cids = report_data.get("cids_alignment")
-    if cids and cids.get("mapped_count", 0) > 0:
+    selected_mapped_count = cids.get("selected_mapped_count", cids.get("mapped_count", 0)) if cids else 0
+    if cids and cids.get("taxonomy_lens") and selected_mapped_count > 0:
         rows.append([_("STANDARDS ALIGNMENT (CIDS v%(version)s)") % {"version": cids["cids_version"]}])
         rows.append([_("Reporting Lens"), cids.get("taxonomy_lens_label", "")])
         if cids["program_cids"].get("sector_code"):
@@ -613,7 +614,7 @@ def generate_funder_report_csv_rows(report_data: dict[str, Any]) -> list[list[st
         rows.append([])
         rows.append([
             _("%(mapped)s of %(total)s indicators mapped for the selected reporting lens.")
-            % {"mapped": cids["mapped_count"], "total": cids["total_count"]}
+            % {"mapped": selected_mapped_count, "total": cids["total_count"]}
         ])
 
     return rows

--- a/konote/middleware/embed_framing.py
+++ b/konote/middleware/embed_framing.py
@@ -38,13 +38,12 @@ class EmbedFramingMiddleware:
         self._cookie_names = (settings.CSRF_COOKIE_NAME, settings.SESSION_COOKIE_NAME)
 
     def __call__(self, request):
-        response = self.get_response(request)
-
         is_embed = (
             request.GET.get("embed") == "1"
             and request.path.startswith(_EMBEDDABLE_PREFIXES)
         )
         if not is_embed:
+            response = self.get_response(request)
             return response
 
         if not self._csp_header:
@@ -53,8 +52,11 @@ class EmbedFramingMiddleware:
                 "Set EMBED_ALLOWED_ORIGINS in the environment."
             )
 
+        response = self.get_response(request)
+
         # 1. Allow framing from configured origins.
         response["Content-Security-Policy"] = self._csp_header
+        response.xframe_options_exempt = True
         # Remove X-Frame-Options: DENY set by XFrameOptionsMiddleware.
         # CSP frame-ancestors is the authoritative directive.
         if "X-Frame-Options" in response:

--- a/templates/reports/html_report.html
+++ b/templates/reports/html_report.html
@@ -567,7 +567,7 @@
 {% endif %}
 
 {# CIDS Standards Alignment appendix (legacy layout) #}
-{% if report_data.cids_alignment and report_data.cids_alignment.mapped_count > 0 %}
+{% if report_data.cids_alignment and report_data.cids_alignment.taxonomy_lens and report_data.cids_alignment.selected_mapped_count > 0 %}
 <details>
 <summary class="report-header-bar">{% trans "Standards Alignment" %}</summary>
 <p style="font-size: 0.85rem; color: #718096; margin-bottom: 0.8rem;">
@@ -600,7 +600,7 @@
     </tbody>
 </table>
 <p style="font-size: 0.85rem; color: #718096;">
-    {% blocktrans with mapped=report_data.cids_alignment.mapped_count total=report_data.cids_alignment.total_count %}{{ mapped }} of {{ total }} indicators mapped for the selected reporting lens.{% endblocktrans %}
+    {% blocktrans with mapped=report_data.cids_alignment.selected_mapped_count total=report_data.cids_alignment.total_count %}{{ mapped }} of {{ total }} indicators mapped for the selected reporting lens.{% endblocktrans %}
 </p>
 {% if report_data.cids_alignment.lens_summary %}
 <h4 style="margin-top: 0.8rem;">{{ report_data.cids_alignment.taxonomy_lens_label }} {% trans "Summary" %}</h4>

--- a/templates/reports/pdf_funder_outcome_report.html
+++ b/templates/reports/pdf_funder_outcome_report.html
@@ -506,7 +506,7 @@
 {% endif %}
 
 {# CIDS Standards Alignment appendix (always shown in legacy layout if data exists) #}
-{% if report_data.cids_alignment and report_data.cids_alignment.mapped_count > 0 %}
+{% if report_data.cids_alignment and report_data.cids_alignment.taxonomy_lens and report_data.cids_alignment.selected_mapped_count > 0 %}
 <div class="page-break"></div>
 <div class="report-header">{% trans "Standards Alignment" %}</div>
 <p style="font-size: 9pt; color: #718096; margin-bottom: 0.5cm;">
@@ -541,7 +541,7 @@
     </tbody>
 </table>
 <p style="font-size: 9pt; color: #718096;">
-    {% blocktrans with mapped=report_data.cids_alignment.mapped_count total=report_data.cids_alignment.total_count %}{{ mapped }} of {{ total }} indicators mapped for the selected reporting lens.{% endblocktrans %}
+    {% blocktrans with mapped=report_data.cids_alignment.selected_mapped_count total=report_data.cids_alignment.total_count %}{{ mapped }} of {{ total }} indicators mapped for the selected reporting lens.{% endblocktrans %}
 </p>
 
 {% if report_data.cids_alignment.lens_summary %}

--- a/templates/reports/report_preview.html
+++ b/templates/reports/report_preview.html
@@ -317,7 +317,7 @@
 {% endfor %}
 {% endif %}
 
-{% if report_data.cids_alignment and report_data.cids_alignment.mapped_count > 0 %}
+{% if report_data.cids_alignment and report_data.cids_alignment.taxonomy_lens and report_data.cids_alignment.selected_mapped_count > 0 %}
 <section class="preview-section">
     <h2>{% trans "Standards Alignment" %}</h2>
     <p>
@@ -351,7 +351,7 @@
         </table>
     </div>
     <p>
-        {% blocktrans with mapped=report_data.cids_alignment.mapped_count total=report_data.cids_alignment.total_count %}
+        {% blocktrans with mapped=report_data.cids_alignment.selected_mapped_count total=report_data.cids_alignment.total_count %}
         {{ mapped }} of {{ total }} indicators mapped for the selected reporting lens.
         {% endblocktrans %}
     </p>

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -1679,6 +1679,8 @@ class FunderReportViewTests(TestCase):
         self.program_two = Program.objects.create(name="Second Program", status="active")
 
     def _seed_cids_export_data(self):
+        from apps.reports.models import Partner, ReportTemplate
+
         client_file = ClientFile.objects.create()
         client_file.first_name = "Test"
         client_file.last_name = "Participant"


### PR DESCRIPTION
Correct the registration redirect to use the appropriate namespace and enhance the CIDS alignment logic to ensure accurate mapping counts. Adjustments improve the handling of standards alignment data in reports and templates.