### PR TITLE
fix: guard migration 0009 against missing report_templates table

### DIFF
--- a/apps/reports/migrations/0009_migrate_templates_to_partners.py
+++ b/apps/reports/migrations/0009_migrate_templates_to_partners.py
@@ -12,6 +12,17 @@ def forwards(apps, schema_editor):
     ReportTemplate = apps.get_model("reports", "ReportTemplate")
     Partner = apps.get_model("reports", "Partner")
 
+    # Check if the report_templates table exists — on fresh databases where
+    # FunderProfile was never created, the rename in 0006 may have been faked
+    # and the M2M through table won't exist yet.
+    from django.db import connection
+    with connection.cursor() as cursor:
+        cursor.execute(
+            "SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_name = 'report_templates')"
+        )
+        if not cursor.fetchone()[0]:
+            return
+
     for template in ReportTemplate.objects.all():
         partner = Partner.objects.create(
             name=template.name,


### PR DESCRIPTION
## Summary
- Production Railway DB never had FunderProfile, so migration 0006 (rename → ReportTemplate) gets faked and `report_templates_programs` M2M table doesn't exist
- Migration 0009 crashes trying to query that table during data migration
- Fix: check if the table exists before attempting the migration; skip if not (nothing to migrate anyway)

## Test plan
- [ ] Deploy to Railway production — container should start without migration crash
- [ ] Verify demo.konote.ca loads the login page

🤖 Generated with [Claude Code](https://claude.com/claude-code)