### PR TITLE
fix: deployment doc overhaul — cost reconciliation, navigation, structural fixes

### DIFF
--- a/.claude/skills/deployment-planning/SKILL.md
+++ b/.claude/skills/deployment-planning/SKILL.md
@@ -193,6 +193,8 @@ Each file has a `<!-- COST_VERSION -->` header. Before updating, compare key val
 | 5 agencies | ~$92/agency | ~$169/agency | ~$77/agency |
 | 30 agencies | ~$65/agency | ~$142/agency | ~$50/agency |
 
+Key Vault is $2/agency/month (per-agency vault, not shared). These figures include Key Vault in the per-agency hosting cost.
+
 **These figures change.** Always read `hosting-budget-scenarios.md` for current numbers.
 
 ### Why OVHcloud Over Azure
@@ -209,7 +211,7 @@ Read the `COST_VERSION` header in `tasks/hosting-cost-comparison.md` for current
 - ~200 participants/agency, ~2 visits/month
 - All AI self-hosted (Qwen3.5 + NLLB-200) — $0 API costs
 - Support at $100/hr, LLM-assisted (reduces human hours)
-- Single-tenant currently; multi-tenant planned (would reduce hosting cost)
+- Single-tenant currently; multi-tenant planned (would reduce hosting cost). Each agency has its own Azure Key Vault ($2/mo) for encryption key storage.
 
 ### Onboarding Cost
 

--- a/.claude/skills/deployment-planning/SKILL.md
+++ b/.claude/skills/deployment-planning/SKILL.md
@@ -186,12 +186,12 @@ Each file has a `<!-- COST_VERSION -->` header. Before updating, compare key val
 
 ## Quick Reference
 
-### Per-Agency Monthly Cost (Year 2+, as of 2026-03-04)
+### Per-Agency Monthly Cost (Year 2+, as of 2026-03-14)
 
 | Network size | OVHcloud | Azure (list) | Azure (nonprofit grant) |
 |---|---|---|---|
-| 5 agencies | ~$92/agency | ~$169/agency | ~$77/agency |
-| 30 agencies | ~$65/agency | ~$142/agency | ~$50/agency |
+| 5 agencies | ~$94/agency | ~$171/agency | ~$77/agency |
+| 30 agencies | ~$67/agency | ~$144/agency | ~$50/agency |
 
 Key Vault is $2/agency/month (per-agency vault, not shared). These figures include Key Vault in the per-agency hosting cost.
 

--- a/docs/archive/deploy-azure.md
+++ b/docs/archive/deploy-azure.md
@@ -1,3 +1,5 @@
+> **ARCHIVED:** This deployment method is no longer the recommended path. OVHcloud is preferred for most agencies. This guide is maintained for agencies that specifically require Azure hosting. See [Deployment Index](../deployment-index.md) for current options.
+
 # KoNote Web — Azure Deployment Guide
 
 This guide walks you through deploying KoNote Web to Microsoft Azure. We'll use Azure Container Apps to run the application and Azure Database for PostgreSQL to store your data.

--- a/docs/archive/deploy-elestio.md
+++ b/docs/archive/deploy-elestio.md
@@ -1,3 +1,5 @@
+> **ARCHIVED:** Elest.io deployment is no longer supported. See [Deployment Index](../deployment-index.md) for current deployment options (OVHcloud recommended).
+
 # Deploying KoNote Web to Elest.io
 
 This guide walks you through deploying KoNote Web on **Elest.io**, a cloud hosting platform that runs Docker applications.

--- a/docs/deploy-ovhcloud.md
+++ b/docs/deploy-ovhcloud.md
@@ -1,5 +1,9 @@
 # Deploying KoNote on OVHcloud VPS
 
+> **Audience:** Technical staff deploying KoNote to an OVHcloud VPS.
+> **Assumes:** SSH access, comfort with the command line, access to a domain registrar.
+> **Read first:** [Deployment Index](deployment-index.md) for an overview of all deployment options.
+
 ## Two Paths: Automated or Manual
 
 | Path | Time | Best for |

--- a/docs/deploy-ovhcloud.md
+++ b/docs/deploy-ovhcloud.md
@@ -28,7 +28,7 @@ The script generates all credentials, SSHes into the VPS, hardens the OS, instal
 - **Safe to re-run** — skips already-completed steps
 - **Dry-run mode** — add `--dry-run` to preview without executing
 - **Full options** — run `./scripts/deploy-konote-vps.sh --help`
