### PR TITLE
fix: simplify dashboard and insights — remove duplication and bloat

### DIFF
--- a/apps/reports/insights_views.py
+++ b/apps/reports/insights_views.py
@@ -38,9 +38,7 @@ from .metric_insights import (
 )
 from .insights_fhir import (
     get_goal_source_distribution,
-    get_goal_source_vs_achievement,
     get_practice_health,
-    get_cohort_comparison,
 )
 
 # Map DB values to human-readable labels for suggestion priorities
@@ -293,9 +291,7 @@ def program_insights(request):
 
         # ── FHIR metadata features ──
         goal_source_dist = get_goal_source_distribution(program, date_from, date_to)
-        goal_source_crosstab = get_goal_source_vs_achievement(program, date_from, date_to)
         practice_health = get_practice_health(program, date_from, date_to)
-        cohort_data = get_cohort_comparison(program, date_from, date_to)
 
         # Enrich achievement rates with not-achieved count and journey context
         for metric_id, ach in achievement_rates_data.items():
@@ -384,9 +380,7 @@ def program_insights(request):
             "outcomes_summary": outcomes_summary,
             # FHIR metadata features
             "goal_source_dist": goal_source_dist,
-            "goal_source_crosstab": goal_source_crosstab,
             "practice_health": practice_health,
-            "cohort_data": cohort_data,
             **expand_flags,
             **interp,
         })

--- a/templates/clients/executive_dashboard.html
+++ b/templates/clients/executive_dashboard.html
@@ -262,79 +262,10 @@
                 <h3>{{ stat.program.translated_name }}</h3>
             </header>
 
