### PR TITLE
Add nonce support and browser tests for CSP config generator

### DIFF
--- a/apps/admin_settings/config_generator_views.py
+++ b/apps/admin_settings/config_generator_views.py
@@ -14,4 +14,7 @@ CONFIG_GENERATOR_PATH = Path(__file__).resolve().parent.parent.parent / "tools" 
 def config_generator(request):
     """Serve the config generator HTML file directly."""
     html = CONFIG_GENERATOR_PATH.read_text(encoding="utf-8")
+    nonce = str(getattr(request, "csp_nonce", ""))
+    if nonce:
+        html = html.replace("<script>", f'<script nonce="{nonce}">', 1)
     return HttpResponse(html)

--- a/tests/test_config_generator_csp_browser.py
+++ b/tests/test_config_generator_csp_browser.py
@@ -1,0 +1,67 @@
+"""Collected browser smoke tests for the CSP-safe config generator."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+pytestmark = pytest.mark.browser
+
+CONFIG_PATH = Path(__file__).resolve().parent.parent / "tools" / "config-generator.html"
+FILE_URL = CONFIG_PATH.as_uri()
+
+
+@pytest.fixture
+def page(browser):
+    """Open the config generator in a fresh browser page."""
+    p = browser.new_page()
+    p.goto(FILE_URL)
+    p.wait_for_load_state("domcontentloaded")
+    yield p
+    p.close()
+
+
+@pytest.fixture
+def browser(playwright):
+    b = playwright.chromium.launch(headless=True)
+    yield b
+    b.close()
+
+
+@pytest.fixture
+def playwright():
+    from playwright.sync_api import sync_playwright
+
+    with sync_playwright() as pw:
+        yield pw
+
+
+def test_feature_dependency_auto_enables_parent(page):
+    """Checking a dependent feature should re-enable its required parent."""
+    page.click('button[data-tab="features"]')
+
+    portal_cb = page.locator("#feat_participant_portal")
+    journal_cb = page.locator("#feat_portal_journal")
+
+    if journal_cb.is_checked():
+        journal_cb.uncheck()
+    if portal_cb.is_checked():
+        portal_cb.uncheck()
+
+    journal_cb.check()
+
+    assert portal_cb.is_checked()
+
+
+def test_added_program_appears_in_review_json(page):
+    """Programs added through the UI should appear in the generated JSON preview."""
+    page.click('button:text("Generate All Keys")')
+    page.click('button[data-tab="programs-metrics"]')
+    page.click('button:text("+ Add Program")')
+    page.fill("#programs-list .prog-name", "Test Program")
+
+    page.click('button[data-tab="review"]')
+
+    parsed = json.loads(page.text_content("#json-preview"))
+    assert parsed["programs"][0]["name"] == "Test Program"

--- a/tests/test_config_generator_view.py
+++ b/tests/test_config_generator_view.py
@@ -1,0 +1,54 @@
+"""Regression tests for the admin config generator view under CSP."""
+
+from cryptography.fernet import Fernet
+from django.test import Client, TestCase, override_settings
+
+from apps.auth_app.models import User
+import konote.encryption as enc_module
+
+
+TEST_KEY = Fernet.generate_key().decode()
+
+
+@override_settings(FIELD_ENCRYPTION_KEY=TEST_KEY)
+class ConfigGeneratorViewTest(TestCase):
+    """Ensure the admin config generator renders with a CSP-safe script tag."""
+
+    def setUp(self):
+        enc_module._fernet = None
+        self.client = Client()
+        self.admin = User.objects.create_user(
+            username="admin",
+            password="testpass123",
+            is_admin=True,
+            display_name="Admin",
+        )
+        self.staff = User.objects.create_user(
+            username="staff",
+            password="testpass123",
+            is_admin=False,
+            display_name="Staff",
+        )
+
+    def tearDown(self):
+        enc_module._fernet = None
+
+    def test_admin_view_injects_nonce_into_script_tag(self):
+        self.client.login(username="admin", password="testpass123")
+
+        response = self.client.get("/admin/settings/config-generator/")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "KoNote Configuration Generator")
+        self.assertIn(b'<script nonce="', response.content)
+        self.assertIn("Content-Security-Policy", response.headers)
+        csp = response.headers["Content-Security-Policy"]
+        self.assertIn("script-src 'self' https://unpkg.com https://cdn.jsdelivr.net", csp)
+        self.assertNotIn("script-src-attr", csp)
+
+    def test_non_admin_cannot_access_generator(self):
+        self.client.login(username="staff", password="testpass123")
+
+        response = self.client.get("/admin/settings/config-generator/")
+
+        self.assertEqual(response.status_code, 403)

--- a/tools/config-generator.html
+++ b/tools/config-generator.html
@@ -554,6 +554,106 @@ const DEFAULT_TERMS = {
 };
 
 // =============================================================================
+// CSP-SAFE LEGACY HANDLER SHIM
+// =============================================================================
+
+const INLINE_HANDLER_ATTRS = ['onclick', 'onchange', 'oninput'];
+
+function moveInlineHandler(el, attr) {
+  if (!el || !el.hasAttribute || !el.hasAttribute(attr)) return;
+  el.setAttribute('data-' + attr.slice(2), el.getAttribute(attr));
+  el.removeAttribute(attr);
+}
+
+function hoistInlineHandlers(root = document) {
+  INLINE_HANDLER_ATTRS.forEach((attr) => {
+    if (root.nodeType === Node.ELEMENT_NODE) moveInlineHandler(root, attr);
+    if (!root.querySelectorAll) return;
+    root.querySelectorAll('[' + attr + ']').forEach((el) => moveInlineHandler(el, attr));
+  });
+}
+
+function matchLegacyCall(expression, pattern) {
+  const match = expression.match(pattern);
+  return match ? match[1] : null;
+}
+
+function syncBrandColour(value) {
+  document.getElementById('brand_colour').value = value;
+}
+
+function runLegacyClick(expression, element) {
+  if (!expression) return false;
+  if (expression === 'generateSecretKey()') return generateSecretKey(), true;
+  if (expression === 'generateEncryptionKey()') return generateEncryptionKey(), true;
+  if (expression === 'generateEmailHashKey()') return generateEmailHashKey(), true;
+  if (expression === 'generateAllKeys()') return generateAllKeys(), true;
+  if (expression === 'addProgram()') return addProgram(), true;
+  if (expression === 'addTemplate()') return addTemplate(), true;
+  if (expression === 'addFieldGroup()') return addFieldGroup(), true;
+  if (expression === 'downloadEnv()') return downloadEnv(), true;
+  if (expression === 'downloadJson()') return downloadJson(), true;
+  if (expression === 'this.parentElement.remove()') return element.parentElement?.remove(), true;
+  if (expression === 'this.parentElement.parentElement.remove()') return element.parentElement?.parentElement?.remove(), true;
+
+  const copyTarget = matchLegacyCall(expression, /^copyToClipboard\('([^']+)'\)$/);
+  if (copyTarget) return copyToClipboard(copyTarget), true;
+
+  const sectionId = matchLegacyCall(expression, /^addSection\((\d+)\)$/);
+  if (sectionId !== null) return addSection(Number(sectionId)), true;
+
+  const targetId = matchLegacyCall(expression, /^addTarget\((\d+)\)$/);
+  if (targetId !== null) return addTarget(Number(targetId)), true;
+
+  const fieldGroupId = matchLegacyCall(expression, /^addField\((\d+)\)$/);
+  if (fieldGroupId !== null) return addField(Number(fieldGroupId)), true;
+
+  return false;
+}
+
+function runLegacyChange(expression, element) {
+  if (!expression) return false;
+  if (expression === 'toggleDbMode()') return toggleDbMode(), true;
+  if (expression === 'toggleAuthMode()') return toggleAuthMode(), true;
+  if (expression === 'applySmtpPreset()') return applySmtpPreset(), true;
+  if (expression === 'toggleFieldOptions(this)') return toggleFieldOptions(element), true;
+  if (expression === "document.getElementById('brand_colour').value=this.value") return syncBrandColour(element.value), true;
+
+  const featureKey = matchLegacyCall(expression, /^handleFeatureDep\('([^']+)'\)$/);
+  if (featureKey) return handleFeatureDep(featureKey), true;
+
+  return false;
+}
+
+function runLegacyInput(expression, element) {
+  if (!expression) return false;
+  if (expression === 'deriveDomainFields()') return deriveDomainFields(), true;
+  if (expression === 'filterMetrics()') return filterMetrics(), true;
+  if (expression === "document.getElementById('brand_colour').value=this.value") return syncBrandColour(element.value), true;
+  return false;
+}
+
+document.addEventListener('click', (event) => {
+  const element = event.target.closest('[data-click]');
+  if (!element) return;
+  if (runLegacyClick(element.dataset.click, element)) {
+    event.preventDefault();
+  }
+});
+
+document.addEventListener('change', (event) => {
+  const element = event.target.closest('[data-change]');
+  if (!element) return;
+  runLegacyChange(element.dataset.change, element);
+});
+
+document.addEventListener('input', (event) => {
+  const element = event.target.closest('[data-input]');
+  if (!element) return;
+  runLegacyInput(element.dataset.input, element);
+});
+
+// =============================================================================
 // TAB NAVIGATION
 // =============================================================================
 
@@ -689,6 +789,7 @@ function buildFeatureTable() {
   }
   html += '</tbody></table>';
   container.innerHTML = html;
+  hoistInlineHandlers(container);
 }
 
 function handleFeatureDep(key) {
@@ -758,6 +859,7 @@ function addProgram(name, description, colour) {
     </div>
   `;
   container.appendChild(div);
+  hoistInlineHandlers(div);
 }
 
 // =============================================================================
@@ -791,6 +893,7 @@ function buildMetricsList() {
     html += '</div></details>';
   }
   container.innerHTML = html;
+  hoistInlineHandlers(container);
 }
 
 function filterMetrics() {
@@ -825,6 +928,7 @@ function addTemplate() {
     <button class="add-btn outline" onclick="addSection(${id})" style="font-size:0.75rem;">+ Add Section</button>
   `;
   container.appendChild(div);
+  hoistInlineHandlers(div);
 }
 
 function addSection(tplId) {
@@ -842,6 +946,7 @@ function addSection(tplId) {
     <button class="add-btn outline" onclick="addTarget(${id})" style="font-size:0.7rem;">+ Add Target</button>
   `;
   container.appendChild(div);
+  hoistInlineHandlers(div);
 }
 
 function addTarget(secId) {
@@ -855,6 +960,7 @@ function addTarget(secId) {
     <button class="outline" onclick="this.parentElement.remove()" style="font-size:0.7rem; padding:0.2rem 0.5rem; color:var(--kn-danger);">&times;</button>
   `;
   container.appendChild(div);
+  hoistInlineHandlers(div);
 }
 
 // =============================================================================
@@ -877,6 +983,7 @@ function addFieldGroup() {
     <button class="add-btn outline" onclick="addField(${id})" style="font-size:0.75rem;">+ Add Field</button>
   `;
   container.appendChild(div);
+  hoistInlineHandlers(div);
 }
 
 function addField(fgId) {
@@ -905,6 +1012,7 @@ function addField(fgId) {
     </div>
   `;
   container.appendChild(div);
+  hoistInlineHandlers(div);
 }
 
 function toggleFieldOptions(sel) {
@@ -1208,6 +1316,7 @@ function downloadJson() {
 // INITIALISE
 // =============================================================================
 
+hoistInlineHandlers(document);
 buildFeatureTable();
 buildTerminologyTable();
 buildMetricsList();


### PR DESCRIPTION
This pull request introduces Content Security Policy (CSP) compliance for the admin config generator by ensuring that all inline event handlers are safely migrated to use nonces and delegated event listeners. It also adds comprehensive tests to verify CSP safety, both at the Django view level and in browser-based scenarios. The changes modernize the handling of legacy inline JavaScript and improve the maintainability and security of the configuration generator.

**CSP Compliance and Event Handler Refactor:**

* Added a CSP-safe shim in `tools/config-generator.html` that scans for legacy inline event handlers (`onclick`, `onchange`, `oninput`), moves their JS expressions to `data-*` attributes, and delegates event handling via global listeners. This ensures compatibility with CSP nonces and removes the need for inline handlers. (`[tools/config-generator.htmlR556-R655](diffhunk://#diff-0ee7a13e27ac06814e462d62e71ab7b152375411bc1e0b6631d08c6633cefa97R556-R655)`)
* Updated all dynamic UI rendering functions in `tools/config-generator.html` to call `hoistInlineHandlers` after DOM updates, ensuring that any new elements receive CSP-safe event delegation. (`[[1]](diffhunk://#diff-0ee7a13e27ac06814e462d62e71ab7b152375411bc1e0b6631d08c6633cefa97R792)`, `[[2]](diffhunk://#diff-0ee7a13e27ac06814e462d62e71ab7b152375411bc1e0b6631d08c6633cefa97R862)`, `[[3]](diffhunk://#diff-0ee7a13e27ac06814e462d62e71ab7b152375411bc1e0b6631d08c6633cefa97R896)`, `[[4]](diffhunk://#diff-0ee7a13e27ac06814e462d62e71ab7b152375411bc1e0b6631d08c6633cefa97R931)`, `[[5]](diffhunk://#diff-0ee7a13e27ac06814e462d62e71ab7b152375411bc1e0b6631d08c6633cefa97R949)`, `[[6]](diffhunk://#diff-0ee7a13e27ac06814e462d62e71ab7b152375411bc1e0b6631d08c6633cefa97R963)`, `[[7]](diffhunk://#diff-0ee7a13e27ac06814e462d62e71ab7b152375411bc1e0b6631d08c6633cefa97R986)`, `[[8]](diffhunk://#diff-0ee7a13e27ac06814e462d62e71ab7b152375411bc1e0b6631d08c6633cefa97R1015)`, `[[9]](diffhunk://#diff-0ee7a13e27ac06814e462d62e71ab7b152375411bc1e0b6631d08c6633cefa97R1319)`)

**Django View and Security Enhancements:**

* Modified the `config_generator` Django view to inject a CSP nonce into the first `<script>` tag of the served HTML, supporting strict CSP headers. (`[apps/admin_settings/config_generator_views.pyR17-R19](diffhunk://#diff-c917eec67fb7a211b2eca2ddaa027b0781c6ada219c0fb43bd66c484187bef6eR17-R19)`)

**Testing Improvements:**

* Added regression tests for the Django admin config generator view to verify that the nonce is injected into the script tag, the correct CSP headers are present, and access is restricted to admins. (`[tests/test_config_generator_view.pyR1-R54](diffhunk://#diff-f6b560876b618b3992013097278780c6084b3a75fc53b0f7e93bfa8c5e91a3cfR1-R54)`)
* Introduced browser-based smoke tests (using Playwright) to ensure that the CSP-safe config generator works as expected in the browser, including feature dependencies and JSON output. (`[tests/test_config_generator_csp_browser.pyR1-R67](diffhunk://#diff-de42c5b32b3780bf7194e50e568cc6da7b1c709e0cb76a7afe61514f717f60b3R1-R67)`)