### PR TITLE
🛡️ Sentinel: [HIGH] Add missing rate limiting to demo_portal_login

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** User-controlled data (consortium names, demographic labels, metrics) was not sanitized before being written to CSV exports in `apps/consortia/views.py`. The unsanitized `consortium.name` was also directly included in the `Content-Disposition` header filename.
 **Learning:** This exposes the application to CSV injection (Formula execution in Excel/LibreOffice) and potential HTTP header injection/path traversal attacks in dynamically generated filenames. This pattern was missing in the newer consortia app despite protections existing in the older reports app.
 **Prevention:** Always use `sanitise_csv_row` and `sanitise_filename` from `apps.reports.csv_utils` whenever dynamically generating CSV files and headers that contain user-provided text values.
+
+## 2024-03-05 - [Missing Rate Limiting on Demo Portal Login]
+**Vulnerability:** The `demo_portal_login` view in `apps/auth_app/views.py` lacked rate limiting protection.
+**Learning:** Even demo-specific authentication endpoints are susceptible to brute-force or Denial-of-Service (DoS) attacks if left unprotected. All authentication-related routes must enforce uniform rate limits.
+**Prevention:** Always apply the `@ratelimit(key="ip", rate="10/m", method=["POST"], block=True)` decorator (or appropriate thresholds) to all authentication endpoints, including those intended solely for demo purposes.

--- a/apps/auth_app/views.py
+++ b/apps/auth_app/views.py
@@ -385,6 +385,7 @@ def demo_login(request, role):
 
 @csrf_exempt
 @require_POST
+@ratelimit(key="ip", rate="10/m", method=["POST"], block=True)
 def demo_portal_login(request, record_id):
     """Quick-login as a demo participant. Only available when DEMO_MODE is enabled."""
     if not settings.DEMO_MODE:


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `demo_portal_login` view in `apps/auth_app/views.py` was missing rate limiting, making it vulnerable to brute-force or Denial-of-Service (DoS) attacks.
🎯 Impact: An attacker could continuously hit the endpoint, potentially consuming server resources or attempting brute-force identification of demo accounts.
🔧 Fix: Added `@ratelimit(key="ip", rate="10/m", method=["POST"], block=True)` to enforce uniform security, matching other authentication views.
✅ Verification: Ran test suite (`test_security.py`) to ensure no regressions were introduced and verified that `ratelimit` is properly imported in `views.py`. Also added learning to `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [18063930263812738416](https://jules.google.com/task/18063930263812738416) started by @pboachie*