### PR TITLE
Add support for hyphen-prefixed Fernet keys in key rotation

### DIFF
--- a/apps/auth_app/management/commands/rotate_encryption_key.py
+++ b/apps/auth_app/management/commands/rotate_encryption_key.py
@@ -35,6 +35,10 @@ from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction
 
 
+KEY_OPTION_FLAGS = {"--old-key", "--new-key"}
+KNOWN_OPTION_FLAGS = KEY_OPTION_FLAGS | {"--dry-run"}
+
+
 # Registry of (model_class, [encrypted_field_names])
 def _get_encrypted_models():
     """Import models lazily to avoid app-registry issues."""
@@ -102,8 +106,52 @@ def _re_encrypt_bytes(raw_bytes, old_fernet, new_fernet):
     return new_fernet.encrypt(plaintext)
 
 
+def _normalise_key_option_args(args):
+    """Convert key args to --flag=value form when the value starts with '-'.
+
+    Django's ``call_command()`` replays required keyword options through
+    argparse as separate tokens. Valid Fernet keys can begin with ``-``, which
+    makes argparse think the value is another option. Rewriting only the key
+    flags to ``--flag=value`` removes that ambiguity while preserving meaning.
+    """
+    if not args:
+        return args
+
+    normalised = []
+    index = 0
+    while index < len(args):
+        token = args[index]
+        if (
+            token in KEY_OPTION_FLAGS
+            and index + 1 < len(args)
+            and args[index + 1].startswith("-")
+            and args[index + 1] not in KNOWN_OPTION_FLAGS
+        ):
+            normalised.append(f"{token}={args[index + 1]}")
+            index += 2
+            continue
+
+        normalised.append(token)
+        index += 1
+
+    return normalised
+
+
 class Command(BaseCommand):
     help = "Re-encrypt all PII fields from an old Fernet key to a new one."
+
+    def create_parser(self, prog_name, subcommand, **kwargs):
+        parser = super().create_parser(prog_name, subcommand, **kwargs)
+        original_parse_args = parser.parse_args
+
+        def parse_args(args=None, namespace=None):
+            return original_parse_args(
+                _normalise_key_option_args(args),
+                namespace,
+            )
+
+        parser.parse_args = parse_args
+        return parser
 
     def add_arguments(self, parser):
         parser.add_argument(

--- a/tests/test_rotate_encryption_key.py
+++ b/tests/test_rotate_encryption_key.py
@@ -15,6 +15,13 @@ def _safe_fernet_key():
         if not key.startswith("-"):
             return key
 
+
+def _hyphen_prefixed_fernet_key():
+    while True:
+        key = Fernet.generate_key().decode()
+        if key.startswith("-"):
+            return key
+
 TEST_KEY = _safe_fernet_key()
 OLD_KEY = _safe_fernet_key()
 NEW_KEY = _safe_fernet_key()
@@ -159,7 +166,7 @@ class RotateEncryptionKeyInvalidKeyTest(TestCase):
         enc_module._fernet = None
 
     def test_invalid_old_key_raises_error(self):
-        valid_key = Fernet.generate_key().decode()
+        valid_key = _hyphen_prefixed_fernet_key()
         with self.assertRaises(CommandError) as ctx:
             call_command(
                 "rotate_encryption_key",


### PR DESCRIPTION
This pull request addresses an issue with Fernet keys that start with a hyphen, which can cause ambiguity in Django's command-line argument parsing. The main change is to ensure that such keys are handled correctly when passed as command-line arguments, preventing them from being misinterpreted as option flags. The updates include both code changes in the command implementation and enhancements to the test suite.

**Command-line argument handling improvements:**

* Added `_normalise_key_option_args` function in `rotate_encryption_key.py` to rewrite key arguments to `--flag=value` form when the value starts with a hyphen, preventing argparse from misinterpreting Fernet keys as option flags.
* Modified the `Command` class in `rotate_encryption_key.py` to use the new normalization function in its argument parser, ensuring robust handling of hyphen-prefixed keys.
* Introduced `KEY_OPTION_FLAGS` and `KNOWN_OPTION_FLAGS` constants to support the normalization logic.

**Test suite enhancements:**

* Added `_hyphen_prefixed_fernet_key` utility in `test_rotate_encryption_key.py` to generate Fernet keys starting with a hyphen for more thorough testing.
* Updated the `test_invalid_old_key_raises_error` test to use a hyphen-prefixed Fernet key, validating the new argument normalization logic.