### PR TITLE
🎨 Palette: Hide decorative arrows from screen readers in Survey Public Form

### DIFF
--- a/templates/surveys/public_form.html
+++ b/templates/surveys/public_form.html
@@ -137,8 +137,8 @@
     {% endfor %}
 
     <div id="page-nav" style="display:flex; gap:1rem; justify-content:flex-end; margin-top:1rem" hidden>
-        <button type="button" id="page-prev" class="outline">&larr; {% trans "Back" %}</button>
-        <button type="button" id="page-next">{% trans "Next" %} &rarr;</button>
+        <button type="button" id="page-prev" class="outline"><span aria-hidden="true">&larr;</span> {% trans "Back" %}</button>
+        <button type="button" id="page-next">{% trans "Next" %} <span aria-hidden="true">&rarr;</span></button>
     </div>
     <button type="submit" id="submit-btn">{% trans "Submit" %}</button>
 </form>


### PR DESCRIPTION
🎨 Palette: Add aria-hidden to decorative arrows in Survey Public Form

💡 What: Wrapped `&larr;` and `&rarr;` decorative HTML entities in `<span aria-hidden="true">` on the multi-page navigation buttons of the survey public form (`templates/surveys/public_form.html`).
🎯 Why: Screen readers read these entities out loud (e.g., "Leftwards arrow Back"), which is distracting and unnecessary context. Hiding them ensures screen readers only announce the meaningful text ("Back" and "Next").
♿ Accessibility: Improved screen reader experience by hiding decorative visual elements that do not provide extra context.

---
*PR created automatically by Jules for task [1459536888689950826](https://jules.google.com/task/1459536888689950826) started by @pboachie*