### PR TITLE
🎨 Palette: Wrap decorative HTML entities in aria-hidden

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -16,3 +16,7 @@
 ## 2025-03-11 - Add Empty State Styles with A11y to Portal
 **Learning:** Many pages in the portal application render empty states inside `<article class="portal-empty-state">` blocks. However, the corresponding styling for `.portal-empty-state` was completely missing from `portal.css`. Also, when using CSS pseudo-elements to add an emoji icon (like `content: "\1F4CB"`), screen readers will try to read it. Using the `/ ""` syntax (`content: "\1F4CB" / ""`) ensures it stays decorative and prevents it from being read aloud.
 **Action:** When adding empty state CSS with emojis or icons using `::before`, always include `/ ""` to avoid screen readers announcing decorative visuals.
+
+## 2024-05-18 - Wrapped Decorative HTML Entities in `aria-hidden`
+**Learning:** When creating elements with decorative HTML entities (like `&times;` or `&rarr;`) inside elements that are already labeled using `aria-label` or `aria-labelledby`, the decorative entity should be wrapped in an element with `aria-hidden="true"` (like `<span aria-hidden="true">&times;</span>`). If not wrapped, screen readers might read out the literal symbol names alongside the intended accessible label, leading to confusing or redundant announcements for screen reader users.
+**Action:** Always verify if a visual-only character has meaning that conflicts with or duplicates the element's existing aria-label, and wrap it in `<span aria-hidden="true">` to preserve a clean auditory experience.

--- a/templates/clients/home.html
+++ b/templates/clients/home.html
@@ -20,7 +20,7 @@
 <article class="onboarding-banner" id="onboarding-banner" role="complementary" aria-label="{% trans 'Welcome banner' %}" hidden>
     <header>
         <strong>{% blocktrans with product_name=site.product_name|default:"KoNote" %}Welcome to {{ product_name }}! Need help getting started?{% endblocktrans %}</strong>
-        <button type="button" class="close-btn" id="dismiss-onboarding" aria-label="{% trans 'Dismiss welcome banner' %}">&times;</button>
+        <button type="button" class="close-btn" id="dismiss-onboarding" aria-label="{% trans 'Dismiss welcome banner' %}"><span aria-hidden="true">&times;</span></button>
     </header>
     <ul>
         <li>{% blocktrans with clients=term.client_plural|default:"participants" %}Use the search bar to find {{ clients }}, or the "+ New" button to register one{% endblocktrans %}</li>


### PR DESCRIPTION
Wrapped the decorative `&times;` entity in the onboarding banner close button inside an element with `aria-hidden="true"`. This prevents screen readers from announcing "multiplication sign" or "times" redundantly alongside the existing `aria-label`.

Also recorded this learning in `.Jules/palette.md` for future reference.

---
*PR created automatically by Jules for task [11170133471562345110](https://jules.google.com/task/11170133471562345110) started by @pboachie*