### PR TITLE
🎨 Palette: Hide decorative HTML entities from screen readers

### DIFF
--- a/apps/portal/templates/portal/_new_since_banner.html
+++ b/apps/portal/templates/portal/_new_since_banner.html
@@ -47,7 +47,7 @@
                 class="portal-banner-dismiss"
                 data-dismiss-banner="true"
                 aria-label="{% trans 'Dismiss this notice' %}">
-            &times;
+            <span aria-hidden="true">&times;</span>
         </button>
     </div>
 </div>

--- a/apps/portal/templates/portal/correction_request.html
+++ b/apps/portal/templates/portal/correction_request.html
@@ -53,6 +53,6 @@
 {% endif %}
 
 <p>
-    <a href="{% url 'portal:goals' %}">&larr; {% trans "Back to My Goals" %}</a>
+    <a href="{% url 'portal:goals' %}"><span aria-hidden="true">&larr;</span> {% trans "Back to My Goals" %}</a>
 </p>
 {% endblock %}

--- a/apps/portal/templates/portal/discuss_next.html
+++ b/apps/portal/templates/portal/discuss_next.html
@@ -28,6 +28,6 @@
 </form>
 
 <p>
-    <a href="{% url 'portal:dashboard' %}">&larr; {% trans "Back to Home" %}</a>
+    <a href="{% url 'portal:dashboard' %}"><span aria-hidden="true">&larr;</span> {% trans "Back to Home" %}</a>
 </p>
 {% endblock %}

--- a/apps/portal/templates/portal/goal_detail.html
+++ b/apps/portal/templates/portal/goal_detail.html
@@ -83,7 +83,7 @@
 </p>
 
 <p>
-    <a href="{% url 'portal:goals' %}">&larr; {% trans "Back to My Goals" %}</a>
+    <a href="{% url 'portal:goals' %}"><span aria-hidden="true">&larr;</span> {% trans "Back to My Goals" %}</a>
 </p>
 {% endblock %}
 

--- a/apps/portal/templates/portal/journal_create.html
+++ b/apps/portal/templates/portal/journal_create.html
@@ -26,6 +26,6 @@
 </form>
 
 <p>
-    <a href="{% url 'portal:journal' %}">&larr; {% trans "Back to My Journal" %}</a>
+    <a href="{% url 'portal:journal' %}"><span aria-hidden="true">&larr;</span> {% trans "Back to My Journal" %}</a>
 </p>
 {% endblock %}

--- a/apps/portal/templates/portal/mfa_verify.html
+++ b/apps/portal/templates/portal/mfa_verify.html
@@ -40,7 +40,7 @@
     </form>
 
     <p>
-        <a href="{% url 'portal:login' %}">&larr; {% trans "Back to sign in" %}</a>
+        <a href="{% url 'portal:login' %}"><span aria-hidden="true">&larr;</span> {% trans "Back to sign in" %}</a>
     </p>
 </article>
 {% endblock %}

--- a/apps/portal/templates/portal/password_change.html
+++ b/apps/portal/templates/portal/password_change.html
@@ -54,6 +54,6 @@
 </form>
 
 <p>
-    <a href="{% url 'portal:settings' %}">&larr; {% trans "Back to Settings" %}</a>
+    <a href="{% url 'portal:settings' %}"><span aria-hidden="true">&larr;</span> {% trans "Back to Settings" %}</a>
 </p>
 {% endblock %}

--- a/apps/portal/templates/portal/password_reset_confirm.html
+++ b/apps/portal/templates/portal/password_reset_confirm.html
@@ -76,7 +76,7 @@
     {% endif %}
 
     <p>
-        <a href="{% url 'portal:login' %}">&larr; {% trans "Back to sign in" %}</a>
+        <a href="{% url 'portal:login' %}"><span aria-hidden="true">&larr;</span> {% trans "Back to sign in" %}</a>
     </p>
 </article>
 {% endblock %}

--- a/apps/portal/templates/portal/password_reset_request.html
+++ b/apps/portal/templates/portal/password_reset_request.html
@@ -46,7 +46,7 @@
     {% endif %}
 
     <p>
-        <a href="{% url 'portal:login' %}">&larr; {% trans "Back to sign in" %}</a>
+        <a href="{% url 'portal:login' %}"><span aria-hidden="true">&larr;</span> {% trans "Back to sign in" %}</a>
     </p>
 </article>
 {% endblock %}

--- a/apps/portal/templates/portal/survey_fill.html
+++ b/apps/portal/templates/portal/survey_fill.html
@@ -157,18 +157,18 @@
 
     <div class="survey-nav">
         {% if is_multi_page and page_num > 1 %}
-        <a href="?page={{ page_num|add:"-1" }}" class="outline">&larr; {% trans "Back" %}</a>
+        <a href="?page={{ page_num|add:"-1" }}" class="outline"><span aria-hidden="true">&larr;</span> {% trans "Back" %}</a>
         {% endif %}
 
         {% if is_multi_page and not is_last_page %}
-        <button type="submit" name="action" value="next">{% trans "Next" %} &rarr;</button>
+        <button type="submit" name="action" value="next">{% trans "Next" %} <span aria-hidden="true">&rarr;</span></button>
         {% else %}
         <button type="submit" name="action" value="submit">{% trans "Submit" %}</button>
         {% endif %}
     </div>
 </form>
 
-<p><a href="{% url 'portal:surveys' %}">&larr; {% trans "Back to surveys" %}</a></p>
+<p><a href="{% url 'portal:surveys' %}"><span aria-hidden="true">&larr;</span> {% trans "Back to surveys" %}</a></p>
 
 <style>
 .survey-progress { margin-bottom: 1rem; }

--- a/apps/portal/templates/portal/survey_review.html
+++ b/apps/portal/templates/portal/survey_review.html
@@ -61,5 +61,5 @@
 </section>
 {% endif %}
 
-<p><a href="{% url 'portal:surveys' %}">&larr; {% trans "Back to surveys" %}</a></p>
+<p><a href="{% url 'portal:surveys' %}"><span aria-hidden="true">&larr;</span> {% trans "Back to surveys" %}</a></p>
 {% endblock %}


### PR DESCRIPTION
### 💡 What:
Added `aria-hidden="true"` to wrapper `<span>` elements around decorative HTML entities like `&larr;` (←), `&rarr;` (→), and `&times;` (×) across the Participant Portal templates.

### 🎯 Why:
Screen readers will natively read these HTML entities out loud (e.g., "leftwards arrow", "multiplication sign"). When used as decorative icons alongside text like "Back to My Goals" or a dismiss button with an `aria-label`, reading the symbol creates auditory clutter and confusion for users relying on assistive technology.

### ♿ Accessibility:
- Wrapped 13 instances of decorative entities in `<span aria-hidden="true">`.
- This ensures the visual presentation remains identical while significantly improving the experience for screen reader users by removing redundant or confusing announcements.

*(Recorded in `.Jules/palette.md`)*

---
*PR created automatically by Jules for task [7128616948106134276](https://jules.google.com/task/7128616948106134276) started by @pboachie*