### PR TITLE
🎨 Palette: Improve accessibility for portal form errors

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -5,6 +5,7 @@
 ## 2025-03-10 - Add ARIA Labels to Copy Buttons
 **Learning:** Many "Copy" buttons in the app use the `copy-btn` class but lack `aria-label`s. Screen readers might just read "Copy" out of context, which can be confusing (e.g., "Copy what?").
 **Action:** Add descriptive `aria-label` attributes to these buttons (e.g., `aria-label="{% trans 'Copy calendar link' %}"`) to improve accessibility.
+
 ## 2024-05-24 - Screen Reader Compatibility for HTML Entities
 **Learning:** Decorative HTML entities like `&larr;` (left arrow), `&rarr;` (right arrow), and `&times;` (multiply/close icon) are read aloud by screen readers, creating confusing navigation text like "leftwards arrow Back to sign in" instead of just "Back to sign in".
 **Action:** Always wrap decorative HTML entities in a `<span aria-hidden="true">` to hide them from assistive technologies while keeping them visible on screen.
@@ -16,3 +17,7 @@
 ## 2025-03-11 - Add Empty State Styles with A11y to Portal
 **Learning:** Many pages in the portal application render empty states inside `<article class="portal-empty-state">` blocks. However, the corresponding styling for `.portal-empty-state` was completely missing from `portal.css`. Also, when using CSS pseudo-elements to add an emoji icon (like `content: "\1F4CB"`), screen readers will try to read it. Using the `/ ""` syntax (`content: "\1F4CB" / ""`) ensures it stays decorative and prevents it from being read aloud.
 **Action:** When adding empty state CSS with emojis or icons using `::before`, always include `/ ""` to avoid screen readers announcing decorative visuals.
+
+## 2025-03-27 - Add `.portal-field-error` to form error linking logic
+**Learning:** The participant portal application uses its own specific CSS classes for form validation errors, specifically `.portal-field-error`. The global `linkErrorMessages()` script in `static/js/app.js` (which automatically manages `aria-describedby` and `aria-invalid` attributes) was not targeting this class. This resulted in a disjointed experience for screen reader users in the portal, as form errors were not properly linked to their corresponding input fields.
+**Action:** When working on generic global utility scripts for accessibility (like linking form errors), ensure all variants of form error classes used across different sub-applications (like the portal) are included in the element selectors.

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -127,7 +127,7 @@ document.body.addEventListener("htmx:configRequest", function (event) {
 // and links the preceding input/select/textarea
 (function () {
     function linkErrorMessages() {
-        var errors = document.querySelectorAll("small.error, small.badge-danger");
+        var errors = document.querySelectorAll("small.error, small.badge-danger, small.portal-field-error");
         errors.forEach(function (errorEl) {
             // Walk backwards through siblings to find the form control
             var sibling = errorEl.previousElementSibling;
@@ -440,7 +440,7 @@ document.body.addEventListener("htmx:configRequest", function (event) {
 
     function hasValidationErrors(target) {
         if (!target || !(target instanceof Element)) return false;
-        var selector = "[aria-invalid='true'], .error-summary, small.error, small.badge-danger";
+        var selector = "[aria-invalid='true'], .error-summary, small.error, small.badge-danger, small.portal-field-error";
         return target.matches(selector) || !!target.querySelector(selector);
     }
 


### PR DESCRIPTION
💡 What: The global `linkErrorMessages()` function in `static/js/app.js` was updated to target `small.portal-field-error`.
🎯 Why: Form validation errors in the participant portal use the class `portal-field-error`, but the script responsible for automatically linking errors to their input fields via `aria-describedby` and setting `aria-invalid` was only looking for `.error` and `.badge-danger`. This resulted in screen reader users in the portal not having the error messages announced when interacting with invalid fields.
♿ Accessibility: Improved screen reader experience in the portal by ensuring that all field-level validation errors are explicitly associated with their input fields.

---
*PR created automatically by Jules for task [6702103992486739779](https://jules.google.com/task/6702103992486739779) started by @pboachie*