### PR TITLE
🎨 Palette: Improve screen reader context for Report Preview Print buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,3 +5,7 @@
 ## 2025-03-10 - Add ARIA Labels to Copy Buttons
 **Learning:** Many "Copy" buttons in the app use the `copy-btn` class but lack `aria-label`s. Screen readers might just read "Copy" out of context, which can be confusing (e.g., "Copy what?").
 **Action:** Add descriptive `aria-label` attributes to these buttons (e.g., `aria-label="{% trans 'Copy calendar link' %}"`) to improve accessibility.
+
+## 2025-03-10 - Add Contextual ARIA Labels to Print Buttons
+**Learning:** "Print" buttons often lack context when read by screen readers. Adding an `aria-label` that includes the object being printed (e.g. `aria-label="{% trans 'Print report' %}"`) makes the action clearer, similar to expanding "Read more" to "Read more about [Subject]". Since the `aria-label` contains the visible text "Print", it complies with WCAG 2.1 SC 2.5.3 (Label in Name).
+**Action:** Ensure action buttons like "Print", "Download", or "Edit" have descriptive `aria-label`s that provide context on what the action applies to, while still including the visible text.

--- a/templates/reports/report_preview.html
+++ b/templates/reports/report_preview.html
@@ -130,7 +130,7 @@
             </button>
         </form>
         {% endif %}
-        <button type="button" class="outline secondary" data-print-page style="display: inline-flex; align-items: center; gap: 0.5rem;">
+        <button type="button" class="outline secondary" data-print-page aria-label="{% trans 'Print report' %}" style="display: inline-flex; align-items: center; gap: 0.5rem;">
             <span aria-hidden="true">&#x1F5A8;</span> {% trans "Print" %}
         </button>
     </div>
@@ -609,7 +609,7 @@
             </button>
         </form>
         {% endif %}
-        <button type="button" class="outline secondary" data-print-page style="display: inline-flex; align-items: center; gap: 0.5rem;">
+        <button type="button" class="outline secondary" data-print-page aria-label="{% trans 'Print report' %}" style="display: inline-flex; align-items: center; gap: 0.5rem;">
             <span aria-hidden="true">&#x1F5A8;</span> {% trans "Print" %}
         </button>
     </div>


### PR DESCRIPTION
💡 What: Added `aria-label="{% trans 'Print report' %}"` to the "Print" buttons on the report preview page.
🎯 Why: "Print" buttons often lack context when read by screen readers. Expanding the label clarifies *what* is being printed without changing the visual UI.
♿ Accessibility: Improves context for screen reader users and complies with WCAG 2.1 SC 2.5.3 (Label in Name) by ensuring the visible text "Print" is contained within the ARIA label.

---
*PR created automatically by Jules for task [14280203399729719918](https://jules.google.com/task/14280203399729719918) started by @pboachie*