-            {# Metric insight indicators -- quick-scan overview #}
-            <div class="exec-insight-bar" aria-label="{% trans 'Program insight indicators' %}">
-                {% if stat.trend_direction %}
-                <span class="exec-indicator exec-trend-{{ stat.trend_direction }}">
-                    {% if stat.trend_direction == "improving" %}
-                    <span aria-hidden="true">&uarr;</span> {% trans "Improving" %}
-                    {% elif stat.trend_direction == "declining" %}
-                    <span aria-hidden="true">&darr;</span> {% trans "Declining" %}
-                    {% else %}
-                    <span aria-hidden="true">&ndash;</span> {% trans "Stable" %}
-                    {% endif %}
-                </span>
-                {% endif %}
-
-                <span class="exec-indicator exec-completeness-{{ stat.data_completeness_level }}" aria-label="{% trans 'Data completeness' %}: {{ stat.data_completeness_pct }}%">
-                    {% if stat.data_completeness_level == "full" %}
-                    {% trans "Data: Full" %}
-                    {% elif stat.data_completeness_level == "partial" %}
-                    {% trans "Data: Partial" %}
-                    {% else %}
-                    {% trans "Data: Low" %}
-                    {% endif %}
-                </span>
-
-                {% if stat.urgent_theme_count > 0 %}
-                <span class="exec-indicator exec-urgent" aria-label="{% trans 'Urgent suggestion themes' %}">
-                    {{ stat.urgent_theme_count }} {% trans "urgent" %}
-                </span>
-                {% endif %}
-            </div>
-
             {% include "clients/_exec_program_summary.html" %}
 
             <div class="program-metrics">
-                {# Census #}
-                <div class="metric-row">
-                    <span class="metric-label">{% trans "Total" %} {{ term.client_plural|default:"Participants" }}</span>
-                    <span class="metric-value">{{ stat.total }}</span>
-                </div>
-                <div class="metric-row">
-                    <span class="metric-label">{% trans "Active" %}</span>
-                    <span class="metric-value">{{ stat.active }}</span>
-                </div>
-
-                <hr>
-
-                {# Activity #}
-                <div class="metric-row highlight">
-                    <span class="metric-label">{% trans "New this month" %}</span>
-                    <span class="metric-value">{{ stat.new_this_month }}</span>
-                </div>
-                <div class="metric-row highlight">
-                    <span class="metric-label">{% trans "Notes this week" %}</span>
-                    <span class="metric-value">{{ stat.notes_this_week }}</span>
-                </div>
-
-                <hr>
-
-                {# Engagement & outcomes #}
-                {% if stat.suppress_pct %}
-                <div class="metric-row">
-                    <span class="metric-label secondary"><small>{% trans "Percentages hidden (fewer than 5 active participants)" %}</small></span>
-                </div>
-                {% endif %}
-                {% if stat.engagement_quality is not None %}
-                <div class="metric-row {% if stat.engagement_quality >= 70 %}metric-success{% elif stat.engagement_quality >= 40 %}metric-neutral{% else %}metric-warning{% endif %}">
-                    <span class="metric-label" title="{% trans 'Percentage of sessions this period where staff observed Engaged or Fully invested participation' %}">{% trans "Engagement Quality" %}</span>
-                    <span class="metric-value">{{ stat.engagement_quality }}%
-                        <span class="sr-only">{% if stat.engagement_quality >= 70 %}({% trans "Good" %}){% elif stat.engagement_quality >= 40 %}({% trans "Fair" %}){% else %}({% trans "Low" %}){% endif %}</span>
-                    </span>
-                </div>
-                {% endif %}
-
+                {# Outcomes & activity — only rows that aren't in the summary sentence #}
                 {% if stat.goal_completion is not None %}
                 <div class="metric-row">
                     <span class="metric-label">{% trans "Goal Completion Rate" %}</span>
@@ -355,33 +286,20 @@
                 {% if stat.group_attendance is not None %}
                 <div class="metric-row {% if stat.group_attendance >= 75 %}metric-success{% elif stat.group_attendance >= 50 %}metric-neutral{% else %}metric-warning{% endif %}">
                     <span class="metric-label">{% trans "Group Attendance" %}</span>
-                    <span class="metric-value">{{ stat.group_attendance }}%
-                        <span class="sr-only">{% if stat.group_attendance >= 75 %}({% trans "Good" %}){% elif stat.group_attendance >= 50 %}({% trans "Fair" %}){% else %}({% trans "Low" %}){% endif %}</span>
-                    </span>
+                    <span class="metric-value">{{ stat.group_attendance }}%</span>
                 </div>
                 {% endif %}
 
-                <hr>
-
-                {# Pipeline & adoption #}
+                {% if stat.intake_pending > 0 %}
                 <div class="metric-row">
                     <span class="metric-label" title="{% trans 'Participants registered but not yet marked Active — waiting for intake to be completed' %}">{% trans "Intake Pipeline" %}</span>
                     <span class="metric-value">{{ stat.intake_pending }}</span>
                 </div>
-
-                {% if show_portal and stat.portal_adoption is not None %}
-                <div class="metric-row">
-                    <span class="metric-label" title="{% trans 'Percentage of active participants who have logged into the participant portal at least once' %}">{% trans "Portal Adoption" %}</span>
-                    <span class="metric-value">{{ stat.portal_adoption }}%</span>
-                </div>
                 {% endif %}
 
+                {# Suggestion themes — named themes with priority badges #}
                 {% if stat.top_themes %}
                 <hr>
-                {# Theme names -- executives see what suggestions are about #}
-                <div class="metric-row">
-                    <span class="metric-label">{% trans "Suggestion Themes" %}</span>
-                </div>
                 <ul class="theme-compact-list" role="list" aria-label="{{ stat.program.translated_name }} {% trans 'suggestion themes' %}">
                     {% for theme in stat.top_themes %}
                     <li>
@@ -399,12 +317,8 @@
                     <a href="{% url 'suggestion_themes:theme_list' %}?program={{ stat.program.pk }}" class="metric-link">+{{ stat.theme_overflow }} {% trans "more" %} &rarr;</a>
                 </div>
                 {% endif %}
-                <div class="metric-row">
-                    <a href="{% url 'suggestion_themes:theme_list' %}?program={{ stat.program.pk }}" class="metric-link">{% trans "View themes" %} &rarr;</a>
-                </div>
                 {% elif stat.suggestion_total > 0 %}
                 <hr>
-                {# Fallback: raw suggestion count when no themes exist #}
                 <div class="metric-row {% if stat.suggestion_important > 0 %}metric-warning{% endif %}">
                     <span class="metric-label">{% trans "Suggestions" %}</span>
                     <span class="metric-value">
@@ -414,20 +328,13 @@
                         {% endif %}
                     </span>
                 </div>
-                <div class="metric-row">
-                    <a href="{% url 'reports:program_insights' %}?program={{ stat.program.pk }}" class="metric-link">{% trans "View in Outcome Insights" %} &rarr;</a>
-                </div>
                 {% endif %}
 
-                {# Program Learning section #}
+                {# Program Learning — outcome headline, trend, completeness #}
                 {% if stat.learning %}
                 <hr>
                 <div class="program-learning" aria-label="{% trans 'Program Learning' %}">
-                    <div class="metric-row">
-                        <span class="metric-label"><strong>{% trans "Program Learning" %}</strong></span>
-                    </div>
-
-                    {# Line 1: Lead outcome headline #}
+                    {# Lead outcome headline #}
                     {% if stat.learning.suppress %}
                     <div class="metric-row">
                         <span class="metric-label secondary"><small>{% trans "Outcome data suppressed (fewer than 5 participants with data)" %}</small></span>
@@ -448,7 +355,7 @@
                     </div>
                     {% endif %}
 
-                    {# Line 2: Target + trend direction #}
+                    {# Target + trend direction #}
                     {% if stat.learning.target_rate or stat.learning.trend_direction %}
                     <div class="metric-row">
                         <span class="metric-label">
@@ -462,7 +369,7 @@
                     </div>
                     {% endif %}
 
-                    {# Line 3: Data completeness indicator #}
+                    {# Data completeness #}
                     <div class="metric-row">
                         <span class="metric-label">
                             {% if stat.learning.completeness_level == "full" %}
@@ -479,17 +386,6 @@
                         </span>
                     </div>
 
-                    {# Line 4: Feedback themes count + urgency #}
-                    <div class="metric-row {% if stat.learning.has_urgent_theme %}metric-warning{% endif %}">
-                        <span class="metric-label">
-                            {{ stat.learning.theme_open_count }} {% trans "feedback themes to review" %}
-                            {% if stat.learning.has_urgent_theme %}
-                            <span class="badge badge-danger badge-sm">{% trans "Urgent" %}</span>
-                            {% endif %}
-                        </span>
-                    </div>
-
-                    {# Link to program learning page #}
                     <div class="metric-row">
                         <a href="{% url 'reports:program_insights' %}?program={{ stat.program.pk }}" class="metric-link">{% trans "View program learning" %} &rarr;</a>
                     </div>

--- a/templates/reports/_insights_basic.html
+++ b/templates/reports/_insights_basic.html
@@ -317,57 +317,43 @@
 {% endif %}
 
 {# ══════════════════════════════════════════════════════════════════ #}
-{# ── Section 2: Where Participants Are (Layer 1 — distributions) ── #}
+{# ── Section 2: Outcome Progress (merged distributions + outcomes) ─ #}
 {# ══════════════════════════════════════════════════════════════════ #}
-{% if metric_distributions %}
-<details id="section-distributions" {% if expand_distributions %}open{% endif %} class="insights-section">
+{% if metric_distributions or achievement_rates or instrument_aggregates %}
+<details id="section-outcome-progress" {% if expand_distributions or expand_outcomes %}open{% endif %} class="insights-section">
     <summary>
-        <strong>{% trans "Where Participants Are" %}</strong> —
-        {% if distributions_summary %}{{ distributions_summary }}{% endif %}
+        <strong>{% trans "Outcome Progress" %}</strong> —
+        {% if outcomes_summary %}{{ outcomes_summary }}
+        {% elif distributions_summary %}{{ distributions_summary }}
+        {% endif %}
     </summary>
+
+    {% if metric_distributions %}
+    <h3>{% trans "Where Participants Are" %}</h3>
     {% include "reports/_insights_distributions.html" %}
-</details>
-{% endif %}
+    {% endif %}
 
-{# ══════════════════════════════════════════════════════════════════ #}
-{# ── Section 2b: Instrument Battery Aggregates ──────────────────── #}
-{# ══════════════════════════════════════════════════════════════════ #}
-{% if instrument_aggregates %}
-<details id="section-instruments" {% if expand_distributions %}open{% endif %} class="insights-section">
-    <summary>
-        <strong>{% trans "Instrument Batteries" %}</strong>
-    </summary>
-    {% include "reports/_insights_instruments.html" %}
-</details>
-{% endif %}
-
-{# ══════════════════════════════════════════════════════════════════ #}
-{# ── Section 3: Program Outcomes (Layer 2 — achievement rates) ──── #}
-{# ══════════════════════════════════════════════════════════════════ #}
-{% if achievement_rates %}
-<details id="section-outcomes" {% if expand_outcomes %}open{% endif %} class="insights-section">
-    <summary>
-        <strong>{% trans "Program Outcomes" %}</strong> —
-        {% if outcomes_summary %}{{ outcomes_summary }}{% endif %}
-    </summary>
+    {% if achievement_rates %}
+    <h3>{% trans "Achievement Rates" %}</h3>
     {% include "reports/_insights_metrics.html" %}
+    {% endif %}
+
+    {% if instrument_aggregates %}
+    <h3>{% trans "Instrument Batteries" %}</h3>
+    {% include "reports/_insights_instruments.html" %}
+    {% endif %}
 </details>
 {% endif %}
 
 {# ══════════════════════════════════════════════════════════════════ #}
-{# ── Section 3b: Practice Quality (Features A, B, C) ──────────── #}
+{# ── Section 3: Practice Indicators (goal source + voice) ──────── #}
 {# ══════════════════════════════════════════════════════════════════ #}
 {% include "reports/_insights_practice_quality.html" %}
 
 {# ══════════════════════════════════════════════════════════════════ #}
-{# ── Section 3c: Cohort Comparison (Feature E) ────────────────── #}
+{# ── Section 4: Staff Assessments & Engagement ─────────────────── #}
 {# ══════════════════════════════════════════════════════════════════ #}
-{% include "reports/_insights_cohort.html" %}
-
-{# ══════════════════════════════════════════════════════════════════ #}
-{# ── Section 4: Staff Assessments Over Time (Layer 3, relabelled) ─ #}
-{# ══════════════════════════════════════════════════════════════════ #}
-{% if structured.descriptor_trend %}
+{% if structured.descriptor_trend or structured.engagement_distribution %}
 <details id="section-staff-assessments" {% if expand_staff_assessments %}open{% endif %} class="insights-section">
     <summary>
         <strong>{% trans "Staff Assessments" %}</strong> —
@@ -376,6 +362,7 @@
         {% endif %}
     </summary>
 
+    {% if structured.descriptor_trend %}
     <h3>{% trans "Staff Assessments Over Time" %}</h3>
     <p class="chart-description muted">{% trans "How workers rate participant progress at each session — a professional judgment, not a measured score." %}</p>
     {% if interp_trend %}<p class="insight-interpretation">{{ interp_trend }}</p>{% endif %}
@@ -412,7 +399,7 @@
         </table>
     </details>
 
-    {# ── Descriptor snapshot (current totals) ── #}
+    {# Descriptor snapshot (current totals) #}
     {% if structured.descriptor_distribution %}
     <h4>{% trans "Current Period" %}</h4>
     <div class="descriptor-pills">
@@ -422,18 +409,10 @@
     </div>
     {% if interp_snapshot %}<p class="insight-interpretation">{{ interp_snapshot }}</p>{% endif %}
     {% endif %}
-</details>
-{% endif %}
+    {% endif %}
 
-{# ══════════════════════════════════════════════════════════════════ #}
-{# ── Section 5: Engagement (Layer 3) ────────────────────────────── #}
-{# ══════════════════════════════════════════════════════════════════ #}
-{% if structured.engagement_distribution %}
-<details id="section-engagement" {% if expand_engagement %}open{% endif %} class="insights-section">
-    <summary>
-        <strong>{% trans "Engagement" %}</strong> —
-        {% for label, pct in structured.engagement_distribution.items %}{% if forloop.first %}{{ pct }}% {{ label|lower }}{% endif %}{% endfor %}
-    </summary>
+    {# Engagement (folded into staff assessments) #}
+    {% if structured.engagement_distribution %}
     <h3>{% trans "Engagement" %}</h3>
     <p class="chart-description muted">{% trans "How actively participants are engaging with their program — based on what staff observe during sessions." %}</p>
     <div class="descriptor-pills">
@@ -442,6 +421,7 @@
         {% endfor %}
     </div>
     {% if interp_engagement %}<p class="insight-interpretation">{{ interp_engagement }}</p>{% endif %}
+    {% endif %}
 </details>
 {% endif %}
 
@@ -483,8 +463,5 @@
 {# Chart init moved to app.js — inline scripts break when loaded via HTMX due to CSP nonce mismatch #}
 {% endif %}
 
-{# Chart.js for goal source distribution (Feature A) #}
-{% if goal_source_dist.sufficient %}
-{{ goal_source_dist|json_script:"goal-source-data" }}
-{% endif %}
+{# Goal source chart removed — table is clearer for 3-4 categories #}
 

--- a/templates/reports/_insights_practice_quality.html
+++ b/templates/reports/_insights_practice_quality.html
@@ -1,33 +1,24 @@
 {% load i18n %}
-{# Practice Health Bar (Feature C) + Goal Source Distribution (Feature A) + Cross-tab (Feature B) #}
+{# Practice Indicators — jointly developed % + participant voice % + goal source table #}
 
 {% if practice_health %}
 {% with ph=practice_health %}
-{# Show section if at least one indicator is visible #}
-{% if ph.jointly_developed.show or ph.data_completeness.show or ph.participant_voice.show or ph.sessions_per_participant.show %}
-<details id="section-practice-quality" class="insights-section">
+{# Show section if jointly developed or participant voice data exists #}
+{% if ph.jointly_developed.show or ph.participant_voice.show %}
+<details id="section-practice-indicators" class="insights-section">
     <summary>
-        <strong>{% trans "Practice Quality" %}</strong> —
+        <strong>{% trans "Practice Indicators" %}</strong> —
         {% if ph.jointly_developed.show %}{{ ph.jointly_developed.value }} {% trans "jointly developed" %}{% endif %}
         {% if ph.jointly_developed.show and ph.participant_voice.show %} · {% endif %}
         {% if ph.participant_voice.show %}{{ ph.participant_voice.value }} {% trans "participant voice" %}{% endif %}
     </summary>
 
-    {# ── Practice Health Bar ── #}
-    <h3>{% trans "Practice Health" %}</h3>
-    <p class="chart-description muted">{% trans "Key indicators of collaborative practice quality. Green means strong, amber is developing, red needs attention." %}</p>
-
-    <div class="practice-health-bar" role="list" aria-label="{% trans 'Practice health indicators' %}">
+    {# Practice indicators — only jointly developed and participant voice #}
+    <div class="practice-health-bar" role="list" aria-label="{% trans 'Practice indicators' %}">
         {% if ph.jointly_developed.show %}
         <div class="practice-health-item practice-health-{{ ph.jointly_developed.level }}" role="listitem">
             <span class="practice-health-value">{{ ph.jointly_developed.value }}</span>
             <span class="practice-health-label">{{ ph.jointly_developed.label }}</span>
-        </div>
-        {% endif %}
-        {% if ph.data_completeness.show %}
-        <div class="practice-health-item practice-health-{{ ph.data_completeness.level }}" role="listitem">
-            <span class="practice-health-value">{{ ph.data_completeness.value }}</span>
-            <span class="practice-health-label">{{ ph.data_completeness.label }}</span>
         </div>
         {% endif %}
         {% if ph.participant_voice.show %}
@@ -36,20 +27,13 @@
             <span class="practice-health-label">{{ ph.participant_voice.label }}</span>
         </div>
         {% endif %}
-        {% if ph.sessions_per_participant.show %}
-        <div class="practice-health-item practice-health-neutral" role="listitem">
-            <span class="practice-health-value">{{ ph.sessions_per_participant.value }}</span>
-            <span class="practice-health-label">{{ ph.sessions_per_participant.label }}</span>
-        </div>
-        {% endif %}
     </div>
 
-    {# ── Goal Source Distribution (Feature A) ── #}
+    {# Goal Source Distribution table (no chart — table is clearer for 3-4 categories) #}
     {% if goal_source_dist.sufficient %}
     <h3>{% trans "Goal Source Distribution" %}</h3>
     <p class="chart-description muted">{% trans "Who initiated each goal — jointly developed goals reflect collaborative practice." %}</p>
 
-    {# Accessible data table (always visible) #}
     <table role="table" aria-label="{% trans 'Goal source distribution' %}">
         <thead>
             <tr>
@@ -75,48 +59,6 @@
             </tr>
         </tfoot>
     </table>
-
-    {# Chart.js horizontal bar chart #}
-    <div class="chart-container" style="position: relative; height: 200px;">
-        <canvas id="goal-source-chart"
-                aria-label="{% trans 'Bar chart showing goal source distribution' %}"
-                role="img"></canvas>
-    </div>
-    {% endif %}
-
-    {# ── Goal Source vs Achievement Cross-tab (Feature B) ── #}
-    {% if goal_source_crosstab.sufficient %}
-    <details>
-        <summary>
-            <strong>{% trans "Goal Source vs. Achievement" %}</strong>
-        </summary>
-        <p class="chart-description muted">{% trans "Does who initiated the goal affect whether it's achieved? Larger differences suggest goal-setting process matters." %}</p>
-
-        <table role="table" aria-label="{% trans 'Goal source vs achievement cross-tabulation' %}">
-            <thead>
-                <tr>
-                    <th scope="col">{% trans "Source" %}</th>
-                    <th scope="col" style="text-align: right;">{% trans "Achieved" %}</th>
-                    <th scope="col" style="text-align: right;">{% trans "Total" %}</th>
-                    <th scope="col" style="text-align: right;">{% trans "Rate" %}</th>
-                </tr>
-            </thead>
-            <tbody>
-                {% for row in goal_source_crosstab.rows %}
-                <tr>
-                    <td>{{ row.label }}</td>
-                    <td style="text-align: right;">{{ row.achieved }}</td>
-                    <td style="text-align: right;">{{ row.total }}</td>
-                    <td style="text-align: right;">{{ row.rate }}%</td>
-                </tr>
-                {% endfor %}
-            </tbody>
-        </table>
-
-        {% if goal_source_crosstab.comparison_sentence %}
-        <p class="insight-interpretation">{{ goal_source_crosstab.comparison_sentence }}</p>
-        {% endif %}
-    </details>
     {% endif %}
 
 </details>


### PR DESCRIPTION
## Summary

Major simplification of both reporting pages based on expert panel review.

### Executive Dashboard — per-program cards
Removed: insight indicators bar, census rows (total/active/new), notes this week,
engagement quality %, portal adoption, duplicate theme counts in Program Learning.

Each program card shrinks from ~20 data points to ~8. Summary sentence replaces
census rows. Kept: goal completion, no-show rate, group attendance, named themes,
Program Learning (outcome/trend/completeness).

### Outcome Insights — section consolidation
- Merged "Where Participants Are" + "Program Outcomes" + "Instrument Batteries"
  into single **"Outcome Progress"** section
- Renamed "Practice Quality" to **"Practice Indicators"**; removed data completeness
  and sessions/participant from health bar; removed cross-tab and bar chart
- Folded **Engagement** into Staff Assessments section
- **Removed entirely**: Cohort Comparison (insufficient N), Goal Source vs Achievement
  cross-tab (causal inference unjustified)

Sections reduced from 8 to 5.

## Test plan
- [ ] Verify dashboard loads with simplified program cards
- [ ] Verify Insights page loads with merged Outcome Progress section
- [ ] Check Practice Indicators shows only jointly-developed % and participant voice %

🤖 Generated with [Claude Code](https://claude.com/claude-code)