### PR TITLE
🛡️ Sentinel: [HIGH] Fix missing rate limiting on token/invite endpoints

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** The `demo_portal_login` view was missing rate limiting, making it vulnerable to brute-force or DoS attacks.
 **Learning:** Even endpoints designed for demo purposes need to be protected. The `django-ratelimit` decorator with `block=True` should be applied uniformly to all authentication-related endpoints.
 **Prevention:** Always ensure the `@ratelimit(key="ip", rate="...", method="POST", block=True)` decorator is present on any view that processes login or authentication requests. Also make sure the import is present: `from django_ratelimit.decorators import ratelimit`.
+
+## 2024-03-05 - [Missing Rate Limiting on Invite/Token Endpoints]
+**Vulnerability:** The endpoints `accept_invite`, `staff_assisted_login`, and `invite_accept` did not have rate limiting, making them vulnerable to brute-force or DoS attacks as they handle one-time tokens or register users.
+**Learning:** Endpoints that consume one-time tokens, magic links, or process user registrations act as authentication boundaries and must be protected. Brute-forcing tokens could compromise security, while flooding them could cause Denial-of-Service.
+**Prevention:** Always ensure the `@ratelimit(key="ip", rate="...", method=["GET", "POST"], block=True)` decorator is applied to token-handling and registration views (not just direct username/password login endpoints). Include `from django_ratelimit.decorators import ratelimit`.

--- a/apps/auth_app/invite_views.py
+++ b/apps/auth_app/invite_views.py
@@ -8,6 +8,7 @@ from django.http import Http404
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils import timezone
 from django.utils.translation import gettext as _
+from django_ratelimit.decorators import ratelimit
 
 from apps.programs.models import UserProgramRole
 
@@ -52,6 +53,7 @@ def invite_create(request):
     return render(request, "auth_app/invite_form.html", {"form": form})
 
 
+@ratelimit(key="ip", rate="10/m", method=["GET", "POST"], block=True)
 def invite_accept(request, code):
     """Public view — new user registers via invite link."""
     invite = get_object_or_404(Invite, code=code)

--- a/apps/portal/views.py
+++ b/apps/portal/views.py
@@ -333,6 +333,7 @@ def emergency_logout(request):
 
 
 @portal_feature_required
+@ratelimit(key="ip", rate="10/m", method=["GET", "POST"], block=True)
 def accept_invite(request, token):
     """Accept a portal invite — register a new ParticipantUser.
 
@@ -1020,6 +1021,7 @@ def password_reset_confirm(request):
 
 
 @portal_feature_required
+@ratelimit(key="ip", rate="10/m", method=["GET", "POST"], block=True)
 def staff_assisted_login(request, token):
     """Log a participant in via a staff-generated one-time token."""
     from apps.portal.models import StaffAssistedLoginToken


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The endpoints `accept_invite`, `staff_assisted_login`, and `invite_accept` did not have rate limiting, making them vulnerable to brute-force or DoS attacks.
🎯 **Impact:** An attacker could brute force one-time tokens or flood the registration endpoints.
🔧 **Fix:** Applied `@ratelimit(key="ip", rate="10/m", method=["GET", "POST"], block=True)` to these views to secure the authentication boundaries.
✅ **Verification:** Verified with code review and `compileall`. Documented in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [15682431894908746916](https://jules.google.com/task/15682431894908746916) started by @pboachie*