### PR TITLE
fix: compress help guide and privacy page layout

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -5470,18 +5470,122 @@ article[aria-label="notification"].fading-out {
     margin-right: 0.25rem;
 }
 
+/* ---- Content page layout (shared by help, privacy, and similar static pages) ---- */
+.content-page {
+    max-width: 860px;
+    margin: 0 auto;
+    padding: 1.25rem 1rem;
+}
+
+.content-page > h1 {
+    margin-bottom: 0.5rem;
+}
+
+.content-page section {
+    margin-bottom: 1.25rem;
+    padding-bottom: 1rem;
+    border-bottom: 1px solid var(--kn-border-light, #e8e6e1);
+}
+
+.content-page section:last-child {
+    border-bottom: none;
+    margin-bottom: 0;
+}
+
+/* Tighter heading sizes than theme.css defaults for dense reference content */
+.content-page h2 {
+    color: var(--pico-primary, #3176aa);
+    border-bottom: 2px solid var(--pico-primary, #3176aa);
+    padding-bottom: 0.35rem;
+    margin-bottom: 0.5rem;
+    font-size: 1.15rem;
+}
+
+.content-page h3 {
+    margin-top: 0.85rem;
+    margin-bottom: 0.35rem;
+    color: var(--kn-text-secondary, #4a5568);
+    font-size: 1rem;
+}
+
+.content-page h4 {
+    margin-top: 0.75rem;
+    margin-bottom: 0.25rem;
+    font-size: 0.95rem;
+}
+
+.content-page p {
+    margin-bottom: 0.5rem;
+}
+
+.content-page table {
+    margin: 0.5rem 0 0.75rem;
+    font-size: 0.9rem;
+}
+
+.content-page table th,
+.content-page table td {
+    padding: 0.4rem 0.6rem;
+}
+
+.content-page ol, .content-page ul {
+    margin-left: 1.25rem;
+    margin-bottom: 0.5rem;
+}
+
+.content-page li {
+    margin-bottom: 0.2rem;
+    line-height: 1.45;
+}
+
+@media (max-width: 768px) {
+    .content-page {
+        padding: 1rem 0.75rem;
+    }
+    .content-page section {
+        margin-bottom: 1rem;
+        padding-bottom: 0.75rem;
+    }
+    .content-page table {
+        font-size: 0.85rem;
+    }
+    .content-page table th,
+    .content-page table td {
+        padding: 0.3rem 0.5rem;
+    }
+}
+
+@media print {
+    .content-page section {
+        break-inside: avoid;
+    }
+}
+
 /* ---- Pill navigation (shared by help + privacy pages) ---- */
 .pill-nav {
-    background: var(--pico-card-background-color, #f5f5f5);
-    padding: 1rem 1.5rem;
-    border-radius: 8px;
-    margin-bottom: 2rem;
+    background: var(--kn-card-bg, #fff);
+    padding: 0.75rem 1rem;
+    border-radius: var(--kn-radius-card, 8px);
+    margin-bottom: 1.5rem;
+    border: 1px solid var(--kn-border-light, #e8e6e1);
+}
+
+/* Must come after .content-page to override h2 styles (same specificity, later wins) */
+.pill-nav h2 {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--kn-text-muted, #64748b);
+    margin: 0 0 0.5rem 0;
+    padding: 0;
+    border: none;
+    font-weight: 600;
 }
 
 .pill-nav ul {
     display: flex;
     flex-wrap: wrap;
-    gap: 0.5rem;
+    gap: 0.35rem;
     list-style: none;
     padding: 0;
     margin: 0;
@@ -5493,19 +5597,48 @@ article[aria-label="notification"].fading-out {
 
 .pill-nav a {
     display: block;
-    padding: 0.4rem 0.9rem;
-    background: var(--pico-primary-background, #3176aa);
-    color: var(--pico-primary-inverse, #fff);
+    padding: 0.25rem 0.65rem;
+    background: transparent;
+    color: var(--pico-primary, #3176aa);
+    border: 1px solid var(--pico-primary, #3176aa);
     border-radius: 2rem;
     text-decoration: none;
-    font-size: 0.85rem;
+    font-size: 0.8rem;
     white-space: nowrap;
-    transition: opacity 0.15s;
+    transition: background var(--kn-transition), color var(--kn-transition);
+    line-height: 1.4;
 }
 
 .pill-nav a:hover,
 .pill-nav a:focus {
-    opacity: 0.85;
+    background: var(--pico-primary, #3176aa);
+    color: var(--pico-primary-inverse, #fff);
+}
+
+/* Compact grid layout for help page with many nav items */
+.help-page .pill-nav ul {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+    gap: 0.3rem;
+}
+
+.help-page .pill-nav a {
+    text-align: center;
+}
+
+@media (max-width: 768px) {
+    .pill-nav {
+        padding: 0.5rem 0.75rem;
+    }
+    .help-page .pill-nav ul {
+        grid-template-columns: repeat(2, 1fr);
+    }
+}
+
+@media (max-width: 480px) {
+    .help-page .pill-nav ul {
+        grid-template-columns: 1fr;
+    }
 }
 
 /* ---- CIDS / classification inline utilities ---- */

--- a/templates/pages/help.html
+++ b/templates/pages/help.html
@@ -4,7 +4,7 @@
 {% block title %}{% trans "Help" %} - {{ site.product_name|default:"KoNote" }}{% endblock %}
 
 {% block content %}
-<div class="help-page">
+<div class="content-page help-page">
     <h1>{% trans "KoNote Help" %}</h1>
 
     <p>{% trans "Welcome to KoNote! This guide helps you find what you need quickly." %}</p>
@@ -791,66 +791,28 @@
 </div>
 
 <style>
-.help-page {
-    max-width: 900px;
-    margin: 0 auto;
-    padding: 2rem 1rem;
+/* Page-specific overrides — shared styles are in main.css .content-page */
+.help-page > h1 {
+    margin-bottom: 0.25rem;
 }
 
-/* pill-nav styles are in main.css */
-
-.pill-nav h2 {
-    margin-top: 0;
-    font-size: 1.1rem;
-}
-
-.help-page section {
-    margin-bottom: 3rem;
-    padding-bottom: 2rem;
-    border-bottom: 1px solid var(--pico-muted-border-color, #e0e0e0);
-}
-
-.help-page section:last-child {
-    border-bottom: none;
-}
-
-.help-page h2 {
-    color: var(--pico-primary, #1976d2);
-    border-bottom: 2px solid var(--pico-primary, #1976d2);
-    padding-bottom: 0.5rem;
-}
-
-.help-page h3 {
-    margin-top: 1.5rem;
-    color: var(--pico-secondary, #607d8b);
-}
-
-.help-page table {
-    margin: 1rem 0;
+.help-page > p:first-of-type {
+    margin-bottom: 1rem;
+    color: var(--kn-text-secondary, #4a5568);
+    font-size: 0.9rem;
 }
 
 .help-page kbd {
-    background: var(--pico-muted-background-color, #e0e0e0);
-    border: 1px solid var(--pico-muted-border-color, #ccc);
+    background: var(--kn-neutral-bg, #e9ecef);
+    border: 1px solid var(--kn-border, #d1d5db);
     border-radius: 4px;
-    padding: 0.15rem 0.4rem;
+    padding: 0.1rem 0.35rem;
     font-family: monospace;
-    font-size: 0.9em;
-}
-
-.help-page ol, .help-page ul {
-    margin-left: 1.5rem;
-}
-
-.help-page li {
-    margin-bottom: 0.5rem;
+    font-size: 0.85em;
 }
 
 @media print {
-    .help-nav {
-        break-inside: avoid;
-    }
-    .help-page section {
+    .pill-nav {
         break-inside: avoid;
     }
 }

--- a/templates/pages/privacy.html
+++ b/templates/pages/privacy.html
@@ -4,7 +4,7 @@
 {% block title %}{% trans "Privacy Policy" %} - {{ site.product_name|default:"KoNote" }}{% endblock %}
 
 {% block content %}
-<div class="privacy-page">
+<div class="content-page privacy-page">
     <h1>{% trans "Privacy Policy" %}</h1>
 
     <div class="notice">
@@ -209,60 +209,26 @@
 </div>
 
 <style>
+/* Page-specific overrides — shared styles are in main.css .content-page */
 .privacy-page {
     max-width: 800px;
-    margin: 0 auto;
-    padding: 2rem 1rem;
 }
 
 .privacy-page .notice {
-    background: var(--pico-form-element-background-color, #fff3cd);
-    border: 1px solid var(--pico-form-element-border-color, #ffc107);
-    border-radius: 8px;
-    padding: 1.5rem;
-    margin-bottom: 2rem;
+    background: var(--kn-info-bg, #d1ecf1);
+    border: 1px solid var(--kn-border, #d1d5db);
+    border-radius: var(--kn-radius-card, 8px);
+    padding: 0.75rem 1rem;
+    margin-bottom: 1rem;
+    font-size: 0.9rem;
 }
 
-/* pill-nav styles are in main.css */
-
-.privacy-page section {
-    margin-bottom: 2rem;
-    padding-bottom: 1.5rem;
-    border-bottom: 1px solid var(--pico-muted-border-color, #e0e0e0);
+.privacy-page .notice p {
+    margin-bottom: 0.25rem;
 }
 
-.privacy-page section:last-child {
-    border-bottom: none;
-}
-
-.privacy-page h2 {
-    color: var(--pico-primary, #1976d2);
-    border-bottom: 2px solid var(--pico-primary, #1976d2);
-    padding-bottom: 0.5rem;
-    margin-top: 2rem;
-}
-
-.privacy-page h3 {
-    margin-top: 1.5rem;
-    color: var(--pico-secondary, #607d8b);
-}
-
-.privacy-page ul {
-    margin-left: 1.5rem;
-}
-
-.privacy-page li {
-    margin-bottom: 0.5rem;
-}
-
-.privacy-page table {
-    margin: 1rem 0;
-}
-
-@media print {
-    .privacy-page section {
-        break-inside: avoid;
-    }
+.privacy-page .notice p:last-child {
+    margin-bottom: 0;
 }
 </style>
 {% endblock %}


### PR DESCRIPTION
## Summary
- Redesign pill-nav TOC from solid-blue pills to outlined pills in CSS grid layout — more compact and scannable
- Cut section spacing ~55% across help guide and privacy policy pages (80px gaps → 36px)
- Extract shared `.content-page` class to main.css, eliminating ~50 lines of duplicated inline CSS
- Fix CSS variable references to use `--kn-*` theme tokens with proper dark-mode fallbacks
- Fix pill contrast to meet WCAG AA (4.88:1)
- Add mobile breakpoints (768px, 480px) for both pages

## Test plan
- [ ] View `/help/` page — verify TOC pills display in compact grid, sections are tighter
- [ ] View `/privacy/` page — verify notice box is info-blue, sections are tighter
- [ ] Check both pages on mobile (or narrow browser) — pills should collapse to 2-col then 1-col
- [ ] Toggle dark mode — verify all colours adapt (pill borders, headings, kbd, notice box)
- [ ] Check French locale — verify pill labels don't overflow or clip

🤖 Generated with [Claude Code](https://claude.com/claude-code)