-- **Design doc** — see [deploy script design](plans/2026-02-20-deploy-script-design.md) for architecture decisions
+- **Design doc** — see [deploy script design](plans/archive/2026-02-20-deploy-script-design.md) for architecture decisions
 
 After the script finishes, skip to [Section 7: Point Your Domain to the VPS](#7-point-your-domain-to-the-vps) (if DNS isn't already configured) or [Section 12: Set Up External Monitoring](#12-set-up-external-monitoring) to complete the remaining manual steps. Backups and internal monitoring are handled automatically by the ops sidecar.
 

--- a/docs/deploying-konote.md
+++ b/docs/deploying-konote.md
@@ -1,5 +1,9 @@
 # Deploying KoNote
 
+> **Audience:** Anyone choosing a deployment path — technical staff, managers, or nonprofit directors.
+> **Assumes:** Basic familiarity with web hosting concepts. No command-line knowledge needed.
+> **Start here:** [Deployment Index](deployment-index.md) if you're unsure which guide you need.
+
 This guide covers everything you need to get KoNote running — from local development to production. Choose your path:
 
 | I want to... | Go to... |

--- a/docs/deployment-index.md
+++ b/docs/deployment-index.md
@@ -1,0 +1,48 @@
+# KoNote Deployment Guide
+
+This page helps you find the right deployment document for your situation. **OVHcloud Beauharnois (QC) is the recommended hosting platform** for most agencies — it's 60-70% cheaper than Azure and provides stronger data sovereignty.
+
+## Which Guide Do I Need?
+
+| I want to... | Read this | Time |
+|---|---|---|
+| **Understand deployment options and costs** | [Deployment Planning skill](/deployment-planning) or `tasks/hosting-cost-comparison.md` | 10 min |
+| **Deploy KoNote on OVHcloud (recommended)** | [deploy-ovhcloud.md](deploy-ovhcloud.md) | 45-90 min |
+| **Deploy KoNote on Azure** | [deploy-azure.md](archive/deploy-azure.md) (archived — for agencies that require Azure) | 1-2 hrs |
+| **Set up the self-hosted LLM server** | [llm-deployment-guide.md](llm-deployment-guide.md) (for AI assistants) | 30 min |
+| **Update an existing instance** | `konote-ops/deployment/update-checklist.md` | 15 min |
+| **Troubleshoot a deployment problem** | `konote-ops/deployment/runbook.md` | varies |
+| **Migrate to a new VPS** | `konote-ops/deployment/vps-migration-runbook.md` | 2-4 hrs |
+| **Understand the onboarding process** | `tasks/deployment-protocol.md` | 20 min |
+| **Review cost assumptions** | `tasks/hosting-cost-comparison.md` (primary source) | 15 min |
+| **See client-facing budget figures** | `konote-prosper-canada/deliverables/hosting-budget-scenarios.md` | 10 min |
+| **Run cost scenarios** | `konote-prosper-canada/deliverables/tools/costing-model-calculator.html` (browser) | 5 min |
+
+## Deployment Tiers
+
+KoNote supports three deployment tiers. All maintain the same data isolation and encryption guarantees.
+
+| Tier | Who | Monthly Cost | Key Feature |
+|---|---|---|---|
+| **1. Self-hosted** | Agencies with technical capacity | ~$15/mo (VPS only) | Cheapest. Secure by default via built-in encryption. |
+| **2. Managed OVHcloud** (recommended) | Most agencies | ~$65-92/agency | LO manages infrastructure. Shared monitoring, isolated data. |
+| **3. Azure** | Agencies requiring Azure | ~$77-169/agency | Azure managed services. Higher cost, US CLOUD Act trade-off. |
+
+See the `/deployment-planning` skill for full tier descriptions and the cost source chain.
+
+## Key Principles
+
+- **Every agency's data is isolated.** Agencies never share a database, encryption key, or KoNote instance — even when sharing a VPS.
+- **OVHcloud is preferred** for cost and data sovereignty. Azure is supported but not the default.
+- **Cost figures live in `tasks/hosting-cost-comparison.md`** (primary source). All other cost docs derive from it via a documented source chain.
+
+## Architecture Decisions
+
+Major deployment decisions are recorded in Design Rationale Records (DRRs). Read these before proposing changes:
+
+- `tasks/design-rationale/ovhcloud-deployment.md` — hosting stack, self-healing, backups
+- `tasks/design-rationale/multi-tenancy.md` — schema-per-tenant isolation
+- `tasks/design-rationale/data-access-residency-policy.md` — data sovereignty, CLOUD Act
+- `tasks/design-rationale/self-hosted-llm-infrastructure.md` — AI hosting
+
+Use the `design-rationale` skill to check proposals against these DRRs.

--- a/docs/llm-deployment-guide.md
+++ b/docs/llm-deployment-guide.md
@@ -1,5 +1,8 @@
 # KoNote Deployment Guide — For AI Assistants
 
+> **Audience:** AI coding assistants (Claude Code). This guide is structured for automated execution, not human reading.
+> **For humans:** See [deploy-ovhcloud.md](deploy-ovhcloud.md) for the human-readable OVHcloud deployment guide.
+
 This guide is designed to be given to an AI coding assistant (Claude Code, Cursor, GitHub Copilot, etc.) so it can deploy KoNote on behalf of a nonprofit. It is structured as unambiguous, sequential instructions with exact commands and expected outputs.
 
 **For the full human-readable guide with explanations**, see [deploy-ovhcloud.md](deploy-ovhcloud.md).

--- a/tasks/deployment-protocol.md
+++ b/tasks/deployment-protocol.md
@@ -1,4 +1,4 @@
-# Agency Deployment Protocol — Azure
+# Agency Deployment Protocol
 
 **Purpose:** End-to-end process for deploying KoNote for a new client organisation on Azure. Covers discovery through go-live and follow-up.
 
@@ -33,7 +33,7 @@ Agency onboarding involves three distinct interviews, each with different staff 
 |-------|------|--------|-------------|----------|--------|
 | 0 | Discovery Call | Sara | Yes | 60 min | Discovery Worksheet |
 | 1 | Permissions Setup | Sara | Yes (2 sessions) | 2 × 45 min | Signed Configuration Summary |
-| 2 | Azure Infrastructure | Prince | No (needs client IT) | 2–4 hours | Running instance |
+| 2 | Infrastructure Setup | Prince | No (needs client IT) | 2–4 hours | Running instance |
 | 3 | Workflow Customisation | Sara | Yes | 60–90 min | Customisation Worksheet |
 | 4 | Go-Live Verification | Prince + Sara | Yes (walkthrough) | 60 min | Signed go-live confirmation |
 | 5 | 30-Day Check-In | Sara | Yes | 30 min | Updated config + action items |
@@ -233,19 +233,42 @@ After both sessions:
 
 ---
 
-## Phase 2: Azure Infrastructure Setup
+## Phase 2: Infrastructure Setup
 
-**Purpose:** Build the Azure environment and deploy KoNote using the signed Configuration Summary.
+**Purpose:** Provision hosting infrastructure and deploy KoNote using the signed Configuration Summary.
 
 **Who:** Prince (developer). May need the client's IT contact for Azure AD configuration.
 
-**Duration:** 2–4 hours
+**Duration:** 45 min – 4 hours (depends on platform)
+
+### Platform Choice
+
+The agency chooses their hosting platform during Phase 0 (Discovery). Phase 2 follows the appropriate path:
+
+| Platform | Guide | Typical Setup Time |
+|---|---|---|
+| **OVHcloud (recommended)** | [deploy-ovhcloud.md](../docs/deploy-ovhcloud.md) | 45-90 min |
+| **Azure** | [deploy-azure.md](../docs/archive/deploy-azure.md) | 1-2 hours |
+| **Self-hosted** | [deploying-konote.md](../docs/deploying-konote.md) | Varies |
+
+Regardless of platform, all instances use:
+- Per-agency Azure Key Vault (or OVHcloud KMS) for encryption key storage
+- Docker Compose stack (runs identically on any platform)
+- Caddy for automatic HTTPS
+
+For OVHcloud deployments, follow `docs/deploy-ovhcloud.md` — the 16-step guide covers VPS provisioning, Docker setup, and DNS configuration.
+
+---
+
+### Azure Path
+
+The remainder of this section documents the Azure-specific setup steps. For OVHcloud or self-hosted deployments, follow the platform guide linked above and skip to [Phase 3](#phase-3-workflow-customisation-interview).
 
 **Full technical guide:** [Deploy to Azure](../docs/deploying-konote.md#deploy-to-azure) (in deploying-konote.md)
 
 ---
 
-### Pre-Flight Checklist
+### Pre-Flight Checklist (Azure)
 
 Before touching Azure, confirm all inputs are ready:
 

--- a/tasks/deployment-workflow-design.md
+++ b/tasks/deployment-workflow-design.md
@@ -1,3 +1,7 @@
+> **Status:** DRAFT — problem statement only, no implementation recommendations yet.
+> **Date:** 2026-02 (original). Not actively being worked on.
+> **Context:** This document scopes the deployment workflow problem (how nonprofits move from demo to production). The phases described here ("Assessment / Customisation / Production") are separate from the deployment protocol phases (0-5) which cover infrastructure setup and onboarding.
+
 # Task: Design the Nonprofit Deployment Workflow
 
 ## Context

--- a/tasks/design-rationale/multi-tenancy.md
+++ b/tasks/design-rationale/multi-tenancy.md
@@ -3,7 +3,7 @@
 **Feature:** Schema-per-tenant multi-tenancy using django-tenants, with per-tenant encryption and consortium data model
 **Status:** Decided. Implementation starts after first single-tenant agency deployment is live.
 **Date:** 2026-02-21
-**Implementation plan:** `tasks/multi-tenancy-implementation-plan.md`
+**Implementation plan:** To be written when MT-CORE1 starts. Sequencing: first agency must be live on single-tenant deployment before multi-tenancy work begins (see anti-patterns below).
 
 ---
 
@@ -152,4 +152,4 @@ A future developer might think "Consortium belongs in the consortia app." It doe
 
 ## Expert Panel Source
 
-Panel convened 2026-02-20: Software Architect, Nonprofit Technology Strategist, Privacy & Compliance Specialist, Systems Thinker. Followed by code review that identified and resolved 11 issues. Full implementation plan at `tasks/multi-tenancy-implementation-plan.md`.
+Panel convened 2026-02-20: Software Architect, Nonprofit Technology Strategist, Privacy & Compliance Specialist, Systems Thinker. Followed by code review that identified and resolved 11 issues. Full implementation plan to be written when MT-CORE1 starts.

--- a/tasks/hosting-cost-comparison.md
+++ b/tasks/hosting-cost-comparison.md
@@ -1,22 +1,23 @@
 # Hosting Cost Comparison: Azure vs OVHcloud
 
-*Last updated: 2026-03-04*
+*Last updated: 2026-03-14*
 
 <!-- COST_VERSION
-date: 2026-03-04
+date: 2026-03-14
 role: Component pricing source (all scenarios)
-llm_vps: VPS-4, $31 CAD/mo (shared, all agencies)
+llm_vps: VPS-4, $40 CAD/mo (shared, all agencies)
 app_vps_single: VPS-2, $14 CAD/mo (per agency)
 app_vps_multi: VPS-3, $27 CAD/mo (shared)
 ai_api_per_agency: ~$7 CAD/mo (translation + metrics)
-key_vault: ~$2 CAD/mo
-ovh_single_1_agency: $57 CAD/mo
-ovh_multi_10_agencies: $13 CAD/mo/agency
-azure_single_1_agency: $132 CAD/mo
-azure_multi_10_agencies: $46 CAD/mo/agency
-ops_hours_1_agency: ~1 hr/mo human (LLM-assisted)
-ops_hours_5_agencies_network: ~2.5 hr/mo human (LLM-assisted)
-ops_hours_10_agencies_mt: ~4.5-5 hr/mo human (LLM-assisted)
+key_vault: $2 CAD/mo per agency
+ovh_single_1_agency: $66 CAD/mo
+ovh_multi_10_agencies: $16 CAD/mo/agency
+azure_single_1_agency: $141 CAD/mo
+azure_multi_10_agencies: $48 CAD/mo/agency
+ops_hours_1_agency: ~1 hr/mo (human-only; ~4-5 hr/mo total including LLM work)
+ops_hours_5_agencies_network: ~2.5 hr/mo (human-only)
+ops_hours_10_agencies_mt: ~4.5-5 hr/mo (human-only)
+ops_hours_note: human-only hours shown; total work hours (LLM + human) are 4-5x higher
 ops_model: LLM-assisted (see docs/llm-operations-runbook.md)
 downstream: p0-managed-service-plan.md, konote-prosper-canada/deliverables/costing-model.md
 -->
@@ -85,10 +86,12 @@ This document compares two hosting approaches for KoNote, both using Azure Key V
 | VPS-1 | 4 | 8 GB | 75 GB NVMe | ~$9 |
 | VPS-2 | 6 | 12 GB | 100 GB NVMe | ~$14 |
 | VPS-3 | 8 | 24 GB | 200 GB NVMe | ~$27 |
-| VPS-4 | 12 | 48 GB | 300 GB NVMe | ~$31 |
+| VPS-4 | 12 | 48 GB | 300 GB NVMe | ~$40 |
 | VPS-6 | 24 | 96 GB | 400 GB NVMe | ~$105 |
 
 *Prices verified March 2026 from OVHcloud configurator. All plans include unlimited traffic. OVH parent is French-incorporated (OVH Groupe SA) — not subject to US CLOUD Act. VPS-6 price may need re-verification. Source: [OVHcloud Canada VPS](https://www.ovhcloud.com/en-ca/vps/).*
+
+*Note: Downstream cost documents (costing-model.md, hosting-budget-scenarios.md) use VPS-1 at $15/mo rather than VPS-2 at $14/mo because premium backup is operationally required for self-managed PostgreSQL on OVHcloud. The $15 figure includes the premium backup add-on.*
 
 ### AI API Costs (OpenRouter / Claude)
 
@@ -106,7 +109,7 @@ This document compares two hosting approaches for KoNote, both using Azure Key V
 |------|--------|
 | Model | Qwen3.5-35B-A3B (35B params, 3B active, MoE, Apache 2.0) |
 | Runtime | Ollama, CPU-only, nightly batch + on-demand insights |
-| Hosting | OVHcloud VPS-4 (~$31 CAD/mo), Beauharnois, QC (shared endpoint) |
+| Hosting | OVHcloud VPS-4 (~$40 CAD/mo), Beauharnois, QC (shared endpoint) |
 | VPS specs | 12 vCPUs, 48 GB RAM, 300 GB NVMe |
 | Tokens per suggestion call | ~800 (prompt + suggestion + response) |
 | Volume (10 agencies) | ~1,000 suggestions/month = ~800K tokens/month |
@@ -130,8 +133,8 @@ KoNote application and databases on Azure Canada Central. Self-hosted LLM on OVH
 | Azure Key Vault | $2 | Negligible operation volume |
 | OpenRouter AI (translation) | $2 | ~100 calls/mo × gpt-4o-mini |
 | OpenRouter AI (metrics/targets) | $5 | ~200 calls/mo × Sonnet 4.5 |
-| OVHcloud VPS-4 (LLM, shared) | $31 | 1/N share of shared VPS-4 |
-| **Total per agency** | **~$132** | |
+| OVHcloud VPS-4 (LLM, shared) | $40 | 1/N share of shared VPS-4 |
+| **Total per agency** | **~$141** | |
 
 ### Multi-Agency Scaling — Single Tenant (one VM + DB per agency)
 
@@ -140,11 +143,11 @@ KoNote application and databases on Azure Canada Central. Self-hosted LLM on OVH
 | Azure VMs (B2s each) | $55 | $275 | $550 |
 | Azure PostgreSQL x2 per agency (B1ms) | $34 | $170 | $340 |
 | PostgreSQL storage | $3 | $15 | $30 |
-| Azure Key Vault (shared) | $2 | $2 | $2 |
+| Azure Key Vault (per agency) | $2 | $10 | $20 |
 | OpenRouter AI (shared pool) | $7 | $35 | $70 |
-| OVHcloud LLM VPS-4 (shared) | $31 | $31 | $31 |
-| **Total** | **$132** | **$528** | **$1,023** |
-| **Per agency** | **$132** | **$106** | **$102** |
+| OVHcloud LLM VPS-4 (shared) | $40 | $40 | $40 |
+| **Total** | **$141** | **$545** | **$1,050** |
+| **Per agency** | **$141** | **$109** | **$105** |
 
 ### Multi-Agency Scaling — Multi-Tenant (shared infrastructure)
 
@@ -155,11 +158,11 @@ KoNote application and databases on Azure Canada Central. Self-hosted LLM on OVH
 | Azure VM (B4ms shared) | $194 | $194 | $194 |
 | Azure PostgreSQL x2 (B2ms shared) | $144 | $144 | $144 |
 | PostgreSQL storage (100 GB) | $16 | $16 | $16 |
-| Azure Key Vault (shared) | $2 | $2 | $2 |
+| Azure Key Vault (per agency) | $2 | $10 | $20 |
 | OpenRouter AI (shared pool) | $7 | $35 | $70 |
-| OVHcloud LLM VPS-4 (shared) | $31 | $31 | $31 |
-| **Total** | **$394** | **$422** | **$457** |
-| **Per agency** | **$394** | **$84** | **$46** |
+| OVHcloud LLM VPS-4 (shared) | $40 | $40 | $40 |
+| **Total** | **$403** | **$439** | **$484** |
+| **Per agency** | **$403** | **$88** | **$48** |
 
 ---
 
@@ -175,21 +178,21 @@ KoNote application, databases, and LLM all on OVHcloud VPS(es) in Beauharnois. S
 | Azure Key Vault | $2 | Encryption key management |
 | OpenRouter AI (translation) | $2 | ~100 calls/mo × gpt-4o-mini |
 | OpenRouter AI (metrics/targets) | $5 | ~200 calls/mo × Sonnet 4.5 |
-| OVHcloud LLM VPS-4 (shared) | $31 | 1/N share of shared VPS-4 |
+| OVHcloud LLM VPS-4 (shared) | $40 | 1/N share of shared VPS-4 |
 | Automated backups (OVH option) | $3 | Optional add-on |
-| **Total per agency** | **~$57** | |
+| **Total per agency** | **~$66** | |
 
 ### Multi-Agency Scaling — Single Tenant (one VPS per agency)
 
 | Component | 1 Agency | 5 Agencies | 10 Agencies |
 |-----------|----------|------------|-------------|
 | OVHcloud VPS-2 per agency | $14 | $70 | $140 |
-| Azure Key Vault (shared) | $2 | $2 | $2 |
+| Azure Key Vault (per agency) | $2 | $10 | $20 |
 | OpenRouter AI (shared pool) | $7 | $35 | $70 |
-| OVHcloud LLM VPS-4 (shared) | $31 | $31 | $31 |
+| OVHcloud LLM VPS-4 (shared) | $40 | $40 | $40 |
 | Backup add-ons | $3 | $15 | $30 |
-| **Total** | **$57** | **$153** | **$273** |
-| **Per agency** | **$57** | **$31** | **$27** |
+| **Total** | **$66** | **$170** | **$300** |
+| **Per agency** | **$66** | **$34** | **$30** |
 
 ### Multi-Agency Scaling — Multi-Tenant (shared infrastructure)
 
@@ -198,14 +201,14 @@ KoNote application, databases, and LLM all on OVHcloud VPS(es) in Beauharnois. S
 | Component | 1 Agency | 5 Agencies | 10 Agencies |
 |-----------|----------|------------|-------------|
 | OVHcloud VPS-3 (shared app + DB) | $27 | $27 | $27 |
-| OVHcloud VPS-4 (LLM, shared) | $31 | $31 | $31 |
-| Azure Key Vault (shared) | $2 | $2 | $2 |
+| OVHcloud VPS-4 (LLM, shared) | $40 | $40 | $40 |
+| Azure Key Vault (per agency) | $2 | $10 | $20 |
 | OpenRouter AI (shared pool) | $7 | $35 | $70 |
 | Backup add-ons | $3 | $3 | $3 |
-| **Total** | **$70** | **$98** | **$133** |
-| **Per agency** | **$70** | **$20** | **$13** |
+| **Total** | **$79** | **$115** | **$160** |
+| **Per agency** | **$79** | **$23** | **$16** |
 
-*At 10+ agencies, consider upgrading app VPS to VPS-4 (~$31) for headroom.*
+*At 10+ agencies, consider upgrading app VPS to VPS-4 (~$40) for headroom.*
 
 ---
 
@@ -223,19 +226,19 @@ KoNote application, databases, and LLM all on OVHcloud VPS(es) in Beauharnois. S
 
 | Scale | Azure Single-Tenant | Azure Multi-Tenant | OVH Single-Tenant | OVH Multi-Tenant |
 |-------|--------------------|--------------------|--------------------|--------------------|
-| 1 agency | $132 | $394* | $57 | $70* |
-| 5 agencies | $106 | $84 | $31 | $20 |
-| 10 agencies | $102 | $46 | $27 | $13 |
+| 1 agency | $141 | $403* | $66 | $79* |
+| 5 agencies | $109 | $88 | $34 | $23 |
+| 10 agencies | $105 | $48 | $30 | $16 |
 
-*\*Multi-tenant with 1 agency is more expensive due to the larger shared VM — cost advantage kicks in at 3+ agencies. All scenarios include ~$31/mo shared LLM VPS (VPS-4).*
+*\*Multi-tenant with 1 agency is more expensive due to the larger shared VM — cost advantage kicks in at 3+ agencies. All scenarios include ~$40/mo shared LLM VPS (VPS-4). Azure Key Vault is $2/mo per agency (each agency gets its own vault for data isolation).*
 
 ### Total Monthly Cost (CAD)
 
 | Scale | Azure Single-Tenant | Azure Multi-Tenant | OVH Single-Tenant | OVH Multi-Tenant |
 |-------|--------------------|--------------------|--------------------|--------------------|
-| 1 agency | $132 | $394 | $57 | $70 |
-| 5 agencies | $528 | $422 | $153 | $98 |
-| 10 agencies | $1,023 | $457 | $273 | $133 |
+| 1 agency | $141 | $403 | $66 | $79 |
+| 5 agencies | $545 | $439 | $170 | $115 |
+| 10 agencies | $1,050 | $484 | $300 | $160 |
 
 ---
 
@@ -266,10 +269,10 @@ These costs apply to both Azure and OVHcloud hosting scenarios.
 | Item | Value |
 |------|-------|
 | Model | Qwen3.5-35B-A3B on Ollama (primary); Qwen3.5-27B (backup/quality) |
-| Hosting | OVHcloud VPS-4 (~$31 CAD/mo shared — 12 vCPUs, 48 GB RAM) |
+| Hosting | OVHcloud VPS-4 (~$40 CAD/mo shared — 12 vCPUs, 48 GB RAM) |
 | Volume (10 agencies) | ~1,000 suggestions/month |
 | CPU inference time | ~1–2 hours/month (nightly batch) |
-| Per-agency cost (10 agencies) | ~$3 CAD/mo |
+| Per-agency cost (10 agencies) | ~$4 CAD/mo |
 | API cost | $0 (self-hosted, Apache 2.0 licence) |
 
 ---
@@ -332,15 +335,17 @@ Total automation cost: ~$0 additional (uses free tiers of monitoring services).
 
 ## Recommendations
 
-1. **For 1–3 agencies (launch phase)**: OVHcloud single-tenant at ~$57/agency/month vs ~$132 on Azure. The ~$31 LLM VPS is a fixed cost that becomes negligible at scale.
+**OVHcloud Beauharnois is recommended for most agencies** due to 60-70% lower cost and stronger data sovereignty (French-incorporated parent, not subject to US CLOUD Act). Azure is supported for agencies with existing Microsoft agreements, nonprofit grants, or specific compliance requirements that mandate a hyperscaler.
 
-2. **For 5–10 agencies (growth phase)**: Implement multi-tenancy first (MT-CORE1), then OVHcloud multi-tenant brings costs to $13–20/agency/month — still dramatically cheaper than Azure single-tenant.
+1. **For 1–3 agencies (launch phase)**: OVHcloud single-tenant at ~$66/agency/month vs ~$141 on Azure. The ~$40 LLM VPS is a fixed cost that becomes negligible at scale.
 
-3. **Azure makes sense if**: The agency or funder requires Azure specifically, or if the operational burden of self-managing PostgreSQL is unacceptable.
+2. **For 5–10 agencies (growth phase)**: Implement multi-tenancy first (MT-CORE1), then OVHcloud multi-tenant brings costs to $16–23/agency/month — still dramatically cheaper than Azure single-tenant.
 
-4. **LLM hosting**: One shared OVHcloud VPS-4 (~$31 CAD/month) serves all agencies — whether 1 or 100. Upgrade in-place if more capacity is needed (VPS-6 at ~$105). Complete data sovereignty on participant suggestions.
+3. **Azure makes sense if**: The agency or funder requires Azure specifically, has existing Microsoft nonprofit grants, or if the operational burden of self-managing PostgreSQL is unacceptable.
 
-5. **Key Vault**: Use Azure Key Vault in both scenarios. The CLOUD Act exposure is limited to the encryption key only, and the operational simplicity of managed KMS outweighs the theoretical risk for KoNote's threat model.
+4. **LLM hosting**: One shared OVHcloud VPS-4 (~$40 CAD/month) serves all agencies — whether 1 or 100. Upgrade in-place if more capacity is needed (VPS-6 at ~$105). Complete data sovereignty on participant suggestions.
+
+5. **Key Vault**: Use Azure Key Vault in both scenarios ($2 CAD/mo per agency — each agency gets its own vault for data isolation). The CLOUD Act exposure is limited to the encryption key only, and the operational simplicity of managed KMS outweighs the theoretical risk for KoNote's threat model.
 
 ---
 
@@ -403,10 +408,10 @@ Combines infrastructure costs from Scenario B (OVHcloud) with LLM-assisted suppo
 
 | Scale | Infrastructure/agency | Support/agency | **All-in/agency** |
 |-------|----------------------|----------------|-------------------|
-| 1 agency | $57 | $0 (internal) | **$57** |
-| 5 agencies (single-tenant, network) | $31 | ~$62 | **~$93** |
-| 5 agencies (multi-tenant) | $20 | ~$62 | **~$82** |
-| 10 agencies (multi-tenant, network) | $13 | ~$52 | **~$65** |
+| 1 agency | $66 | $0 (internal) | **$66** |
+| 5 agencies (single-tenant, network) | $34 | ~$62 | **~$96** |
+| 5 agencies (multi-tenant) | $23 | ~$62 | **~$85** |
+| 10 agencies (multi-tenant, network) | $16 | ~$52 | **~$68** |
 
 > **Note on support cost comparison:** The previous version of this section estimated 4–5 hr/mo (1 agency) assuming a traditional sysadmin doing all tasks manually. With the LLM-assisted model, human time drops to ~1 hr/mo because the LLM handles the technical work and the human only reviews and approves. The total *work* is similar — it's the *human portion* that's dramatically lower.
 

--- a/tasks/p0-managed-service-plan.md
+++ b/tasks/p0-managed-service-plan.md
@@ -1,19 +1,20 @@
 # P0 Deliverable: Managed Service Model
 
 <!-- COST_VERSION
-date: 2026-03-04
+date: 2026-03-14
 role: Managed service model (derives from hosting-cost-comparison.md)
 llm_vps: VPS-4, $40 CAD/mo
+key_vault: $2 CAD/mo per agency
 ovh_single_1_agency: $74 CAD/mo
 ovh_multi_10_agencies: $15 CAD/mo/agency
-ops_hours_1_agency: 4-5 hr/mo
+ops_hours_1_agency: 4-5 hr/mo (total LLM+human work); ~1 hr/mo human-only
 upstream: tasks/hosting-cost-comparison.md
 downstream: konote-prosper-canada/deliverables/costing-model.md
 -->
 
 **Requirement ID:** MA5 (managed hosting and support), related to MA3/MA4
 **Deliverable type:** Costed plan
-**Date:** 2026-03-04 (updated with self-healing support cost impact)
+**Date:** 2026-03-14 (reconciled with upstream cost docs)
 **Source documents:** tasks/hosting-cost-comparison.md, tasks/design-rationale/ovhcloud-deployment.md, tasks/deployment-protocol.md, tasks/saas-service-agreement.md, tasks/design-rationale/data-access-residency-policy.md
 
 ---
@@ -106,7 +107,7 @@ Both paths are fully supported. The choice depends on the agency's requirements 
 
 - Server hosting (VPS or Azure VM)
 - Database hosting (self-managed or Azure managed)
-- Encryption key management (Azure Key Vault: ~$2/mo)
+- Encryption key management (Azure Key Vault: $2/mo per agency — each agency gets its own vault for data isolation)
 - AI API costs (translation + metrics generation: ~$7/agency/mo)
 - Self-hosted LLM for suggestion theme tagging + outcome insights (shared OVHcloud VPS-4: ~$4/agency/mo at 10 agencies)
 - Backup storage
@@ -118,14 +119,14 @@ The 4-layer self-healing automation handles ~99% of operational incidents automa
 
 | Item | Estimate | When needed |
 |------|----------|-------------|
-| KoNote team time (~4–5 hr/mo for 1 agency; ~2 hr/mo per agency at scale) | Internal cost | Always |
+| KoNote team time (~4–5 hr/mo total LLM+human for 1 agency, ~1 hr/mo human-only; ~2 hr/mo per agency at scale) | Internal cost | Always |
 | Freelance sysadmin on-call retainer | ~$75–150 CAD/mo | 3–5 agencies (recommended) |
 | Canadian MSP | ~$300–500 CAD/mo | 10+ agencies or when 24/7 SLA required |
 | SaaS agreement legal review | One-time ~$2,000–5,000 | Before first managed agency |
 | SSL certificates | $0 (Let's Encrypt via Caddy) | Always |
 | Domain registration | ~$15–20/year per agency | If LogicalOutcomes provides subdomain |
 
-**Impact of self-healing on support costs:** Without automation, managing even one OVHcloud VPS would require ~10–15 hours/month of sysadmin time (manual monitoring, backup management, incident response). With the 4-layer stack, this drops to ~4–5 hours/month — most of which is reviewing automated reports and applying software updates. At 5 agencies, the per-agency support burden is ~2 hours/month.
+**Impact of self-healing on support costs:** Without automation, managing even one OVHcloud VPS would require ~10–15 hours/month of sysadmin time (manual monitoring, backup management, incident response). With the 4-layer stack, total work drops to ~4–5 hours/month (LLM + human combined), of which only ~1 hour/month is human time — reviewing automated reports, approving deployments, and handling agency requests. At 5 agencies, the per-agency support burden is ~2 hours/month total.
 
 ---
 


### PR DESCRIPTION
## Summary

Comprehensive documentation overhaul addressing all findings from the deployment documentation review (report: `reports/doc-review-deployment-2026-03-14.md`). Executed as 4 parallel work streams.

### Phase 1: Cost Reconciliation
- **LLM VPS**: upstream updated from $31 to $40 (was already $40 in all downstream docs)
- **Azure Key Vault**: changed from $2 shared to **$2 per agency** — each agency gets its own vault for data isolation. All scenario totals recalculated.
- **Ops hours**: labelled as "human-only" vs "total (LLM+human)" in all COST_VERSION headers
- **OVHcloud framed as default** path; Azure for agencies that require it
- All COST_VERSION dates bumped to 2026-03-14

### Phase 2: Navigation & Entry Points
- **Created `docs/deployment-index.md`** — single entry point with scenario-to-document map
- **Added audience headers** to `deploying-konote.md`, `deploy-ovhcloud.md`, `llm-deployment-guide.md`
- **Added archive banners** to `deploy-azure.md` and `deploy-elestio.md`

### Phase 3: Structural Fixes
- **Fixed dangling reference** in `multi-tenancy.md` (nonexistent implementation plan)
- **Fixed broken path** in `deploy-ovhcloud.md` (design doc in wrong directory)
- **Generalised deployment protocol** — was Azure-only, now supports OVHcloud path
- **Added status note** to `deployment-workflow-design.md` (DRAFT, not active)
- **Updated `/deployment-planning` skill** with correct per-agency figures

### Cross-Repo Changes (already pushed)
- **konote-prosper-canada**: Calculator fixed (Key Vault $0.40→$2.00/agency), `costing-model.md` and `hosting-budget-scenarios.md` updated
- **konote-ops**: Created `deployment/index.md` entry point with glossary

## New per-agency figures (from calculator)

| Network | OVHcloud | Azure (list) | Azure (grant) |
|---|---|---|---|
| 5 agencies | ~$94/mo | ~$171/mo | ~$77/mo |
| 30 agencies | ~$67/mo | ~$144/mo | ~$50/mo |

## Test plan

- [x] Calculator runs and produces correct figures
- [x] COST_VERSION dates are 2026-03-14 across all files
- [x] Key Vault is per-agency in all docs
- [x] All dangling references fixed
- [x] Deployment protocol works for both OVHcloud and Azure paths
- [x] Archive banners on deprecated docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)