### PR TITLE
Merge pull request #539 from LogicalOutcomes/develop

### DIFF
--- a/apps/reports/migrations/0009_migrate_templates_to_partners.py
+++ b/apps/reports/migrations/0009_migrate_templates_to_partners.py
@@ -4,21 +4,111 @@ For each existing template, a Partner is created with the template's name
 and partner_type="funder" (safe default). The template's programs M2M is
 copied to the partner's programs M2M, and the template is linked to the
 new partner.
+
+Some production databases were left in a partially-migrated state where the
+legacy ReportTemplate/FunderProfile M2M table was missing even though the main
+tables existed. Accessing ``template.programs`` through the ORM crashes in that
+state, so this migration reads the join table defensively and falls back to the
+pre-rename table name when needed.
 """
 from django.db import migrations
+
+
+CURRENT_TEMPLATE_PROGRAMS_TABLE = "report_templates_programs"
+LEGACY_TEMPLATE_PROGRAMS_TABLE = "funder_profiles_programs"
+
+
+def _get_existing_tables(connection):
+    return set(connection.introspection.table_names())
+
+
+def _read_program_ids(connection, quote_name, table_name, template_column, template_pk):
+    with connection.cursor() as cursor:
+        cursor.execute(
+            f"SELECT {quote_name('program_id')} "
+            f"FROM {quote_name(table_name)} "
+            f"WHERE {quote_name(template_column)} = %s",
+            [template_pk],
+        )
+        return [row[0] for row in cursor.fetchall()]
+
+
+def _get_template_program_ids(connection, quote_name, template_pk, existing_tables=None):
+    existing_tables = (
+        existing_tables
+        if existing_tables is not None
+        else _get_existing_tables(connection)
+    )
+
+    if CURRENT_TEMPLATE_PROGRAMS_TABLE in existing_tables:
+        return _read_program_ids(
+            connection,
+            quote_name,
+            CURRENT_TEMPLATE_PROGRAMS_TABLE,
+            "reporttemplate_id",
+            template_pk,
+        )
+
+    if LEGACY_TEMPLATE_PROGRAMS_TABLE in existing_tables:
+        return _read_program_ids(
+            connection,
+            quote_name,
+            LEGACY_TEMPLATE_PROGRAMS_TABLE,
+            "funderprofile_id",
+            template_pk,
+        )
+
+    return []
+
+
+def _ensure_partner_programs_table(schema_editor, Partner, existing_tables=None):
+    existing_tables = (
+        existing_tables
+        if existing_tables is not None
+        else _get_existing_tables(schema_editor.connection)
+    )
+    through_model = Partner._meta.get_field("programs").remote_field.through
+    through_table = through_model._meta.db_table
+
+    if through_table not in existing_tables:
+        schema_editor.create_model(through_model)
+        existing_tables.add(through_table)
+
+    return through_table
 
 
 def forwards(apps, schema_editor):
     ReportTemplate = apps.get_model("reports", "ReportTemplate")
     Partner = apps.get_model("reports", "Partner")
+    connection = schema_editor.connection
+    existing_tables = _get_existing_tables(connection)
+
+    _ensure_partner_programs_table(schema_editor, Partner, existing_tables)
+
+    # Check if the report_templates table exists — on fresh databases where
+    # FunderProfile was never created, the rename in 0006 may have been faked
+    # and the M2M through table won't exist yet.
+    from django.db import connection
+    with connection.cursor() as cursor:
+        cursor.execute(
+            "SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_name = 'report_templates')"
+        )
+        if not cursor.fetchone()[0]:
+            return
 
     for template in ReportTemplate.objects.all():
         partner = Partner.objects.create(
             name=template.name,
             partner_type="funder",
         )
-        # Copy programs from template to partner
-        partner.programs.set(template.programs.all())
+        program_ids = _get_template_program_ids(
+            connection,
+            schema_editor.quote_name,
+            template.pk,
+            existing_tables,
+        )
+        if program_ids:
+            partner.programs.set(program_ids)
         # Link template to partner
         template.partner = partner
         template.save(update_fields=["partner"])
@@ -28,10 +118,12 @@ def backwards(apps, schema_editor):
     # Reverse: copy partner.programs back to template.programs, unlink partner
     ReportTemplate = apps.get_model("reports", "ReportTemplate")
     Partner = apps.get_model("reports", "Partner")
+    existing_tables = _get_existing_tables(schema_editor.connection)
 
     for template in ReportTemplate.objects.select_related("partner").all():
         if template.partner:
-            template.programs.set(template.partner.programs.all())
+            if CURRENT_TEMPLATE_PROGRAMS_TABLE in existing_tables:
+                template.programs.set(template.partner.programs.all())
             template.partner = None
             template.save(update_fields=["partner"])
 

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -1,10 +1,12 @@
 """Tests for the reports app — fiscal year functionality, metric export, demographics, and achievements."""
+from importlib import import_module
 import json
 import shutil
 import tempfile
 from datetime import date, datetime, timedelta
 from unittest.mock import patch
 
+from django.db import connection
 from django.test import TestCase, Client, override_settings
 from django.utils import timezone
 from django.utils.translation import override as translation_override
@@ -67,6 +69,64 @@ def create_test_partner(name="Test Partner", partner_type="funder", **kwargs):
 
 
 TEST_KEY = Fernet.generate_key().decode()
+
+
+class ReportTemplateProgramMigrationFallbackTests(TestCase):
+    """Regression tests for drift-tolerant program copying in reports.0009."""
+
+    databases = {"default"}
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.migration_module = import_module(
+            "apps.reports.migrations.0009_migrate_templates_to_partners"
+        )
+
+    def _drop_table_if_exists(self, table_name):
+        with connection.cursor() as cursor:
+            cursor.execute(f'DROP TABLE IF EXISTS {connection.ops.quote_name(table_name)}')
+
+    def test_get_template_program_ids_reads_legacy_join_table(self):
+        """The migration should fall back to the pre-rename join table when needed."""
+        self._drop_table_if_exists("funder_profiles_programs")
+        self.addCleanup(self._drop_table_if_exists, "funder_profiles_programs")
+
+        with connection.cursor() as cursor:
+            cursor.execute(
+                """
+                CREATE TABLE funder_profiles_programs (
+                    funderprofile_id bigint NOT NULL,
+                    program_id bigint NOT NULL
+                )
+                """
+            )
+            cursor.execute(
+                """
+                INSERT INTO funder_profiles_programs (funderprofile_id, program_id)
+                VALUES (7, 101), (7, 102), (8, 103)
+                """
+            )
+
+        program_ids = self.migration_module._get_template_program_ids(
+            connection,
+            connection.ops.quote_name,
+            7,
+            {"funder_profiles_programs"},
+        )
+
+        self.assertEqual(program_ids, [101, 102])
+
+    def test_get_template_program_ids_returns_empty_when_join_tables_missing(self):
+        """The migration should skip program copying instead of crashing when both join tables are absent."""
+        program_ids = self.migration_module._get_template_program_ids(
+            connection,
+            connection.ops.quote_name,
+            7,
+            set(),
+        )
+
+        self.assertEqual(program_ids, [])
 
 
 class FiscalYearUtilsTest(TestCase):


### PR DESCRIPTION
This pull request improves the robustness of the `0009_migrate_templates_to_partners` migration by making it tolerant to partially-migrated or inconsistent database states, particularly regarding missing or renamed join tables. It also adds regression tests to ensure this fallback logic works as intended.

**Migration robustness improvements:**

* Refactored the migration to defensively read program IDs from either the current (`report_templates_programs`) or legacy (`funder_profiles_programs`) join tables, preventing crashes if one is missing. This logic is encapsulated in new helper functions (`_get_template_program_ids`, `_read_program_ids`, etc.).
* Updated the migration's `forwards` and `backwards` functions to use the new fallback logic, ensuring safe copying of program relationships even if join tables are missing or renamed. [[1]](diffhunk://#diff-eb8afe9aecdcb2719d282542d10465cd276cfb684159f9317f9ec26bcf66ef2aR7-R111) [[2]](diffhunk://#diff-eb8afe9aecdcb2719d282542d10465cd276cfb684159f9317f9ec26bcf66ef2aR121-R125)

**Testing improvements:**

* Added `ReportTemplateProgramMigrationFallbackTests` to verify that the migration correctly falls back to the legacy join table and gracefully handles the absence of both join tables.
* Imported required modules for testing, such as `import_module` and `connection`, to support the new tests.