### PR TITLE
docs: foundation design rationale + /design-rationale skill

### DIFF
--- a/.claude/skills/design-rationale/SKILL.md
+++ b/.claude/skills/design-rationale/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: design-rationale
+description: Use when proposing new features, reviewing code changes, evaluating integration requests, or onboarding to KoNote — checks proposals against Design Rationale Records (DRRs) to identify conflicts with established architectural decisions, rejected anti-patterns, and privacy/security constraints before implementation begins.
+---
+
+# Design Rationale Review
+
+Review proposed features and code changes against KoNote's Design Rationale Records (DRRs) — expert-vetted architectural decisions that govern privacy, security, data modelling, and feature design. Prevents re-introducing designs that were already evaluated and rejected.
+
+## When to Use
+
+- A client, stakeholder, or developer proposes a new feature or integration
+- A PR or code change touches areas governed by DRRs (auth, data access, AI, reporting, encryption, data export)
+- Onboarding a new developer who needs to understand why things are designed a certain way
+- Evaluating whether a "Parking Lot" feature is ready to build
+- Someone asks "why can't we just...?" about an architectural constraint
+
+## Workflow
+
+```dot
+digraph review_flow {
+    rankdir=TB;
+    "Describe the proposal" [shape=box];
+    "Match keywords to DRR index" [shape=box];
+    "Read each relevant DRR" [shape=box];
+    "Any anti-pattern matches?" [shape=diamond];
+    "CONFLICT: Report with DRR citations" [shape=box, style=filled, fillcolor="#ffcccc"];
+    "Any graduated paths triggered?" [shape=diamond];
+    "CAUTION: Conditions may now be met" [shape=box, style=filled, fillcolor="#ffffcc"];
+    "CLEAR: No conflicts found" [shape=box, style=filled, fillcolor="#ccffcc"];
+
+    "Describe the proposal" -> "Match keywords to DRR index";
+    "Match keywords to DRR index" -> "Read each relevant DRR";
+    "Read each relevant DRR" -> "Any anti-pattern matches?";
+    "Any anti-pattern matches?" -> "CONFLICT: Report with DRR citations" [label="yes"];
+    "Any anti-pattern matches?" -> "Any graduated paths triggered?" [label="no"];
+    "Any graduated paths triggered?" -> "CAUTION: Conditions may now be met" [label="yes"];
+    "Any graduated paths triggered?" -> "CLEAR: No conflicts found" [label="no"];
+}
+```
+
+### Step 1: Identify the Proposal
+
+Get a clear description of what's being proposed. This can come from:
+- The user's message (e.g., "a client wants a live API for participant data")
+- A PR diff (e.g., code adding a new endpoint or model)
+- A feature request or TODO item
+
+If the proposal is vague, ask: "What data does this touch? Who initiates the action? Does it cross the boundary of a single KoNote instance?"
+
+### Step 2: Find Relevant DRRs
+
+Read `@.claude/skills/design-rationale/drr-index.md` and match the proposal's keywords to the topic index. Cast a wide net — a "webhook notification" proposal touches API, data export, AND privacy DRRs, not just the obvious one.
+
+**Always start with the relevant Foundation Principle:**
+- Participant-facing, note design, bilingual, or accessibility changes -> `foundation-collaborative-practice.md`
+- Data sharing, cross-agency, community data, demographics -> `foundation-data-sovereignty.md`
+- Auth, permissions, encryption, exports, logging -> `foundation-security-by-default.md`
+- New dependencies, hosting, cost, deployment, evaluation -> `foundation-nonprofit-sustainability.md`
+
+**Then check implementation-level DRRs:**
+- Any data leaving a KoNote instance -> `no-live-api-individual-data.md`
+- Any new permission or visibility logic -> `access-tiers.md`, `phipa-consent-enforcement.md`
+- Any new entity or relationship type -> `circles-family-entity.md`, `fhir-informed-modelling.md`
+- Any AI/LLM feature -> `ai-feature-toggles.md`, `self-hosted-llm-infrastructure.md`
+- Any reporting or aggregate data -> `reporting-architecture.md`, `cids-privacy-architecture.md`
+- Any infrastructure change -> `ovhcloud-deployment.md`, `data-access-residency-policy.md`
+
+### Step 3: Read and Assess Each DRR
+
+For each relevant DRR, read the full file from `tasks/design-rationale/` and check:
+
+1. **Anti-Patterns section**: Does the proposal match any explicitly rejected design? Quote the specific anti-pattern.
+2. **Expert Panel Findings**: What were the reasons for the current design? Do they still apply?
+3. **Graduated Complexity Path**: Did the DRR say "reconsider when X happens"? Has X happened?
+4. **Status**: Is this Decided (enforce), Draft (read but flexible), or Parking Lot (don't build)?
+
+### Step 4: Produce the Review
+
+Structure your output as follows:
+
+---
+
+**Proposal:** [one-line summary]
+
+**DRRs Consulted:** [list of files read]
+
+**Verdict:** CONFLICT / CAUTION / CLEAR
+
+**Findings:**
+
+For each relevant DRR:
+- **[DRR name]** — [Conflict | Caution | Clear]
+  - What the DRR says (quote the anti-pattern or decision)
+  - How the proposal relates
+  - What to do instead (if conflict)
+
+**Recommendation:** [approve / modify / reject, with specific guidance]
+
+---
+
+## Review Depth by Context
+
+| Context | Depth |
+|---|---|
+| Client feature request | Full review — check all keyword matches |
+| PR code review | Targeted — focus on DRRs related to changed files |
+| Quick "can we do X?" question | Index scan — cite the relevant DRR and its verdict |
+| New developer onboarding | Explain the reasoning, not just the rule |
+
+## Common Proposals and Their DRR Verdicts
+
+These come up repeatedly. The answers are settled:
+
+| Proposal | Verdict | Key DRR |
+|---|---|---|
+| Live API for individual PII | **Rejected** | `no-live-api-individual-data.md` |
+| Webhook/push notifications with PII | **Rejected** | `no-live-api-individual-data.md` |
+| Bidirectional CRM sync | **Rejected** | `no-live-api-individual-data.md` |
+| FHIR server or FHIR API | **Rejected** | `fhir-informed-modelling.md` |
+| Row-level multi-tenancy | **Rejected** | `multi-tenancy.md` |
+| Per-agency LLM deployment | **Rejected** | `self-hosted-llm-infrastructure.md` |
+| Person-to-person global relationships | **Rejected** | `circles-family-entity.md` |
+| Executives seeing individual data in reports | **Rejected** | `reporting-architecture.md`, `access-tiers.md` |
+| AI features accessing PII without toggle | **Rejected** | `ai-feature-toggles.md` |
+| PWA for offline field work | **Rejected** | `offline-field-collection.md` |
+| Translation as optional/toggleable | **Rejected** | `bilingual-requirements.md` |
+| Hosting outside Canada | **Rejected** | `data-access-residency-policy.md` |
+| English-only UI (no French) | **Rejected** | `foundation-collaborative-practice.md`, `bilingual-requirements.md` |
+| Inaccessible portal features | **Rejected** | `foundation-collaborative-practice.md` |
+| Cross-agency individual data combination | **Rejected** | `foundation-data-sovereignty.md`, `multi-tenancy.md` |
+| Staff-initiated JSON/PDF export | **Approved** | `no-live-api-individual-data.md` |
+| Aggregate cross-agency reporting | **Approved with constraints** | `cids-privacy-architecture.md` (k>=5) |
+| FHIR-informed model naming | **Approved** | `fhir-informed-modelling.md` |
+
+## When a DRR Needs Updating
+
+If you find that:
+- A "reconsider when" condition has been met
+- New information invalidates the original reasoning
+- A client need genuinely can't be met by the approved alternatives
+
+**Do not override the DRR.** Instead:
+1. Document the new evidence
+2. Flag for GK (subject matter expert) review
+3. If approved, update the DRR file before implementing the change

--- a/.claude/skills/design-rationale/drr-index.md
+++ b/.claude/skills/design-rationale/drr-index.md
@@ -1,0 +1,91 @@
+# DRR Keyword Index
+
+All files live in `tasks/design-rationale/`. Read the full DRR before making judgements — this index helps you find which DRRs are relevant, not replace reading them.
+
+## Start Here: Foundation Principles
+
+For any proposal, **always check the relevant foundation first**, then drill into implementation decisions.
+
+| Foundation | Covers | Read when proposal involves... |
+|---|---|---|
+| `foundation-collaborative-practice.md` | Two-lens notes, alliance, portal, feedback, strengths-based language, bilingual by design, accessible by design | Note design, participant-facing features, UX, feedback, goal-setting, bilingual/French, accessibility/WCAG |
+| `foundation-data-sovereignty.md` | OCAP, Black data governance, Canadian sovereignty, no cross-agency combination | Data sharing, cross-agency features, community data, demographics, hosting location, AI providers |
+| `foundation-security-by-default.md` | Encryption, RBAC, audit, fail-closed, session security | Auth, permissions, exports, logging, error handling, new roles or access paths |
+| `foundation-nonprofit-sustainability.md` | Minimal tech stack, cost, self-healing ops, evaluation-driven config | New dependencies, frameworks, hosting changes, deployment, pricing, metric/evaluation architecture |
+
+## Quick Lookup by Topic (Implementation Decisions)
+
+| If the proposal involves... | Read these DRRs |
+|---|---|
+| **API, REST, GraphQL, webhook, sync, integration, CRM, real-time data** | `no-live-api-individual-data.md`, `cids-privacy-architecture.md`, `data-access-residency-policy.md` |
+| **FHIR, HL7, health data, EHR/EMR, clinical interoperability** | `fhir-informed-modelling.md`, `no-live-api-individual-data.md` |
+| **Family, household, relationships, circles, network, dependents** | `circles-family-entity.md` |
+| **Multi-tenancy, schema isolation, cross-agency, shared database** | `multi-tenancy.md`, `data-access-residency-policy.md` |
+| **Permissions, roles, access tiers, front desk, executive, gated access** | `access-tiers.md`, `phipa-consent-enforcement.md` |
+| **Consent, PHIPA, cross-program notes, clinical note visibility** | `phipa-consent-enforcement.md`, `access-tiers.md` |
+| **AI, LLM, machine learning, suggestions, scoring, prompts** | `ai-feature-toggles.md`, `self-hosted-llm-infrastructure.md` |
+| **Encryption, key rotation, PII, decryption, Fernet** | `encryption-key-rotation.md`, `no-live-api-individual-data.md` |
+| **Reports, dashboards, funder reporting, executive view, exports** | `reporting-architecture.md`, `insights-metric-distributions.md`, `funder-reporting-profiles.md`, `executive-dashboard-redesign.md` |
+| **CIDS, Common Approach, indicators, taxonomy, classification** | `cids-privacy-architecture.md`, `cids-batch-classification-workflow.md`, `cids-metadata-assignment.md`, `funder-reporting-profiles.md` |
+| **Surveys, questionnaires, instruments, PHQ-9, standardised tools** | `survey-metric-unification.md`, `insights-metric-distributions.md` |
+| **Offline, field work, mobile, ODK, data collection** | `offline-field-collection.md` |
+| **Deployment, hosting, VPS, Docker, OVHcloud, infrastructure** | `ovhcloud-deployment.md`, `self-hosted-llm-infrastructure.md` |
+| **Bilingual, French, translation, Official Languages Act** | `foundation-collaborative-practice.md`, `bilingual-requirements.md` |
+| **Accessibility, WCAG, a11y, screen reader, keyboard navigation** | `foundation-collaborative-practice.md` |
+| **EGAP, Black data governance, Black communities, anti-Black racism** | `foundation-data-sovereignty.md`, `multi-tenancy.md` |
+| **Documents, SharePoint, Google Drive, file storage, attachments** | `document-integration.md` |
+| **Data export, data portability, migration, offboarding** | `no-live-api-individual-data.md`, `cids-privacy-architecture.md` |
+| **Data residency, Canadian hosting, foreign access, subpoena risk** | `data-access-residency-policy.md`, `ovhcloud-deployment.md` |
+| **Metrics, outcomes, progress notes, scoring, measurement** | `survey-metric-unification.md`, `insights-metric-distributions.md`, `cids-metadata-assignment.md` |
+| **Data sovereignty, OCAP, Indigenous data, community ownership** | `foundation-data-sovereignty.md`, `multi-tenancy.md`, `no-live-api-individual-data.md` |
+| **Participant portal, collaborative features, alliance rating** | `foundation-collaborative-practice.md`, `insights-metric-distributions.md` |
+| **Cost, pricing, tech stack, dependencies, frameworks** | `foundation-nonprofit-sustainability.md`, `ovhcloud-deployment.md`, `self-hosted-llm-infrastructure.md` |
+
+## DRR Status Reference
+
+| Status | Meaning |
+|---|---|
+| **Foundation Principle** | Core design philosophy. Governs multiple implementation decisions. |
+| **Decided** | Approved and enforced. Do not override without stakeholder approval. |
+| **Implemented** | Decided AND built. Code exists — check implementation before modifying. |
+| **Approved** | Reviewed by expert panel, awaiting implementation. |
+| **Draft** | Under development. Decisions may change — still read before building. |
+| **Parking Lot** | Not yet clear we should build. Do not implement without explicit approval. |
+
+## Full DRR Inventory (26 files)
+
+### Foundation Principles (4)
+
+| File | Scope |
+|---|---|
+| `foundation-collaborative-practice.md` | The "Ko" — documentation WITH participants, two-lens notes, alliance, feedback, bilingual by design, accessible by design |
+| `foundation-data-sovereignty.md` | Individual, community (OCAP, EGAP), and national data ownership |
+| `foundation-security-by-default.md` | High security for non-technical operators — encryption, RBAC, immutable audit, fail-closed |
+| `foundation-nonprofit-sustainability.md` | Affordable tech stack, self-healing ops, evaluation-driven configuration |
+
+### Implementation Decisions (22)
+
+| File | Status | Scope |
+|---|---|---|
+| `access-tiers.md` | Decided | Three permission tiers, PERM-P5/P6/P8, demographic visibility |
+| `ai-feature-toggles.md` | Decided | Two-tier AI split (tools-only vs. participant data) |
+| `bilingual-requirements.md` | Decided | EN/FR translation, legal obligations, tooling |
+| `cids-batch-classification-workflow.md` | Draft | Admin-facing batch AI classification for reporting taxonomies |
+| `cids-metadata-assignment.md` | Draft | When metadata gets assigned (creation vs. deferred) |
+| `cids-privacy-architecture.md` | Decided | Three-layer compliance (metadata / aggregate / exemplar) |
+| `circles-family-entity.md` | Decided | Family/network entity, 6+ anti-patterns |
+| `data-access-residency-policy.md` | Decided | Canadian residency by data access level |
+| `document-integration.md` | Decided | SharePoint + Google Drive integration |
+| `encryption-key-rotation.md` | Decided | Master/tenant key rotation procedures |
+| `executive-dashboard-redesign.md` | Approved | Dashboard UX with accessibility focus |
+| `fhir-informed-modelling.md` | Decided | FHIR concepts without FHIR compliance |
+| `funder-reporting-profiles.md` | Parking Lot | Template-based funder reporting |
+| `insights-metric-distributions.md` | Decided | Outcome Insights page, metric aggregation |
+| `multi-tenancy.md` | Decided | Schema-per-tenant via django-tenants |
+| `no-live-api-individual-data.md` | Decided | No live API for PII — export-only model |
+| `offline-field-collection.md` | Decided | ODK Central for offline field collection |
+| `ovhcloud-deployment.md` | Decided | OVHcloud VPS architecture, self-healing |
+| `phipa-consent-enforcement.md` | Decided | Cross-program clinical note consent filtering |
+| `reporting-architecture.md` | Decided | Template-driven vs. ad-hoc reporting |
+| `self-hosted-llm-infrastructure.md` | Decided | Shared Ollama VPS, data isolation |
+| `survey-metric-unification.md` | Decided | Surveys and metrics as one construct |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -237,25 +237,37 @@ Some features involve complex trade-offs (legal, privacy, data modelling, adopti
 
 **Do not override DRR decisions without explicit stakeholder approval.** If circumstances have changed, document why in the DRR before proceeding.
 
-Current DRRs (read the file before modifying related features — all in `tasks/design-rationale/`):
-- `circles-family-entity.md` — Circles (family/network entity)
-- `multi-tenancy.md` — Multi-tenancy architecture
-- `reporting-architecture.md` — Reporting system
-- `executive-dashboard-redesign.md` — Executive dashboard UX
-- `offline-field-collection.md` — Offline field collection (ODK Central)
-- `phipa-consent-enforcement.md` — PHIPA cross-program consent
-- `insights-metric-distributions.md` — Insights page & program reporting
-- `bilingual-requirements.md` — Bilingual (EN/FR) requirements
-- `ai-feature-toggles.md` — AI feature toggle split
-- `ovhcloud-deployment.md` — OVHcloud deployment architecture
-- `data-access-residency-policy.md` — Data access & residency policy
+Current DRRs (all in `tasks/design-rationale/` — see `README.md` there for the full navigation guide):
+
+**Foundation Principles — read these first:**
+- `foundation-collaborative-practice.md` — The "Ko" in KoNote: documentation WITH participants, two-lens notes, alliance, feedback-informed improvement
+- `foundation-data-sovereignty.md` — Individual, community (OCAP, Black data governance), and national data ownership
+- `foundation-security-by-default.md` — High security for non-technical operators: encryption, RBAC, immutable audit, fail-closed
+- `foundation-nonprofit-sustainability.md` — Affordable tech stack, self-healing ops, evaluation-driven configuration
+
+**Implementation Decisions — read before modifying related features:**
+- `access-tiers.md` — Three permission tiers, PERM-P5/P6/P8, demographic visibility
+- `ai-feature-toggles.md` — Two-tier AI split (tools-only vs. participant data)
+- `bilingual-requirements.md` — EN/FR translation, legal obligations
+- `cids-batch-classification-workflow.md` — Batch AI classification for reporting taxonomies
+- `cids-metadata-assignment.md` — When metadata gets assigned (creation vs. deferred)
+- `cids-privacy-architecture.md` — Three-layer compliance for CIDS reporting
+- `circles-family-entity.md` — Family/network entity, 6+ anti-patterns
+- `data-access-residency-policy.md` — Canadian residency by data access level
 - `document-integration.md` — SharePoint + Google Drive integration
-- `no-live-api-individual-data.md` — No live API for individual PII
-- `self-hosted-llm-infrastructure.md` — Self-hosted LLM (Ollama/OVHcloud)
-- `encryption-key-rotation.md` — Encryption key rotation procedures
-- `access-tiers.md` — Access tiers, PERM-P5/P6/P8, and demographic visibility (DEMO-VIS1)
-- `funder-reporting-profiles.md` — Funder reporting profiles (CIDS template-based reporting)
-- `cids-privacy-architecture.md` — CIDS Full Tier privacy-first architecture (three-layer compliance)
+- `encryption-key-rotation.md` — Key rotation procedures and custody
+- `executive-dashboard-redesign.md` — Dashboard UX with accessibility focus
+- `fhir-informed-modelling.md` — FHIR concepts without FHIR compliance
+- `funder-reporting-profiles.md` — Template-based funder reporting (Parking Lot)
+- `insights-metric-distributions.md` — Outcome Insights page, metric aggregation
+- `multi-tenancy.md` — Schema-per-tenant via django-tenants
+- `no-live-api-individual-data.md` — No live API for PII, export-only model
+- `offline-field-collection.md` — ODK Central for offline field collection
+- `ovhcloud-deployment.md` — OVHcloud VPS, self-healing, backup
+- `phipa-consent-enforcement.md` — Cross-program clinical note consent filtering
+- `reporting-architecture.md` — Template-driven vs. ad-hoc reporting
+- `self-hosted-llm-infrastructure.md` — Shared Ollama VPS, data isolation
+- `survey-metric-unification.md` — Surveys and metrics as one construct
 
 ### How Claude Manages Tasks
 

--- a/tasks/design-rationale/README.md
+++ b/tasks/design-rationale/README.md
@@ -1,0 +1,94 @@
+# KoNote Design Rationale
+
+This directory contains the architectural decisions that govern KoNote's design. If you're new to the project, start with the **Foundation Principles** — they explain *why* KoNote works the way it does. Then consult the implementation decisions when you're modifying a specific feature.
+
+## How to Use This Directory
+
+1. **Before proposing a new feature:** Read the relevant foundation principle, then check the implementation decisions it references.
+2. **Before modifying existing code:** Find the implementation decision that governs that feature. If one exists, read it before changing anything.
+3. **If you think a decision should change:** Document the new evidence, flag for GK (subject-matter expert) review, and update the DRR *before* implementing.
+
+Use `/design-rationale` in Claude Code to automatically check a proposal against all DRRs.
+
+---
+
+## Foundation Principles
+
+These 4 documents capture KoNote's core design philosophy. **Read these first.**
+
+| Document | What it covers |
+|---|---|
+| [Collaborative Practice](foundation-collaborative-practice.md) | The "Ko" in KoNote — documentation WITH participants, two-lens notes, alliance rating, feedback-informed improvement, strengths-based language |
+| [Data Sovereignty & Rights](foundation-data-sovereignty.md) | Participant and community data ownership, OCAP principles, Black data governance, Canadian digital sovereignty, intentional absence of cross-agency data combination |
+| [Security by Default](foundation-security-by-default.md) | High security for non-technical operators — encryption, RBAC, immutable audit, fail-closed consent, session security |
+| [Nonprofit Sustainability](foundation-nonprofit-sustainability.md) | Minimal tech stack, affordable hosting, self-healing ops, evaluation-driven configuration, managed service model |
+
+---
+
+## Implementation Decisions by Topic
+
+These are detailed decisions with expert panel findings and anti-patterns. Grouped by the foundation principle they support.
+
+### Collaborative Practice
+
+| Document | Status | Scope | See also |
+|---|---|---|---|
+| [insights-metric-distributions.md](insights-metric-distributions.md) | Decided | Outcome Insights page, metric aggregation, suggestion themes | Sustainability |
+| [survey-metric-unification.md](survey-metric-unification.md) | Decided | Surveys and metrics as one construct | Sustainability |
+| [circles-family-entity.md](circles-family-entity.md) | Decided | Family/network entity, 6+ anti-patterns | |
+
+### Data Sovereignty & Privacy
+
+| Document | Status | Scope | See also |
+|---|---|---|---|
+| [data-access-residency-policy.md](data-access-residency-policy.md) | Decided | Canadian residency requirements by data access level | Security |
+| [no-live-api-individual-data.md](no-live-api-individual-data.md) | Decided | No live API for PII — export-only model | Security |
+| [phipa-consent-enforcement.md](phipa-consent-enforcement.md) | Decided | Cross-program clinical note consent filtering | Security, Collab |
+| [cids-privacy-architecture.md](cids-privacy-architecture.md) | Decided | Three-layer compliance for CIDS reporting | Sustainability |
+| [encryption-key-rotation.md](encryption-key-rotation.md) | Decided | Master/tenant key rotation procedures | Security |
+
+### Security & Access Control
+
+| Document | Status | Scope | See also |
+|---|---|---|---|
+| [access-tiers.md](access-tiers.md) | Decided | Three permission tiers, PERM-P5/P6/P8, demographic visibility | Sovereignty |
+| [ai-feature-toggles.md](ai-feature-toggles.md) | Decided | Two-tier AI split (tools-only vs. participant data) | Sovereignty, Sustainability |
+
+### Evaluation & Reporting
+
+| Document | Status | Scope | See also |
+|---|---|---|---|
+| [reporting-architecture.md](reporting-architecture.md) | Decided | Template-driven vs. ad-hoc reporting | Sovereignty |
+| [funder-reporting-profiles.md](funder-reporting-profiles.md) | Parking Lot | Template-based funder reporting configuration | |
+| [executive-dashboard-redesign.md](executive-dashboard-redesign.md) | Approved | Dashboard UX with accessibility focus | Collab |
+| [cids-batch-classification-workflow.md](cids-batch-classification-workflow.md) | Draft | Batch AI classification for reporting taxonomies | |
+| [cids-metadata-assignment.md](cids-metadata-assignment.md) | Draft | When metadata gets assigned (creation vs. deferred) | |
+
+### Infrastructure & Deployment
+
+| Document | Status | Scope | See also |
+|---|---|---|---|
+| [ovhcloud-deployment.md](ovhcloud-deployment.md) | Decided | OVHcloud VPS architecture, self-healing, backup | Sovereignty |
+| [self-hosted-llm-infrastructure.md](self-hosted-llm-infrastructure.md) | Decided | Shared Ollama VPS, data isolation model | Sovereignty |
+| [multi-tenancy.md](multi-tenancy.md) | Decided | Schema-per-tenant via django-tenants | Sovereignty, Sustainability |
+
+### Interoperability & Integration
+
+| Document | Status | Scope | See also |
+|---|---|---|---|
+| [fhir-informed-modelling.md](fhir-informed-modelling.md) | Decided | FHIR concepts without FHIR compliance | |
+| [bilingual-requirements.md](bilingual-requirements.md) | Decided | EN/FR translation, legal obligations | Collab, Sustainability |
+| [document-integration.md](document-integration.md) | Decided | SharePoint + Google Drive integration | |
+| [offline-field-collection.md](offline-field-collection.md) | Decided | ODK Central for offline field collection | |
+
+---
+
+## Status Key
+
+| Status | Meaning |
+|---|---|
+| **Decided** | Approved and enforced. Do not override without stakeholder approval. |
+| **Implemented** | Decided AND built. Check implementation before modifying. |
+| **Approved** | Reviewed by expert panel, awaiting implementation. |
+| **Draft** | Under development. Decisions may change — still read before building. |
+| **Parking Lot** | Not yet clear we should build. Do not implement without explicit approval. |

--- a/tasks/design-rationale/foundation-collaborative-practice.md
+++ b/tasks/design-rationale/foundation-collaborative-practice.md
@@ -5,6 +5,8 @@
 Status: Foundation Principle
 Created: 2026-03-14
 
+> **In plain language:** KoNote is designed so that staff and participants write notes together, not separately. The participant's voice — their words, their feedback, their rating of the relationship — is a core part of every note, not an afterthought. The name itself means "collaborative note" and works in both English and French.
+
 ---
 
 ## Core Principle
@@ -84,6 +86,26 @@ KoNote is designed to make these practices the path of least resistance, not an 
 
 **Anti-pattern:** Hardcoded clinical terminology that assumes every agency uses the same words. The terminology system exists because collaborative practice means respecting how each community describes its own relationships.
 
+### 8. Bilingual by Design
+
+**What:** KoNote is fully bilingual in English and French — not as a localisation add-on, but as a structural design constraint. The name itself is bilingual: "Note" is the same word in both languages, and "Ko-" reads as a stylised prefix for "co-" (*collaboration, coopération, collectif*) — a prefix that carries the same meaning in both English and French. French speakers parse "KoNote" as *co-note* = collaborative notes. In English, the exact same logic applies. There is also a subtle echo of the French verb *connoter* (to connote), suggesting depth, context, and significance beyond surface-level documentation — a fitting resonance for social services where notes carry real weight.
+
+Every template, every label, every system message exists in both languages. The translation pipeline (`translate_strings`) is part of the development workflow, not an afterthought. Translation is exempt from AI feature toggles because it is a legal requirement, not an optional feature.
+
+**Why:** The Official Languages Act and many federal/provincial funding agreements require bilingual service delivery. For agencies serving francophone communities in Ontario, Quebec, or New Brunswick, a system that only works in English is not usable. But beyond legal compliance, bilingual design is an expression of collaborative practice — if the system can't speak the participant's language, it cannot be truly collaborative.
+
+**Anti-pattern:** Treating French as a translation layer applied after the English version is complete. In KoNote, both languages are first-class — new features are not considered complete until both language versions exist. See `bilingual-requirements.md` for the detailed implementation decisions.
+
+### 9. Accessible by Design
+
+**What:** KoNote targets WCAG 2.2 AA compliance: semantic HTML, sufficient colour contrast, keyboard navigation, screen reader compatibility, and alt text for meaningful images. Accessibility is not a separate checklist applied after development — it is a constraint on every template and component from the start.
+
+**Why:** Collaborative documentation only works if all participants can use the system. A participant who uses a screen reader, has low vision, or has motor impairments must be able to navigate the portal, read their goals, rate the alliance, and write journal entries. If the portal is inaccessible, that participant is excluded from the "Ko" in KoNote — the collaboration becomes staff-only by default, which contradicts the foundational principle.
+
+Many nonprofit participants have accessibility needs — people with disabilities are disproportionately represented in social services. Designing for accessibility is not an edge case; it is designing for the actual user base.
+
+**Anti-pattern:** Treating accessibility as a post-launch polish item or a compliance checkbox. If a portal feature is built without keyboard navigation, a screen reader user discovers a broken experience — and the "fix it later" approach means they're excluded for however long "later" takes.
+
 ---
 
 ## Anti-Patterns Summary
@@ -97,6 +119,16 @@ KoNote is designed to make these practices the path of least resistance, not an 
 | Annual feedback surveys | Too infrequent; low response rates; feedback loop too slow to drive real improvement |
 | Deficit-focused clinical language | Pathologises participants; contradicts strengths-based practice; harmful when participants read their own records |
 | Hardcoded terminology | Not every community uses clinical language; forced terminology is a barrier to adoption |
+| French as a translation afterthought | Bilingual design is a legal requirement and a collaborative principle, not a localisation layer |
+| Accessibility as post-launch polish | Excluding participants with disabilities contradicts collaborative practice |
+
+---
+
+## Connections to Other Foundations
+
+- **Data Sovereignty**: Bilingual design supports francophone communities' right to services in their language. Accessible design ensures no participant is excluded from data access rights.
+- **Security by Default**: Accessibility constraints (semantic HTML, no reliance on colour alone) also improve security posture by reducing attack surface from custom UI workarounds.
+- **Nonprofit Sustainability**: Bilingual compliance is a legal prerequisite for federal funding — agencies that can't demonstrate it lose funding eligibility. See `bilingual-requirements.md`.
 
 ---
 
@@ -107,6 +139,7 @@ These existing Design Rationale Records contain the detailed implementation spec
 - **`insights-metric-distributions.md`** — How suggestion themes and outcome distributions are aggregated for program learning. Includes the "service-framing, not person-labelling" principle for dashboard language.
 - **`survey-metric-unification.md`** — Surveys and metrics as a unified construct, enabling participant self-report and staff observation to be captured through the same measurement infrastructure.
 - **`circles-family-entity.md`** — Family and network entity design, extending collaborative practice beyond the individual to recognise that participants exist in relational contexts.
+- **`bilingual-requirements.md`** — EN/FR translation pipeline, legal obligations, and tooling for bilingual-by-design development.
 
 ---
 

--- a/tasks/design-rationale/foundation-data-sovereignty.md
+++ b/tasks/design-rationale/foundation-data-sovereignty.md
@@ -1,0 +1,154 @@
+# Foundation: Data Sovereignty & Rights
+
+**Individual, Community, and National Data Ownership**
+
+Status: Foundation Principle
+Created: 2026-03-14
+
+> **In plain language:** Your data belongs to you — not to KoNote, not to a tech company, and not to a foreign government. The system is built so that communities control their own data, individuals can see and correct their own records, and no one can combine data across agencies without explicit community consent.
+
+---
+
+## Core Principle
+
+KoNote is designed so that data belongs to the people and communities it describes — not to KoNote, not to a hosting provider, and not to any government with a subpoena power that overrides Canadian law. This principle operates at three levels: individual participants own their personal information, communities own their collective data, and Canadian nonprofits retain sovereignty over where their data resides and who can access it.
+
+The architecture enforces these principles structurally — not through policies that can be ignored, but through technical design that makes violation impossible. Schema-per-tenant isolation means cross-agency queries cannot happen, not that they are merely forbidden. Export-only data portability means no persistent external access channel exists, not that one exists but is discouraged. Self-hosted AI means participant data never leaves Canadian infrastructure, not that it leaves but is "anonymised first." The gap between "we promise not to" and "we built it so you can't" is where trust lives.
+
+---
+
+## Individual Participant Rights
+
+### 1. Correction Rights (PHIPA/PIPEDA)
+
+Participants can request corrections to their records through the portal. The `CorrectionRequest` model supports both informal paths ("I'll bring it up next session") and formal written requests. Staff must respond within the regulatory timeline. Corrections are appended — the original record is preserved with an amendment notation, not silently overwritten. This protects both the participant's right to accuracy and the clinical record's integrity.
+
+### 2. Data Access
+
+PIPEDA gives Canadians the right to see what information is held about them. The participant portal makes this self-service — participants view their own goals, notes, and progress without making a formal access request. This is not a convenience feature. It is a structural implementation of a legal right. The alternative — requiring participants to submit formal requests and wait 30 days — creates a power asymmetry that discourages people from exercising their rights.
+
+### 3. Erasure Workflow
+
+Erasure uses a two-person process: a Program Manager requests it, an admin approves it. PII is stripped and the anonymised record is retained for aggregate statistics. The process is irreversible by design — this prevents accidental or coerced reversal. Once erasure is approved, no one (including KoNote developers, hosting administrators, or the agency itself) can reconstruct the individual's identity from remaining data. The two-person requirement prevents a single compromised or pressured account from erasing records to cover up harm.
+
+### 4. Consent as Ongoing
+
+The `ConsentEvent` model is append-only: it records grant and withdraw events with reasons and timestamps. Consent is never a single checkbox at intake that covers everything forever. Cross-program sharing is per-client configurable. Consent to aggregate reporting is explicit opt-in.
+
+**Anti-pattern: one-time blanket consent at intake.** Many systems collect a single signature at enrollment and treat it as permanent, irrevocable permission for all data uses. This violates the spirit of PIPEDA's meaningful consent requirement. KoNote treats consent as a living state that participants can change at any time, with each change recorded and enforced structurally through the PHIPA consent filtering layer.
+
+---
+
+## Community Data Sovereignty
+
+This is where KoNote's design philosophy diverges most sharply from conventional SaaS platforms. Data about communities has historically been extracted, combined, and used in ways those communities never consented to and often cannot see. KoNote's architecture is built to make that pattern structurally impossible.
+
+### 1. OCAP Principles (First Nations)
+
+The First Nations principles of **Ownership, Control, Access, and Possession** (OCAP) are the most developed framework for Indigenous data sovereignty. KoNote's architecture supports OCAP through:
+
+- **Ownership**: Each agency or community owns its data in an isolated schema. KoNote (the software) has no claim on the data. The licensing model is designed to ensure that data belongs to the agency, not to KoNote or its developers — this principle should be formalised in every service agreement.
+- **Control**: Communities control what data is collected (custom fields, configurable demographics), who sees it (role-based access with granular permissions), and whether it is shared (export-only — no live API, no automatic reporting to external bodies).
+- **Access**: The community has full access through the admin interface and export functions. Data portability is a right, not a premium feature. Full agency export is available to every agency regardless of pricing tier.
+- **Possession**: Schema-per-tenant means the community's data is physically separated at the database level. No cross-agency queries are possible — not restricted by policy, but prevented by architecture. Data stays in Canadian data centres (OVHcloud Beauharnois, QC).
+
+**Anti-pattern: multi-agency data lakes where community data is combined with other agencies' data without community control.** Many platforms aggregate data across clients into a single database, then offer "insights" that the contributing communities cannot review, correct, or withdraw from. This directly violates OCAP's ownership and control principles.
+
+### 2. Black Data Governance (EGAP)
+
+The **EGAP Framework** — **Engagement, Governance, Access, and Protection** — is the Black community equivalent of OCAP. Where OCAP centres First Nations data sovereignty, EGAP addresses the specific harms that data collection has inflicted on Black communities: surveillance, profiling, deficit narratives, and systemic exclusion. Alongside EGAP, related frameworks (the Black Health Alliance's position papers, the Us/We approach) emphasise that data about Black communities has historically been used to justify funding cuts, target neighbourhoods for policing, and reinforce deficit narratives rather than support empowerment.
+
+KoNote's architecture supports EGAP through:
+
+- **Engagement**: Community-controlled demographic fields are optional and self-identified. Agencies configure their own intake forms and choose which demographic categories to collect. No external body dictates what identity data must be gathered — the community decides what's relevant to their services and their people.
+- **Governance**: Agency-level settings, RBAC with program-scoped access, and feature toggles give the community control over how their data is used internally. No data leaves the instance without deliberate community action. Aggregate reporting requires explicit opt-in (`consent_to_aggregate_reporting`), not opt-out.
+- **Access**: Full export capability ensures the community can retrieve all their data at any time. The participant portal provides individual-level access. Admin dashboards provide community-level visibility. Data portability is a right, not a premium feature.
+- **Protection**: Mandatory small-cell suppression (k>=5) prevents re-identification in small populations. All PII is encrypted at rest with per-tenant keys. No cross-agency data combination is possible. The export-only model means no external system can pull data without deliberate community action.
+
+**Anti-pattern: automatic demographic disaggregation that exposes small community populations.** A report showing "2 Black youth in Program X had declining outcomes" identifies those individuals to anyone familiar with the program. KoNote's small-cell suppression is mandatory, not optional — it cannot be overridden by staff, administrators, or funders.
+
+### 3. The Intentional Absence of Multi-Agency Combination
+
+KoNote deliberately does NOT combine individual-level data across agencies. This is not a missing feature — it is a design principle. Cross-agency data combination:
+
+- **Violates OCAP** — the community loses control of how their data is used once it enters a combined dataset
+- **Enables surveillance patterns** — tracking individuals across service touchpoints creates a profile that no single agency intended to build
+- **Undermines trust** — participants consented to share information with their agency, not to be tracked across every service they access
+- **Concentrates power** — whoever controls the combined dataset has analytical power over all participating communities, with none of the accountability
+
+**What IS permitted:** agencies can voluntarily publish de-identified aggregate reports to a consortium or funder. These are one-way, community-initiated, and contain no individual records. The `PublishedReport` model enforces this boundary. An agency can share "we served 45 youth and 78% showed improvement" without sharing who those youth are or any details that could identify them.
+
+---
+
+## Canadian Digital Sovereignty
+
+### 1. Independence from US Tech Giants
+
+KoNote uses OVHcloud (French parent company, not subject to US CLOUD Act), self-hosted Ollama for AI processing of participant data (not OpenAI/Anthropic APIs), and open-source software throughout the stack. This is not anti-American sentiment — it is a legal risk calculation. The US CLOUD Act allows US courts to compel any US-incorporated company, or any US person, to produce data regardless of where it is stored. Hosting participant data on AWS, Azure, or Google Cloud means a US court can order its disclosure without Canadian judicial oversight.
+
+**Anti-pattern: building on AWS/Azure/Google Cloud where a US government subpoena can compel data disclosure without Canadian judicial review.** The risk is not theoretical — US law enforcement regularly uses CLOUD Act powers, and the threshold for access is lower than Canadian courts require.
+
+### 2. Data Residency
+
+All participant data is hosted in Beauharnois, QC. The `data-access-residency-policy` DRR establishes the access tier framework for anyone with SSH, database, or encryption key access. The hosting choice is deliberate: OVHcloud's Beauharnois data centre is operated by a French-incorporated company with no US subsidiary that could be compelled under the CLOUD Act.
+
+### 3. No Vendor Lock-In
+
+Docker Compose deployment works on any Linux VPS. Django and PostgreSQL are open-source. An agency can move to a different hosting provider by copying files and restoring a database backup. The full agency export produces a self-contained encrypted archive that includes everything needed to reconstruct the instance.
+
+**Anti-pattern: proprietary platforms that hold data hostage when contracts end.** Many SaaS platforms make it technically difficult or contractually expensive to extract your own data. KoNote treats data portability as a right — the export function exists from day one, not as an afterthought when a client threatens to leave.
+
+### 4. AI Sovereignty
+
+Participant data never leaves the self-hosted LLM server (Ollama on the Canadian VPS). The `ai-feature-toggles` DRR enforces a strict split: Tier 1 (operational AI touching participant content) runs self-hosted; Tier 2 (tools-only AI processing program metadata, no PII) may use cloud APIs; Tier 3 (evaluation) is external and non-PII only. Agencies with heightened sovereignty concerns can disable cloud AI tiers entirely.
+
+**Anti-pattern: sending participant data to cloud AI APIs for "AI-powered insights."** Once participant data reaches an external LLM provider's servers, it is subject to that provider's jurisdiction, retention policies, and training practices — regardless of what their terms of service promise today.
+
+---
+
+## Anti-Patterns Summary
+
+| Anti-pattern | Why it is rejected |
+|---|---|
+| Multi-agency data lake | Violates OCAP; enables surveillance; concentrates power |
+| Live API for individual PII | Persistent attack surface; bypasses consent model |
+| Hosting on US cloud (AWS/Azure/GCP) | US CLOUD Act subpoena risk without Canadian judicial oversight |
+| Blanket one-time consent | Consent must be ongoing, specific, and revocable |
+| Automatic demographic disaggregation | Small-cell exposure; re-identification risk for marginalised communities |
+| Proprietary platform lock-in | Community loses ability to leave with their data |
+| Cloud AI APIs for participant data | Data leaves Canadian jurisdiction; sovereignty lost |
+
+---
+
+## Connections to Other Foundations
+
+- **Collaborative Practice**: The participant portal (data access rights) is also a collaborative tool. Consent as ongoing aligns with the two-lens note design — participants are partners, not subjects. Bilingual design supports francophone communities' sovereignty over their service experience.
+- **Security by Default**: Encryption, RBAC, and fail-closed consent are the *enforcement mechanisms* for the sovereignty principles described here. Security is the "how"; sovereignty is the "why."
+- **Nonprofit Sustainability**: Multi-tenancy for cost sharing is also schema isolation for data sovereignty. The same architecture serves both purposes — affordable AND sovereign.
+
+---
+
+## Related Implementation Decisions
+
+These DRRs implement specific aspects of the principles described above:
+
+- `data-access-residency-policy.md` — Access tiers by data sensitivity level
+- `no-live-api-individual-data.md` — Export-only model, no live API for individual PII
+- `phipa-consent-enforcement.md` — Cross-program consent filtering
+- `cids-privacy-architecture.md` — Three-layer compliance for cross-agency aggregate reporting
+- `multi-tenancy.md` — Schema-per-tenant isolation
+- `encryption-key-rotation.md` — Per-tenant encryption keys
+- `self-hosted-llm-infrastructure.md` — Self-hosted AI for data sovereignty
+- `ovhcloud-deployment.md` — Canadian hosting architecture
+- `ai-feature-toggles.md` — Three-tier AI split (self-hosted vs. cloud)
+- `access-tiers.md` — RBAC and demographic visibility controls
+
+---
+
+## When to Revisit
+
+If Canada adopts legislation equivalent to EU GDPR adequacy agreements that provide enforceable protections against foreign government access, the US cloud restriction could be relaxed — but only if the legal protection is structural (treaty-level), not merely contractual (terms of service).
+
+If Indigenous communities develop specific data governance standards for nonprofit service software beyond OCAP, incorporate them. If Black data governance frameworks produce concrete technical requirements, implement them.
+
+The principles themselves — community ownership, individual rights, structural enforcement over policy promises — should not change. These are not implementation choices that might be superseded by better technology. They are values that the architecture exists to serve.

--- a/tasks/design-rationale/foundation-nonprofit-sustainability.md
+++ b/tasks/design-rationale/foundation-nonprofit-sustainability.md
@@ -1,0 +1,181 @@
+# Foundation: Nonprofit Sustainability
+
+**Affordable, Simple, and Evaluation-Ready**
+
+Status: Foundation Principle
+Created: 2026-03-14
+
+> **In plain language:** KoNote is designed to be affordable for small nonprofits and simple enough to run without a dedicated IT team. It uses a deliberately simple tech stack, heals itself when things go wrong, and is built so that the data you collect actually feeds evaluation, reporting, and sector-wide learning — not just a filing cabinet.
+
+---
+
+## Core Principle
+
+KoNote exists because nonprofits doing critical community work shouldn't need enterprise budgets or dedicated IT teams to track outcomes effectively. Every architectural choice — from the tech stack to the hosting model to the deployment automation — is made with a cost-conscious, non-technical operator in mind. The system must be cheap enough that a small agency can afford it, simple enough that it can be maintained by a generalist, and evaluation-ready so that the data collected actually improves programs and satisfies funders.
+
+This principle is not about austerity — it is about fitness for context. Nonprofits operate with constrained budgets, high staff turnover, and limited technical capacity. A system that requires a dedicated DevOps engineer, a JavaScript build pipeline, or $500/month in cloud hosting is not a viable tool for a 5-person agency running employment programs. KoNote's architecture treats these constraints as design requirements, not limitations to work around later.
+
+---
+
+## Minimal Tech Stack
+
+### 1. No JavaScript Frameworks
+
+Django server-rendered templates + HTMX + Pico CSS. No React, Vue, webpack, npm, or Node.js. The frontend is HTML that Django renders and HTMX makes interactive. This means: no JavaScript build pipeline, no node_modules (0 bytes vs 300+ MB), no transpilation, no bundling.
+
+**Why:** Every added build tool is a maintenance burden. React introduces 100+ transitive dependencies. Each dependency is a potential security vulnerability and a point of failure during upgrades. Nonprofits don't need a SPA — they need forms that work.
+
+**Anti-pattern:** "Let's use React for a richer UI." The marginal UX improvement doesn't justify the 10x increase in build complexity, dependency surface, and required expertise.
+
+### 2. 46 Dependencies Total
+
+The entire production stack is 46 Python packages. Compare to a typical Django + React project: 500+. Fewer dependencies = faster builds, simpler security scanning, fewer upgrade conflicts. Every dependency must justify its presence — there is no "add it now, evaluate it later."
+
+### 3. Alpine-Based Containers
+
+All Docker images use Alpine Linux (5-20 MB vs 300+ MB for Debian/Ubuntu). The ops sidecar (Dockerfile.ops) is 21 MB. Builds take seconds, not minutes. Smaller images mean faster deployments, less disk usage, and a smaller attack surface.
+
+### 4. Configuration Over Code
+
+~60 environment variables control deployment. Feature toggles (demo mode, auth mode, AI provider) work without code changes. `.env.example` is the documentation. An agency can switch from local auth to Azure SSO, enable or disable AI features, or change their terminology — all by editing environment variables. No code deployments required for configuration changes.
+
+---
+
+## Cost-Conscious Hosting
+
+### 1. OVHcloud Over Azure
+
+Single-tenant hosting costs ~$26 CAD/month on OVHcloud vs ~$132/month on Azure. Multi-tenant at 10 agencies: ~$13/agency/month vs ~$46/agency/month. OVHcloud is 60-70% cheaper because it's unmanaged VPS — the self-healing automation (described below) makes this safe. *(These figures are illustrative — for current pricing, see `tasks/hosting-cost-comparison.md`.)*
+
+**Why not Azure/AWS by default?** Managed cloud services are priced for organisations that value convenience over cost. Nonprofits value cost over convenience. An unmanaged VPS with good automation is cheaper AND more transparent — you can see exactly what's running and why.
+
+### 2. Multi-Tenancy for Cost Sharing
+
+Schema-per-tenant (django-tenants) lets multiple agencies share one server without sharing data. PostgreSQL enforces isolation at the schema level. One VPS serves 1-100 agencies. Cost per agency drops as more join. No agency can see another's data, but they share compute, storage, and operational overhead.
+
+### 3. Shared AI Server
+
+One OVHcloud VPS (~$40 CAD/month) running Ollama serves all agencies. Qwen3.5-35B (MoE, only 3B active parameters per token) handles nightly theme processing. Cost per agency at 10 agencies: ~$4/month vs $27-68/month per-agency with cloud APIs. *(For current model selection and costs, see `tasks/hosting-cost-comparison.md`.)*
+
+**Anti-pattern:** Per-agency AI deployment. At $400/month per agency for a dedicated LLM instance, AI features become inaccessible to small organisations. Shared infrastructure with tenant-level data isolation makes AI affordable for everyone.
+
+---
+
+## Self-Healing Operations
+
+Nonprofits can't afford 24/7 ops staff. The system heals itself:
+
+| Layer | Mechanism | Recovery Time |
+|---|---|---|
+| 1 | Docker restart policies + autoheal container | 30-90 seconds |
+| 2 | UptimeRobot -> OVHcloud API webhook -> VPS reboot | 15-20 minutes |
+| 3 | Ops sidecar cron (backups, disk monitoring, health reports) | Prevention |
+| 4 | Email alerts to KoNote team | Escalation |
+
+Operational burden: ~1-5 hours/month per agency (mostly reviewing reports), down from 10-15 hours without automation. The deploy script (`deploy.sh`) handles git pull, container rebuild, health checks, and migration failure detection in one command.
+
+**Anti-pattern:** Requiring a sysadmin on-call. Nonprofits don't have one. The system must recover from common failures without human intervention.
+
+---
+
+## Managed Service Model
+
+KoNote can be deployed in three models, each appropriate for different organisational capacities:
+
+- **Self-managed**: Agency runs their own VPS. Docker Compose deployment, no vendor lock-in. Requires some technical comfort but no dedicated IT staff — the automation handles the hard parts.
+- **Managed service**: A network or intermediary hosts multiple agencies. Published pricing at 10-agency scale: ~$15/agency/month (infrastructure) + support costs. The intermediary handles deployment and monitoring; agencies focus on service delivery.
+- **Consortium**: Multiple agencies share infrastructure and aggregate reporting. Each agency retains data sovereignty — they choose what to publish and what stays private. Shared infrastructure reduces costs; shared reporting increases sector learning.
+
+**Anti-pattern:** Pricing models that are affordable only at enterprise scale. KoNote must be affordable for a 5-person agency. If the cheapest option requires 50+ users to break even, small agencies are excluded by design.
+
+---
+
+## Built for Evaluation, Not Retrofitted
+
+The system is designed so that an initial evaluation assessment feeds directly into how KoNote is configured. Data collection is not an afterthought bolted onto case management — it is built into the structure of every interaction. This section connects directly to the collaborative practice foundation — the evaluation pipeline starts with collaborative goal-setting (see Foundation: Collaborative Practice) and ends with sector-wide learning.
+
+### 1. Evaluation Framework to Program Setup
+
+The EvaluationFramework model stores the program's theory of change, outcome chain, and risk analysis. This feeds which metrics are configured, what measurement schedule is used, and what reporting structure applies. Configuration follows from evaluation design, not the reverse.
+
+### 2. Metric Definitions with Full Metadata
+
+Each metric carries standardised instrument info (PHQ-9, GAD-7), scoring bands, directionality, CIDS alignment, IRIS+ codes, SDG goals. A metric is not just a number field — it is an evaluation instrument with provenance and rationale. When a funder asks "what are you measuring and why?", the answer is embedded in the metric definition itself.
+
+### 3. The Pipeline
+
+Evaluation assessment -> metric configuration -> daily data collection (progress notes with structured observations) -> automatic aggregation (insights, trends, suggestion themes) -> executive dashboards -> funder reports -> consortium publishing -> sector-wide learning.
+
+Each step feeds the next. Data collected in a progress note today appears in tonight's theme analysis, tomorrow's dashboard, and next quarter's funder report — without anyone re-entering it. In practice, this pipeline is iterative: metrics are refined after initial data collection, instruments may be replaced, and funder requirements change mid-grant. The architecture supports this through version-tracked metric definitions with append-only rationale logs.
+
+### 4. CIDS Alignment
+
+Metrics, programs, and demographics map to Common Approach (CIDS) taxonomy codes for sector-wide comparability. This matters at scale: when 50 agencies use KoNote and all map to CIDS, the sector can say "across Ontario, 68% of employment programs report positive outcomes for SDG 8." That's policy-level impact built from individual progress notes.
+
+Classification happens through admin-facing batch workflows, not during frontline note-taking. The worker writing a note should never need to know what CIDS code applies — that mapping is the evaluation lead's job, done once per metric. This division of labour is deliberate: frontline staff focus on the participant relationship; the evaluator (or evaluation lead) configures frameworks, selects instruments, and manages taxonomy alignment.
+
+**Anti-pattern:** Outcome tools that collect data but don't connect to evaluation methodology. Data without a theory of change is just noise. If a metric doesn't trace back to an outcome in the evaluation framework, it shouldn't exist. Equally: asking case workers to do taxonomy classification during a session is an anti-pattern — it burdens frontline staff with work that belongs to the evaluation function.
+
+---
+
+## Sector-Wide Learning
+
+KoNote contributes to the broader nonprofit sector through:
+
+- **CIDS exports**: Standardised data that can be compared across agencies using Common Approach codes. Agencies that use KoNote speak the same measurement language, even if their programs differ.
+- **Consortium reporting**: De-identified aggregate snapshots published voluntarily by each agency. No agency is forced to share — but the infrastructure makes sharing easy when they choose to.
+- **Funder reporting profiles**: Structured templates aligned to funder requirements (e.g., IRIS+, SDGs). Reporting is a configuration task, not a data entry task.
+- **Open source**: The software itself is a contribution. Other nonprofits can adopt, adapt, and improve it. No vendor lock-in, no proprietary data formats.
+
+**Anti-pattern:** Proprietary platforms where data format is vendor-locked and cross-agency comparison requires buying the same product. The sector learns faster when data is interoperable and tools are shared.
+
+---
+
+## Anti-Patterns Summary
+
+| Anti-pattern | Why it's rejected |
+|---|---|
+| React / JavaScript framework | 10x build complexity for marginal UX gain |
+| Enterprise cloud hosting (Azure/AWS default) | 3-5x cost; not necessary for this scale |
+| Per-agency AI deployment | $400/month vs $4/month shared |
+| 24/7 ops staff requirement | Nonprofits don't have one; automate instead |
+| Enterprise-only pricing | Small agencies excluded |
+| Outcome tools without evaluation methodology | Data without theory of change is noise |
+| Proprietary data formats | Vendor lock-in; sector can't learn from each other |
+
+---
+
+## Connections to Other Foundations
+
+- **Collaborative Practice**: The evaluation pipeline starts with collaborative goal-setting and ends with sector-wide learning. The minimal tech stack keeps the interface simple enough for participants to use alongside staff during sessions.
+- **Data Sovereignty**: Multi-tenancy serves both cost sharing AND data sovereignty — same architecture, dual purpose. The shared AI server maintains data isolation while making AI affordable.
+- **Security by Default**: Self-healing ops and Alpine containers reduce the attack surface. Fewer dependencies mean fewer security vulnerabilities to patch. The sustainability constraint ("no dedicated IT") forces security to be architectural.
+
+---
+
+## Related Implementation Decisions
+
+These existing Design Rationale Records contain the detailed implementation specifics for features shaped by this principle:
+
+- **`multi-tenancy.md`** — Schema-per-tenant architecture that enables cost sharing without data sharing.
+- **`ovhcloud-deployment.md`** — Self-healing deployment, backup strategy, and monitoring on unmanaged VPS.
+- **`self-hosted-llm-infrastructure.md`** — Shared Ollama server with tenant-level data isolation.
+- **`reporting-architecture.md`** — Template-driven reporting that connects evaluation frameworks to funder requirements.
+- **`cids-privacy-architecture.md`** — Three-layer compliance model for sector reporting without compromising participant privacy.
+- **`funder-reporting-profiles.md`** — Funder-specific report templates configured through admin workflows.
+- **`cids-batch-classification-workflow.md`** — Admin-facing taxonomy classification that keeps CIDS complexity away from frontline staff.
+- **`cids-metadata-assignment.md`** — When metadata gets assigned (creation vs. deferred), balancing data quality with workflow simplicity.
+- **`bilingual-requirements.md`** — EN/FR as a legal requirement, not an optional feature. Bilingual support is part of the sustainability commitment to Canadian nonprofits.
+
+---
+
+## When to Revisit
+
+This foundation principle should be revisited if:
+
+- Nonprofit sector IT capacity significantly increases (shared SOC services, managed hosting co-ops emerge), in which case some simplification choices could be relaxed.
+- The scale exceeds ~2,000 participants per agency, at which point the in-memory search (required by field-level encryption) needs re-architecture.
+- Managed cloud pricing drops to parity with unmanaged VPS, removing the cost advantage of self-hosting.
+- A JavaScript framework emerges that is genuinely zero-config, zero-dependency, and maintenance-free (this has not happened in 15 years of JavaScript frameworks).
+
+The principle — affordable for small agencies with minimal IT — should not change. The specific implementation choices (OVHcloud, Alpine, 46 dependencies) may evolve, but the constraints they serve are permanent features of the nonprofit sector.

--- a/tasks/design-rationale/foundation-security-by-default.md
+++ b/tasks/design-rationale/foundation-security-by-default.md
@@ -1,0 +1,150 @@
+# Foundation: Security by Default
+
+**High Security for Non-Technical Operators**
+
+Status: Foundation Principle
+Created: 2026-03-14
+
+> **In plain language:** KoNote is secure even if you don't have an IT team. Every security protection is built into the system and turned on by default — you can't accidentally make it insecure by misconfiguring a setting. If something goes wrong, the system blocks access rather than leaking data.
+
+---
+
+## Core Principle
+
+Canadian nonprofits handle deeply sensitive personal information — mental health notes, domestic violence documentation, substance use records, immigration status — but typically lack dedicated IT security staff. KoNote's security model is therefore architectural, not configurable. Security is enforced by the structure of the code, not by policies that a non-technical admin might misconfigure.
+
+The system should be secure even if the operator doesn't fully understand why. Every security control described below is on by default, cannot be turned off through the admin interface, and fails closed rather than open. If a control can't determine whether an action is safe, it denies the action.
+
+---
+
+## Design Decisions
+
+### 1. Encryption at Rest — All PII Fields
+
+Every field containing personally identifiable information is Fernet-encrypted (AES-128-CBC + HMAC-SHA256). This is not optional. Property accessors (`client.first_name`) handle encryption and decryption transparently — calling code never touches ciphertext directly. Per-tenant encryption keys mean one agency's key cannot decrypt another agency's data.
+
+The system validates encryption key round-trip on every startup. If the key is missing, corrupt, or misconfigured, the application will not start. This makes key misconfiguration a loud, immediate failure rather than a silent data exposure.
+
+**Anti-pattern:** Relying on database-level encryption alone (doesn't protect against SQL injection or backup theft) or making encryption opt-in per agency.
+
+### 2. Role-Based Access Control — Permission Matrix as Single Source of Truth
+
+Four roles (Front Desk, Direct Service, Program Manager, Executive) are governed by an explicit permission matrix defined in one place. Every permission key is validated at import time — a typo in a permission key raises an error, not a silent denial. Missing entries in the matrix default to DENY, not ALLOW.
+
+The matrix is checked at three layers: view decorator, middleware, and template tag. This means a permission is enforced even if one layer is accidentally bypassed.
+
+**Anti-pattern:** Role checks scattered across individual views where one missed check means a bypass.
+
+### 3. Fail-Closed Consent Filtering
+
+PHIPA cross-program consent filtering returns empty results on failure, not all results. If the consent check cannot determine whether sharing is permitted, it denies access. Two enforcement functions cover the two access patterns: `apply_consent_filter()` for list views (querysets), `check_note_consent_or_403()` for single-note views.
+
+This means a bug in consent logic results in a staff member seeing too little data, not too much. Over-restriction is recoverable; over-exposure is not.
+
+**Anti-pattern:** Fail-open consent (show everything unless explicitly blocked). One bug = full data exposure.
+
+### 4. Immutable Audit Log — Separate Database
+
+All state-changing requests, client record views, and failed access attempts are logged to a separate PostgreSQL database. The Django ORM raises `PermissionError` on update or delete attempts against audit records. The database role used for the audit connection is INSERT-only at the PostgreSQL level.
+
+Separating the audit database from the application database means that a compromised application cannot alter its own evidence trail.
+
+**Anti-pattern:** Audit logs in the same database as application data (compromised app = compromised audit trail).
+
+### 5. Negative Access Lists for Safety
+
+`ClientAccessBlock` is checked BEFORE role-based access. If a staff member is blocked from a client (conflict of interest, DV perpetrator on staff), no role can override it. Blocks have no time-based expiry — they must be manually cleared by a Program Manager or higher.
+
+This exists because domestic violence scenarios require individual-level blocking that supersedes all role permissions. A Direct Service worker who is a client's abuser must never see that client's records, regardless of their role.
+
+**Anti-pattern:** Relying on role restrictions alone. DV scenarios require individual-level blocking that overrides all roles.
+
+### 6. Session Security
+
+Sessions time out after 30 minutes of inactivity. Sessions are stored server-side — the cookie contains only an opaque token, never session data. All cookies are set with `HttpOnly`, `Secure`, and `SameSite` flags. Content Security Policy uses nonce-based script allowlisting, blocking inline script injection.
+
+These defaults are tuned for the environments where KoNote is actually used: shared workstations in shelters, drop-in centres, and community agencies where a staff member may walk away from an unlocked screen.
+
+**Anti-pattern:** Long session timeouts in shared-computer environments (staff workstations in shelters and community centres).
+
+### 7. Rate Limiting and Account Lockout
+
+Login attempts are limited to 5 per minute. Password reset requests are limited to 10 per minute. After 5 consecutive failed login attempts, the account is locked for a 15-minute cooldown period. Passwords are hashed with Argon2 (memory-hard, GPU-resistant).
+
+These controls protect against brute-force attacks without requiring the operator to configure a WAF or external rate limiter.
+
+**Anti-pattern:** No rate limiting on login endpoints. Brute-force attacks on weak passwords.
+
+### 8. Two-Person Safety Rules
+
+Certain actions require two people to complete:
+
+- **Alert cancellation**: staff recommends, Program Manager approves
+- **DV flag removal**: staff requests, Program Manager approves
+- **Data erasure**: Program Manager requests, admin executes
+
+No single person can make a safety-critical change. This protects against both human error and coercion — a staff member under pressure from a client's abuser cannot unilaterally remove a safety flag.
+
+**Anti-pattern:** Any safety-critical action completable by one person. Human error or coercion becomes unrecoverable.
+
+### 9. Secure Exports with Time-Limited Links
+
+Exports use UUID-based links that expire after 24 hours. Admins can revoke an export link before it is downloaded. Elevated exports (100+ records) have a 10-minute delay with admin notification, giving time to intervene if the export was unauthorized. Export files are stored outside the web root and served through Django, not directly by the web server.
+
+**Anti-pattern:** Direct file download URLs that never expire. Leaked links = permanent data exposure.
+
+### 10. Demo Mode Isolation
+
+Demo users see demo data only. Real users see real data only. Demo users cannot modify agency settings. The `is_demo` flag is enforced at middleware and query level, not just in the UI — even if a demo user crafts a direct API request, they cannot reach production data.
+
+This allows agencies to trial KoNote and train new staff without risk of contaminating real records or exposing real client data during a demonstration.
+
+**Anti-pattern:** Test accounts that can see real data, or demo data mixed into production queries.
+
+---
+
+## Anti-Patterns Summary
+
+| Anti-pattern | Why it's rejected |
+|---|---|
+| Opt-in encryption | Nonprofits won't enable it; one missed field = PII exposure |
+| Scattered role checks | One missed check = bypass |
+| Fail-open consent | One bug = full data exposure |
+| Audit in same database | Compromised app = compromised evidence |
+| Role-only access control | DV scenarios need individual blocking |
+| Long session timeouts | Shared computers in shelters/community centres |
+| No rate limiting | Brute-force attacks on weak passwords |
+| Single-person safety actions | Human error or coercion becomes unrecoverable |
+| Permanent download links | Leaked links = permanent data exposure |
+| Mixed demo/real data | Test activity contaminates production |
+
+---
+
+## The Guiding Test
+
+Ask: **"If a nonprofit runs this with zero IT expertise, can they accidentally make it insecure?"**
+
+If the answer is yes, the security control is not architectural enough.
+
+---
+
+## Connections to Other Foundations
+
+- **Data Sovereignty**: Security controls are the enforcement layer for sovereignty principles. Encryption protects community ownership; RBAC enforces community control; the immutable audit trail proves compliance with data governance commitments.
+- **Collaborative Practice**: Session security and CSP protect the participant portal. Accessible, secure design ensures that collaborative features don't introduce attack vectors. Two-person safety rules protect DV participants.
+- **Nonprofit Sustainability**: Security must be zero-config to be affordable. Every control described here works without a dedicated IT team, which is the sustainability constraint in action.
+
+---
+
+## Related Implementation Decisions
+
+- `access-tiers.md` — Three permission tiers with progressive access control
+- `phipa-consent-enforcement.md` — Cross-program consent filtering rules
+- `encryption-key-rotation.md` — Key rotation procedures and custody
+- `ai-feature-toggles.md` — Participant data never sent to cloud AI
+
+---
+
+## When to Revisit
+
+If the Canadian nonprofit sector develops shared security infrastructure (e.g., a nonprofit SOC service or sector-wide managed security), some operational controls could potentially be relaxed. The principle itself — security must be architectural, not configurable — should not change.


### PR DESCRIPTION
## Summary
- Add 4 foundation DRR documents capturing KoNote's core design philosophy (collaborative practice, data sovereignty, security by default, nonprofit sustainability)
- Add `/design-rationale` skill for automated DRR review of proposed features
- Add README.md navigation hub organising all 26 DRRs into a two-tier structure
- Update CLAUDE.md DRR list with all 26 files including foundation tier

## Foundation Principles

| Document | Covers |
|---|---|
| Collaborative Practice | The "Ko" — two-lens notes, alliance, portal, feedback, bilingual by design, accessible by design |
| Data Sovereignty | OCAP, EGAP (Black data governance), Canadian digital sovereignty, no cross-agency combination |
| Security by Default | Encryption, RBAC, immutable audit, fail-closed consent, 10 architectural controls |
| Nonprofit Sustainability | Minimal tech stack, self-healing ops, evaluation-driven config, sector-wide learning |

## /design-rationale Skill
Invokable via `/design-rationale` — reviews proposed features against all DRRs and produces structured CONFLICT/CAUTION/CLEAR verdicts with citations.

## Test plan
- [ ] Verify `/design-rationale` skill appears in skill list
- [ ] Test skill with a sample proposal (e.g., "live API for client data")
- [ ] Confirm all 4 foundation docs render correctly on GitHub
- [ ] Verify README.md links resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)