### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix rate limit bypass on password reset and login endpoints

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** User-controlled data (consortium names, demographic labels, metrics) was not sanitized before being written to CSV exports in `apps/consortia/views.py`. The unsanitized `consortium.name` was also directly included in the `Content-Disposition` header filename.
 **Learning:** This exposes the application to CSV injection (Formula execution in Excel/LibreOffice) and potential HTTP header injection/path traversal attacks in dynamically generated filenames. This pattern was missing in the newer consortia app despite protections existing in the older reports app.
 **Prevention:** Always use `sanitise_csv_row` and `sanitise_filename` from `apps.reports.csv_utils` whenever dynamically generating CSV files and headers that contain user-provided text values.
+## 2024-05-24 - Rate Limiting Bypass in django-ratelimit
+
+**Vulnerability:** The `@ratelimit` decorator from `django-ratelimit` was used on sensitive endpoints (like `password_reset_confirm` and `demo_login`) without the `block=True` argument, and the views did not manually check `request.limited`. This meant the decorator would track the rate but never block requests, allowing attackers to completely bypass rate limits and perform brute-force attacks against password reset tokens.
+**Learning:** In this project, `django-ratelimit` defaults to just setting `request.limited = True` if the limit is exceeded. It does not automatically return a 403 response unless `block=True` is explicitly passed.
+**Prevention:** Always verify that `@ratelimit` decorators on sensitive endpoints either include `block=True` or that the view explicitly contains `if getattr(request, 'limited', False):` logic to handle the rate limit.

--- a/apps/auth_app/views.py
+++ b/apps/auth_app/views.py
@@ -337,7 +337,7 @@ def azure_callback(request):
 
 @csrf_exempt
 @require_POST
-@ratelimit(key="ip", rate="10/m", method=["POST"])
+@ratelimit(key="ip", rate="10/m", method=["POST"], block=True)
 def demo_login(request, role):
     """Quick-login as a demo user. Only available when DEMO_MODE is enabled."""
     if not settings.DEMO_MODE:

--- a/apps/portal/views.py
+++ b/apps/portal/views.py
@@ -959,7 +959,7 @@ def password_reset_request(request):
 
 
 @portal_feature_required
-@ratelimit(key="ip", rate="10/m", method=["POST"])
+@ratelimit(key="ip", rate="10/m", method=["POST"], block=True)
 def password_reset_confirm(request):
     """Enter the emailed reset code and set a new password."""
     from apps.portal.forms import PortalPasswordResetConfirmForm


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `@ratelimit` decorator on `password_reset_confirm` (portal) and `demo_login` (auth) endpoints lacked the `block=True` parameter and didn't manually check `request.limited`. This meant rate limits were tracked but not enforced.
🎯 Impact: Attackers could completely bypass rate limiting, enabling brute-force attacks against portal password reset tokens and demo login endpoints.
🔧 Fix: Added `block=True` to both endpoints, ensuring requests exceeding the threshold receive a 403 Forbidden response.
✅ Verification: Code reviewed. `django-ratelimit` documentation confirms `block=True` is required to automatically deny requests. Logged the learning in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [11188183227424608865](https://jules.google.com/task/11188183227424608865) started by @pboachie*