### PR TITLE
🎨 Palette: Add `aria-invalid` automatically via template filter

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2025-03-10 - Add ARIA Labels to Copy Buttons
 **Learning:** Many "Copy" buttons in the app use the `copy-btn` class but lack `aria-label`s. Screen readers might just read "Copy" out of context, which can be confusing (e.g., "Copy what?").
 **Action:** Add descriptive `aria-label` attributes to these buttons (e.g., `aria-label="{% trans 'Copy calendar link' %}"`) to improve accessibility.
+
+## 2025-03-10 - Apply `aria-invalid` to forms with errors globally
+**Learning:** We use `templates/includes/_form_field.html` a lot to render form fields. By injecting `aria-invalid="true"` alongside `aria-describedby` logic inside `apps/auth_app/templatetags/form_tags.py`, we can natively apply this accessibility standard to the entire project whenever there are validation errors, rather than explicitly hard-coding it into every individual form field template or relying on client-side JS.
+**Action:** When updating template filters that process widget HTML (like `aria_describedby`), look for opportunities to apply related accessibility attributes directly (like `aria-invalid="true"`) to ensure broad, consistent coverage across the application.

--- a/apps/auth_app/templatetags/form_tags.py
+++ b/apps/auth_app/templatetags/form_tags.py
@@ -27,15 +27,23 @@ def describedby_ids(field):
 
 @register.filter(name="aria_describedby")
 def aria_describedby(bound_field, describedby_id):
-    """Add aria-describedby attribute to a rendered form widget."""
-    if not describedby_id:
-        return bound_field
+    """Add aria-describedby (and aria-invalid if errors exist) attribute to a rendered form widget."""
     html = str(bound_field)
-    if "aria-describedby=" in html:
+
+    attributes = []
+    if describedby_id and "aria-describedby=" not in html:
+        attributes.append(f'aria-describedby="{describedby_id}"')
+
+    if hasattr(bound_field, "errors") and bound_field.errors and "aria-invalid=" not in html:
+        attributes.append('aria-invalid="true"')
+
+    if not attributes:
         return bound_field
+
+    attrs_str = " ".join(attributes)
     html = re.sub(
         r"(<(?:input|select|textarea)\b)",
-        rf'\1 aria-describedby="{describedby_id}"',
+        rf"\1 {attrs_str}",
         html,
         count=1,
     )

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -23619,3 +23619,13 @@ msgstr "Que signifient ces termes\\u00a0?"
 
 msgid "Intake assessment"
 msgstr "Évaluation initiale"
+
+msgid ""
+"Are you sure? This marks the theme as something that won’t be acted on."
+msgstr ""
+
+msgid "Something\\'s shifting"
+msgstr ""
+
+msgid "You don\\'t have permission to do that."
+msgstr ""


### PR DESCRIPTION
💡 **What:** Modified the `aria_describedby` template filter in `apps/auth_app/templatetags/form_tags.py` to automatically inject `aria-invalid="true"` into form widgets that have validation errors.
🎯 **Why:** To programmatically expose the invalid state of form fields to screen readers and assistive technologies. While some forms explicitly defined this logic in their templates, using the centralized `aria_describedby` template filter (which is used by `_form_field.html` and broadly across the application) ensures that all such rendered fields receive the correct ARIA attribute out of the box.
📸 **Before/After:** No visual changes.
♿ **Accessibility:** Screen readers will now reliably announce invalid states on form fields whenever server-side validation fails.

---
*PR created automatically by Jules for task [11315012632466545448](https://jules.google.com/task/11315012632466545448) started by @pboachie*