### PR TITLE
fix: cleanup dead code, cross-program bug, redundant queries

### DIFF
--- a/apps/clients/dashboard_views.py
+++ b/apps/clients/dashboard_views.py
@@ -67,28 +67,8 @@ def _count_without_notes(active_client_ids, program_ids, month_start):
     return len(set(active_client_ids) - clients_with_notes)
 
 
-def _count_stale_episodes(program_id, active_client_ids, thirty_days_ago):
-    """Active episodes with no note in 30+ days (enhanced attention signal).
-
-    Feature G: episode-aware query that's more meaningful than the
-    calendar-month-based _count_without_notes.
-    """
-    if not active_client_ids:
-        return 0
-    clients_with_recent = set(
-        ProgressNote.objects.filter(
-            client_file_id__in=active_client_ids,
-            author_program_id=program_id,
-            created_at__gte=thirty_days_ago,
-            status="default",
-        ).values_list("client_file_id", flat=True)
-    )
-    return len(active_client_ids - clients_with_recent)
-
-
-def _batch_fhir_enrichment(filtered_program_ids, base_client_ids,
-                           enrolment_stats, programs, date_from, date_to,
-                           thirty_days_ago):
+def _batch_fhir_enrichment(filtered_program_ids, enrolment_stats,
+                           programs, thirty_days_ago):
     """Batch FHIR enrichment data for all programs in minimal queries.
 
     Computes program summary sentences and stale episode counts using
@@ -148,7 +128,7 @@ def _batch_fhir_enrichment(filtered_program_ids, base_client_ids,
             joint=Count("id", filter=Q(goal_source="joint")),
             with_achievement=Count("id", filter=Q(achievement_status__gt="")),
             positive=Count("id", filter=Q(
-                achievement_status__in=["achieved", "sustaining", "improving"]
+                achievement_status__in=PlanTarget.POSITIVE_ACHIEVEMENT_STATUSES
             )),
         )
     )
@@ -157,31 +137,32 @@ def _batch_fhir_enrichment(filtered_program_ids, base_client_ids,
         target_data[r["plan_section__program_id"]] = r
 
     # ── Batch query 4: Stale episodes (active enrolments with no recent note) ──
-    active_enrolments = (
-        ClientProgramEnrolment.objects.filter(
-            program_id__in=filtered_program_ids,
-            status="active",
-            client_file_id__in=base_client_ids,
-        )
-        .values_list("program_id", "client_file_id")
-    )
-    active_by_program = {}
-    for pid, cid in active_enrolments:
-        active_by_program.setdefault(pid, set()).add(cid)
-
+    # Use active_ids from enrolment_stats (already queried) to avoid duplicate query.
+    # Query recent notes per-program to avoid cross-program false negatives:
+    # a note in Program B shouldn't clear a stale flag in Program A.
+    active_by_program = {
+        pid: es.get("active_ids", set())
+        for pid, es in enrolment_stats.items()
+    }
     all_active_cids = set()
     for ids in active_by_program.values():
         all_active_cids.update(ids)
-    recent_note_clients = set()
+
+    # Fetch recent notes grouped by (program, client) for correct per-program counting
+    recent_by_program = {}
     if all_active_cids:
-        recent_note_clients = set(
+        recent_rows = (
             ProgressNote.objects.filter(
                 client_file_id__in=all_active_cids,
                 author_program_id__in=filtered_program_ids,
                 created_at__gte=thirty_days_ago,
                 status="default",
-            ).values_list("client_file_id", flat=True)
+            )
+            .values_list("author_program_id", "client_file_id")
+            .distinct()
         )
+        for rpid, rcid in recent_rows:
+            recent_by_program.setdefault(rpid, set()).add(rcid)
 
     # ── Assemble results per program ──
     result = {}
@@ -239,9 +220,10 @@ def _batch_fhir_enrichment(filtered_program_ids, base_client_ids,
                 "goals": goal_count, "joint_pct": joint_pct,
             }
 
-        # Stale episodes
+        # Stale episodes (per-program: only notes in THIS program count)
         prog_active = active_by_program.get(pid, set())
-        stale = len(prog_active - recent_note_clients)
+        prog_recent = recent_by_program.get(pid, set())
+        stale = len(prog_active - prog_recent)
 
         result[pid] = {
             "summary_sentence": summary,
@@ -1341,12 +1323,11 @@ def _build_executive_context(request):
         filtered_program_ids, month_start.date(), today,
     )
 
-    # Batch FHIR enrichment (summary, funder stats, stale episodes)
+    # Batch FHIR enrichment (summary sentence + stale episodes)
     thirty_days_ago = now - timedelta(days=30)
     fhir_map = _batch_fhir_enrichment(
-        filtered_program_ids, base_client_ids, enrolment_stats,
-        filtered_programs, learning_date_from, learning_date_to,
-        thirty_days_ago,
+        filtered_program_ids, enrolment_stats,
+        filtered_programs, thirty_days_ago,
     )
 
     # Assemble per-program stat dicts

--- a/apps/plans/models.py
+++ b/apps/plans/models.py
@@ -431,6 +431,8 @@ class PlanTarget(models.Model):
     # Use this for queries that mean "goals still in play."
     # Metric collection (note forms) should use status="default" only.
     ACTIVE_STATUSES = ["default", "on_hold"]
+    # Achievement statuses that count as positive outcomes.
+    POSITIVE_ACHIEVEMENT_STATUSES = ["achieved", "sustaining", "improving"]
 
     plan_section = models.ForeignKey(PlanSection, on_delete=models.CASCADE, related_name="targets")
     client_file = models.ForeignKey("clients.ClientFile", on_delete=models.CASCADE, related_name="plan_targets")

--- a/apps/reports/insights_fhir.py
+++ b/apps/reports/insights_fhir.py
@@ -37,15 +37,16 @@ def get_goal_source_distribution(program, date_from=None, date_to=None):
     if date_to:
         qs = qs.filter(created_at__lte=date_to)
 
-    rows = qs.values("goal_source").annotate(
+    rows = list(qs.values("goal_source").annotate(
         count=Count("id"),
-        participants=Count("client_file_id", distinct=True),
-    ).order_by("-count")
+    ).order_by("-count"))
 
     total = sum(r["count"] for r in rows)
-    total_participants = len(set(
-        qs.values_list("client_file_id", flat=True)
-    ))
+    # Distinct participant count (single efficient query)
+    total_participants = (
+        qs.values("client_file_id").distinct().count()
+        if total >= MIN_GOALS_FOR_SOURCE_DIST else 0
+    )
     sufficient = (
         total >= MIN_GOALS_FOR_SOURCE_DIST
         and total_participants >= MIN_DISTINCT_PARTICIPANTS
@@ -106,7 +107,7 @@ def get_goal_source_vs_achievement(program, date_from=None, date_to=None):
         if total < SMALL_PROGRAM_THRESHOLD:
             continue  # suppress small cells
         achieved = group.filter(
-            achievement_status__in=["achieved", "sustaining", "improving"]
+            achievement_status__in=PlanTarget.POSITIVE_ACHIEVEMENT_STATUSES
         ).count()
         rate = round(achieved / total * 100) if total else 0
         rows.append({
@@ -153,8 +154,15 @@ def get_goal_source_vs_achievement(program, date_from=None, date_to=None):
     }
 
 
-def get_practice_health(program, date_from=None, date_to=None):
+def get_practice_health(program, date_from=None, date_to=None,
+                        goal_source_dist=None, data_completeness=None):
     """Practice quality indicators for the health bar (Feature C).
