### PR TITLE
fix: pill-nav layout broken by Pico CSS nav flex

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -5563,6 +5563,7 @@ article[aria-label="notification"].fading-out {
 
 /* ---- Pill navigation (shared by help + privacy pages) ---- */
 .pill-nav {
+    display: block;  /* Override Pico CSS nav flex layout */
     background: var(--kn-card-bg, #fff);
     padding: 0.75rem 1rem;
     border-radius: var(--kn-radius-card, 8px);
@@ -5615,29 +5616,9 @@ article[aria-label="notification"].fading-out {
     color: var(--pico-primary-inverse, #fff);
 }
 
-/* Compact grid layout for help page with many nav items */
-.help-page .pill-nav ul {
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
-    gap: 0.3rem;
-}
-
-.help-page .pill-nav a {
-    text-align: center;
-}
-
 @media (max-width: 768px) {
     .pill-nav {
         padding: 0.5rem 0.75rem;
-    }
-    .help-page .pill-nav ul {
-        grid-template-columns: repeat(2, 1fr);
-    }
-}
-
-@media (max-width: 480px) {
-    .help-page .pill-nav ul {
-        grid-template-columns: 1fr;
     }
 }
 


### PR DESCRIPTION
## Summary
- Pico CSS v2 applies `display: flex` + `justify-content: space-between` to `<nav>` elements, which caused the `<h2>` and `<ul>` inside `.pill-nav` to sit side-by-side — squeezing pills into a narrow single column on the right
- Fix: add `display: block` to `.pill-nav` to override Pico's nav layout
- Removed CSS grid overrides (`.help-page .pill-nav ul`) that compounded the problem — the existing `flex-wrap` on the `<ul>` handles multi-item wrapping correctly

## Test plan
- [ ] Verify help page pill-nav renders as wrapped horizontal pills on desktop
- [ ] Verify privacy page pill-nav renders similarly
- [ ] Check mobile (narrow viewport) — pills should wrap naturally
- [ ] Verify dark mode still looks correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)