### PR TITLE
Enhance deployment-planning skill with tiers and cost reconciliation

### DIFF
--- a/.claude/skills/deployment-planning/SKILL.md
+++ b/.claude/skills/deployment-planning/SKILL.md
@@ -193,6 +193,8 @@ Each file has a `<!-- COST_VERSION -->` header. Before updating, compare key val
 | 5 agencies | ~$92/agency | ~$169/agency | ~$77/agency |
 | 30 agencies | ~$65/agency | ~$142/agency | ~$50/agency |
 
+Key Vault is $2/agency/month (per-agency vault, not shared). These figures include Key Vault in the per-agency hosting cost.
+
 **These figures change.** Always read `hosting-budget-scenarios.md` for current numbers.
 
 ### Why OVHcloud Over Azure
@@ -209,7 +211,7 @@ Read the `COST_VERSION` header in `tasks/hosting-cost-comparison.md` for current
 - ~200 participants/agency, ~2 visits/month
 - All AI self-hosted (Qwen3.5 + NLLB-200) — $0 API costs
 - Support at $100/hr, LLM-assisted (reduces human hours)
-- Single-tenant currently; multi-tenant planned (would reduce hosting cost)
+- Single-tenant currently; multi-tenant planned (would reduce hosting cost). Each agency has its own Azure Key Vault ($2/mo) for encryption key storage.
 
 ### Onboarding Cost
 