+
+    Args:
+        goal_source_dist: Pre-computed result from get_goal_source_distribution
+            (avoids redundant query when caller already has it).
+        data_completeness: Pre-computed result from get_data_completeness
+            (avoids redundant query when caller already has it).
 
     Returns dict of indicator dicts, each with:
         value, label, level (good/fair/low), show (bool)
@@ -162,7 +170,7 @@ def get_practice_health(program, date_from=None, date_to=None):
     indicators = {}
 
     # 1. % goals jointly developed
-    source_dist = get_goal_source_distribution(program, date_from, date_to)
+    source_dist = goal_source_dist or get_goal_source_distribution(program, date_from, date_to)
     if source_dist["sufficient"]:
         joint_row = next(
             (s for s in source_dist["sources"] if s["source"] == "joint"),
@@ -183,9 +191,11 @@ def get_practice_health(program, date_from=None, date_to=None):
     else:
         indicators["jointly_developed"] = {"show": False}
 
-    # 2. Data completeness (reuse existing function)
-    from apps.reports.metric_insights import get_data_completeness
-    completeness = get_data_completeness(program, date_from, date_to)
+    # 2. Data completeness (reuse existing function or pre-computed value)
+    if data_completeness is None:
+        from apps.reports.metric_insights import get_data_completeness
+        data_completeness = get_data_completeness(program, date_from, date_to)
+    completeness = data_completeness
     if completeness and completeness.get("enrolled_count", 0) > 0:
         pct = completeness.get("completeness_pct", 0)
         level = "good" if pct >= 80 else ("fair" if pct >= 50 else "low")
@@ -328,7 +338,7 @@ def get_cohort_comparison(program, date_from=None, date_to=None):
         with_achievement = target_qs.filter(achievement_status__gt="")
         total_with = with_achievement.count()
         achieved = with_achievement.filter(
-            achievement_status__in=["achieved", "sustaining", "improving"]
+            achievement_status__in=PlanTarget.POSITIVE_ACHIEVEMENT_STATUSES
         ).count()
         ach_pct = (
             round(achieved / total_with * 100) if total_with >= 10 else None
@@ -433,7 +443,7 @@ def build_program_summary(program, enrolment_stats, period_label="quarter"):
     with_achievement = goal_qs.filter(achievement_status__gt="")
     total_tracked = with_achievement.count()
     positive = with_achievement.filter(
-        achievement_status__in=["achieved", "sustaining", "improving"]
+        achievement_status__in=PlanTarget.POSITIVE_ACHIEVEMENT_STATUSES
     ).count()
 
     if total_tracked >= 10:
@@ -562,7 +572,7 @@ def build_funder_stats(program, date_from=None, date_to=None):
     ).count()
     if total_tracked >= 10:
         positive = ach_qs.filter(
-            achievement_status__in=["achieved", "sustaining", "improving"]
+            achievement_status__in=PlanTarget.POSITIVE_ACHIEVEMENT_STATUSES
         ).count()
         pct = round(positive / total_tracked * 100)
         coverage = (

--- a/apps/reports/insights_views.py
+++ b/apps/reports/insights_views.py
@@ -291,7 +291,11 @@ def program_insights(request):
 
         # ── FHIR metadata features ──
         goal_source_dist = get_goal_source_distribution(program, date_from, date_to)
-        practice_health = get_practice_health(program, date_from, date_to)
+        practice_health = get_practice_health(
+            program, date_from, date_to,
+            goal_source_dist=goal_source_dist,
+            data_completeness=data_completeness,
+        )
 
         # Enrich achievement rates with not-achieved count and journey context
         for metric_id, ach in achievement_rates_data.items():

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -2114,57 +2114,6 @@ document.body.addEventListener("htmx:afterSettle", function (event) {
         });
     }
 
-    // Goal source distribution horizontal bar chart (Feature A)
-    function initGoalSourceChart() {
-        var el = document.getElementById('goal-source-data');
-        if (!el) return;
-        var data;
-        try { data = JSON.parse(el.textContent); } catch (e) { return; }
-        if (!data || !data.sources) return;
-
-        var ctx = document.getElementById('goal-source-chart');
-        if (!ctx || ctx.getAttribute('data-chart-init')) return;
-        ctx.setAttribute('data-chart-init', '1');
-
-        // Filter out suppressed sources for the chart
-        var visible = data.sources.filter(function (s) { return !s.suppressed; });
-        if (visible.length === 0) return;
-
-        var colours = ['#5e81ac', '#a3be8c', '#ebcb8b', '#bf616a', '#b48ead'];
-
-        new Chart(ctx.getContext('2d'), {
-            type: 'bar',
-            data: {
-                labels: visible.map(function (s) { return s.label; }),
-                datasets: [{
-                    data: visible.map(function (s) { return s.pct; }),
-                    backgroundColor: visible.map(function (_, i) { return colours[i % colours.length]; }),
-                    borderWidth: 0,
-                }],
-            },
-            options: {
-                indexAxis: 'y',
-                responsive: true,
-                maintainAspectRatio: false,
-                animation: { duration: animDuration },
-                plugins: {
-                    legend: { display: false },
-                    tooltip: {
-                        callbacks: {
-                            label: function (c) {
-                                var src = visible[c.dataIndex];
-                                return src.label + ': ' + src.count + ' (' + src.pct + '%)';
-                            }
-                        }
-                    }
-                },
-                scales: {
-                    x: { beginAtZero: true, max: 100, ticks: { callback: function (v) { return v + '%'; } } },
-                },
-            },
-        });
-    }
-
     // Unified dispatcher — runs all chart initialisers that find their data element
     function initAllCharts() {
         if (typeof Chart === 'undefined') return;
@@ -2172,7 +2121,6 @@ document.body.addEventListener("htmx:afterSettle", function (event) {
         initClientTrendChart();
         initDescriptorTrendChart();
         initDistributionTrendCharts();
-        initGoalSourceChart();
     }
 
     // Run on initial page load


### PR DESCRIPTION
## Summary
- Fix cross-program stale episode counting bug (notes per-program, not global)
- Remove dead code: _count_stale_episodes, initGoalSourceChart
- Avoid 3-4 redundant queries on Insights page (pass pre-computed data)
- Add PlanTarget.POSITIVE_ACHIEVEMENT_STATUSES constant (replaces 5 hardcoded lists)
- Remove unused params from _batch_fhir_enrichment
- Use enrolment_stats active_ids instead of re-querying

## Test plan
- [ ] Verify dashboard stale episodes count correctly per-program
- [ ] Verify Insights page loads without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)