### PR TITLE
Merge pull request #546 from LogicalOutcomes/develop

### DIFF
--- a/apps/reports/migrations/0010_cleanup_partner_nonnull_remove_programs.py
+++ b/apps/reports/migrations/0010_cleanup_partner_nonnull_remove_programs.py
@@ -6,7 +6,43 @@ Partner assigned, so the AlterField to non-nullable is safe.
 Programs are now managed on the Partner entity, not the ReportTemplate.
 """
 import django.db.models.deletion
-from django.db import migrations, models
+from django.db import connection, migrations, models
+
+
+def _table_exists(table_name):
+    with connection.cursor() as cursor:
+        cursor.execute(
+            "SELECT EXISTS (SELECT FROM information_schema.tables WHERE table_name = %s)",
+            [table_name],
+        )
+        return cursor.fetchone()[0]
+
+
+def _column_exists(table_name, column_name):
+    with connection.cursor() as cursor:
+        cursor.execute(
+            "SELECT EXISTS (SELECT FROM information_schema.columns "
+            "WHERE table_name = %s AND column_name = %s)",
+            [table_name, column_name],
+        )
+        return cursor.fetchone()[0]
+
+
+def forwards(apps, schema_editor):
+    """Apply schema changes only if the tables/columns actually exist.
+
+    On fresh databases where FunderProfile was never created, the
+    report_templates table and its programs M2M may not exist yet.
+    """
+    # Make partner FK non-nullable (only if the column exists and is nullable)
+    if _table_exists("report_templates") and _column_exists("report_templates", "partner_id"):
+        schema_editor.execute(
+            'ALTER TABLE "report_templates" ALTER COLUMN "partner_id" SET NOT NULL'
+        )
+
+    # Drop the programs M2M through table (only if it exists)
+    if _table_exists("report_templates_programs"):
+        schema_editor.execute('DROP TABLE "report_templates_programs"')
 
 
 class Migration(migrations.Migration):
@@ -16,20 +52,27 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        # Make partner FK non-nullable (all rows already have a value from 0009)
-        migrations.AlterField(
-            model_name="reporttemplate",
-            name="partner",
-            field=models.ForeignKey(
-                help_text="The partner this report template belongs to.",
-                on_delete=django.db.models.deletion.CASCADE,
-                related_name="report_templates",
-                to="reports.partner",
-            ),
-        ),
-        # Remove the programs M2M (now lives on Partner)
-        migrations.RemoveField(
-            model_name="reporttemplate",
-            name="programs",
+        # Use SeparateDatabaseAndState so Django's state tracker knows the
+        # field changes happened, but the actual SQL is conditional.
+        migrations.SeparateDatabaseAndState(
+            state_operations=[
+                migrations.AlterField(
+                    model_name="reporttemplate",
+                    name="partner",
+                    field=models.ForeignKey(
+                        help_text="The partner this report template belongs to.",
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="report_templates",
+                        to="reports.partner",
+                    ),
+                ),
+                migrations.RemoveField(
+                    model_name="reporttemplate",
+                    name="programs",
+                ),
+            ],
+            database_operations=[
+                migrations.RunPython(forwards, migrations.RunPython.noop),
+            ],
         ),
     ]

--- a/apps/tenants/management/commands/setup_public_tenant.py
+++ b/apps/tenants/management/commands/setup_public_tenant.py
@@ -82,11 +82,34 @@ class Command(BaseCommand):
                 "Re-run with --domain <your-domain>."
             )
 
-        # Idempotent: skip if this domain is already registered.
+        # Idempotent: if primary domain is already registered, just ensure
+        # any new ALLOWED_HOSTS entries are registered as secondary domains.
         if AgencyDomain.objects.filter(domain=domain).exists():
-            self.stdout.write(
-                f"Domain '{domain}' is already registered — nothing to do."
-            )
+            agency_domain = AgencyDomain.objects.get(domain=domain)
+            agency = agency_domain.tenant
+            raw = os.environ.get("ALLOWED_HOSTS", "")
+            all_hosts = [h.strip() for h in raw.split(",") if h.strip()]
+            added = False
+            for host in all_hosts:
+                if (
+                    host != domain
+                    and not host.startswith(".")
+                    and host not in ("localhost", "127.0.0.1", "0.0.0.0")
+                    and not AgencyDomain.objects.filter(domain=host).exists()
+                ):
+                    AgencyDomain.objects.create(
+                        domain=host,
+                        tenant=agency,
+                        is_primary=False,
+                    )
+                    self.stdout.write(
+                        self.style.SUCCESS(f"  Secondary domain '{host}' registered.")
+                    )
+                    added = True
+            if not added:
+                self.stdout.write(
+                    f"Domain '{domain}' is already registered — nothing to do."
+                )
             return
 
         # Wrap agency creation + domain registration + localhost registration
@@ -121,6 +144,27 @@ class Command(BaseCommand):
             self.stdout.write(
                 self.style.SUCCESS(f"  Domain '{domain}' registered.")
             )
+
+            # Register all other valid domains from ALLOWED_HOSTS as secondary
+            # domains so requests via alternate domains (e.g. demo-dev.konote.ca
+            # alongside konote-dev.llewelyn.ca) resolve to the same tenant.
+            raw = os.environ.get("ALLOWED_HOSTS", "")
+            all_hosts = [h.strip() for h in raw.split(",") if h.strip()]
+            for host in all_hosts:
+                if (
+                    host != domain
+                    and not host.startswith(".")
+                    and host not in ("localhost", "127.0.0.1", "0.0.0.0")
+                    and not AgencyDomain.objects.filter(domain=host).exists()
+                ):
+                    AgencyDomain.objects.create(
+                        domain=host,
+                        tenant=agency,
+                        is_primary=False,
+                    )
+                    self.stdout.write(
+                        self.style.SUCCESS(f"  Secondary domain '{host}' registered.")
+                    )
 
             # Register 'localhost' as a secondary domain so Docker health checks
             # (curl http://localhost:8000/auth/login/) can resolve to a tenant.


### PR DESCRIPTION
This pull request introduces improvements to database migrations for safer schema updates and enhances the setup process for public tenants by ensuring all relevant domains are registered. The migration changes make schema modifications more robust on fresh databases, while the setup script now automatically registers all valid secondary domains from `ALLOWED_HOSTS` for a tenant, improving multi-domain support.

**Database migration robustness:**
- The migration in `0010_cleanup_partner_nonnull_remove_programs.py` now checks for the existence of tables and columns before altering the schema. This prevents errors when running migrations on fresh databases where some tables may not exist. The actual SQL is executed conditionally using a `forwards` function, wrapped in a `SeparateDatabaseAndState` operation. [[1]](diffhunk://#diff-1c9bdb69abb94d2235a588d52bf71547892ed9e4730f138a4981cc311930a6f5L9-R45) [[2]](diffhunk://#diff-1c9bdb69abb94d2235a588d52bf71547892ed9e4730f138a4981cc311930a6f5L19-R58) [[3]](diffhunk://#diff-1c9bdb69abb94d2235a588d52bf71547892ed9e4730f138a4981cc311930a6f5L30-R77)

**Tenant domain registration improvements:**
- The `setup_public_tenant.py` management command now automatically registers all valid domains from the `ALLOWED_HOSTS` environment variable as secondary domains for a tenant. This ensures that requests via alternate domains resolve to the same tenant, improving support for multi-domain setups and Docker environments. [[1]](diffhunk://#diff-bacd798c0cbef0ec2ca53670456a7d2024a3306af1f13b0ebf894392416eab3bL85-R109) [[2]](diffhunk://#diff-bacd798c0cbef0ec2ca53670456a7d2024a3306af1f13b0ebf894392416eab3bR148-R168)