### PR TITLE
🎨 Palette: Add empty state styling for portal

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,11 @@
 ## 2025-03-10 - Add ARIA Labels to Copy Buttons
 **Learning:** Many "Copy" buttons in the app use the `copy-btn` class but lack `aria-label`s. Screen readers might just read "Copy" out of context, which can be confusing (e.g., "Copy what?").
 **Action:** Add descriptive `aria-label` attributes to these buttons (e.g., `aria-label="{% trans 'Copy calendar link' %}"`) to improve accessibility.
+
+## 2025-03-11 - Add Empty State Styles to Portal
+**Learning:** Many pages in the portal application render empty states inside `<article class="portal-empty-state">` blocks. However, the corresponding styling for `.portal-empty-state` was completely missing from `portal.css`, which left these states looking like unstyled text blocks and failing to guide users who have no content yet.
+**Action:** When creating new layouts (like the portal application), ensure that foundational components like empty states are properly styled to avoid "broken" looking pages for new users.
+
+## 2025-03-11 - Add Empty State Styles with A11y to Portal
+**Learning:** Many pages in the portal application render empty states inside `<article class="portal-empty-state">` blocks. However, the corresponding styling for `.portal-empty-state` was completely missing from `portal.css`. Also, when using CSS pseudo-elements to add an emoji icon (like `content: "\1F4CB"`), screen readers will try to read it. Using the `/ ""` syntax (`content: "\1F4CB" / ""`) ensures it stays decorative and prevents it from being read aloud.
+**Action:** When adding empty state CSS with emojis or icons using `::before`, always include `/ ""` to avoid screen readers announcing decorative visuals.

--- a/static/css/portal.css
+++ b/static/css/portal.css
@@ -347,6 +347,28 @@ a.portal-card article {
     font-style: italic;
 }
 
+/* ---- Empty states ---- */
+.portal-empty-state {
+    text-align: center;
+    padding: 3rem 1rem;
+    color: var(--pico-muted-color, #666);
+    background: #f5f0eb;
+    border-radius: 8px;
+    border: 1px dashed var(--pico-muted-border-color, #ddd);
+}
+.portal-empty-state::before {
+    content: "\1F4CB" / "";
+    display: block;
+    font-size: 2rem;
+    line-height: 1;
+    margin: 0 auto 1rem;
+    opacity: 0.45;
+}
+.portal-empty-state p {
+    margin-bottom: 0;
+    font-size: 0.95rem;
+}
+
 /* ---- Progress page redesign ---- */
 
 /* Card grid — single column, comfortable spacing */


### PR DESCRIPTION
💡 What: Added `.portal-empty-state` styles to `portal.css` to render empty states as dashed boxes with a decorative clipboard icon.
🎯 Why: Several portal pages (e.g., Journal, Milestones, Progress) rely on `<article class="portal-empty-state">` when there is no content, but this class had no styling applied, rendering as unstyled plain text. Adding styling provides clear visual structure to these states.
♿ Accessibility: The clipboard emoji added via CSS `::before` includes ` / ""` to ensure it remains purely decorative and is ignored by screen readers.

---
*PR created automatically by Jules for task [13789446583833343091](https://jules.google.com/task/13789446583833343091) started by @pboachie*