### PR TITLE
🎨 Palette: Add accessible content mapping to empty state icon

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -16,3 +16,6 @@
 ## 2025-03-11 - Add Empty State Styles with A11y to Portal
 **Learning:** Many pages in the portal application render empty states inside `<article class="portal-empty-state">` blocks. However, the corresponding styling for `.portal-empty-state` was completely missing from `portal.css`. Also, when using CSS pseudo-elements to add an emoji icon (like `content: "\1F4CB"`), screen readers will try to read it. Using the `/ ""` syntax (`content: "\1F4CB" / ""`) ensures it stays decorative and prevents it from being read aloud.
 **Action:** When adding empty state CSS with emojis or icons using `::before`, always include `/ ""` to avoid screen readers announcing decorative visuals.
+## 2024-05-18 - Accessible CSS Emoji Content
+**Learning:** When using CSS pseudo-elements (`::before`, `::after`) to display decorative emojis or text-based icons, screen readers will read them aloud by default (e.g., reading out "clipboard"). This is not accessible or useful to users.
+**Action:** Append `/ ""` to the `content` property (e.g., `content: "\1F4CB" / "";`) to explicitly tell screen readers to read the emoji as an empty string, preventing unnecessary announcements.

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -1766,7 +1766,7 @@ button.outline.secondary:hover {
 }
 /* Static icon above empty state text */
 .empty-state::before {
-    content: "\1F4CB";  /* clipboard emoji — renders as text glyph */
+    content: "\1F4CB" / "";  /* clipboard emoji — renders as text glyph */
     display: block;
     font-size: 2rem;
     line-height: 1;


### PR DESCRIPTION
💡 What: The UX enhancement added
Added `/ ""` to the `content` property for `.empty-state::before` pseudo-element.

🎯 Why: The user problem it solves
Screen readers will read the decorative clipboard emoji ("📋") aloud (e.g., saying "clipboard"). This adds noise to the user experience without providing useful information since it's just a visual enhancement for the empty state. This change tells screen readers to ignore it by mapping the content to an empty string.

📸 Before/After: Visuals are exactly the same (verified via playwright screenshot), purely an accessibility fix.

♿ Accessibility: Decorative icon hidden from screen readers.

---
*PR created automatically by Jules for task [2799409247146453251](https://jules.google.com/task/2799409247146453251) started by @pboachie*