### PR TITLE
fix: align tier cost ranges with calculator output

### DIFF
--- a/.claude/skills/deployment-planning/SKILL.md
+++ b/.claude/skills/deployment-planning/SKILL.md
@@ -53,7 +53,7 @@ KoNote supports a range of deployment options, from bare-bones self-hosted to fu
 - Audit logs in a separate tamper-resistant database
 - RBAC middleware enforcing role-based access on every request
 
-**Cost:** VPS hosting only (~$15 CAD/mo for OVHcloud VPS-1). No LO support fees.
+**Cost:** VPS hosting + Key Vault (~$17 CAD/mo for OVHcloud VPS-1 + per-agency Key Vault). No LO support fees.
 
 **Docs:** `docs/deploy-ovhcloud.md`, `docs/deploying-konote.md`
 
@@ -71,7 +71,7 @@ KoNote supports a range of deployment options, from bare-bones self-hosted to fu
 
 What is **never** shared: databases, encryption keys, application instances, participant data.
 
-**Cost:** ~$92/agency/mo (5-agency network) to ~$65/agency/mo (30-agency network), Year 2+. See `hosting-budget-scenarios.md` for current figures.
+**Cost:** ~$94/agency/mo (5-agency network) to ~$67/agency/mo (30-agency network), Year 2+. See `hosting-budget-scenarios.md` for current figures.
 
 **Docs:** `tasks/p0-managed-service-plan.md`, `tasks/deployment-protocol.md`
 
@@ -88,7 +88,7 @@ What is **never** shared: databases, encryption keys, application instances, par
 
 **Trade-off:** Azure's parent company (Microsoft) is US-incorporated and subject to the US CLOUD Act. Data is in Canada (Toronto/Canada Central), but the corporate jurisdiction is American. See `tasks/design-rationale/data-access-residency-policy.md`.
 
-**Cost:** ~$169/agency/mo (list price) or ~$77/agency/mo (with nonprofit grant). See `hosting-budget-scenarios.md`.
+**Cost:** ~$171/agency/mo (list price) or ~$77/agency/mo (with nonprofit grant). See `hosting-budget-scenarios.md`.
 
 **Docs:** `docs/archive/deploy-azure.md` (archived but still accurate for Azure path)
 

--- a/docs/deployment-index.md
+++ b/docs/deployment-index.md
@@ -24,9 +24,9 @@ KoNote supports three deployment tiers. All maintain the same data isolation and
 
 | Tier | Who | Monthly Cost | Key Feature |
 |---|---|---|---|
-| **1. Self-hosted** | Agencies with technical capacity | ~$15/mo (VPS only) | Cheapest. Secure by default via built-in encryption. |
-| **2. Managed OVHcloud** (recommended) | Most agencies | ~$65-92/agency | LO manages infrastructure. Shared monitoring, isolated data. |
-| **3. Azure** | Agencies requiring Azure | ~$77-169/agency | Azure managed services. Higher cost, US CLOUD Act trade-off. |
+| **1. Self-hosted** | Agencies with technical capacity | ~$17/mo (VPS + Key Vault) | Cheapest. Secure by default via built-in encryption. |
+| **2. Managed OVHcloud** (recommended) | Most agencies | ~$67-94/agency | LO manages infrastructure. Shared monitoring, isolated data. |
+| **3. Azure** | Agencies requiring Azure | ~$77-171/agency | Azure managed services. Higher cost, US CLOUD Act trade-off. |
 
 See the `/deployment-planning` skill for full tier descriptions and the cost source chain.
 

--- a/tasks/deployment-protocol.md
+++ b/tasks/deployment-protocol.md
@@ -1,6 +1,6 @@
 # Agency Deployment Protocol
 
-**Purpose:** End-to-end process for deploying KoNote for a new client organisation on Azure. Covers discovery through go-live and follow-up.
+**Purpose:** End-to-end process for deploying KoNote for a new client organisation. Covers discovery through go-live and follow-up. Supports OVHcloud (recommended), Azure, or self-hosted deployment.
 
 **Team roles:**
 - **Sara** (PM) — leads client-facing sessions (Phases 0, 1, 3, 4 walkthrough, 5)


### PR DESCRIPTION
## Summary

Review follow-up from PR #518. Three places still showed old cost ranges after Key Vault changed to per-agency.

- `deployment-index.md`: Self-hosted $15->$17, Managed OVH $65-92->$67-94, Azure $77-169->$77-171
- `deployment-protocol.md`: purpose line updated from Azure-specific to platform-agnostic
- `deployment-planning` skill: tier cost descriptions match calculator output

🤖 Generated with [Claude Code](https://claude.com/claude-code)