### PR TITLE
fix: guard migration 0010 against missing report_templates table

### DIFF
--- a/apps/reports/migrations/0010_cleanup_partner_nonnull_remove_programs.py
+++ b/apps/reports/migrations/0010_cleanup_partner_nonnull_remove_programs.py
@@ -6,7 +6,43 @@ Partner assigned, so the AlterField to non-nullable is safe.
 Programs are now managed on the Partner entity, not the ReportTemplate.
 """
 import django.db.models.deletion
-from django.db import migrations, models
+from django.db import connection, migrations, models
+
+
+def _table_exists(table_name):
+    with connection.cursor() as cursor:
+        cursor.execute(
+            "SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_name = %s)",
+            [table_name],
+        )
+        return cursor.fetchone()[0]
+
+
+def _column_exists(table_name, column_name):
+    with connection.cursor() as cursor:
+        cursor.execute(
+            "SELECT EXISTS (SELECT FROM information_schema.columns "
+            "WHERE table_name = %s AND column_name = %s)",
+            [table_name, column_name],
+        )
+        return cursor.fetchone()[0]
+
+
+def forwards(apps, schema_editor):
+    """Apply schema changes only if the tables/columns actually exist.
+
+    On fresh databases where FunderProfile was never created, the
+    report_templates table and its programs M2M may not exist yet.
+    """
+    # Make partner FK non-nullable (only if the column exists and is nullable)
+    if _table_exists("report_templates") and _column_exists("report_templates", "partner_id"):
+        schema_editor.execute(
+            'ALTER TABLE "report_templates" ALTER COLUMN "partner_id" SET NOT NULL'
+        )
+
+    # Drop the programs M2M through table (only if it exists)
+    if _table_exists("report_templates_programs"):
+        schema_editor.execute('DROP TABLE "report_templates_programs"')
 
 
 class Migration(migrations.Migration):
@@ -16,20 +52,27 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        # Make partner FK non-nullable (all rows already have a value from 0009)
-        migrations.AlterField(
-            model_name="reporttemplate",
-            name="partner",
-            field=models.ForeignKey(
-                help_text="The partner this report template belongs to.",
-                on_delete=django.db.models.deletion.CASCADE,
-                related_name="report_templates",
-                to="reports.partner",
-            ),
-        ),
-        # Remove the programs M2M (now lives on Partner)
-        migrations.RemoveField(
-            model_name="reporttemplate",
-            name="programs",
+        # Use SeparateDatabaseAndState so Django's state tracker knows the
+        # field changes happened, but the actual SQL is conditional.
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.AlterField(
+                    model_name="reporttemplate",
+                    name="partner",
+                    field=models.ForeignKey(
+                        help_text="The partner this report template belongs to.",
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="report_templates",
+                        to="reports.partner",
+                    ),
+                ),
+                migrations.RemoveField(
+                    model_name="reporttemplate",
+                    name="programs",
+                ),
+            ],
+            database_operations=[
+                migrations.RunPython(forwards, migrations.RunPython.noop),
+            ],
         ),
     ]


### PR DESCRIPTION
## Summary
- Migration 0010 crashes trying to `RemoveField` on `report_templates_programs` table that doesn't exist on fresh databases
- Same root cause as #540 (0009 fix) — FunderProfile was never created on the production Railway DB
- Fix: use `SeparateDatabaseAndState` to conditionally apply schema changes only if tables exist

## Test plan
- [ ] Deploy to Railway production — should get past both 0009 and 0010 without crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)