### PR TITLE
🎨 Palette: Improve button accessibility with contextual ARIA labels

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -5,3 +5,7 @@
 ## 2025-03-10 - Add ARIA Labels to Copy Buttons
 **Learning:** Many "Copy" buttons in the app use the `copy-btn` class but lack `aria-label`s. Screen readers might just read "Copy" out of context, which can be confusing (e.g., "Copy what?").
 **Action:** Add descriptive `aria-label` attributes to these buttons (e.g., `aria-label="{% trans 'Copy calendar link' %}"`) to improve accessibility.
+
+## 2025-03-10 - Add Contextual ARIA Labels to Action Buttons in Lists
+**Learning:** Action buttons like "Approve" and "Dismiss" in dynamically generated lists (like survey assignments) lack context for screen readers when they don't explicitly reference the target item. A user tabbing through the page would hear "Approve, button", "Dismiss, button", etc., multiple times without knowing *what* is being approved.
+**Action:** Always add descriptive `aria-label` attributes to generic action buttons inside iterative loops, using `{% blocktrans %}` to include the item's name dynamically (e.g., `aria-label="{% blocktrans with name=a.survey.name %}Approve {{ name }}{% endblocktrans %}"`).

--- a/templates/surveys/client_surveys.html
+++ b/templates/surveys/client_surveys.html
@@ -51,18 +51,18 @@
                 {% if a.status == "awaiting_approval" %}
                 <form method="post" action="{% url 'surveys:approve_assignment' assignment_id=a.pk %}" style="display:inline">
                     {% csrf_token %}
-                    <button type="submit" class="outline" style="padding:0.25rem 0.5rem">{% trans "Approve" %}</button>
+                    <button type="submit" class="outline" style="padding:0.25rem 0.5rem" aria-label="{% blocktrans with name=a.survey.name %}Approve {{ name }}{% endblocktrans %}">{% trans "Approve" %}</button>
                 </form>
                 <form method="post" action="{% url 'surveys:dismiss_assignment' assignment_id=a.pk %}" style="display:inline">
                     {% csrf_token %}
-                    <button type="submit" class="outline secondary" style="padding:0.25rem 0.5rem">{% trans "Dismiss" %}</button>
+                    <button type="submit" class="outline secondary" style="padding:0.25rem 0.5rem" aria-label="{% blocktrans with name=a.survey.name %}Dismiss {{ name }}{% endblocktrans %}">{% trans "Dismiss" %}</button>
                 </form>
                 {% elif a.status == "pending" or a.status == "in_progress" %}
                 <a href="{% url 'surveys:staff_data_entry' client_id=client.pk survey_id=a.survey.pk %}">{% trans "Enter on behalf" %}</a>
                 ·
                 <form method="post" action="{% url 'surveys:dismiss_assignment' assignment_id=a.pk %}" style="display:inline">
                     {% csrf_token %}
-                    <button type="submit" class="outline secondary" style="padding:0.25rem 0.5rem">{% trans "Dismiss" %}</button>
+                    <button type="submit" class="outline secondary" style="padding:0.25rem 0.5rem" aria-label="{% blocktrans with name=a.survey.name %}Dismiss {{ name }}{% endblocktrans %}">{% trans "Dismiss" %}</button>
                 </form>
                 {% endif %}
             </td>


### PR DESCRIPTION
## 💡 What: Added contextual `aria-label`s to survey assignment action buttons

The "Approve" and "Dismiss" buttons in the survey assignments table (`templates/surveys/client_surveys.html`) were generic strings ("Approve", "Dismiss"). I wrapped them with an explicit `aria-label` attribute dynamically formatted with the current survey's name (e.g., `aria-label="Approve {{ name }}"`).

## 🎯 Why: Improved Screen Reader Context

When users tabbing through the interface encounter repeated action buttons in a table or list, generic labels like "Approve" or "Dismiss" offer no context about *what* is being approved or dismissed. This is particularly disorienting if the screen reader user tabs past the associated row text. By adding the survey name to the `aria-label`, assistive technology announces the exact item the button affects.

## ♿ Accessibility: Improved Action Clarity

*   Added dynamic `aria-label` attributes to "Approve" and "Dismiss" buttons in `client_surveys.html`.
*   Used Django's `{% blocktrans %}` to enable proper localization for the dynamic strings without introducing duplicate wording onto the screen itself.

---
*PR created automatically by Jules for task [2043630984585988598](https://jules.google.com/task/2043630984585988598) started by @pboachie*