### PR TITLE
🛡️ Sentinel: [HIGH] Fix Missing rate limit on demo portal login

### DIFF
--- a/apps/auth_app/views.py
+++ b/apps/auth_app/views.py
@@ -385,6 +385,7 @@ def demo_login(request, role):
 
 @csrf_exempt
 @require_POST
+@ratelimit(key="ip", rate="10/m", method=["POST"], block=True)
 def demo_portal_login(request, record_id):
     """Quick-login as a demo participant. Only available when DEMO_MODE is enabled."""
     if not settings.DEMO_MODE:


### PR DESCRIPTION
## 🚨 Severity
HIGH

## 💡 Vulnerability
The `demo_portal_login` endpoint in `apps/auth_app/views.py` was missing rate limiting. 

## 🎯 Impact
Without rate limiting, this auth endpoint could be abused for Denial-of-Service (DoS) attacks or targeted account enumeration if demo mode is enabled in publicly accessible environments.

## 🔧 Fix
Added the `@ratelimit(key="ip", rate="10/m", method=["POST"], block=True)` decorator to standardise rate limit coverage across authentication endpoints.

## ✅ Verification
Tested tests pass locally. Verified the endpoint works normally and `test_language_switching.py` + `test_security.py` execution is successful.

---
*PR created automatically by Jules for task [8575463908171936194](https://jules.google.com/task/8575463908171936194) started by @pboachie*