### PR TITLE
🛡️ Sentinel: [HIGH] Fix Rate Limit Bypass on Sensitive Endpoints

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** User-controlled data (consortium names, demographic labels, metrics) was not sanitized before being written to CSV exports in `apps/consortia/views.py`. The unsanitized `consortium.name` was also directly included in the `Content-Disposition` header filename.
 **Learning:** This exposes the application to CSV injection (Formula execution in Excel/LibreOffice) and potential HTTP header injection/path traversal attacks in dynamically generated filenames. This pattern was missing in the newer consortia app despite protections existing in the older reports app.
 **Prevention:** Always use `sanitise_csv_row` and `sanitise_filename` from `apps.reports.csv_utils` whenever dynamically generating CSV files and headers that contain user-provided text values.
+
+## 2026-03-15 - [Rate Limit Bypass on Sensitive Endpoints]
+**Vulnerability:** The `@ratelimit` decorator from `django-ratelimit` was used on sensitive endpoints like `password_reset_confirm` and `demo_login` without the `block=True` parameter.
+**Learning:** `django-ratelimit` defaults to just setting `request.limited = True` when limits are exceeded. Without `block=True` (or explicit checks in the view logic for `request.limited`), the execution continues and the rate limit is silently bypassed.
+**Prevention:** Always include `block=True` when applying the `@ratelimit` decorator unless the view explicitly checks `request.limited` to handle rate-limited requests manually.

--- a/apps/auth_app/views.py
+++ b/apps/auth_app/views.py
@@ -337,7 +337,7 @@ def azure_callback(request):
 
 @csrf_exempt
 @require_POST
-@ratelimit(key="ip", rate="10/m", method=["POST"])
+@ratelimit(key="ip", rate="10/m", method=["POST"], block=True)
 def demo_login(request, role):
     """Quick-login as a demo user. Only available when DEMO_MODE is enabled."""
     if not settings.DEMO_MODE:

--- a/apps/portal/views.py
+++ b/apps/portal/views.py
@@ -959,7 +959,7 @@ def password_reset_request(request):
 
 
 @portal_feature_required
-@ratelimit(key="ip", rate="10/m", method=["POST"])
+@ratelimit(key="ip", rate="10/m", method=["POST"], block=True)
 def password_reset_confirm(request):
     """Enter the emailed reset code and set a new password."""
     from apps.portal.forms import PortalPasswordResetConfirmForm


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The `@ratelimit` decorator from `django-ratelimit` was used on sensitive endpoints (`password_reset_confirm` and `demo_login`) without the `block=True` parameter. By default, `django-ratelimit` only annotates the request object with `request.limited = True` but does not halt execution, silently allowing attackers to bypass the rate limits if the view logic doesn't explicitly check the annotation.
🎯 **Impact:** Attackers could perform brute-force attacks on the password reset confirmation endpoint or spam the demo login endpoint, leading to potential account compromise or denial of service.
🔧 **Fix:** Added `block=True` to the `@ratelimit` decorator on both `password_reset_confirm` (apps/portal/views.py) and `demo_login` (apps/auth_app/views.py). This enforces the limit by raising a `Ratelimited` exception (translating to a 403 Forbidden response) when the rate limit is exceeded. Added an entry to `.jules/sentinel.md` documenting the learning.
✅ **Verification:** Verified by running tests using `pytest` for `test_portal_password_reset.py` and `test_auth_views.py` ensuring no regressions were introduced. Also used `grep` to verify no other occurrences of `@ratelimit` were missing the `block=` argument across the codebase.

---
*PR created automatically by Jules for task [4022372158276078533](https://jules.google.com/task/4022372158276078533) started by @pboachie*