### PR TITLE
Restrict CI workflow to read-only permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     name: Run tests


### PR DESCRIPTION
Public repos inherit the repository-level default GITHUB_TOKEN permissions. Explicitly set contents: read so fork PRs can never escalate privileges if repo defaults change.