### PR TITLE
fix: update Powered by KoNote links to www.konote.ca

### DIFF
--- a/templates/auth/login.html
+++ b/templates/auth/login.html
@@ -142,7 +142,7 @@
                 {% if site.support_email %}<span>{% trans "Support:" %} <a href="mailto:{{ site.support_email }}">{{ site.support_email }}</a></span>{% endif %}
             </div>
             <div class="site-footer-links">
-                <a href="https://logicaloutcomes.github.io/konote-website/" class="powered-by" target="_blank" rel="noopener">
+                <a href="https://www.konote.ca" class="powered-by" target="_blank" rel="noopener">
                     <img src="{% static 'img/konote-icon.png' %}" alt="" width="20" height="20">
                     {% trans "Powered by" %} KoNote
                 </a>

--- a/templates/base.html
+++ b/templates/base.html
@@ -305,7 +305,7 @@
                 {% if site.organization_name %}
                 <strong>{% if site.organization_website %}<a href="{{ site.organization_website }}" target="_blank" rel="noopener">{{ site.organization_name }}</a>{% else %}{{ site.organization_name }}{% endif %}</strong>
                 {% endif %}
-                <a href="https://logicaloutcomes.github.io/konote-website/" class="powered-by" target="_blank" rel="noopener">
+                <a href="https://www.konote.ca" class="powered-by" target="_blank" rel="noopener">
                     <img src="{% static 'img/konote-icon.png' %}" alt="" width="20" height="20">
                     {% trans "Powered by" %} KoNote
                 </a>


### PR DESCRIPTION
## Summary
- Updated "Powered by KoNote" footer links from old GitHub Pages URL (`logicaloutcomes.github.io/konote-website`) to `https://www.konote.ca`
- Fixed in both `base.html` (main app footer) and `login.html` (login page footer)

## Test plan
- [ ] Verify footer link on any authenticated page points to www.konote.ca
- [ ] Verify footer link on login page points to www.konote.ca

🤖 Generated with [Claude Code](https://claude.com/claude-code)