### PR TITLE
🛡️ Sentinel: [HIGH] Add rate limiting to sensitive MFA and password endpoints

### DIFF
--- a/apps/auth_app/views.py
+++ b/apps/auth_app/views.py
@@ -618,6 +618,7 @@ def mfa_verify(request):
 
 
 @login_required
+@ratelimit(key="ip", rate="5/m", method="POST", block=True)
 def mfa_setup(request):
     """Enable TOTP MFA — show QR code and confirm with a verification code."""
     import secrets
@@ -673,6 +674,7 @@ def mfa_setup(request):
 
 
 @login_required
+@ratelimit(key="ip", rate="5/m", method="POST", block=True)
 def mfa_disable(request):
     """Disable TOTP MFA — requires re-entering a valid code."""
     from django.contrib import messages

--- a/apps/portal/views.py
+++ b/apps/portal/views.py
@@ -505,6 +505,7 @@ def consent_flow(request):
 
 
 @portal_feature_required
+@ratelimit(key="ip", rate="5/m", method="POST", block=True)
 def mfa_setup(request):
     """Set up TOTP-based multi-factor authentication.
 
@@ -550,6 +551,7 @@ def mfa_setup(request):
 
 
 @portal_feature_required
+@ratelimit(key="ip", rate="5/m", method="POST", block=True)
 def mfa_verify(request):
     """Verify a TOTP code — used during login (MFA step) and setup confirmation."""
     from apps.portal.forms import MFAVerifyForm
@@ -849,6 +851,7 @@ def settings_view(request):
 
 
 @portal_login_required
+@ratelimit(key="ip", rate="5/m", method="POST", block=True)
 def password_change(request):
     """Change the participant's password."""
     from apps.portal.forms import PortalPasswordChangeForm


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Several endpoints related to Multi-Factor Authentication (MFA setup, verification, disabling) and password change lack rate limiting for POST requests.
🎯 Impact: Attackers could repeatedly hit these endpoints to brute-force MFA verification codes, spam setup requests, or attempt unlimited password changes on authenticated sessions. 
🔧 Fix: Added `@ratelimit(key="ip", rate="5/m", method="POST", block=True)` to these sensitive view functions.
✅ Verification: Ran unit tests for MFA endpoints and password reset functionalities using `pytest`. Evaluated changes locally to verify decorators are active and tests pass.

---
*PR created automatically by Jules for task [11748047392389060405](https://jules.google.com/task/11748047392389060405) started by @pboachie*