### PR TITLE
🛡️ Sentinel: [HIGH] Fix missing rate limiting on invite_accept endpoint

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** The `demo_portal_login` view was missing rate limiting, making it vulnerable to brute-force or DoS attacks.
 **Learning:** Even endpoints designed for demo purposes need to be protected. The `django-ratelimit` decorator with `block=True` should be applied uniformly to all authentication-related endpoints.
 **Prevention:** Always ensure the `@ratelimit(key="ip", rate="...", method="POST", block=True)` decorator is present on any view that processes login or authentication requests. Also make sure the import is present: `from django_ratelimit.decorators import ratelimit`.
+
+## 2024-03-05 - [Missing Rate Limiting on Invite Endpoints]
+**Vulnerability:** The `invite_accept` endpoint in `apps/auth_app/invite_views.py` allowed unauthenticated users to accept invites and register without rate limits.
+**Learning:** This made it vulnerable to brute force and DoS attacks by making it easy to test combinations of `code` or flood the endpoint with POST requests.
+**Prevention:** As with all public/authentication-related endpoints, ensure the `@ratelimit(key="ip", rate="...", method=["GET", "POST"], block=True)` decorator is applied. When using `key="ip"`, note that it assumes correct proxy settings are present (e.g. `X-Forwarded-For`) so it doesn't just block the proxy IP.

--- a/apps/auth_app/invite_views.py
+++ b/apps/auth_app/invite_views.py
@@ -8,6 +8,7 @@ from django.http import Http404
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils import timezone
 from django.utils.translation import gettext as _
+from django_ratelimit.decorators import ratelimit
 
 from apps.programs.models import UserProgramRole
 
@@ -52,6 +53,7 @@ def invite_create(request):
     return render(request, "auth_app/invite_form.html", {"form": form})
 
 
+@ratelimit(key="ip", rate="10/m", method=["GET", "POST"], block=True)
 def invite_accept(request, code):
     """Public view — new user registers via invite link."""
     invite = get_object_or_404(Invite, code=code)


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The `invite_accept` endpoint in `apps/auth_app/invite_views.py` allowed unauthenticated users to accept invites and register without rate limits.
🎯 **Impact:** This made the endpoint vulnerable to brute force attacks on the invite code and DoS attacks through rapid POST requests.
🔧 **Fix:** Added the `@ratelimit(key="ip", rate="10/m", method=["GET", "POST"], block=True)` decorator to the `invite_accept` view.
✅ **Verification:** Verified by checking existing usages of `django-ratelimit` and running the security test suite. Added learning to Sentinel journal.

---
*PR created automatically by Jules for task [2964699360881522137](https://jules.google.com/task/2964699360881522137) started by @pboachie*