--- a/.claude/skills/deployment-planning/SKILL.md
+++ b/.claude/skills/deployment-planning/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: deployment-planning
+description: Use when anyone asks about KoNote hosting costs, deployment options, per-agency pricing, budget scenarios, cost assumptions, managed service model, Azure vs OVHcloud comparison, onboarding costs, or needs to update cost figures. Also use when a new developer or manager needs deployment context.
+---
+
+# Deployment Planning & Costing Reference
+
+Answer questions about KoNote deployment options, hosting costs, and cost assumptions by reading the authoritative source documents listed below. Never guess figures — always read the current file.
+
+## When to Use
+
+- "How much does KoNote cost per agency?"
+- "What are the hosting options?"
+- "Why OVHcloud instead of Azure?"
+- "Can you update the cost model for a new VPS price?"
+- "What's the onboarding process for a new agency?"
+- "Where's the costing calculator?"
+- New developer/manager needs deployment context
+
+## When NOT to Use
+
+- **Running a deployment** — use `/deploy-to-vps` instead
+- **Reviewing a code change against architectural decisions** — use the `design-rationale` skill instead (it has the full DRR review workflow)
+- **Debugging a deployment failure** — use `konote-ops/deployment/runbook.md` directly
+
+## Cross-Repo Paths
+
+Files prefixed `konote-prosper-canada/` are in a **separate repo**. Locate it relative to the konote repo (typically `../konote-prosper-canada/` or search for it under the user's GitHub directory). Files prefixed `konote-ops/` are in the **private ops repo** (`../konote-ops/`).
+
+## Document Inventory
+
+Read the files relevant to the question. **Always start with the source-of-truth for the topic.**
+
+### Cost & Pricing (read these for any cost question)
+
+| File | Role | What it contains |
+|------|------|-----------------|
+| `tasks/hosting-cost-comparison.md` | **Primary source** — component pricing | Azure vs OVHcloud pricing tables, VPS tiers, AI costs, scenarios at 1/5/10 agencies, data sovereignty analysis |
+| `tasks/p0-managed-service-plan.md` | Managed service model | What LO provides vs agency, support tiers, deployment protocol summary, scaling plan |
+| `konote-prosper-canada/deliverables/costing-model.md` | Detailed scenarios | 5-agency and 30-agency network costing, support hour breakdowns, Azure vs OVHcloud per-agency |
+| `konote-prosper-canada/deliverables/hosting-budget-scenarios.md` | Client-facing summary | Polished per-agency tables, onboarding costs, 3-year TCO, funding model options |
+
+### Calculator (for running custom scenarios)
+
+| File | How to use |
+|------|-----------|
+| `konote-prosper-canada/deliverables/tools/costing-model-calculator.py` | `python costing-model-calculator.py` — change assumptions at top of file, re-run for updated figures |
+| `konote-prosper-canada/deliverables/tools/costing-model-calculator.html` | Open in browser — interactive version with sliders |
+
+### Deployment Architecture & Rationale (DRRs)
+
+| File | Governs |
+|------|---------|
+| `tasks/design-rationale/ovhcloud-deployment.md` | Full OVHcloud stack, 4-layer self-healing, backup strategy, encryption key management, VPS sizing, risk registry |
+| `tasks/design-rationale/multi-tenancy.md` | Schema-per-tenant architecture — prerequisite for cost reduction at 5+ agencies |
+| `tasks/design-rationale/data-access-residency-policy.md` | Canadian data residency, who can access production, CLOUD Act analysis |
+| `tasks/design-rationale/self-hosted-llm-infrastructure.md` | Self-hosted LLM costing (Ollama + Qwen on shared VPS), why not cloud AI APIs |
+
+### Deployment How-To Guides
+
+| File | Purpose |
+|------|---------|
+| `docs/deploy-ovhcloud.md` | Step-by-step OVHcloud VPS deployment (16 steps, 45-90 min) |
+| `docs/deploying-konote.md` | General deployment overview |
+| `docs/deploy-dev-vps.md` | Dev/demo VPS setup |
+| `docs/llm-deployment-guide.md` | Self-hosted LLM (Ollama) deployment |
+| `docs/archive/deploy-azure.md` | Azure deployment (archived — for reference only) |
+
+### Onboarding & Agreements
+
+| File | Purpose |
+|------|---------|
+| `tasks/deployment-protocol.md` | 5-phase onboarding: Discovery -> Permissions -> Infrastructure -> Customisation -> Go-Live -> 30-Day Check-In |
+| `tasks/deployment-workflow-design.md` | Workflow design for deployment process |
+| `tasks/saas-service-agreement.md` | SaaS agreement template (required before first managed agency) |
+
+### Operations (private repo)
+
+| File | Purpose |
+|------|---------|
+| `konote-ops/deployment/runbook.md` | Deployment runbook, troubleshooting, checklists |
+| `konote-ops/deployment/vps-migration-runbook.md` | VPS migration procedures |
+| `konote-ops/deployment/hardening-guide.md` | VPS security hardening |
+| `konote-ops/deployment/update-checklist.md` | Update verification checklist |
+| `konote-ops/deployment/env-template.md` | Environment variable reference |
+
+## Cost Source Chain
+
+Cost data flows upstream to downstream. **When updating any cost file, reconcile from upstream first.**
+
+```
+tasks/hosting-cost-comparison.md          <-- PRIMARY SOURCE (component pricing)
+        |
+        v
+tasks/p0-managed-service-plan.md          <-- managed service model
+        |
+        v
+konote-prosper-canada/deliverables/costing-model.md    <-- detailed scenarios
+        |
+        v
+konote-prosper-canada/deliverables/hosting-budget-scenarios.md  <-- client summary
+konote-prosper-canada/deliverables/tools/costing-model-calculator.*  <-- calculator
+```
+
+Each file has a `<!-- COST_VERSION -->` header. Before updating, compare key values across the chain. If values don't match, reconcile upstream first, then cascade downstream.
+
+**Cross-repo constraint:** `konote` and `konote-prosper-canada` cannot be updated in the same session. Note in the commit message which downstream files need updating.
+
+## Quick Reference
+
+### Per-Agency Monthly Cost (Year 2+, as of 2026-03-04)
+
+| Network size | OVHcloud | Azure (list) | Azure (nonprofit grant) |
+|---|---|---|---|
+| 5 agencies | ~$92/agency | ~$169/agency | ~$77/agency |
+| 30 agencies | ~$65/agency | ~$142/agency | ~$50/agency |
+
+**These figures change.** Always read `hosting-budget-scenarios.md` for current numbers.
+
+### Why OVHcloud Over Azure
+
+Read `tasks/design-rationale/ovhcloud-deployment.md` for the full analysis. Summary:
+- **60-70% lower cost** than Azure
+- **Not subject to US CLOUD Act** (OVH Groupe SA is French-incorporated)
+- **Canadian data residency** (Beauharnois, QC data centre)
+- **Exception:** Agencies with concerns about Canadian law enforcement may need Azure or a risk assessment
+
+### Key Cost Assumptions
+
+Read the `COST_VERSION` header in `tasks/hosting-cost-comparison.md` for current values. Key assumptions:
+- ~200 participants/agency, ~2 visits/month
+- All AI self-hosted (Qwen3.5 + NLLB-200) — $0 API costs
+- Support at $100/hr, LLM-assisted (reduces human hours)
+- Single-tenant currently; multi-tenant planned (would reduce hosting cost)
+
+### Onboarding Cost
+
+One-time per agency: $800-$2,200 depending on size. See `hosting-budget-scenarios.md` Section "One-Time Onboarding Costs".
+
+## How to Update Cost Assumptions
+
+1. Read `tasks/hosting-cost-comparison.md` (the primary source)
+2. Make changes there first
+3. Run `python konote-prosper-canada/deliverables/tools/costing-model-calculator.py` to regenerate figures
+4. Update downstream files: `p0-managed-service-plan.md` -> `costing-model.md` -> `hosting-budget-scenarios.md`
+5. Bump `COST_VERSION` date in each updated file
+6. Note cross-repo updates needed in commit messages

--- a/.claude/skills/deployment-planning/SKILL.md
+++ b/.claude/skills/deployment-planning/SKILL.md
@@ -23,6 +23,84 @@ Answer questions about KoNote deployment options, hosting costs, and cost assump
 - **Reviewing a code change against architectural decisions** — use the `design-rationale` skill instead (it has the full DRR review workflow)
 - **Debugging a deployment failure** — use `konote-ops/deployment/runbook.md` directly
 
+## Core Principle: Data Isolation
+
+**Every agency's participant data is fully isolated.** Agencies never share a KoNote instance, database, or encryption key — even when they share hosting infrastructure. Multiple instances can run on the same VPS for cost and operational efficiency, but data never crosses instance boundaries.
+
+This is enforced by:
+- **Per-instance databases** — each agency has its own PostgreSQL databases (main + audit)
+- **Per-agency encryption keys** — each agency's PII is encrypted with its own Fernet key, stored in a managed key service (Azure Key Vault or OVHcloud KMS)
+- **Schema-per-tenant isolation** — when multi-tenancy is enabled, PostgreSQL schema boundaries prevent cross-agency queries (see `tasks/design-rationale/multi-tenancy.md`)
+- **No shared participant tables** — row-level tenant isolation was explicitly rejected as an anti-pattern (one missed filter = data leak)
+
+**This principle is non-negotiable.** Any deployment option that combines participant data across agencies violates PHIPA and KoNote's design rationale. See the `design-rationale` skill for the full DRR review process.
+
+## Deployment Tiers
+
+KoNote supports a range of deployment options, from bare-bones self-hosted to fully managed. All tiers maintain the same data isolation and encryption guarantees — the difference is who manages the infrastructure and what operational support is included.
+
+### Tier 1: Self-Hosted (DIY)
+
+**Who:** Nonprofits with technical capacity (or a volunteer/consultant) who want the lowest cost.
+
+**What they get:** The open-source repo, deployment documentation, and Docker Compose stack. The agency deploys to their own VPS or server, manages their own backups, updates, and monitoring.
+
+**Why it's secure enough:** KoNote's security is built into the application, not bolted on by the hosting layer:
+- Fernet (AES-256) encryption on all PII fields at the application level
+- Encryption key stored in a managed key service (not in `.env`)
+- Docker healthchecks and autoheal for container recovery
+- Caddy with automatic HTTPS (Let's Encrypt)
+- Audit logs in a separate tamper-resistant database
+- RBAC middleware enforcing role-based access on every request
+
+**Cost:** VPS hosting only (~$15 CAD/mo for OVHcloud VPS-1). No LO support fees.
+
+**Docs:** `docs/deploy-ovhcloud.md`, `docs/deploying-konote.md`
+
+### Tier 2: Managed OVHcloud (Recommended)
+
+**Who:** Most agencies. LO handles infrastructure; the agency focuses on using KoNote.
+
+**What they get:** A fully hosted, maintained KoNote instance on OVHcloud Beauharnois (QC). LO provides setup, updates, backups, monitoring, and incident response.
+
+**Shared infrastructure, isolated data:** Multiple agencies can run on the same bare VPS, sharing:
+- Joint monitoring (UptimeRobot, health reports)
+- 4-layer self-healing automation (Docker autoheal, VPS auto-reboot, preventive cron, human escalation)
+- Shared LLM server for AI features (suggestions, translation)
+- Operational efficiencies (one update cycle covers all instances on the VPS)
+
+What is **never** shared: databases, encryption keys, application instances, participant data.
+
+**Cost:** ~$92/agency/mo (5-agency network) to ~$65/agency/mo (30-agency network), Year 2+. See `hosting-budget-scenarios.md` for current figures.
+
+**Docs:** `tasks/p0-managed-service-plan.md`, `tasks/deployment-protocol.md`
+
+### Tier 3: Azure Hosting
+
+**Who:** Agencies that require or prefer Azure — typically those with existing Microsoft agreements, Azure nonprofit grants, or specific compliance requirements.
+
+**What they get:** Same KoNote application deployed on Azure VM with Azure-managed PostgreSQL, Azure Key Vault, and Azure Monitor. Higher cost but leverages the Azure ecosystem.
+
+**Why choose Azure over OVHcloud:**
+- Agency already has Azure nonprofit credits ($2,000 USD/year — often enough to cover KoNote hosting)
+- Compliance requirements that specifically mandate a hyperscaler
+- Preference for managed database services over self-managed PostgreSQL
+
+**Trade-off:** Azure's parent company (Microsoft) is US-incorporated and subject to the US CLOUD Act. Data is in Canada (Toronto/Canada Central), but the corporate jurisdiction is American. See `tasks/design-rationale/data-access-residency-policy.md`.
+
+**Cost:** ~$169/agency/mo (list price) or ~$77/agency/mo (with nonprofit grant). See `hosting-budget-scenarios.md`.
+
+**Docs:** `docs/archive/deploy-azure.md` (archived but still accurate for Azure path)
+
+### Optional Add-Ons (Any Tier)
+
+| Service | Description | Availability |
+|---------|-------------|-------------|
+| **Penetration testing** | Third-party security audit of the agency's KoNote instance | On request, for agencies or networks willing to fund it |
+| **Evaluation framework setup** | CIDS Full Tier configuration with impact model, counterfactuals, and reporting profiles | Per-program, requires evaluation interview (see `tasks/deployment-protocol.md` Interview 3) |
+| **Self-hosted LLM** | Dedicated or shared Ollama server for AI suggestions and translation | Included in Tier 2; optional for Tier 1/3 |
+| **Cross-agency reporting** | Aggregate reporting dashboard for funder networks (k>=5 cell suppression) | Requires consortium setup; see `tasks/design-rationale/cids-privacy-architecture.md` |
+
 ## Cross-Repo Paths
 
 Files prefixed `konote-prosper-canada/` are in a **separate repo**. Locate it relative to the konote repo (typically `../konote-prosper-canada/` or search for it under the user's GitHub directory). Files prefixed `konote-ops/` are in the **private ops repo** (`../konote-ops/`).

--- a/.claude/skills/deployment-planning/SKILL.md
+++ b/.claude/skills/deployment-planning/SKILL.md
@@ -53,7 +53,7 @@ KoNote supports a range of deployment options, from bare-bones self-hosted to fu
 - Audit logs in a separate tamper-resistant database
 - RBAC middleware enforcing role-based access on every request
 
-**Cost:** VPS hosting only (~$15 CAD/mo for OVHcloud VPS-1). No LO support fees.
+**Cost:** VPS hosting + Key Vault (~$17 CAD/mo for OVHcloud VPS-1 + per-agency Key Vault). No LO support fees.
 
 **Docs:** `docs/deploy-ovhcloud.md`, `docs/deploying-konote.md`
 
@@ -71,7 +71,7 @@ KoNote supports a range of deployment options, from bare-bones self-hosted to fu
 
 What is **never** shared: databases, encryption keys, application instances, participant data.
 
-**Cost:** ~$92/agency/mo (5-agency network) to ~$65/agency/mo (30-agency network), Year 2+. See `hosting-budget-scenarios.md` for current figures.
+**Cost:** ~$94/agency/mo (5-agency network) to ~$67/agency/mo (30-agency network), Year 2+. See `hosting-budget-scenarios.md` for current figures.
 
 **Docs:** `tasks/p0-managed-service-plan.md`, `tasks/deployment-protocol.md`
 
@@ -88,7 +88,7 @@ What is **never** shared: databases, encryption keys, application instances, par
 
 **Trade-off:** Azure's parent company (Microsoft) is US-incorporated and subject to the US CLOUD Act. Data is in Canada (Toronto/Canada Central), but the corporate jurisdiction is American. See `tasks/design-rationale/data-access-residency-policy.md`.
 
-**Cost:** ~$169/agency/mo (list price) or ~$77/agency/mo (with nonprofit grant). See `hosting-budget-scenarios.md`.
+**Cost:** ~$171/agency/mo (list price) or ~$77/agency/mo (with nonprofit grant). See `hosting-budget-scenarios.md`.
 
 **Docs:** `docs/archive/deploy-azure.md` (archived but still accurate for Azure path)
 

--- a/.claude/skills/deployment-planning/SKILL.md
+++ b/.claude/skills/deployment-planning/SKILL.md
@@ -186,12 +186,12 @@ Each file has a `<!-- COST_VERSION -->` header. Before updating, compare key val
 
 ## Quick Reference
 
-### Per-Agency Monthly Cost (Year 2+, as of 2026-03-04)
+### Per-Agency Monthly Cost (Year 2+, as of 2026-03-14)
 
 | Network size | OVHcloud | Azure (list) | Azure (nonprofit grant) |
 |---|---|---|---|
-| 5 agencies | ~$92/agency | ~$169/agency | ~$77/agency |
-| 30 agencies | ~$65/agency | ~$142/agency | ~$50/agency |
+| 5 agencies | ~$94/agency | ~$171/agency | ~$77/agency |
+| 30 agencies | ~$67/agency | ~$144/agency | ~$50/agency |
 
 Key Vault is $2/agency/month (per-agency vault, not shared). These figures include Key Vault in the per-agency hosting cost.
 

--- a/.claude/skills/design-rationale/SKILL.md
+++ b/.claude/skills/design-rationale/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: design-rationale
+description: Use when proposing new features, reviewing code changes, evaluating integration requests, or onboarding to KoNote — checks proposals against Design Rationale Records (DRRs) to identify conflicts with established architectural decisions, rejected anti-patterns, and privacy/security constraints before implementation begins.
+---
+
+# Design Rationale Review
+
+Review proposed features and code changes against KoNote's Design Rationale Records (DRRs) — expert-vetted architectural decisions that govern privacy, security, data modelling, and feature design. Prevents re-introducing designs that were already evaluated and rejected.
+
+## When to Use
+
+- A client, stakeholder, or developer proposes a new feature or integration
+- A PR or code change touches areas governed by DRRs (auth, data access, AI, reporting, encryption, data export)
+- Onboarding a new developer who needs to understand why things are designed a certain way
+- Evaluating whether a "Parking Lot" feature is ready to build
+- Someone asks "why can't we just...?" about an architectural constraint
+
+## Workflow
+
+```dot
+digraph review_flow {
+    rankdir=TB;
+    "Describe the proposal" [shape=box];
+    "Match keywords to DRR index" [shape=box];
+    "Read each relevant DRR" [shape=box];
+    "Any anti-pattern matches?" [shape=diamond];
+    "CONFLICT: Report with DRR citations" [shape=box, style=filled, fillcolor="#ffcccc"];
+    "Any graduated paths triggered?" [shape=diamond];
+    "CAUTION: Conditions may now be met" [shape=box, style=filled, fillcolor="#ffffcc"];
+    "CLEAR: No conflicts found" [shape=box, style=filled, fillcolor="#ccffcc"];
+
+    "Describe the proposal" -> "Match keywords to DRR index";
+    "Match keywords to DRR index" -> "Read each relevant DRR";
+    "Read each relevant DRR" -> "Any anti-pattern matches?";
+    "Any anti-pattern matches?" -> "CONFLICT: Report with DRR citations" [label="yes"];
+    "Any anti-pattern matches?" -> "Any graduated paths triggered?" [label="no"];
+    "Any graduated paths triggered?" -> "CAUTION: Conditions may now be met" [label="yes"];
+    "Any graduated paths triggered?" -> "CLEAR: No conflicts found" [label="no"];
+}
+```
+
+### Step 1: Identify the Proposal
+
+Get a clear description of what's being proposed. This can come from:
+- The user's message (e.g., "a client wants a live API for participant data")
+- A PR diff (e.g., code adding a new endpoint or model)
+- A feature request or TODO item
+
+If the proposal is vague, ask: "What data does this touch? Who initiates the action? Does it cross the boundary of a single KoNote instance?"
+
+### Step 2: Find Relevant DRRs
+
+Read `@.claude/skills/design-rationale/drr-index.md` and match the proposal's keywords to the topic index. Cast a wide net — a "webhook notification" proposal touches API, data export, AND privacy DRRs, not just the obvious one.
+
+**Always start with the relevant Foundation Principle:**
+- Participant-facing, note design, bilingual, or accessibility changes -> `foundation-collaborative-practice.md`
+- Data sharing, cross-agency, community data, demographics -> `foundation-data-sovereignty.md`
+- Auth, permissions, encryption, exports, logging -> `foundation-security-by-default.md`
+- New dependencies, hosting, cost, deployment, evaluation -> `foundation-nonprofit-sustainability.md`
+
+**Then check implementation-level DRRs:**
+- Any data leaving a KoNote instance -> `no-live-api-individual-data.md`
+- Any new permission or visibility logic -> `access-tiers.md`, `phipa-consent-enforcement.md`
+- Any new entity or relationship type -> `circles-family-entity.md`, `fhir-informed-modelling.md`
+- Any AI/LLM feature -> `ai-feature-toggles.md`, `self-hosted-llm-infrastructure.md`
+- Any reporting or aggregate data -> `reporting-architecture.md`, `cids-privacy-architecture.md`
+- Any infrastructure change -> `ovhcloud-deployment.md`, `data-access-residency-policy.md`
+
+### Step 3: Read and Assess Each DRR
+
+For each relevant DRR, read the full file from `tasks/design-rationale/` and check:
+
+1. **Anti-Patterns section**: Does the proposal match any explicitly rejected design? Quote the specific anti-pattern.
+2. **Expert Panel Findings**: What were the reasons for the current design? Do they still apply?
+3. **Graduated Complexity Path**: Did the DRR say "reconsider when X happens"? Has X happened?
+4. **Status**: Is this Decided (enforce), Draft (read but flexible), or Parking Lot (don't build)?
+
+### Step 4: Produce the Review
+
+Structure your output as follows:
+
+---
+
+**Proposal:** [one-line summary]
+
+**DRRs Consulted:** [list of files read]
+
+**Verdict:** CONFLICT / CAUTION / CLEAR
+
+**Findings:**
+
+For each relevant DRR:
+- **[DRR name]** — [Conflict | Caution | Clear]
+  - What the DRR says (quote the anti-pattern or decision)
+  - How the proposal relates
+  - What to do instead (if conflict)
+
+**Recommendation:** [approve / modify / reject, with specific guidance]
+
+---
+
+## Review Depth by Context
+
+| Context | Depth |
+|---|---|
+| Client feature request | Full review — check all keyword matches |
+| PR code review | Targeted — focus on DRRs related to changed files |
+| Quick "can we do X?" question | Index scan — cite the relevant DRR and its verdict |
+| New developer onboarding | Explain the reasoning, not just the rule |
+
+## Common Proposals and Their DRR Verdicts
+
+These come up repeatedly. The answers are settled:
+
+| Proposal | Verdict | Key DRR |
+|---|---|---|
+| Live API for individual PII | **Rejected** | `no-live-api-individual-data.md` |
+| Webhook/push notifications with PII | **Rejected** | `no-live-api-individual-data.md` |
+| Bidirectional CRM sync | **Rejected** | `no-live-api-individual-data.md` |
+| FHIR server or FHIR API | **Rejected** | `fhir-informed-modelling.md` |
+| Row-level multi-tenancy | **Rejected** | `multi-tenancy.md` |
+| Per-agency LLM deployment | **Rejected** | `self-hosted-llm-infrastructure.md` |
+| Person-to-person global relationships | **Rejected** | `circles-family-entity.md` |
+| Executives seeing individual data in reports | **Rejected** | `reporting-architecture.md`, `access-tiers.md` |
+| AI features accessing PII without toggle | **Rejected** | `ai-feature-toggles.md` |
+| PWA for offline field work | **Rejected** | `offline-field-collection.md` |
+| Translation as optional/toggleable | **Rejected** | `bilingual-requirements.md` |
+| Hosting outside Canada | **Rejected** | `data-access-residency-policy.md` |
+| English-only UI (no French) | **Rejected** | `foundation-collaborative-practice.md`, `bilingual-requirements.md` |
+| Inaccessible portal features | **Rejected** | `foundation-collaborative-practice.md` |
+| Cross-agency individual data combination | **Rejected** | `foundation-data-sovereignty.md`, `multi-tenancy.md` |
+| Staff-initiated JSON/PDF export | **Approved** | `no-live-api-individual-data.md` |
+| Aggregate cross-agency reporting | **Approved with constraints** | `cids-privacy-architecture.md` (k>=5) |
+| FHIR-informed model naming | **Approved** | `fhir-informed-modelling.md` |
+
+## When a DRR Needs Updating
+
+If you find that:
+- A "reconsider when" condition has been met
+- New information invalidates the original reasoning
+- A client need genuinely can't be met by the approved alternatives
+
+**Do not override the DRR.** Instead:
+1. Document the new evidence
+2. Flag for GK (subject matter expert) review
+3. If approved, update the DRR file before implementing the change

--- a/.claude/skills/design-rationale/drr-index.md
+++ b/.claude/skills/design-rationale/drr-index.md
@@ -1,0 +1,91 @@
+# DRR Keyword Index
+
+All files live in `tasks/design-rationale/`. Read the full DRR before making judgements — this index helps you find which DRRs are relevant, not replace reading them.
+
+## Start Here: Foundation Principles
+
+For any proposal, **always check the relevant foundation first**, then drill into implementation decisions.
+
+| Foundation | Covers | Read when proposal involves... |
+|---|---|---|
+| `foundation-collaborative-practice.md` | Two-lens notes, alliance, portal, feedback, strengths-based language, bilingual by design, accessible by design | Note design, participant-facing features, UX, feedback, goal-setting, bilingual/French, accessibility/WCAG |
+| `foundation-data-sovereignty.md` | OCAP, Black data governance, Canadian sovereignty, no cross-agency combination | Data sharing, cross-agency features, community data, demographics, hosting location, AI providers |
+| `foundation-security-by-default.md` | Encryption, RBAC, audit, fail-closed, session security | Auth, permissions, exports, logging, error handling, new roles or access paths |
+| `foundation-nonprofit-sustainability.md` | Minimal tech stack, cost, self-healing ops, evaluation-driven config | New dependencies, frameworks, hosting changes, deployment, pricing, metric/evaluation architecture |
+
+## Quick Lookup by Topic (Implementation Decisions)
+
+| If the proposal involves... | Read these DRRs |
+|---|---|
+| **API, REST, GraphQL, webhook, sync, integration, CRM, real-time data** | `no-live-api-individual-data.md`, `cids-privacy-architecture.md`, `data-access-residency-policy.md` |
+| **FHIR, HL7, health data, EHR/EMR, clinical interoperability** | `fhir-informed-modelling.md`, `no-live-api-individual-data.md` |
+| **Family, household, relationships, circles, network, dependents** | `circles-family-entity.md` |
+| **Multi-tenancy, schema isolation, cross-agency, shared database** | `multi-tenancy.md`, `data-access-residency-policy.md` |
+| **Permissions, roles, access tiers, front desk, executive, gated access** | `access-tiers.md`, `phipa-consent-enforcement.md` |
+| **Consent, PHIPA, cross-program notes, clinical note visibility** | `phipa-consent-enforcement.md`, `access-tiers.md` |
+| **AI, LLM, machine learning, suggestions, scoring, prompts** | `ai-feature-toggles.md`, `self-hosted-llm-infrastructure.md` |
+| **Encryption, key rotation, PII, decryption, Fernet** | `encryption-key-rotation.md`, `no-live-api-individual-data.md` |
+| **Reports, dashboards, funder reporting, executive view, exports** | `reporting-architecture.md`, `insights-metric-distributions.md`, `funder-reporting-profiles.md`, `executive-dashboard-redesign.md` |
+| **CIDS, Common Approach, indicators, taxonomy, classification** | `cids-privacy-architecture.md`, `cids-batch-classification-workflow.md`, `cids-metadata-assignment.md`, `funder-reporting-profiles.md` |
+| **Surveys, questionnaires, instruments, PHQ-9, standardised tools** | `survey-metric-unification.md`, `insights-metric-distributions.md` |
+| **Offline, field work, mobile, ODK, data collection** | `offline-field-collection.md` |
+| **Deployment, hosting, VPS, Docker, OVHcloud, infrastructure** | `ovhcloud-deployment.md`, `self-hosted-llm-infrastructure.md` |
+| **Bilingual, French, translation, Official Languages Act** | `foundation-collaborative-practice.md`, `bilingual-requirements.md` |
+| **Accessibility, WCAG, a11y, screen reader, keyboard navigation** | `foundation-collaborative-practice.md` |
+| **EGAP, Black data governance, Black communities, anti-Black racism** | `foundation-data-sovereignty.md`, `multi-tenancy.md` |
+| **Documents, SharePoint, Google Drive, file storage, attachments** | `document-integration.md` |
+| **Data export, data portability, migration, offboarding** | `no-live-api-individual-data.md`, `cids-privacy-architecture.md` |
+| **Data residency, Canadian hosting, foreign access, subpoena risk** | `data-access-residency-policy.md`, `ovhcloud-deployment.md` |
+| **Metrics, outcomes, progress notes, scoring, measurement** | `survey-metric-unification.md`, `insights-metric-distributions.md`, `cids-metadata-assignment.md` |
+| **Data sovereignty, OCAP, Indigenous data, community ownership** | `foundation-data-sovereignty.md`, `multi-tenancy.md`, `no-live-api-individual-data.md` |
+| **Participant portal, collaborative features, alliance rating** | `foundation-collaborative-practice.md`, `insights-metric-distributions.md` |
+| **Cost, pricing, tech stack, dependencies, frameworks** | `foundation-nonprofit-sustainability.md`, `ovhcloud-deployment.md`, `self-hosted-llm-infrastructure.md` |
+
+## DRR Status Reference
+
+| Status | Meaning |
+|---|---|
+| **Foundation Principle** | Core design philosophy. Governs multiple implementation decisions. |
+| **Decided** | Approved and enforced. Do not override without stakeholder approval. |
+| **Implemented** | Decided AND built. Code exists — check implementation before modifying. |
+| **Approved** | Reviewed by expert panel, awaiting implementation. |
+| **Draft** | Under development. Decisions may change — still read before building. |
+| **Parking Lot** | Not yet clear we should build. Do not implement without explicit approval. |
+
+## Full DRR Inventory (26 files)
+
+### Foundation Principles (4)
+
+| File | Scope |
+|---|---|
+| `foundation-collaborative-practice.md` | The "Ko" — documentation WITH participants, two-lens notes, alliance, feedback, bilingual by design, accessible by design |
+| `foundation-data-sovereignty.md` | Individual, community (OCAP, EGAP), and national data ownership |
+| `foundation-security-by-default.md` | High security for non-technical operators — encryption, RBAC, immutable audit, fail-closed |
+| `foundation-nonprofit-sustainability.md` | Affordable tech stack, self-healing ops, evaluation-driven configuration |
+
+### Implementation Decisions (22)
+
+| File | Status | Scope |
+|---|---|---|
+| `access-tiers.md` | Decided | Three permission tiers, PERM-P5/P6/P8, demographic visibility |
+| `ai-feature-toggles.md` | Decided | Two-tier AI split (tools-only vs. participant data) |
+| `bilingual-requirements.md` | Decided | EN/FR translation, legal obligations, tooling |
+| `cids-batch-classification-workflow.md` | Draft | Admin-facing batch AI classification for reporting taxonomies |
+| `cids-metadata-assignment.md` | Draft | When metadata gets assigned (creation vs. deferred) |
+| `cids-privacy-architecture.md` | Decided | Three-layer compliance (metadata / aggregate / exemplar) |
+| `circles-family-entity.md` | Decided | Family/network entity, 6+ anti-patterns |
+| `data-access-residency-policy.md` | Decided | Canadian residency by data access level |
+| `document-integration.md` | Decided | SharePoint + Google Drive integration |
+| `encryption-key-rotation.md` | Decided | Master/tenant key rotation procedures |
+| `executive-dashboard-redesign.md` | Approved | Dashboard UX with accessibility focus |
+| `fhir-informed-modelling.md` | Decided | FHIR concepts without FHIR compliance |
+| `funder-reporting-profiles.md` | Parking Lot | Template-based funder reporting |
+| `insights-metric-distributions.md` | Decided | Outcome Insights page, metric aggregation |
+| `multi-tenancy.md` | Decided | Schema-per-tenant via django-tenants |
+| `no-live-api-individual-data.md` | Decided | No live API for PII — export-only model |
+| `offline-field-collection.md` | Decided | ODK Central for offline field collection |
+| `ovhcloud-deployment.md` | Decided | OVHcloud VPS architecture, self-healing |
+| `phipa-consent-enforcement.md` | Decided | Cross-program clinical note consent filtering |
+| `reporting-architecture.md` | Decided | Template-driven vs. ad-hoc reporting |
+| `self-hosted-llm-infrastructure.md` | Decided | Shared Ollama VPS, data isolation |
+| `survey-metric-unification.md` | Decided | Surveys and metrics as one construct |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,7 +35,8 @@ A secure, web-based Participant Outcome Management system for nonprofits. Agenci
 1. `git pull origin develop`
 2. `git worktree prune` — remove stale worktree references
 3. `git status` — if there are uncommitted changes you didn't make, **STOP and tell the user**. Do not stash, discard, or commit someone else's work.
-4. Check the current branch: `git branch --show-current`. If not on `develop`, switch to it before creating a new branch.
+4. `git stash list` — if stashes exist, report them to the user before proceeding. Stashes are orphaned work from previous sessions.
+5. Check the current branch: `git branch --show-current`. If not on `develop`, switch to it before creating a new branch.
 
 ### Working on a Task
 
@@ -65,9 +66,10 @@ Multiple sessions share one repo. Worktrees give each session an isolated direct
 
 Before finishing any session, verify:
 1. `git status` — **no uncommitted changes**. If there are changes, commit them or ask the user what to do.
-2. `git worktree list` — only the main repo and any active session worktrees should appear. Remove stale ones.
-3. Main repo is on `develop` (not stranded on a feature branch).
-4. All merged feature branches are deleted locally.
+2. `git stash list` — if any stashes exist, report them to the user. Check whether the content is already committed; if so, drop them (with user approval).
+3. `git worktree list` — only the main repo and any active session worktrees should appear. Remove stale ones.
+4. Main repo is on `develop` (not stranded on a feature branch).
+5. All merged feature branches are deleted locally.
 
 ## Terminal Command Rules
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -237,25 +237,37 @@ Some features involve complex trade-offs (legal, privacy, data modelling, adopti
 
 **Do not override DRR decisions without explicit stakeholder approval.** If circumstances have changed, document why in the DRR before proceeding.
 
-Current DRRs (read the file before modifying related features — all in `tasks/design-rationale/`):
-- `circles-family-entity.md` — Circles (family/network entity)
-- `multi-tenancy.md` — Multi-tenancy architecture
-- `reporting-architecture.md` — Reporting system
-- `executive-dashboard-redesign.md` — Executive dashboard UX
-- `offline-field-collection.md` — Offline field collection (ODK Central)
-- `phipa-consent-enforcement.md` — PHIPA cross-program consent
-- `insights-metric-distributions.md` — Insights page & program reporting
-- `bilingual-requirements.md` — Bilingual (EN/FR) requirements
-- `ai-feature-toggles.md` — AI feature toggle split
-- `ovhcloud-deployment.md` — OVHcloud deployment architecture
-- `data-access-residency-policy.md` — Data access & residency policy
+Current DRRs (all in `tasks/design-rationale/` — see `README.md` there for the full navigation guide):
+
+**Foundation Principles — read these first:**
+- `foundation-collaborative-practice.md` — The "Ko" in KoNote: documentation WITH participants, two-lens notes, alliance, feedback-informed improvement
+- `foundation-data-sovereignty.md` — Individual, community (OCAP, Black data governance), and national data ownership
+- `foundation-security-by-default.md` — High security for non-technical operators: encryption, RBAC, immutable audit, fail-closed
+- `foundation-nonprofit-sustainability.md` — Affordable tech stack, self-healing ops, evaluation-driven configuration
+
+**Implementation Decisions — read before modifying related features:**
+- `access-tiers.md` — Three permission tiers, PERM-P5/P6/P8, demographic visibility
+- `ai-feature-toggles.md` — Two-tier AI split (tools-only vs. participant data)
+- `bilingual-requirements.md` — EN/FR translation, legal obligations
+- `cids-batch-classification-workflow.md` — Batch AI classification for reporting taxonomies
+- `cids-metadata-assignment.md` — When metadata gets assigned (creation vs. deferred)
+- `cids-privacy-architecture.md` — Three-layer compliance for CIDS reporting
+- `circles-family-entity.md` — Family/network entity, 6+ anti-patterns
+- `data-access-residency-policy.md` — Canadian residency by data access level
 - `document-integration.md` — SharePoint + Google Drive integration
-- `no-live-api-individual-data.md` — No live API for individual PII
-- `self-hosted-llm-infrastructure.md` — Self-hosted LLM (Ollama/OVHcloud)
-- `encryption-key-rotation.md` — Encryption key rotation procedures
-- `access-tiers.md` — Access tiers, PERM-P5/P6/P8, and demographic visibility (DEMO-VIS1)
-- `funder-reporting-profiles.md` — Funder reporting profiles (CIDS template-based reporting)
-- `cids-privacy-architecture.md` — CIDS Full Tier privacy-first architecture (three-layer compliance)
+- `encryption-key-rotation.md` — Key rotation procedures and custody
+- `executive-dashboard-redesign.md` — Dashboard UX with accessibility focus
+- `fhir-informed-modelling.md` — FHIR concepts without FHIR compliance
+- `funder-reporting-profiles.md` — Template-based funder reporting (Parking Lot)
+- `insights-metric-distributions.md` — Outcome Insights page, metric aggregation
+- `multi-tenancy.md` — Schema-per-tenant via django-tenants
+- `no-live-api-individual-data.md` — No live API for PII, export-only model
+- `offline-field-collection.md` — ODK Central for offline field collection
+- `ovhcloud-deployment.md` — OVHcloud VPS, self-healing, backup
+- `phipa-consent-enforcement.md` — Cross-program clinical note consent filtering
+- `reporting-architecture.md` — Template-driven vs. ad-hoc reporting
+- `self-hosted-llm-infrastructure.md` — Shared Ollama VPS, data isolation
+- `survey-metric-unification.md` — Surveys and metrics as one construct
 
 ### How Claude Manages Tasks
 

--- a/docs/archive/deploy-azure.md
+++ b/docs/archive/deploy-azure.md
@@ -1,3 +1,5 @@
+> **ARCHIVED:** This deployment method is no longer the recommended path. OVHcloud is preferred for most agencies. This guide is maintained for agencies that specifically require Azure hosting. See [Deployment Index](../deployment-index.md) for current options.
+
 # KoNote Web — Azure Deployment Guide
 
 This guide walks you through deploying KoNote Web to Microsoft Azure. We'll use Azure Container Apps to run the application and Azure Database for PostgreSQL to store your data.

--- a/docs/archive/deploy-elestio.md
+++ b/docs/archive/deploy-elestio.md
@@ -1,3 +1,5 @@
+> **ARCHIVED:** Elest.io deployment is no longer supported. See [Deployment Index](../deployment-index.md) for current deployment options (OVHcloud recommended).
+
 # Deploying KoNote Web to Elest.io
 
 This guide walks you through deploying KoNote Web on **Elest.io**, a cloud hosting platform that runs Docker applications.

--- a/docs/deploy-ovhcloud.md
+++ b/docs/deploy-ovhcloud.md
@@ -1,5 +1,9 @@
 # Deploying KoNote on OVHcloud VPS
 
+> **Audience:** Technical staff deploying KoNote to an OVHcloud VPS.
+> **Assumes:** SSH access, comfort with the command line, access to a domain registrar.
+> **Read first:** [Deployment Index](deployment-index.md) for an overview of all deployment options.
+
 ## Two Paths: Automated or Manual
 
 | Path | Time | Best for |

--- a/docs/deploy-ovhcloud.md
+++ b/docs/deploy-ovhcloud.md
@@ -28,7 +28,7 @@ The script generates all credentials, SSHes into the VPS, hardens the OS, instal
 - **Safe to re-run** — skips already-completed steps
 - **Dry-run mode** — add `--dry-run` to preview without executing
 - **Full options** — run `./scripts/deploy-konote-vps.sh --help`
-- **Design doc** — see [deploy script design](plans/2026-02-20-deploy-script-design.md) for architecture decisions
+- **Design doc** — see [deploy script design](plans/archive/2026-02-20-deploy-script-design.md) for architecture decisions
 
 After the script finishes, skip to [Section 7: Point Your Domain to the VPS](#7-point-your-domain-to-the-vps) (if DNS isn't already configured) or [Section 12: Set Up External Monitoring](#12-set-up-external-monitoring) to complete the remaining manual steps. Backups and internal monitoring are handled automatically by the ops sidecar.
 

--- a/docs/deploying-konote.md
+++ b/docs/deploying-konote.md
@@ -1,5 +1,9 @@
 # Deploying KoNote
 
+> **Audience:** Anyone choosing a deployment path — technical staff, managers, or nonprofit directors.
+> **Assumes:** Basic familiarity with web hosting concepts. No command-line knowledge needed.
+> **Start here:** [Deployment Index](deployment-index.md) if you're unsure which guide you need.
+
 This guide covers everything you need to get KoNote running — from local development to production. Choose your path:
 
 | I want to... | Go to... |

--- a/docs/deployment-index.md
+++ b/docs/deployment-index.md
@@ -1,0 +1,48 @@
+# KoNote Deployment Guide
+
+This page helps you find the right deployment document for your situation. **OVHcloud Beauharnois (QC) is the recommended hosting platform** for most agencies — it's 60-70% cheaper than Azure and provides stronger data sovereignty.
+
+## Which Guide Do I Need?
+
+| I want to... | Read this | Time |
+|---|---|---|
+| **Understand deployment options and costs** | [Deployment Planning skill](/deployment-planning) or `tasks/hosting-cost-comparison.md` | 10 min |
+| **Deploy KoNote on OVHcloud (recommended)** | [deploy-ovhcloud.md](deploy-ovhcloud.md) | 45-90 min |
+| **Deploy KoNote on Azure** | [deploy-azure.md](archive/deploy-azure.md) (archived — for agencies that require Azure) | 1-2 hrs |
+| **Set up the self-hosted LLM server** | [llm-deployment-guide.md](llm-deployment-guide.md) (for AI assistants) | 30 min |
+| **Update an existing instance** | `konote-ops/deployment/update-checklist.md` | 15 min |
+| **Troubleshoot a deployment problem** | `konote-ops/deployment/runbook.md` | varies |
+| **Migrate to a new VPS** | `konote-ops/deployment/vps-migration-runbook.md` | 2-4 hrs |
+| **Understand the onboarding process** | `tasks/deployment-protocol.md` | 20 min |
+| **Review cost assumptions** | `tasks/hosting-cost-comparison.md` (primary source) | 15 min |
+| **See client-facing budget figures** | `konote-prosper-canada/deliverables/hosting-budget-scenarios.md` | 10 min |
+| **Run cost scenarios** | `konote-prosper-canada/deliverables/tools/costing-model-calculator.html` (browser) | 5 min |
+
+## Deployment Tiers
+
+KoNote supports three deployment tiers. All maintain the same data isolation and encryption guarantees.
+
+| Tier | Who | Monthly Cost | Key Feature |
+|---|---|---|---|
+| **1. Self-hosted** | Agencies with technical capacity | ~$15/mo (VPS only) | Cheapest. Secure by default via built-in encryption. |
+| **2. Managed OVHcloud** (recommended) | Most agencies | ~$65-92/agency | LO manages infrastructure. Shared monitoring, isolated data. |
+| **3. Azure** | Agencies requiring Azure | ~$77-169/agency | Azure managed services. Higher cost, US CLOUD Act trade-off. |
+
+See the `/deployment-planning` skill for full tier descriptions and the cost source chain.
+
+## Key Principles
+
+- **Every agency's data is isolated.** Agencies never share a database, encryption key, or KoNote instance — even when sharing a VPS.
+- **OVHcloud is preferred** for cost and data sovereignty. Azure is supported but not the default.
+- **Cost figures live in `tasks/hosting-cost-comparison.md`** (primary source). All other cost docs derive from it via a documented source chain.
+
+## Architecture Decisions
+
+Major deployment decisions are recorded in Design Rationale Records (DRRs). Read these before proposing changes:
+
+- `tasks/design-rationale/ovhcloud-deployment.md` — hosting stack, self-healing, backups
+- `tasks/design-rationale/multi-tenancy.md` — schema-per-tenant isolation
+- `tasks/design-rationale/data-access-residency-policy.md` — data sovereignty, CLOUD Act
+- `tasks/design-rationale/self-hosted-llm-infrastructure.md` — AI hosting
+
+Use the `design-rationale` skill to check proposals against these DRRs.

--- a/docs/deployment-index.md
+++ b/docs/deployment-index.md
@@ -24,9 +24,9 @@ KoNote supports three deployment tiers. All maintain the same data isolation and
 
 | Tier | Who | Monthly Cost | Key Feature |
 |---|---|---|---|
-| **1. Self-hosted** | Agencies with technical capacity | ~$15/mo (VPS only) | Cheapest. Secure by default via built-in encryption. |
-| **2. Managed OVHcloud** (recommended) | Most agencies | ~$65-92/agency | LO manages infrastructure. Shared monitoring, isolated data. |
-| **3. Azure** | Agencies requiring Azure | ~$77-169/agency | Azure managed services. Higher cost, US CLOUD Act trade-off. |
+| **1. Self-hosted** | Agencies with technical capacity | ~$17/mo (VPS + Key Vault) | Cheapest. Secure by default via built-in encryption. |
+| **2. Managed OVHcloud** (recommended) | Most agencies | ~$67-94/agency | LO manages infrastructure. Shared monitoring, isolated data. |
+| **3. Azure** | Agencies requiring Azure | ~$77-171/agency | Azure managed services. Higher cost, US CLOUD Act trade-off. |
 
 See the `/deployment-planning` skill for full tier descriptions and the cost source chain.
 

--- a/docs/llm-deployment-guide.md
+++ b/docs/llm-deployment-guide.md
@@ -1,5 +1,8 @@
 # KoNote Deployment Guide — For AI Assistants
 
+> **Audience:** AI coding assistants (Claude Code). This guide is structured for automated execution, not human reading.
+> **For humans:** See [deploy-ovhcloud.md](deploy-ovhcloud.md) for the human-readable OVHcloud deployment guide.
+
 This guide is designed to be given to an AI coding assistant (Claude Code, Cursor, GitHub Copilot, etc.) so it can deploy KoNote on behalf of a nonprofit. It is structured as unambiguous, sequential instructions with exact commands and expected outputs.
 
 **For the full human-readable guide with explanations**, see [deploy-ovhcloud.md](deploy-ovhcloud.md).

--- a/tasks/deployment-protocol.md
+++ b/tasks/deployment-protocol.md
@@ -1,4 +1,4 @@
-# Agency Deployment Protocol — Azure
+# Agency Deployment Protocol
 
 **Purpose:** End-to-end process for deploying KoNote for a new client organisation on Azure. Covers discovery through go-live and follow-up.
 
@@ -33,7 +33,7 @@ Agency onboarding involves three distinct interviews, each with different staff 
 |-------|------|--------|-------------|----------|--------|
 | 0 | Discovery Call | Sara | Yes | 60 min | Discovery Worksheet |
 | 1 | Permissions Setup | Sara | Yes (2 sessions) | 2 × 45 min | Signed Configuration Summary |
-| 2 | Azure Infrastructure | Prince | No (needs client IT) | 2–4 hours | Running instance |
+| 2 | Infrastructure Setup | Prince | No (needs client IT) | 2–4 hours | Running instance |
 | 3 | Workflow Customisation | Sara | Yes | 60–90 min | Customisation Worksheet |
 | 4 | Go-Live Verification | Prince + Sara | Yes (walkthrough) | 60 min | Signed go-live confirmation |
 | 5 | 30-Day Check-In | Sara | Yes | 30 min | Updated config + action items |
@@ -233,19 +233,42 @@ After both sessions:
 
 ---
 
-## Phase 2: Azure Infrastructure Setup
+## Phase 2: Infrastructure Setup
 
-**Purpose:** Build the Azure environment and deploy KoNote using the signed Configuration Summary.
+**Purpose:** Provision hosting infrastructure and deploy KoNote using the signed Configuration Summary.
 
 **Who:** Prince (developer). May need the client's IT contact for Azure AD configuration.
 
-**Duration:** 2–4 hours
+**Duration:** 45 min – 4 hours (depends on platform)
+
+### Platform Choice
+
+The agency chooses their hosting platform during Phase 0 (Discovery). Phase 2 follows the appropriate path:
+
+| Platform | Guide | Typical Setup Time |
+|---|---|---|
+| **OVHcloud (recommended)** | [deploy-ovhcloud.md](../docs/deploy-ovhcloud.md) | 45-90 min |
+| **Azure** | [deploy-azure.md](../docs/archive/deploy-azure.md) | 1-2 hours |
+| **Self-hosted** | [deploying-konote.md](../docs/deploying-konote.md) | Varies |
+
+Regardless of platform, all instances use:
+- Per-agency Azure Key Vault (or OVHcloud KMS) for encryption key storage
+- Docker Compose stack (runs identically on any platform)
+- Caddy for automatic HTTPS
+
+For OVHcloud deployments, follow `docs/deploy-ovhcloud.md` — the 16-step guide covers VPS provisioning, Docker setup, and DNS configuration.
+
+---
+
+### Azure Path
+
+The remainder of this section documents the Azure-specific setup steps. For OVHcloud or self-hosted deployments, follow the platform guide linked above and skip to [Phase 3](#phase-3-workflow-customisation-interview).
 
 **Full technical guide:** [Deploy to Azure](../docs/deploying-konote.md#deploy-to-azure) (in deploying-konote.md)
 
 ---
 
-### Pre-Flight Checklist
+### Pre-Flight Checklist (Azure)
 
 Before touching Azure, confirm all inputs are ready:
 

--- a/tasks/deployment-protocol.md
+++ b/tasks/deployment-protocol.md
@@ -1,6 +1,6 @@
 # Agency Deployment Protocol
 
-**Purpose:** End-to-end process for deploying KoNote for a new client organisation on Azure. Covers discovery through go-live and follow-up.
+**Purpose:** End-to-end process for deploying KoNote for a new client organisation. Covers discovery through go-live and follow-up. Supports OVHcloud (recommended), Azure, or self-hosted deployment.
 
 **Team roles:**
 - **Sara** (PM) — leads client-facing sessions (Phases 0, 1, 3, 4 walkthrough, 5)

--- a/tasks/deployment-workflow-design.md
+++ b/tasks/deployment-workflow-design.md
@@ -1,3 +1,7 @@
+> **Status:** DRAFT — problem statement only, no implementation recommendations yet.
+> **Date:** 2026-02 (original). Not actively being worked on.
+> **Context:** This document scopes the deployment workflow problem (how nonprofits move from demo to production). The phases described here ("Assessment / Customisation / Production") are separate from the deployment protocol phases (0-5) which cover infrastructure setup and onboarding.
+
 # Task: Design the Nonprofit Deployment Workflow
 
 ## Context

--- a/tasks/design-rationale/README.md
+++ b/tasks/design-rationale/README.md
@@ -1,0 +1,94 @@
+# KoNote Design Rationale
+
+This directory contains the architectural decisions that govern KoNote's design. If you're new to the project, start with the **Foundation Principles** — they explain *why* KoNote works the way it does. Then consult the implementation decisions when you're modifying a specific feature.
+
+## How to Use This Directory
+
+1. **Before proposing a new feature:** Read the relevant foundation principle, then check the implementation decisions it references.
+2. **Before modifying existing code:** Find the implementation decision that governs that feature. If one exists, read it before changing anything.
+3. **If you think a decision should change:** Document the new evidence, flag for GK (subject-matter expert) review, and update the DRR *before* implementing.
+
+Use `/design-rationale` in Claude Code to automatically check a proposal against all DRRs.
+
+---
+
+## Foundation Principles
+
+These 4 documents capture KoNote's core design philosophy. **Read these first.**
+
+| Document | What it covers |
+|---|---|
+| [Collaborative Practice](foundation-collaborative-practice.md) | The "Ko" in KoNote — documentation WITH participants, two-lens notes, alliance rating, feedback-informed improvement, strengths-based language |
+| [Data Sovereignty & Rights](foundation-data-sovereignty.md) | Participant and community data ownership, OCAP principles, Black data governance, Canadian digital sovereignty, intentional absence of cross-agency data combination |
+| [Security by Default](foundation-security-by-default.md) | High security for non-technical operators — encryption, RBAC, immutable audit, fail-closed consent, session security |
+| [Nonprofit Sustainability](foundation-nonprofit-sustainability.md) | Minimal tech stack, affordable hosting, self-healing ops, evaluation-driven configuration, managed service model |
+
+---
+
+## Implementation Decisions by Topic
+
+These are detailed decisions with expert panel findings and anti-patterns. Grouped by the foundation principle they support.
+
+### Collaborative Practice
+
+| Document | Status | Scope | See also |
+|---|---|---|---|
+| [insights-metric-distributions.md](insights-metric-distributions.md) | Decided | Outcome Insights page, metric aggregation, suggestion themes | Sustainability |
+| [survey-metric-unification.md](survey-metric-unification.md) | Decided | Surveys and metrics as one construct | Sustainability |
+| [circles-family-entity.md](circles-family-entity.md) | Decided | Family/network entity, 6+ anti-patterns | |
+
+### Data Sovereignty & Privacy
+
+| Document | Status | Scope | See also |
+|---|---|---|---|
+| [data-access-residency-policy.md](data-access-residency-policy.md) | Decided | Canadian residency requirements by data access level | Security |
+| [no-live-api-individual-data.md](no-live-api-individual-data.md) | Decided | No live API for PII — export-only model | Security |
+| [phipa-consent-enforcement.md](phipa-consent-enforcement.md) | Decided | Cross-program clinical note consent filtering | Security, Collab |
+| [cids-privacy-architecture.md](cids-privacy-architecture.md) | Decided | Three-layer compliance for CIDS reporting | Sustainability |
+| [encryption-key-rotation.md](encryption-key-rotation.md) | Decided | Master/tenant key rotation procedures | Security |
+
+### Security & Access Control
+
+| Document | Status | Scope | See also |
+|---|---|---|---|
+| [access-tiers.md](access-tiers.md) | Decided | Three permission tiers, PERM-P5/P6/P8, demographic visibility | Sovereignty |
+| [ai-feature-toggles.md](ai-feature-toggles.md) | Decided | Two-tier AI split (tools-only vs. participant data) | Sovereignty, Sustainability |
+
+### Evaluation & Reporting
+
+| Document | Status | Scope | See also |
+|---|---|---|---|
+| [reporting-architecture.md](reporting-architecture.md) | Decided | Template-driven vs. ad-hoc reporting | Sovereignty |
+| [funder-reporting-profiles.md](funder-reporting-profiles.md) | Parking Lot | Template-based funder reporting configuration | |
+| [executive-dashboard-redesign.md](executive-dashboard-redesign.md) | Approved | Dashboard UX with accessibility focus | Collab |
+| [cids-batch-classification-workflow.md](cids-batch-classification-workflow.md) | Draft | Batch AI classification for reporting taxonomies | |
+| [cids-metadata-assignment.md](cids-metadata-assignment.md) | Draft | When metadata gets assigned (creation vs. deferred) | |
+
+### Infrastructure & Deployment
+
+| Document | Status | Scope | See also |
+|---|---|---|---|
+| [ovhcloud-deployment.md](ovhcloud-deployment.md) | Decided | OVHcloud VPS architecture, self-healing, backup | Sovereignty |
+| [self-hosted-llm-infrastructure.md](self-hosted-llm-infrastructure.md) | Decided | Shared Ollama VPS, data isolation model | Sovereignty |
+| [multi-tenancy.md](multi-tenancy.md) | Decided | Schema-per-tenant via django-tenants | Sovereignty, Sustainability |
+
+### Interoperability & Integration
+
+| Document | Status | Scope | See also |
+|---|---|---|---|
+| [fhir-informed-modelling.md](fhir-informed-modelling.md) | Decided | FHIR concepts without FHIR compliance | |
+| [bilingual-requirements.md](bilingual-requirements.md) | Decided | EN/FR translation, legal obligations | Collab, Sustainability |
+| [document-integration.md](document-integration.md) | Decided | SharePoint + Google Drive integration | |
+| [offline-field-collection.md](offline-field-collection.md) | Decided | ODK Central for offline field collection | |
+
+---
+
+## Status Key
+
+| Status | Meaning |
+|---|---|
+| **Decided** | Approved and enforced. Do not override without stakeholder approval. |
+| **Implemented** | Decided AND built. Check implementation before modifying. |
+| **Approved** | Reviewed by expert panel, awaiting implementation. |
+| **Draft** | Under development. Decisions may change — still read before building. |
+| **Parking Lot** | Not yet clear we should build. Do not implement without explicit approval. |

--- a/tasks/design-rationale/foundation-collaborative-practice.md
+++ b/tasks/design-rationale/foundation-collaborative-practice.md
@@ -5,6 +5,8 @@
 Status: Foundation Principle
 Created: 2026-03-14
 
+> **In plain language:** KoNote is designed so that staff and participants write notes together, not separately. The participant's voice — their words, their feedback, their rating of the relationship — is a core part of every note, not an afterthought. The name itself means "collaborative note" and works in both English and French.
+
 ---
 
 ## Core Principle
@@ -84,6 +86,26 @@ KoNote is designed to make these practices the path of least resistance, not an 
 
 **Anti-pattern:** Hardcoded clinical terminology that assumes every agency uses the same words. The terminology system exists because collaborative practice means respecting how each community describes its own relationships.
 
+### 8. Bilingual by Design
+
+**What:** KoNote is fully bilingual in English and French — not as a localisation add-on, but as a structural design constraint. The name itself is bilingual: "Note" is the same word in both languages, and "Ko-" reads as a stylised prefix for "co-" (*collaboration, coopération, collectif*) — a prefix that carries the same meaning in both English and French. French speakers parse "KoNote" as *co-note* = collaborative notes. In English, the exact same logic applies. There is also a subtle echo of the French verb *connoter* (to connote), suggesting depth, context, and significance beyond surface-level documentation — a fitting resonance for social services where notes carry real weight.
+
+Every template, every label, every system message exists in both languages. The translation pipeline (`translate_strings`) is part of the development workflow, not an afterthought. Translation is exempt from AI feature toggles because it is a legal requirement, not an optional feature.
+
+**Why:** The Official Languages Act and many federal/provincial funding agreements require bilingual service delivery. For agencies serving francophone communities in Ontario, Quebec, or New Brunswick, a system that only works in English is not usable. But beyond legal compliance, bilingual design is an expression of collaborative practice — if the system can't speak the participant's language, it cannot be truly collaborative.
+
+**Anti-pattern:** Treating French as a translation layer applied after the English version is complete. In KoNote, both languages are first-class — new features are not considered complete until both language versions exist. See `bilingual-requirements.md` for the detailed implementation decisions.
+
+### 9. Accessible by Design
+
+**What:** KoNote targets WCAG 2.2 AA compliance: semantic HTML, sufficient colour contrast, keyboard navigation, screen reader compatibility, and alt text for meaningful images. Accessibility is not a separate checklist applied after development — it is a constraint on every template and component from the start.
+
+**Why:** Collaborative documentation only works if all participants can use the system. A participant who uses a screen reader, has low vision, or has motor impairments must be able to navigate the portal, read their goals, rate the alliance, and write journal entries. If the portal is inaccessible, that participant is excluded from the "Ko" in KoNote — the collaboration becomes staff-only by default, which contradicts the foundational principle.
+
+Many nonprofit participants have accessibility needs — people with disabilities are disproportionately represented in social services. Designing for accessibility is not an edge case; it is designing for the actual user base.
+
+**Anti-pattern:** Treating accessibility as a post-launch polish item or a compliance checkbox. If a portal feature is built without keyboard navigation, a screen reader user discovers a broken experience — and the "fix it later" approach means they're excluded for however long "later" takes.
+
 ---
 
 ## Anti-Patterns Summary
@@ -97,6 +119,16 @@ KoNote is designed to make these practices the path of least resistance, not an 
 | Annual feedback surveys | Too infrequent; low response rates; feedback loop too slow to drive real improvement |
 | Deficit-focused clinical language | Pathologises participants; contradicts strengths-based practice; harmful when participants read their own records |
 | Hardcoded terminology | Not every community uses clinical language; forced terminology is a barrier to adoption |
+| French as a translation afterthought | Bilingual design is a legal requirement and a collaborative principle, not a localisation layer |
+| Accessibility as post-launch polish | Excluding participants with disabilities contradicts collaborative practice |
+
+---
+
+## Connections to Other Foundations
+
+- **Data Sovereignty**: Bilingual design supports francophone communities' right to services in their language. Accessible design ensures no participant is excluded from data access rights.
+- **Security by Default**: Accessibility constraints (semantic HTML, no reliance on colour alone) also improve security posture by reducing attack surface from custom UI workarounds.
+- **Nonprofit Sustainability**: Bilingual compliance is a legal prerequisite for federal funding — agencies that can't demonstrate it lose funding eligibility. See `bilingual-requirements.md`.
 
 ---
 
@@ -107,6 +139,7 @@ These existing Design Rationale Records contain the detailed implementation spec
 - **`insights-metric-distributions.md`** — How suggestion themes and outcome distributions are aggregated for program learning. Includes the "service-framing, not person-labelling" principle for dashboard language.
 - **`survey-metric-unification.md`** — Surveys and metrics as a unified construct, enabling participant self-report and staff observation to be captured through the same measurement infrastructure.
 - **`circles-family-entity.md`** — Family and network entity design, extending collaborative practice beyond the individual to recognise that participants exist in relational contexts.
+- **`bilingual-requirements.md`** — EN/FR translation pipeline, legal obligations, and tooling for bilingual-by-design development.
 
 ---
 

--- a/tasks/design-rationale/foundation-collaborative-practice.md
+++ b/tasks/design-rationale/foundation-collaborative-practice.md
@@ -1,0 +1,121 @@
+# Foundation: Collaborative Practice
+
+**The "Ko" in KoNote**
+
+Status: Foundation Principle
+Created: 2026-03-14
+
+---
+
+## Core Principle
+
+KoNote means "collaborative note" — the name works in both English and French (*co-note / ko-note*). The application is built on the principle that progress notes are part of the service, not administrative overhead. Documentation happens WITH the participant, not ABOUT them.
+
+This is the single most important design decision in the system. Every other feature — the portal, the goal builder, the alliance rating, the suggestion pipeline, the strengths-based language — exists to support this principle. If a proposed feature makes documentation feel like something staff do alone at their desk after a session, it is working against the grain of the system. If it brings the participant closer to the documentation process, it is aligned.
+
+## Why This Matters
+
+The research basis for collaborative practice is strong across helping professions:
+
+- **Feedback-Informed Treatment (FIT)** shows a 65% improvement in outcomes for at-risk clients when routine feedback is integrated into service delivery (Lambert & Shimokawa, 2011).
+- **Collaborative documentation** is rated helpful by 82% of clients in behavioural health settings, and reduces staff documentation time by shifting note-taking into the session itself (Stanhope et al., 2013).
+- **Routine Outcome Monitoring (ROM)** produces approximately 8% improvement in outcomes when feedback is collected and reviewed regularly (Gondek et al., 2016).
+- **Therapeutic alliance** — the working relationship between participant and worker — is the strongest predictor of outcomes across counselling, case management, and social services. Participant-reported alliance predicts outcomes better than clinician-reported alliance (Horvath et al., 2011).
+
+KoNote is designed to make these practices the path of least resistance, not an add-on that requires extra effort.
+
+---
+
+## How This Principle Shapes the System
+
+### 1. Two-Lens Note Design
+
+**What:** Every progress note has two sides — "Their Perspective" (participant voice: reflection, suggestion, alliance rating) and "Your Observations" (staff: engagement level, clinical notes, follow-up items). The note form presents both lenses as equal structural components.
+
+**Why:** A note that only captures what the worker observed is a clinical record. A note that also captures what the participant experienced is a collaborative record. The two-lens structure makes the participant's voice a first-class part of documentation, not a comment box at the bottom.
+
+**Anti-pattern:** Notes that are staff-only clinical documentation written after the session. The participant's voice is not optional decoration — it is structural. A note without "Their Perspective" is incomplete by design, and the system signals this visually.
+
+### 2. Alliance Rating
+
+**What:** The participant self-rates the working relationship on a 1–5 scale using plain-language anchors (e.g., "I really trust my worker" at the high end). Prompt wording rotates to prevent habituation. The rating can happen in-session (staff records what the participant says) or asynchronously via the portal (participant fills it in within 7 days of the session).
+
+**Why:** The alliance between participant and worker is the strongest single predictor of outcomes. Measuring it routinely — and from the participant's perspective — gives programs a real-time signal about service quality that no administrative metric can provide. A sudden drop in alliance ratings across a caseload is an early warning system.
+
+**Anti-pattern:** Alliance measured only by staff observation or clinical judgment. The research is clear: participant-reported alliance predicts outcomes better than clinician-reported alliance. Staff perception of "how it went" is valuable but is not a substitute for asking the participant directly.
+
+### 3. Participant Portal
+
+**What:** Participants can log into their own portal to view their goals (in their own words), see progress over time, write journal entries, send messages to their worker, rate the alliance, request corrections to their record, and flag items to discuss at the next session.
+
+**Why:** If participants can only see what staff wrote about them, the portal is surveillance. If participants can act on their own information — reflect, respond, prepare for sessions, flag concerns — the portal is a tool for shared ownership of the service relationship.
+
+**Anti-pattern:** A portal that is a read-only view of what staff wrote. The portal is designed for participant ACTION: journaling, messaging, preparing for sessions, rating the relationship, requesting corrections. Every portal feature should pass the test: "Does this give the participant something meaningful to do?"
+
+### 4. Goal Builder
+
+**What:** An AI-assisted conversational goal-setting tool that captures the participant's own words alongside professional outcome language. Every goal stores both `client_goal` (the participant's phrasing, encrypted) and structured outcome metrics (scale definitions, target values, measurement frequency). The participant sees their own words in the portal; the structured metrics drive reporting.
+
+**Why:** Goals defined entirely in clinical or funder language ("Increase self-efficacy score from 2.3 to 3.5 on the GSE-10") are meaningless to the participant. Goals in the participant's own words ("I want to feel confident enough to go to a job interview") are meaningful but hard to measure. KoNote stores both, so the participant sees language they recognise and the program has data it can aggregate.
+
+**Anti-pattern:** Goals defined entirely by staff using clinical language, where the participant's own words are absent or treated as informal context. The participant's phrasing is not a nice-to-have — it is displayed back to them in the portal and is a core part of the collaborative relationship.
+
+### 5. Feedback-Informed Continuous Improvement
+
+**What:** Every progress note includes an optional field for participant suggestions — "Is there anything you'd change about the program or how we work together?" — with a priority level. Suggestions are AI-categorised into themes (SuggestionTheme). Themes are aggregated and surfaced on the executive dashboard so program managers and directors can see patterns across the entire agency.
+
+**Why:** Annual satisfaction surveys are the standard approach to participant feedback in nonprofits. They suffer from low response rates, recall bias, and a feedback loop so slow that problems persist for a full program cycle before anyone notices. By embedding feedback collection in every session, KoNote makes participant voice a continuous signal, not an annual event. Theme aggregation means individual suggestions become actionable program intelligence.
+
+**Anti-pattern:** Participant feedback collected through annual surveys that are summarised in a report nobody reads until the next funding cycle. KoNote makes feedback structural and continuous — every session is an opportunity for the participant to shape the program.
+
+### 6. Strengths-Based Language
+
+**What:** All system language — progress descriptors, alliance anchors, engagement levels, dashboard labels — uses growth-oriented framing. Progress bands use language like "Something's shifting" and "In a good place" rather than deficit labels. Alliance anchors use relational language ("I really trust my worker") not clinical pathology. Engagement observations include "Fully invested" as the highest level, not "Compliant."
+
+**Why:** Language shapes perception. When staff document in deficit-focused language ("client is non-compliant," "resistant to treatment," "low functioning"), it frames the participant as the problem. Strengths-based language frames the documentation as a record of growth and capacity. This is not cosmetic — it changes how staff think about the people they serve and how participants feel when they read their own records through the portal.
+
+**Anti-pattern:** Clinical deficit-focused documentation that pathologises participants. Terms like "non-compliant," "resistant," "low-functioning," and "at-risk" frame participants as deficient. KoNote's language consistently frames data as information about whether the service is working, not whether the person is succeeding or failing. (See also: `insights-metric-distributions.md`, Principle 6 — "Service-framing, not person-labelling.")
+
+### 7. Customisable Terminology
+
+**What:** Agencies choose their own language for core concepts — client/participant/member, worker/counsellor/coach, plan/goal/pathway. All templates use `{{ term.client }}` rather than hardcoded words. Terminology is set once in admin settings and applied system-wide.
+
+**Why:** "Client" is standard in some sectors, alienating in others. A youth drop-in centre may use "member." A counselling agency may use "client." An Indigenous healing program may use "participant" or a word in their own language. Forcing clinical terminology on communities that don't use it creates a barrier to adoption and contradicts the collaborative ethos — if the system doesn't speak the community's language, it isn't truly collaborative.
+
+**Anti-pattern:** Hardcoded clinical terminology that assumes every agency uses the same words. The terminology system exists because collaborative practice means respecting how each community describes its own relationships.
+
+---
+
+## Anti-Patterns Summary
+
+| Anti-pattern | Why it's rejected |
+|---|---|
+| Notes written ABOUT participants after sessions | Undermines the alliance; excludes the participant from their own record |
+| Staff-only alliance assessment | Participant self-report is a stronger outcome predictor than clinician judgment |
+| Portal as a read-only view of staff notes | Participants need to ACT on their information, not passively receive it |
+| Goals defined in clinical language only | Participant's own words reinforce shared ownership; clinical-only goals are meaningless to the person |
+| Annual feedback surveys | Too infrequent; low response rates; feedback loop too slow to drive real improvement |
+| Deficit-focused clinical language | Pathologises participants; contradicts strengths-based practice; harmful when participants read their own records |
+| Hardcoded terminology | Not every community uses clinical language; forced terminology is a barrier to adoption |
+
+---
+
+## Related Implementation Decisions
+
+These existing Design Rationale Records contain the detailed implementation specifics for features shaped by this principle:
+
+- **`insights-metric-distributions.md`** — How suggestion themes and outcome distributions are aggregated for program learning. Includes the "service-framing, not person-labelling" principle for dashboard language.
+- **`survey-metric-unification.md`** — Surveys and metrics as a unified construct, enabling participant self-report and staff observation to be captured through the same measurement infrastructure.
+- **`circles-family-entity.md`** — Family and network entity design, extending collaborative practice beyond the individual to recognise that participants exist in relational contexts.
+
+---
+
+## When to Revisit
+
+This foundation principle should be revisited if:
+
+- Research emerges showing that collaborative documentation produces worse outcomes than traditional staff-only notes.
+- Participant engagement features (portal, alliance rating, suggestion capture) create significant adoption barriers that prevent agencies from using the system at all.
+- Privacy regulations change in ways that make participant access to their own records legally problematic (currently, privacy law favours participant access).
+
+Current evidence strongly favours collaborative approaches. The principle is load-bearing — changing it would require redesigning most of the application's core features.

--- a/tasks/design-rationale/foundation-data-sovereignty.md
+++ b/tasks/design-rationale/foundation-data-sovereignty.md
@@ -1,0 +1,154 @@
+# Foundation: Data Sovereignty & Rights
+
+**Individual, Community, and National Data Ownership**
+
+Status: Foundation Principle
+Created: 2026-03-14
+
+> **In plain language:** Your data belongs to you — not to KoNote, not to a tech company, and not to a foreign government. The system is built so that communities control their own data, individuals can see and correct their own records, and no one can combine data across agencies without explicit community consent.
+
+---
+
+## Core Principle
+
+KoNote is designed so that data belongs to the people and communities it describes — not to KoNote, not to a hosting provider, and not to any government with a subpoena power that overrides Canadian law. This principle operates at three levels: individual participants own their personal information, communities own their collective data, and Canadian nonprofits retain sovereignty over where their data resides and who can access it.
+
+The architecture enforces these principles structurally — not through policies that can be ignored, but through technical design that makes violation impossible. Schema-per-tenant isolation means cross-agency queries cannot happen, not that they are merely forbidden. Export-only data portability means no persistent external access channel exists, not that one exists but is discouraged. Self-hosted AI means participant data never leaves Canadian infrastructure, not that it leaves but is "anonymised first." The gap between "we promise not to" and "we built it so you can't" is where trust lives.
+
+---
+
+## Individual Participant Rights
+
+### 1. Correction Rights (PHIPA/PIPEDA)
+
+Participants can request corrections to their records through the portal. The `CorrectionRequest` model supports both informal paths ("I'll bring it up next session") and formal written requests. Staff must respond within the regulatory timeline. Corrections are appended — the original record is preserved with an amendment notation, not silently overwritten. This protects both the participant's right to accuracy and the clinical record's integrity.
+
+### 2. Data Access
+
+PIPEDA gives Canadians the right to see what information is held about them. The participant portal makes this self-service — participants view their own goals, notes, and progress without making a formal access request. This is not a convenience feature. It is a structural implementation of a legal right. The alternative — requiring participants to submit formal requests and wait 30 days — creates a power asymmetry that discourages people from exercising their rights.
+
+### 3. Erasure Workflow
+
+Erasure uses a two-person process: a Program Manager requests it, an admin approves it. PII is stripped and the anonymised record is retained for aggregate statistics. The process is irreversible by design — this prevents accidental or coerced reversal. Once erasure is approved, no one (including KoNote developers, hosting administrators, or the agency itself) can reconstruct the individual's identity from remaining data. The two-person requirement prevents a single compromised or pressured account from erasing records to cover up harm.
+
+### 4. Consent as Ongoing
+
+The `ConsentEvent` model is append-only: it records grant and withdraw events with reasons and timestamps. Consent is never a single checkbox at intake that covers everything forever. Cross-program sharing is per-client configurable. Consent to aggregate reporting is explicit opt-in.
+
+**Anti-pattern: one-time blanket consent at intake.** Many systems collect a single signature at enrollment and treat it as permanent, irrevocable permission for all data uses. This violates the spirit of PIPEDA's meaningful consent requirement. KoNote treats consent as a living state that participants can change at any time, with each change recorded and enforced structurally through the PHIPA consent filtering layer.
+
+---
+
+## Community Data Sovereignty
+
+This is where KoNote's design philosophy diverges most sharply from conventional SaaS platforms. Data about communities has historically been extracted, combined, and used in ways those communities never consented to and often cannot see. KoNote's architecture is built to make that pattern structurally impossible.
+
+### 1. OCAP Principles (First Nations)
+
+The First Nations principles of **Ownership, Control, Access, and Possession** (OCAP) are the most developed framework for Indigenous data sovereignty. KoNote's architecture supports OCAP through:
+
+- **Ownership**: Each agency or community owns its data in an isolated schema. KoNote (the software) has no claim on the data. The licensing model is designed to ensure that data belongs to the agency, not to KoNote or its developers — this principle should be formalised in every service agreement.
+- **Control**: Communities control what data is collected (custom fields, configurable demographics), who sees it (role-based access with granular permissions), and whether it is shared (export-only — no live API, no automatic reporting to external bodies).
+- **Access**: The community has full access through the admin interface and export functions. Data portability is a right, not a premium feature. Full agency export is available to every agency regardless of pricing tier.
+- **Possession**: Schema-per-tenant means the community's data is physically separated at the database level. No cross-agency queries are possible — not restricted by policy, but prevented by architecture. Data stays in Canadian data centres (OVHcloud Beauharnois, QC).
+
+**Anti-pattern: multi-agency data lakes where community data is combined with other agencies' data without community control.** Many platforms aggregate data across clients into a single database, then offer "insights" that the contributing communities cannot review, correct, or withdraw from. This directly violates OCAP's ownership and control principles.
+
+### 2. Black Data Governance (EGAP)
+
+The **EGAP Framework** — **Engagement, Governance, Access, and Protection** — is the Black community equivalent of OCAP. Where OCAP centres First Nations data sovereignty, EGAP addresses the specific harms that data collection has inflicted on Black communities: surveillance, profiling, deficit narratives, and systemic exclusion. Alongside EGAP, related frameworks (the Black Health Alliance's position papers, the Us/We approach) emphasise that data about Black communities has historically been used to justify funding cuts, target neighbourhoods for policing, and reinforce deficit narratives rather than support empowerment.
+
+KoNote's architecture supports EGAP through:
+
+- **Engagement**: Community-controlled demographic fields are optional and self-identified. Agencies configure their own intake forms and choose which demographic categories to collect. No external body dictates what identity data must be gathered — the community decides what's relevant to their services and their people.
+- **Governance**: Agency-level settings, RBAC with program-scoped access, and feature toggles give the community control over how their data is used internally. No data leaves the instance without deliberate community action. Aggregate reporting requires explicit opt-in (`consent_to_aggregate_reporting`), not opt-out.
+- **Access**: Full export capability ensures the community can retrieve all their data at any time. The participant portal provides individual-level access. Admin dashboards provide community-level visibility. Data portability is a right, not a premium feature.
+- **Protection**: Mandatory small-cell suppression (k>=5) prevents re-identification in small populations. All PII is encrypted at rest with per-tenant keys. No cross-agency data combination is possible. The export-only model means no external system can pull data without deliberate community action.
+
+**Anti-pattern: automatic demographic disaggregation that exposes small community populations.** A report showing "2 Black youth in Program X had declining outcomes" identifies those individuals to anyone familiar with the program. KoNote's small-cell suppression is mandatory, not optional — it cannot be overridden by staff, administrators, or funders.
+
+### 3. The Intentional Absence of Multi-Agency Combination
+
+KoNote deliberately does NOT combine individual-level data across agencies. This is not a missing feature — it is a design principle. Cross-agency data combination:
+
+- **Violates OCAP** — the community loses control of how their data is used once it enters a combined dataset
+- **Enables surveillance patterns** — tracking individuals across service touchpoints creates a profile that no single agency intended to build
+- **Undermines trust** — participants consented to share information with their agency, not to be tracked across every service they access
+- **Concentrates power** — whoever controls the combined dataset has analytical power over all participating communities, with none of the accountability
+
+**What IS permitted:** agencies can voluntarily publish de-identified aggregate reports to a consortium or funder. These are one-way, community-initiated, and contain no individual records. The `PublishedReport` model enforces this boundary. An agency can share "we served 45 youth and 78% showed improvement" without sharing who those youth are or any details that could identify them.
+
+---
+
+## Canadian Digital Sovereignty
+
+### 1. Independence from US Tech Giants
+
+KoNote uses OVHcloud (French parent company, not subject to US CLOUD Act), self-hosted Ollama for AI processing of participant data (not OpenAI/Anthropic APIs), and open-source software throughout the stack. This is not anti-American sentiment — it is a legal risk calculation. The US CLOUD Act allows US courts to compel any US-incorporated company, or any US person, to produce data regardless of where it is stored. Hosting participant data on AWS, Azure, or Google Cloud means a US court can order its disclosure without Canadian judicial oversight.
+
+**Anti-pattern: building on AWS/Azure/Google Cloud where a US government subpoena can compel data disclosure without Canadian judicial review.** The risk is not theoretical — US law enforcement regularly uses CLOUD Act powers, and the threshold for access is lower than Canadian courts require.
+
+### 2. Data Residency
+
+All participant data is hosted in Beauharnois, QC. The `data-access-residency-policy` DRR establishes the access tier framework for anyone with SSH, database, or encryption key access. The hosting choice is deliberate: OVHcloud's Beauharnois data centre is operated by a French-incorporated company with no US subsidiary that could be compelled under the CLOUD Act.
+
+### 3. No Vendor Lock-In
+
+Docker Compose deployment works on any Linux VPS. Django and PostgreSQL are open-source. An agency can move to a different hosting provider by copying files and restoring a database backup. The full agency export produces a self-contained encrypted archive that includes everything needed to reconstruct the instance.
+
+**Anti-pattern: proprietary platforms that hold data hostage when contracts end.** Many SaaS platforms make it technically difficult or contractually expensive to extract your own data. KoNote treats data portability as a right — the export function exists from day one, not as an afterthought when a client threatens to leave.
+
+### 4. AI Sovereignty
+
+Participant data never leaves the self-hosted LLM server (Ollama on the Canadian VPS). The `ai-feature-toggles` DRR enforces a strict split: Tier 1 (operational AI touching participant content) runs self-hosted; Tier 2 (tools-only AI processing program metadata, no PII) may use cloud APIs; Tier 3 (evaluation) is external and non-PII only. Agencies with heightened sovereignty concerns can disable cloud AI tiers entirely.
+
+**Anti-pattern: sending participant data to cloud AI APIs for "AI-powered insights."** Once participant data reaches an external LLM provider's servers, it is subject to that provider's jurisdiction, retention policies, and training practices — regardless of what their terms of service promise today.
+
+---
+
+## Anti-Patterns Summary
+
+| Anti-pattern | Why it is rejected |
+|---|---|
+| Multi-agency data lake | Violates OCAP; enables surveillance; concentrates power |
+| Live API for individual PII | Persistent attack surface; bypasses consent model |
+| Hosting on US cloud (AWS/Azure/GCP) | US CLOUD Act subpoena risk without Canadian judicial oversight |
+| Blanket one-time consent | Consent must be ongoing, specific, and revocable |
+| Automatic demographic disaggregation | Small-cell exposure; re-identification risk for marginalised communities |
+| Proprietary platform lock-in | Community loses ability to leave with their data |
+| Cloud AI APIs for participant data | Data leaves Canadian jurisdiction; sovereignty lost |
+
+---
+
+## Connections to Other Foundations
+
+- **Collaborative Practice**: The participant portal (data access rights) is also a collaborative tool. Consent as ongoing aligns with the two-lens note design — participants are partners, not subjects. Bilingual design supports francophone communities' sovereignty over their service experience.
+- **Security by Default**: Encryption, RBAC, and fail-closed consent are the *enforcement mechanisms* for the sovereignty principles described here. Security is the "how"; sovereignty is the "why."
+- **Nonprofit Sustainability**: Multi-tenancy for cost sharing is also schema isolation for data sovereignty. The same architecture serves both purposes — affordable AND sovereign.
+
+---
+
+## Related Implementation Decisions
+
+These DRRs implement specific aspects of the principles described above:
+
+- `data-access-residency-policy.md` — Access tiers by data sensitivity level
+- `no-live-api-individual-data.md` — Export-only model, no live API for individual PII
+- `phipa-consent-enforcement.md` — Cross-program consent filtering
+- `cids-privacy-architecture.md` — Three-layer compliance for cross-agency aggregate reporting
+- `multi-tenancy.md` — Schema-per-tenant isolation
+- `encryption-key-rotation.md` — Per-tenant encryption keys
+- `self-hosted-llm-infrastructure.md` — Self-hosted AI for data sovereignty
+- `ovhcloud-deployment.md` — Canadian hosting architecture
+- `ai-feature-toggles.md` — Three-tier AI split (self-hosted vs. cloud)
+- `access-tiers.md` — RBAC and demographic visibility controls
+
+---
+
+## When to Revisit
+
+If Canada adopts legislation equivalent to EU GDPR adequacy agreements that provide enforceable protections against foreign government access, the US cloud restriction could be relaxed — but only if the legal protection is structural (treaty-level), not merely contractual (terms of service).
+
+If Indigenous communities develop specific data governance standards for nonprofit service software beyond OCAP, incorporate them. If Black data governance frameworks produce concrete technical requirements, implement them.
+
+The principles themselves — community ownership, individual rights, structural enforcement over policy promises — should not change. These are not implementation choices that might be superseded by better technology. They are values that the architecture exists to serve.

--- a/tasks/design-rationale/foundation-nonprofit-sustainability.md
+++ b/tasks/design-rationale/foundation-nonprofit-sustainability.md
@@ -1,0 +1,181 @@
+# Foundation: Nonprofit Sustainability
+
+**Affordable, Simple, and Evaluation-Ready**
+
+Status: Foundation Principle
+Created: 2026-03-14
+
+> **In plain language:** KoNote is designed to be affordable for small nonprofits and simple enough to run without a dedicated IT team. It uses a deliberately simple tech stack, heals itself when things go wrong, and is built so that the data you collect actually feeds evaluation, reporting, and sector-wide learning — not just a filing cabinet.
+
+---
+
+## Core Principle
+
+KoNote exists because nonprofits doing critical community work shouldn't need enterprise budgets or dedicated IT teams to track outcomes effectively. Every architectural choice — from the tech stack to the hosting model to the deployment automation — is made with a cost-conscious, non-technical operator in mind. The system must be cheap enough that a small agency can afford it, simple enough that it can be maintained by a generalist, and evaluation-ready so that the data collected actually improves programs and satisfies funders.
+
+This principle is not about austerity — it is about fitness for context. Nonprofits operate with constrained budgets, high staff turnover, and limited technical capacity. A system that requires a dedicated DevOps engineer, a JavaScript build pipeline, or $500/month in cloud hosting is not a viable tool for a 5-person agency running employment programs. KoNote's architecture treats these constraints as design requirements, not limitations to work around later.
+
+---
+
+## Minimal Tech Stack
+
+### 1. No JavaScript Frameworks
+
+Django server-rendered templates + HTMX + Pico CSS. No React, Vue, webpack, npm, or Node.js. The frontend is HTML that Django renders and HTMX makes interactive. This means: no JavaScript build pipeline, no node_modules (0 bytes vs 300+ MB), no transpilation, no bundling.
+
+**Why:** Every added build tool is a maintenance burden. React introduces 100+ transitive dependencies. Each dependency is a potential security vulnerability and a point of failure during upgrades. Nonprofits don't need a SPA — they need forms that work.
+
+**Anti-pattern:** "Let's use React for a richer UI." The marginal UX improvement doesn't justify the 10x increase in build complexity, dependency surface, and required expertise.
+
+### 2. 46 Dependencies Total
+
+The entire production stack is 46 Python packages. Compare to a typical Django + React project: 500+. Fewer dependencies = faster builds, simpler security scanning, fewer upgrade conflicts. Every dependency must justify its presence — there is no "add it now, evaluate it later."
+
+### 3. Alpine-Based Containers
+
+All Docker images use Alpine Linux (5-20 MB vs 300+ MB for Debian/Ubuntu). The ops sidecar (Dockerfile.ops) is 21 MB. Builds take seconds, not minutes. Smaller images mean faster deployments, less disk usage, and a smaller attack surface.
+
+### 4. Configuration Over Code
+
+~60 environment variables control deployment. Feature toggles (demo mode, auth mode, AI provider) work without code changes. `.env.example` is the documentation. An agency can switch from local auth to Azure SSO, enable or disable AI features, or change their terminology — all by editing environment variables. No code deployments required for configuration changes.
+
+---
+
+## Cost-Conscious Hosting
+
+### 1. OVHcloud Over Azure
+
+Single-tenant hosting costs ~$26 CAD/month on OVHcloud vs ~$132/month on Azure. Multi-tenant at 10 agencies: ~$13/agency/month vs ~$46/agency/month. OVHcloud is 60-70% cheaper because it's unmanaged VPS — the self-healing automation (described below) makes this safe. *(These figures are illustrative — for current pricing, see `tasks/hosting-cost-comparison.md`.)*
+
+**Why not Azure/AWS by default?** Managed cloud services are priced for organisations that value convenience over cost. Nonprofits value cost over convenience. An unmanaged VPS with good automation is cheaper AND more transparent — you can see exactly what's running and why.
+
+### 2. Multi-Tenancy for Cost Sharing
+
+Schema-per-tenant (django-tenants) lets multiple agencies share one server without sharing data. PostgreSQL enforces isolation at the schema level. One VPS serves 1-100 agencies. Cost per agency drops as more join. No agency can see another's data, but they share compute, storage, and operational overhead.
+
+### 3. Shared AI Server
+
+One OVHcloud VPS (~$40 CAD/month) running Ollama serves all agencies. Qwen3.5-35B (MoE, only 3B active parameters per token) handles nightly theme processing. Cost per agency at 10 agencies: ~$4/month vs $27-68/month per-agency with cloud APIs. *(For current model selection and costs, see `tasks/hosting-cost-comparison.md`.)*
+
+**Anti-pattern:** Per-agency AI deployment. At $400/month per agency for a dedicated LLM instance, AI features become inaccessible to small organisations. Shared infrastructure with tenant-level data isolation makes AI affordable for everyone.
+
+---
+
+## Self-Healing Operations
+
+Nonprofits can't afford 24/7 ops staff. The system heals itself:
+
+| Layer | Mechanism | Recovery Time |
+|---|---|---|
+| 1 | Docker restart policies + autoheal container | 30-90 seconds |
+| 2 | UptimeRobot -> OVHcloud API webhook -> VPS reboot | 15-20 minutes |
+| 3 | Ops sidecar cron (backups, disk monitoring, health reports) | Prevention |
+| 4 | Email alerts to KoNote team | Escalation |
+
+Operational burden: ~1-5 hours/month per agency (mostly reviewing reports), down from 10-15 hours without automation. The deploy script (`deploy.sh`) handles git pull, container rebuild, health checks, and migration failure detection in one command.
+
+**Anti-pattern:** Requiring a sysadmin on-call. Nonprofits don't have one. The system must recover from common failures without human intervention.
+
+---
+
+## Managed Service Model
+
+KoNote can be deployed in three models, each appropriate for different organisational capacities:
+
+- **Self-managed**: Agency runs their own VPS. Docker Compose deployment, no vendor lock-in. Requires some technical comfort but no dedicated IT staff — the automation handles the hard parts.
+- **Managed service**: A network or intermediary hosts multiple agencies. Published pricing at 10-agency scale: ~$15/agency/month (infrastructure) + support costs. The intermediary handles deployment and monitoring; agencies focus on service delivery.
+- **Consortium**: Multiple agencies share infrastructure and aggregate reporting. Each agency retains data sovereignty — they choose what to publish and what stays private. Shared infrastructure reduces costs; shared reporting increases sector learning.
+
+**Anti-pattern:** Pricing models that are affordable only at enterprise scale. KoNote must be affordable for a 5-person agency. If the cheapest option requires 50+ users to break even, small agencies are excluded by design.
+
+---
+
+## Built for Evaluation, Not Retrofitted
+
+The system is designed so that an initial evaluation assessment feeds directly into how KoNote is configured. Data collection is not an afterthought bolted onto case management — it is built into the structure of every interaction. This section connects directly to the collaborative practice foundation — the evaluation pipeline starts with collaborative goal-setting (see Foundation: Collaborative Practice) and ends with sector-wide learning.
+
+### 1. Evaluation Framework to Program Setup
+
+The EvaluationFramework model stores the program's theory of change, outcome chain, and risk analysis. This feeds which metrics are configured, what measurement schedule is used, and what reporting structure applies. Configuration follows from evaluation design, not the reverse.
+
+### 2. Metric Definitions with Full Metadata
+
+Each metric carries standardised instrument info (PHQ-9, GAD-7), scoring bands, directionality, CIDS alignment, IRIS+ codes, SDG goals. A metric is not just a number field — it is an evaluation instrument with provenance and rationale. When a funder asks "what are you measuring and why?", the answer is embedded in the metric definition itself.
+
+### 3. The Pipeline
+
+Evaluation assessment -> metric configuration -> daily data collection (progress notes with structured observations) -> automatic aggregation (insights, trends, suggestion themes) -> executive dashboards -> funder reports -> consortium publishing -> sector-wide learning.
+
+Each step feeds the next. Data collected in a progress note today appears in tonight's theme analysis, tomorrow's dashboard, and next quarter's funder report — without anyone re-entering it. In practice, this pipeline is iterative: metrics are refined after initial data collection, instruments may be replaced, and funder requirements change mid-grant. The architecture supports this through version-tracked metric definitions with append-only rationale logs.
+
+### 4. CIDS Alignment
+
+Metrics, programs, and demographics map to Common Approach (CIDS) taxonomy codes for sector-wide comparability. This matters at scale: when 50 agencies use KoNote and all map to CIDS, the sector can say "across Ontario, 68% of employment programs report positive outcomes for SDG 8." That's policy-level impact built from individual progress notes.
+
+Classification happens through admin-facing batch workflows, not during frontline note-taking. The worker writing a note should never need to know what CIDS code applies — that mapping is the evaluation lead's job, done once per metric. This division of labour is deliberate: frontline staff focus on the participant relationship; the evaluator (or evaluation lead) configures frameworks, selects instruments, and manages taxonomy alignment.
+
+**Anti-pattern:** Outcome tools that collect data but don't connect to evaluation methodology. Data without a theory of change is just noise. If a metric doesn't trace back to an outcome in the evaluation framework, it shouldn't exist. Equally: asking case workers to do taxonomy classification during a session is an anti-pattern — it burdens frontline staff with work that belongs to the evaluation function.
+
+---
+
+## Sector-Wide Learning
+
+KoNote contributes to the broader nonprofit sector through:
+
+- **CIDS exports**: Standardised data that can be compared across agencies using Common Approach codes. Agencies that use KoNote speak the same measurement language, even if their programs differ.
+- **Consortium reporting**: De-identified aggregate snapshots published voluntarily by each agency. No agency is forced to share — but the infrastructure makes sharing easy when they choose to.
+- **Funder reporting profiles**: Structured templates aligned to funder requirements (e.g., IRIS+, SDGs). Reporting is a configuration task, not a data entry task.
+- **Open source**: The software itself is a contribution. Other nonprofits can adopt, adapt, and improve it. No vendor lock-in, no proprietary data formats.
+
+**Anti-pattern:** Proprietary platforms where data format is vendor-locked and cross-agency comparison requires buying the same product. The sector learns faster when data is interoperable and tools are shared.
+
+---
+
+## Anti-Patterns Summary
+
+| Anti-pattern | Why it's rejected |
+|---|---|
+| React / JavaScript framework | 10x build complexity for marginal UX gain |
+| Enterprise cloud hosting (Azure/AWS default) | 3-5x cost; not necessary for this scale |
+| Per-agency AI deployment | $400/month vs $4/month shared |
+| 24/7 ops staff requirement | Nonprofits don't have one; automate instead |
+| Enterprise-only pricing | Small agencies excluded |
+| Outcome tools without evaluation methodology | Data without theory of change is noise |
+| Proprietary data formats | Vendor lock-in; sector can't learn from each other |
+
+---
+
+## Connections to Other Foundations
+
+- **Collaborative Practice**: The evaluation pipeline starts with collaborative goal-setting and ends with sector-wide learning. The minimal tech stack keeps the interface simple enough for participants to use alongside staff during sessions.
+- **Data Sovereignty**: Multi-tenancy serves both cost sharing AND data sovereignty — same architecture, dual purpose. The shared AI server maintains data isolation while making AI affordable.
+- **Security by Default**: Self-healing ops and Alpine containers reduce the attack surface. Fewer dependencies mean fewer security vulnerabilities to patch. The sustainability constraint ("no dedicated IT") forces security to be architectural.
+
+---
+
+## Related Implementation Decisions
+
+These existing Design Rationale Records contain the detailed implementation specifics for features shaped by this principle:
+
+- **`multi-tenancy.md`** — Schema-per-tenant architecture that enables cost sharing without data sharing.
+- **`ovhcloud-deployment.md`** — Self-healing deployment, backup strategy, and monitoring on unmanaged VPS.
+- **`self-hosted-llm-infrastructure.md`** — Shared Ollama server with tenant-level data isolation.
+- **`reporting-architecture.md`** — Template-driven reporting that connects evaluation frameworks to funder requirements.
+- **`cids-privacy-architecture.md`** — Three-layer compliance model for sector reporting without compromising participant privacy.
+- **`funder-reporting-profiles.md`** — Funder-specific report templates configured through admin workflows.
+- **`cids-batch-classification-workflow.md`** — Admin-facing taxonomy classification that keeps CIDS complexity away from frontline staff.
+- **`cids-metadata-assignment.md`** — When metadata gets assigned (creation vs. deferred), balancing data quality with workflow simplicity.
+- **`bilingual-requirements.md`** — EN/FR as a legal requirement, not an optional feature. Bilingual support is part of the sustainability commitment to Canadian nonprofits.
+
+---
+
+## When to Revisit
+
+This foundation principle should be revisited if:
+
+- Nonprofit sector IT capacity significantly increases (shared SOC services, managed hosting co-ops emerge), in which case some simplification choices could be relaxed.
+- The scale exceeds ~2,000 participants per agency, at which point the in-memory search (required by field-level encryption) needs re-architecture.
+- Managed cloud pricing drops to parity with unmanaged VPS, removing the cost advantage of self-hosting.
+- A JavaScript framework emerges that is genuinely zero-config, zero-dependency, and maintenance-free (this has not happened in 15 years of JavaScript frameworks).
+
+The principle — affordable for small agencies with minimal IT — should not change. The specific implementation choices (OVHcloud, Alpine, 46 dependencies) may evolve, but the constraints they serve are permanent features of the nonprofit sector.

--- a/tasks/design-rationale/foundation-security-by-default.md
+++ b/tasks/design-rationale/foundation-security-by-default.md
@@ -1,0 +1,150 @@
+# Foundation: Security by Default
+
+**High Security for Non-Technical Operators**
+
+Status: Foundation Principle
+Created: 2026-03-14
+
+> **In plain language:** KoNote is secure even if you don't have an IT team. Every security protection is built into the system and turned on by default — you can't accidentally make it insecure by misconfiguring a setting. If something goes wrong, the system blocks access rather than leaking data.
+
+---
+
+## Core Principle
+
+Canadian nonprofits handle deeply sensitive personal information — mental health notes, domestic violence documentation, substance use records, immigration status — but typically lack dedicated IT security staff. KoNote's security model is therefore architectural, not configurable. Security is enforced by the structure of the code, not by policies that a non-technical admin might misconfigure.
+
+The system should be secure even if the operator doesn't fully understand why. Every security control described below is on by default, cannot be turned off through the admin interface, and fails closed rather than open. If a control can't determine whether an action is safe, it denies the action.
+
+---
+
+## Design Decisions
+
+### 1. Encryption at Rest — All PII Fields
+
+Every field containing personally identifiable information is Fernet-encrypted (AES-128-CBC + HMAC-SHA256). This is not optional. Property accessors (`client.first_name`) handle encryption and decryption transparently — calling code never touches ciphertext directly. Per-tenant encryption keys mean one agency's key cannot decrypt another agency's data.
+
+The system validates encryption key round-trip on every startup. If the key is missing, corrupt, or misconfigured, the application will not start. This makes key misconfiguration a loud, immediate failure rather than a silent data exposure.
+
+**Anti-pattern:** Relying on database-level encryption alone (doesn't protect against SQL injection or backup theft) or making encryption opt-in per agency.
+
+### 2. Role-Based Access Control — Permission Matrix as Single Source of Truth
+
+Four roles (Front Desk, Direct Service, Program Manager, Executive) are governed by an explicit permission matrix defined in one place. Every permission key is validated at import time — a typo in a permission key raises an error, not a silent denial. Missing entries in the matrix default to DENY, not ALLOW.
+
+The matrix is checked at three layers: view decorator, middleware, and template tag. This means a permission is enforced even if one layer is accidentally bypassed.
+
+**Anti-pattern:** Role checks scattered across individual views where one missed check means a bypass.
+
+### 3. Fail-Closed Consent Filtering
+
+PHIPA cross-program consent filtering returns empty results on failure, not all results. If the consent check cannot determine whether sharing is permitted, it denies access. Two enforcement functions cover the two access patterns: `apply_consent_filter()` for list views (querysets), `check_note_consent_or_403()` for single-note views.
+
+This means a bug in consent logic results in a staff member seeing too little data, not too much. Over-restriction is recoverable; over-exposure is not.
+
+**Anti-pattern:** Fail-open consent (show everything unless explicitly blocked). One bug = full data exposure.
+
+### 4. Immutable Audit Log — Separate Database
+
+All state-changing requests, client record views, and failed access attempts are logged to a separate PostgreSQL database. The Django ORM raises `PermissionError` on update or delete attempts against audit records. The database role used for the audit connection is INSERT-only at the PostgreSQL level.
+
+Separating the audit database from the application database means that a compromised application cannot alter its own evidence trail.
+
+**Anti-pattern:** Audit logs in the same database as application data (compromised app = compromised audit trail).
+
+### 5. Negative Access Lists for Safety
+
+`ClientAccessBlock` is checked BEFORE role-based access. If a staff member is blocked from a client (conflict of interest, DV perpetrator on staff), no role can override it. Blocks have no time-based expiry — they must be manually cleared by a Program Manager or higher.
+
+This exists because domestic violence scenarios require individual-level blocking that supersedes all role permissions. A Direct Service worker who is a client's abuser must never see that client's records, regardless of their role.
+
+**Anti-pattern:** Relying on role restrictions alone. DV scenarios require individual-level blocking that overrides all roles.
+
+### 6. Session Security
+
+Sessions time out after 30 minutes of inactivity. Sessions are stored server-side — the cookie contains only an opaque token, never session data. All cookies are set with `HttpOnly`, `Secure`, and `SameSite` flags. Content Security Policy uses nonce-based script allowlisting, blocking inline script injection.
+
+These defaults are tuned for the environments where KoNote is actually used: shared workstations in shelters, drop-in centres, and community agencies where a staff member may walk away from an unlocked screen.
+
+**Anti-pattern:** Long session timeouts in shared-computer environments (staff workstations in shelters and community centres).
+
+### 7. Rate Limiting and Account Lockout
+
+Login attempts are limited to 5 per minute. Password reset requests are limited to 10 per minute. After 5 consecutive failed login attempts, the account is locked for a 15-minute cooldown period. Passwords are hashed with Argon2 (memory-hard, GPU-resistant).
+
+These controls protect against brute-force attacks without requiring the operator to configure a WAF or external rate limiter.
+
+**Anti-pattern:** No rate limiting on login endpoints. Brute-force attacks on weak passwords.
+
+### 8. Two-Person Safety Rules
+
+Certain actions require two people to complete:
+
+- **Alert cancellation**: staff recommends, Program Manager approves
+- **DV flag removal**: staff requests, Program Manager approves
+- **Data erasure**: Program Manager requests, admin executes
+
+No single person can make a safety-critical change. This protects against both human error and coercion — a staff member under pressure from a client's abuser cannot unilaterally remove a safety flag.
+
+**Anti-pattern:** Any safety-critical action completable by one person. Human error or coercion becomes unrecoverable.
+
+### 9. Secure Exports with Time-Limited Links
+
+Exports use UUID-based links that expire after 24 hours. Admins can revoke an export link before it is downloaded. Elevated exports (100+ records) have a 10-minute delay with admin notification, giving time to intervene if the export was unauthorized. Export files are stored outside the web root and served through Django, not directly by the web server.
+
+**Anti-pattern:** Direct file download URLs that never expire. Leaked links = permanent data exposure.
+
+### 10. Demo Mode Isolation
+
+Demo users see demo data only. Real users see real data only. Demo users cannot modify agency settings. The `is_demo` flag is enforced at middleware and query level, not just in the UI — even if a demo user crafts a direct API request, they cannot reach production data.
+
+This allows agencies to trial KoNote and train new staff without risk of contaminating real records or exposing real client data during a demonstration.
+
+**Anti-pattern:** Test accounts that can see real data, or demo data mixed into production queries.
+
+---
+
+## Anti-Patterns Summary
+
+| Anti-pattern | Why it's rejected |
+|---|---|
+| Opt-in encryption | Nonprofits won't enable it; one missed field = PII exposure |
+| Scattered role checks | One missed check = bypass |
+| Fail-open consent | One bug = full data exposure |
+| Audit in same database | Compromised app = compromised evidence |
+| Role-only access control | DV scenarios need individual blocking |
+| Long session timeouts | Shared computers in shelters/community centres |
+| No rate limiting | Brute-force attacks on weak passwords |
+| Single-person safety actions | Human error or coercion becomes unrecoverable |
+| Permanent download links | Leaked links = permanent data exposure |
+| Mixed demo/real data | Test activity contaminates production |
+
+---
+
+## The Guiding Test
+
+Ask: **"If a nonprofit runs this with zero IT expertise, can they accidentally make it insecure?"**
+
+If the answer is yes, the security control is not architectural enough.
+
+---
+
+## Connections to Other Foundations
+
+- **Data Sovereignty**: Security controls are the enforcement layer for sovereignty principles. Encryption protects community ownership; RBAC enforces community control; the immutable audit trail proves compliance with data governance commitments.
+- **Collaborative Practice**: Session security and CSP protect the participant portal. Accessible, secure design ensures that collaborative features don't introduce attack vectors. Two-person safety rules protect DV participants.
+- **Nonprofit Sustainability**: Security must be zero-config to be affordable. Every control described here works without a dedicated IT team, which is the sustainability constraint in action.
+
+---
+
+## Related Implementation Decisions
+
+- `access-tiers.md` — Three permission tiers with progressive access control
+- `phipa-consent-enforcement.md` — Cross-program consent filtering rules
+- `encryption-key-rotation.md` — Key rotation procedures and custody
+- `ai-feature-toggles.md` — Participant data never sent to cloud AI
+
+---
+
+## When to Revisit
+
+If the Canadian nonprofit sector develops shared security infrastructure (e.g., a nonprofit SOC service or sector-wide managed security), some operational controls could potentially be relaxed. The principle itself — security must be architectural, not configurable — should not change.

--- a/tasks/design-rationale/multi-tenancy.md
+++ b/tasks/design-rationale/multi-tenancy.md
@@ -3,7 +3,7 @@
 **Feature:** Schema-per-tenant multi-tenancy using django-tenants, with per-tenant encryption and consortium data model
 **Status:** Decided. Implementation starts after first single-tenant agency deployment is live.
 **Date:** 2026-02-21
-**Implementation plan:** `tasks/multi-tenancy-implementation-plan.md`
+**Implementation plan:** To be written when MT-CORE1 starts. Sequencing: first agency must be live on single-tenant deployment before multi-tenancy work begins (see anti-patterns below).
 
 ---
 
@@ -152,4 +152,4 @@ A future developer might think "Consortium belongs in the consortia app." It doe
 
 ## Expert Panel Source
 
-Panel convened 2026-02-20: Software Architect, Nonprofit Technology Strategist, Privacy & Compliance Specialist, Systems Thinker. Followed by code review that identified and resolved 11 issues. Full implementation plan at `tasks/multi-tenancy-implementation-plan.md`.
+Panel convened 2026-02-20: Software Architect, Nonprofit Technology Strategist, Privacy & Compliance Specialist, Systems Thinker. Followed by code review that identified and resolved 11 issues. Full implementation plan to be written when MT-CORE1 starts.

--- a/tasks/hosting-cost-comparison.md
+++ b/tasks/hosting-cost-comparison.md
@@ -1,22 +1,23 @@
 # Hosting Cost Comparison: Azure vs OVHcloud
 
-*Last updated: 2026-03-04*
+*Last updated: 2026-03-14*
 
 <!-- COST_VERSION
-date: 2026-03-04
+date: 2026-03-14
 role: Component pricing source (all scenarios)
-llm_vps: VPS-4, $31 CAD/mo (shared, all agencies)
+llm_vps: VPS-4, $40 CAD/mo (shared, all agencies)
 app_vps_single: VPS-2, $14 CAD/mo (per agency)
 app_vps_multi: VPS-3, $27 CAD/mo (shared)
 ai_api_per_agency: ~$7 CAD/mo (translation + metrics)
-key_vault: ~$2 CAD/mo
-ovh_single_1_agency: $57 CAD/mo
-ovh_multi_10_agencies: $13 CAD/mo/agency
-azure_single_1_agency: $132 CAD/mo
-azure_multi_10_agencies: $46 CAD/mo/agency
-ops_hours_1_agency: ~1 hr/mo human (LLM-assisted)
-ops_hours_5_agencies_network: ~2.5 hr/mo human (LLM-assisted)
-ops_hours_10_agencies_mt: ~4.5-5 hr/mo human (LLM-assisted)
+key_vault: $2 CAD/mo per agency
+ovh_single_1_agency: $66 CAD/mo
+ovh_multi_10_agencies: $16 CAD/mo/agency
+azure_single_1_agency: $141 CAD/mo
+azure_multi_10_agencies: $48 CAD/mo/agency
+ops_hours_1_agency: ~1 hr/mo (human-only; ~4-5 hr/mo total including LLM work)
+ops_hours_5_agencies_network: ~2.5 hr/mo (human-only)
+ops_hours_10_agencies_mt: ~4.5-5 hr/mo (human-only)
+ops_hours_note: human-only hours shown; total work hours (LLM + human) are 4-5x higher
 ops_model: LLM-assisted (see docs/llm-operations-runbook.md)
 downstream: p0-managed-service-plan.md, konote-prosper-canada/deliverables/costing-model.md
 -->
@@ -85,10 +86,12 @@ This document compares two hosting approaches for KoNote, both using Azure Key V
 | VPS-1 | 4 | 8 GB | 75 GB NVMe | ~$9 |
 | VPS-2 | 6 | 12 GB | 100 GB NVMe | ~$14 |
 | VPS-3 | 8 | 24 GB | 200 GB NVMe | ~$27 |
-| VPS-4 | 12 | 48 GB | 300 GB NVMe | ~$31 |
+| VPS-4 | 12 | 48 GB | 300 GB NVMe | ~$40 |
 | VPS-6 | 24 | 96 GB | 400 GB NVMe | ~$105 |
 
 *Prices verified March 2026 from OVHcloud configurator. All plans include unlimited traffic. OVH parent is French-incorporated (OVH Groupe SA) — not subject to US CLOUD Act. VPS-6 price may need re-verification. Source: [OVHcloud Canada VPS](https://www.ovhcloud.com/en-ca/vps/).*
+
+*Note: Downstream cost documents (costing-model.md, hosting-budget-scenarios.md) use VPS-1 at $15/mo rather than VPS-2 at $14/mo because premium backup is operationally required for self-managed PostgreSQL on OVHcloud. The $15 figure includes the premium backup add-on.*
 
 ### AI API Costs (OpenRouter / Claude)
 
@@ -106,7 +109,7 @@ This document compares two hosting approaches for KoNote, both using Azure Key V
 |------|--------|
 | Model | Qwen3.5-35B-A3B (35B params, 3B active, MoE, Apache 2.0) |
 | Runtime | Ollama, CPU-only, nightly batch + on-demand insights |
-| Hosting | OVHcloud VPS-4 (~$31 CAD/mo), Beauharnois, QC (shared endpoint) |
+| Hosting | OVHcloud VPS-4 (~$40 CAD/mo), Beauharnois, QC (shared endpoint) |
 | VPS specs | 12 vCPUs, 48 GB RAM, 300 GB NVMe |
 | Tokens per suggestion call | ~800 (prompt + suggestion + response) |
 | Volume (10 agencies) | ~1,000 suggestions/month = ~800K tokens/month |
@@ -130,8 +133,8 @@ KoNote application and databases on Azure Canada Central. Self-hosted LLM on OVH
 | Azure Key Vault | $2 | Negligible operation volume |
 | OpenRouter AI (translation) | $2 | ~100 calls/mo × gpt-4o-mini |
 | OpenRouter AI (metrics/targets) | $5 | ~200 calls/mo × Sonnet 4.5 |
-| OVHcloud VPS-4 (LLM, shared) | $31 | 1/N share of shared VPS-4 |
-| **Total per agency** | **~$132** | |
+| OVHcloud VPS-4 (LLM, shared) | $40 | 1/N share of shared VPS-4 |
+| **Total per agency** | **~$141** | |
 
 ### Multi-Agency Scaling — Single Tenant (one VM + DB per agency)
 
@@ -140,11 +143,11 @@ KoNote application and databases on Azure Canada Central. Self-hosted LLM on OVH
 | Azure VMs (B2s each) | $55 | $275 | $550 |
 | Azure PostgreSQL x2 per agency (B1ms) | $34 | $170 | $340 |
 | PostgreSQL storage | $3 | $15 | $30 |
-| Azure Key Vault (shared) | $2 | $2 | $2 |
+| Azure Key Vault (per agency) | $2 | $10 | $20 |
 | OpenRouter AI (shared pool) | $7 | $35 | $70 |
-| OVHcloud LLM VPS-4 (shared) | $31 | $31 | $31 |
-| **Total** | **$132** | **$528** | **$1,023** |
-| **Per agency** | **$132** | **$106** | **$102** |
+| OVHcloud LLM VPS-4 (shared) | $40 | $40 | $40 |
+| **Total** | **$141** | **$545** | **$1,050** |
+| **Per agency** | **$141** | **$109** | **$105** |
 
 ### Multi-Agency Scaling — Multi-Tenant (shared infrastructure)
 
@@ -155,11 +158,11 @@ KoNote application and databases on Azure Canada Central. Self-hosted LLM on OVH
 | Azure VM (B4ms shared) | $194 | $194 | $194 |
 | Azure PostgreSQL x2 (B2ms shared) | $144 | $144 | $144 |
 | PostgreSQL storage (100 GB) | $16 | $16 | $16 |
-| Azure Key Vault (shared) | $2 | $2 | $2 |
+| Azure Key Vault (per agency) | $2 | $10 | $20 |
 | OpenRouter AI (shared pool) | $7 | $35 | $70 |
-| OVHcloud LLM VPS-4 (shared) | $31 | $31 | $31 |
-| **Total** | **$394** | **$422** | **$457** |
-| **Per agency** | **$394** | **$84** | **$46** |
+| OVHcloud LLM VPS-4 (shared) | $40 | $40 | $40 |
+| **Total** | **$403** | **$439** | **$484** |
+| **Per agency** | **$403** | **$88** | **$48** |
 
 ---
 
@@ -175,21 +178,21 @@ KoNote application, databases, and LLM all on OVHcloud VPS(es) in Beauharnois. S
 | Azure Key Vault | $2 | Encryption key management |
 | OpenRouter AI (translation) | $2 | ~100 calls/mo × gpt-4o-mini |
 | OpenRouter AI (metrics/targets) | $5 | ~200 calls/mo × Sonnet 4.5 |
-| OVHcloud LLM VPS-4 (shared) | $31 | 1/N share of shared VPS-4 |
+| OVHcloud LLM VPS-4 (shared) | $40 | 1/N share of shared VPS-4 |
 | Automated backups (OVH option) | $3 | Optional add-on |
-| **Total per agency** | **~$57** | |
+| **Total per agency** | **~$66** | |
 
 ### Multi-Agency Scaling — Single Tenant (one VPS per agency)
 
 | Component | 1 Agency | 5 Agencies | 10 Agencies |
 |-----------|----------|------------|-------------|
 | OVHcloud VPS-2 per agency | $14 | $70 | $140 |
-| Azure Key Vault (shared) | $2 | $2 | $2 |
+| Azure Key Vault (per agency) | $2 | $10 | $20 |
 | OpenRouter AI (shared pool) | $7 | $35 | $70 |
-| OVHcloud LLM VPS-4 (shared) | $31 | $31 | $31 |
+| OVHcloud LLM VPS-4 (shared) | $40 | $40 | $40 |
 | Backup add-ons | $3 | $15 | $30 |
-| **Total** | **$57** | **$153** | **$273** |
-| **Per agency** | **$57** | **$31** | **$27** |
+| **Total** | **$66** | **$170** | **$300** |
+| **Per agency** | **$66** | **$34** | **$30** |
 
 ### Multi-Agency Scaling — Multi-Tenant (shared infrastructure)
 
@@ -198,14 +201,14 @@ KoNote application, databases, and LLM all on OVHcloud VPS(es) in Beauharnois. S
 | Component | 1 Agency | 5 Agencies | 10 Agencies |
 |-----------|----------|------------|-------------|
 | OVHcloud VPS-3 (shared app + DB) | $27 | $27 | $27 |
-| OVHcloud VPS-4 (LLM, shared) | $31 | $31 | $31 |
-| Azure Key Vault (shared) | $2 | $2 | $2 |
+| OVHcloud VPS-4 (LLM, shared) | $40 | $40 | $40 |
+| Azure Key Vault (per agency) | $2 | $10 | $20 |
 | OpenRouter AI (shared pool) | $7 | $35 | $70 |
 | Backup add-ons | $3 | $3 | $3 |
-| **Total** | **$70** | **$98** | **$133** |
-| **Per agency** | **$70** | **$20** | **$13** |
+| **Total** | **$79** | **$115** | **$160** |
+| **Per agency** | **$79** | **$23** | **$16** |
 
-*At 10+ agencies, consider upgrading app VPS to VPS-4 (~$31) for headroom.*
+*At 10+ agencies, consider upgrading app VPS to VPS-4 (~$40) for headroom.*
 
 ---
 
@@ -223,19 +226,19 @@ KoNote application, databases, and LLM all on OVHcloud VPS(es) in Beauharnois. S
 
 | Scale | Azure Single-Tenant | Azure Multi-Tenant | OVH Single-Tenant | OVH Multi-Tenant |
 |-------|--------------------|--------------------|--------------------|--------------------|
-| 1 agency | $132 | $394* | $57 | $70* |
-| 5 agencies | $106 | $84 | $31 | $20 |
-| 10 agencies | $102 | $46 | $27 | $13 |
+| 1 agency | $141 | $403* | $66 | $79* |
+| 5 agencies | $109 | $88 | $34 | $23 |
+| 10 agencies | $105 | $48 | $30 | $16 |
 
-*\*Multi-tenant with 1 agency is more expensive due to the larger shared VM — cost advantage kicks in at 3+ agencies. All scenarios include ~$31/mo shared LLM VPS (VPS-4).*
+*\*Multi-tenant with 1 agency is more expensive due to the larger shared VM — cost advantage kicks in at 3+ agencies. All scenarios include ~$40/mo shared LLM VPS (VPS-4). Azure Key Vault is $2/mo per agency (each agency gets its own vault for data isolation).*
 
 ### Total Monthly Cost (CAD)
 
 | Scale | Azure Single-Tenant | Azure Multi-Tenant | OVH Single-Tenant | OVH Multi-Tenant |
 |-------|--------------------|--------------------|--------------------|--------------------|
-| 1 agency | $132 | $394 | $57 | $70 |
-| 5 agencies | $528 | $422 | $153 | $98 |
-| 10 agencies | $1,023 | $457 | $273 | $133 |
+| 1 agency | $141 | $403 | $66 | $79 |
+| 5 agencies | $545 | $439 | $170 | $115 |
+| 10 agencies | $1,050 | $484 | $300 | $160 |
 
 ---
 
@@ -266,10 +269,10 @@ These costs apply to both Azure and OVHcloud hosting scenarios.
 | Item | Value |
 |------|-------|
 | Model | Qwen3.5-35B-A3B on Ollama (primary); Qwen3.5-27B (backup/quality) |
-| Hosting | OVHcloud VPS-4 (~$31 CAD/mo shared — 12 vCPUs, 48 GB RAM) |
+| Hosting | OVHcloud VPS-4 (~$40 CAD/mo shared — 12 vCPUs, 48 GB RAM) |
 | Volume (10 agencies) | ~1,000 suggestions/month |
 | CPU inference time | ~1–2 hours/month (nightly batch) |
-| Per-agency cost (10 agencies) | ~$3 CAD/mo |
+| Per-agency cost (10 agencies) | ~$4 CAD/mo |
 | API cost | $0 (self-hosted, Apache 2.0 licence) |
 
 ---
@@ -332,15 +335,17 @@ Total automation cost: ~$0 additional (uses free tiers of monitoring services).
 
 ## Recommendations
 
-1. **For 1–3 agencies (launch phase)**: OVHcloud single-tenant at ~$57/agency/month vs ~$132 on Azure. The ~$31 LLM VPS is a fixed cost that becomes negligible at scale.
+**OVHcloud Beauharnois is recommended for most agencies** due to 60-70% lower cost and stronger data sovereignty (French-incorporated parent, not subject to US CLOUD Act). Azure is supported for agencies with existing Microsoft agreements, nonprofit grants, or specific compliance requirements that mandate a hyperscaler.
 
-2. **For 5–10 agencies (growth phase)**: Implement multi-tenancy first (MT-CORE1), then OVHcloud multi-tenant brings costs to $13–20/agency/month — still dramatically cheaper than Azure single-tenant.
+1. **For 1–3 agencies (launch phase)**: OVHcloud single-tenant at ~$66/agency/month vs ~$141 on Azure. The ~$40 LLM VPS is a fixed cost that becomes negligible at scale.
 
-3. **Azure makes sense if**: The agency or funder requires Azure specifically, or if the operational burden of self-managing PostgreSQL is unacceptable.
+2. **For 5–10 agencies (growth phase)**: Implement multi-tenancy first (MT-CORE1), then OVHcloud multi-tenant brings costs to $16–23/agency/month — still dramatically cheaper than Azure single-tenant.
 
-4. **LLM hosting**: One shared OVHcloud VPS-4 (~$31 CAD/month) serves all agencies — whether 1 or 100. Upgrade in-place if more capacity is needed (VPS-6 at ~$105). Complete data sovereignty on participant suggestions.
+3. **Azure makes sense if**: The agency or funder requires Azure specifically, has existing Microsoft nonprofit grants, or if the operational burden of self-managing PostgreSQL is unacceptable.
 
-5. **Key Vault**: Use Azure Key Vault in both scenarios. The CLOUD Act exposure is limited to the encryption key only, and the operational simplicity of managed KMS outweighs the theoretical risk for KoNote's threat model.
+4. **LLM hosting**: One shared OVHcloud VPS-4 (~$40 CAD/month) serves all agencies — whether 1 or 100. Upgrade in-place if more capacity is needed (VPS-6 at ~$105). Complete data sovereignty on participant suggestions.
+
+5. **Key Vault**: Use Azure Key Vault in both scenarios ($2 CAD/mo per agency — each agency gets its own vault for data isolation). The CLOUD Act exposure is limited to the encryption key only, and the operational simplicity of managed KMS outweighs the theoretical risk for KoNote's threat model.
 
 ---
 
@@ -403,10 +408,10 @@ Combines infrastructure costs from Scenario B (OVHcloud) with LLM-assisted suppo
 
 | Scale | Infrastructure/agency | Support/agency | **All-in/agency** |
 |-------|----------------------|----------------|-------------------|
-| 1 agency | $57 | $0 (internal) | **$57** |
-| 5 agencies (single-tenant, network) | $31 | ~$62 | **~$93** |
-| 5 agencies (multi-tenant) | $20 | ~$62 | **~$82** |
-| 10 agencies (multi-tenant, network) | $13 | ~$52 | **~$65** |
+| 1 agency | $66 | $0 (internal) | **$66** |
+| 5 agencies (single-tenant, network) | $34 | ~$62 | **~$96** |
+| 5 agencies (multi-tenant) | $23 | ~$62 | **~$85** |
+| 10 agencies (multi-tenant, network) | $16 | ~$52 | **~$68** |
 
 > **Note on support cost comparison:** The previous version of this section estimated 4–5 hr/mo (1 agency) assuming a traditional sysadmin doing all tasks manually. With the LLM-assisted model, human time drops to ~1 hr/mo because the LLM handles the technical work and the human only reviews and approves. The total *work* is similar — it's the *human portion* that's dramatically lower.
 

--- a/tasks/p0-managed-service-plan.md
+++ b/tasks/p0-managed-service-plan.md
@@ -1,19 +1,20 @@
 # P0 Deliverable: Managed Service Model
 
 <!-- COST_VERSION
-date: 2026-03-04
+date: 2026-03-14
 role: Managed service model (derives from hosting-cost-comparison.md)
 llm_vps: VPS-4, $40 CAD/mo
+key_vault: $2 CAD/mo per agency
 ovh_single_1_agency: $74 CAD/mo
 ovh_multi_10_agencies: $15 CAD/mo/agency
-ops_hours_1_agency: 4-5 hr/mo
+ops_hours_1_agency: 4-5 hr/mo (total LLM+human work); ~1 hr/mo human-only
 upstream: tasks/hosting-cost-comparison.md
 downstream: konote-prosper-canada/deliverables/costing-model.md
 -->
 
 **Requirement ID:** MA5 (managed hosting and support), related to MA3/MA4
 **Deliverable type:** Costed plan
-**Date:** 2026-03-04 (updated with self-healing support cost impact)
+**Date:** 2026-03-14 (reconciled with upstream cost docs)
 **Source documents:** tasks/hosting-cost-comparison.md, tasks/design-rationale/ovhcloud-deployment.md, tasks/deployment-protocol.md, tasks/saas-service-agreement.md, tasks/design-rationale/data-access-residency-policy.md
 
 ---
@@ -106,7 +107,7 @@ Both paths are fully supported. The choice depends on the agency's requirements 
 
 - Server hosting (VPS or Azure VM)
 - Database hosting (self-managed or Azure managed)
-- Encryption key management (Azure Key Vault: ~$2/mo)
+- Encryption key management (Azure Key Vault: $2/mo per agency — each agency gets its own vault for data isolation)
 - AI API costs (translation + metrics generation: ~$7/agency/mo)
 - Self-hosted LLM for suggestion theme tagging + outcome insights (shared OVHcloud VPS-4: ~$4/agency/mo at 10 agencies)
 - Backup storage
@@ -118,14 +119,14 @@ The 4-layer self-healing automation handles ~99% of operational incidents automa
 
 | Item | Estimate | When needed |
 |------|----------|-------------|
-| KoNote team time (~4–5 hr/mo for 1 agency; ~2 hr/mo per agency at scale) | Internal cost | Always |
+| KoNote team time (~4–5 hr/mo total LLM+human for 1 agency, ~1 hr/mo human-only; ~2 hr/mo per agency at scale) | Internal cost | Always |
 | Freelance sysadmin on-call retainer | ~$75–150 CAD/mo | 3–5 agencies (recommended) |
 | Canadian MSP | ~$300–500 CAD/mo | 10+ agencies or when 24/7 SLA required |
 | SaaS agreement legal review | One-time ~$2,000–5,000 | Before first managed agency |
 | SSL certificates | $0 (Let's Encrypt via Caddy) | Always |
 | Domain registration | ~$15–20/year per agency | If LogicalOutcomes provides subdomain |
 
-**Impact of self-healing on support costs:** Without automation, managing even one OVHcloud VPS would require ~10–15 hours/month of sysadmin time (manual monitoring, backup management, incident response). With the 4-layer stack, this drops to ~4–5 hours/month — most of which is reviewing automated reports and applying software updates. At 5 agencies, the per-agency support burden is ~2 hours/month.
+**Impact of self-healing on support costs:** Without automation, managing even one OVHcloud VPS would require ~10–15 hours/month of sysadmin time (manual monitoring, backup management, incident response). With the 4-layer stack, total work drops to ~4–5 hours/month (LLM + human combined), of which only ~1 hour/month is human time — reviewing automated reports, approving deployments, and handling agency requests. At 5 agencies, the per-agency support burden is ~2 hours/month total.
 
 ---
 


### PR DESCRIPTION
This pull request adds comprehensive documentation for two new Claude skills: deployment planning/costing and design rationale review. These skills are intended to guide both technical and non-technical team members in answering questions about KoNote deployment, cost, and architectural decisions, and to enforce best practices by referencing authoritative source documents and DRRs (Design Rationale Records).

**Deployment Planning & Costing Skill**:

* Introduces `.claude/skills/deployment-planning/SKILL.md`, which details when and how to answer questions about KoNote hosting costs, deployment options, pricing, and onboarding. It emphasizes strict per-agency data isolation, outlines supported deployment tiers (Self-Hosted, Managed OVHcloud, Azure), and provides a source-of-truth document inventory and update workflow for cost figures.

**Design Rationale Review Skill**:

* Adds `.claude/skills/design-rationale/SKILL.md`, which defines a structured workflow for reviewing proposals and code changes against KoNote's DRRs. It includes a decision flowchart, guidance on matching proposals to DRRs, and a template for producing structured reviews, as well as a table of common proposals and their settled DRR verdicts.