### PR TITLE
Enhance multilingual support in dashboard and base templates

### DIFF
--- a/templates/admin_settings/dashboard.html
+++ b/templates/admin_settings/dashboard.html
@@ -1,12 +1,13 @@
 {% extends "base.html" %}
 {% load i18n %}
+{% get_current_language as CURRENT_LANGUAGE %}
 
 {% block title %}{% trans "Settings" %} — {{ site.product_name|default:"KoNote" }}{% endblock %}
 
 {% block content %}
 <div class="page-header">
     <h1>{% trans "Settings" %}</h1>
-    <p>{% trans "Start here for setup, configuration, and core admin tools." %}</p>
+    <p>{% with language_prefix=CURRENT_LANGUAGE|slice:":2" %}{% if language_prefix == "fr" %}Commencez ici pour la configuration, les paramètres et les outils d'administration essentiels.{% else %}{% trans "Start here for setup, configuration, and core admin tools." %}{% endif %}{% endwith %}</p>
 </div>
 
 <div role="group" style="margin-bottom: 1rem;">

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,6 +1,7 @@
 {% load i18n %}
 {% load static %}
 {% load permissions_tags %}
+{% get_current_language as CURRENT_LANGUAGE %}
 <!DOCTYPE html>
 <html lang="{{ LANGUAGE_CODE }}">
 <head>
@@ -64,7 +65,7 @@
 
     {% if user.is_authenticated and user.is_demo %}
     <div class="demo-banner" role="alert" aria-live="polite">
-        <strong>{% trans "Training Mode" %}</strong> — {% trans "changes here do not affect real participant records." %}
+        <strong>{% trans "Training Mode" %}</strong> — {% with language_prefix=CURRENT_LANGUAGE|slice:":2" %}{% if language_prefix == "fr" %}les modifications ici n'affectent pas les vrais dossiers des participants.{% else %}{% trans "changes here do not affect real participant records." %}{% endif %}{% endwith %}
         <span class="demo-banner-user">{% blocktrans with name=user.display_name %}Signed in as {{ name }}.{% endblocktrans %}</span>
     </div>
     {% endif %}
@@ -357,11 +358,13 @@
     <!-- Chart.js — for analysis charts (loaded globally for HTMX compatibility) -->
     <script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
     <!-- Translated strings for app.js (I18N-4) -->
+    {% translate "You don't have permission to do that." as error403_text %}
+    {% translate "Something's shifting" as descriptor_shifting_text %}
     <script nonce="{{ request.csp_nonce }}">
     window.KN = {
         dismissMessage: "{% trans 'Dismiss message' %}",
         errorGeneric: "{% trans 'Something went wrong. Please try again.' %}",
-        error403: '{% trans "You don\'t have permission to do that." %}',
+        error403: "{{ error403_text|escapejs }}",
         error404: "{% trans 'The requested item was not found.' %}",
         error500: "{% trans 'A server error occurred. Please try again later.' %}",
         errorNetwork: "{% trans 'Could not connect to the server. Check your internet connection.' %}",
@@ -398,7 +401,7 @@
         chartDate: "{% trans 'Date' %}",
         descriptorHarder: "{% trans 'Harder right now' %}",
         descriptorHolding: "{% trans 'Holding steady' %}",
-        descriptorShifting: '{% trans "Something\'s shifting" %}',
+        descriptorShifting: "{{ descriptor_shifting_text|escapejs }}",
         descriptorGood: "{% trans 'In a good place' %}",
         chartPercentage: "{% trans 'Percentage' %}",
         chartMonth: "{% trans 'Month' %}",


### PR DESCRIPTION
This pull request adds improved support for French language localization by introducing conditional translations for key admin and banner messages, and updates how translated strings are handled in JavaScript variables for better internationalization. The most important changes are grouped below:

**Localization improvements:**

* [`templates/admin_settings/dashboard.html`](diffhunk://#diff-525c865ba260481c59eadb02f3f67bd2bbbe780ddb247cce93d94864d3c4930bR3-R10): Adds a conditional translation for the admin setup description, displaying a French version if the user’s language is set to French.
* [`templates/base.html`](diffhunk://#diff-690b81fad8df2a1f1ce37c846641d9247e3472d244f17039d2910a5ed0c98d5eL67-R68): Adds conditional translation for the demo banner message, showing a French version when the user’s language is French.
* [`templates/base.html`](diffhunk://#diff-690b81fad8df2a1f1ce37c846641d9247e3472d244f17039d2910a5ed0c98d5eR4): Loads the current language context variable to enable conditional translations throughout the template.

**JavaScript translation handling:**

* [`templates/base.html`](diffhunk://#diff-690b81fad8df2a1f1ce37c846641d9247e3472d244f17039d2910a5ed0c98d5eR361-R367): Moves translation of error and descriptor messages for JavaScript into template variables, ensuring proper escaping and internationalization support. [[1]](diffhunk://#diff-690b81fad8df2a1f1ce37c846641d9247e3472d244f17039d2910a5ed0c98d5eR361-R367) [[2]](diffhunk://#diff-690b81fad8df2a1f1ce37c846641d9247e3472d244f17039d2910a5ed0c98d5eL401-R404)