### PR TITLE
🎨 Palette: Add ARIA labels to progress elements

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -16,3 +16,7 @@
 ## 2025-03-11 - Add Empty State Styles with A11y to Portal
 **Learning:** Many pages in the portal application render empty states inside `<article class="portal-empty-state">` blocks. However, the corresponding styling for `.portal-empty-state` was completely missing from `portal.css`. Also, when using CSS pseudo-elements to add an emoji icon (like `content: "\1F4CB"`), screen readers will try to read it. Using the `/ ""` syntax (`content: "\1F4CB" / ""`) ensures it stays decorative and prevents it from being read aloud.
 **Action:** When adding empty state CSS with emojis or icons using `::before`, always include `/ ""` to avoid screen readers announcing decorative visuals.
+
+## 2025-02-28 - Missing ARIA labels on progress elements
+**Learning:** Found that `<progress>` elements used for CIDS coverage tracking in report and program templates were missing `aria-label` attributes. Without these labels, screen reader users would only hear the value and max limits without knowing what the progress bar represents.
+**Action:** Added `aria-label` attributes to `<progress>` elements in `templates/reports/cids_coverage_dashboard.html`, `templates/reports/cids_export_status.html`, and `templates/programs/evaluation/framework_detail.html` to clearly describe the tracked metric, ensuring compliance with accessibility standards (WCAG 4.1.2 Name, Role, Value).

--- a/templates/programs/evaluation/framework_detail.html
+++ b/templates/programs/evaluation/framework_detail.html
@@ -21,7 +21,7 @@
 <section>
     <h2>{% trans "CIDS Class Coverage" %}</h2>
     <p>{{ cids_coverage|length }} / {{ total_cids_classes }} {% trans "classes mapped" %} ({{ coverage_pct }}%)</p>
-    <progress value="{{ cids_coverage|length }}" max="{{ total_cids_classes }}"></progress>
+    <progress value="{{ cids_coverage|length }}" max="{{ total_cids_classes }}" aria-label="{% trans 'CIDS class coverage' %}"></progress>
 
     {% if framework.is_attested %}
     <article>

--- a/templates/reports/cids_coverage_dashboard.html
+++ b/templates/reports/cids_coverage_dashboard.html
@@ -13,7 +13,7 @@
     <article>
         <header>{% trans "Agency Coverage" %}</header>
         <p><strong>{{ all_classes_count }} / {{ total_classes }}</strong> {% trans "CIDS classes" %}</p>
-        <progress value="{{ all_classes_count }}" max="{{ total_classes }}"></progress>
+        <progress value="{{ all_classes_count }}" max="{{ total_classes }}" aria-label="{% trans 'Total CIDS classes coverage' %}"></progress>
     </article>
     <article>
         <header>{% trans "Programs" %}</header>
@@ -35,7 +35,7 @@
                 <strong>{{ summary.program.name }}</strong>
                 <span>{{ summary.present }} / {{ summary.total }} ({{ summary.pct }}%)</span>
             </div>
-            <progress value="{{ summary.present }}" max="{{ summary.total }}"></progress>
+            <progress value="{{ summary.present }}" max="{{ summary.total }}" aria-label="{% blocktrans with name=summary.program.name %}CIDS coverage for {{ name }}{% endblocktrans %}"></progress>
         </header>
         <figure>
         <table role="grid">

--- a/templates/reports/cids_export_status.html
+++ b/templates/reports/cids_export_status.html
@@ -9,7 +9,7 @@
     <p>{{ program.name }} — {{ present }} / {{ total }} {% trans "classes" %} ({{ pct }}%)</p>
 </hgroup>
 
-<progress value="{{ present }}" max="{{ total }}"></progress>
+<progress value="{{ present }}" max="{{ total }}" aria-label="{% trans 'CIDS export status progress' %}"></progress>
 
 {% if framework %}
 <article>


### PR DESCRIPTION
💡 **What:** Added missing `aria-label` attributes to the `<progress>` components used in CIDS compliance tracking pages.
🎯 **Why:** `<progress>` elements require an accessible name to provide context to screen reader users; otherwise, they only hear the numeric value and max limits without knowing what the metric represents.
♿ **Accessibility:** This ensures compliance with WCAG 4.1.2 (Name, Role, Value) for metric tracking visualizations.

---
*PR created automatically by Jules for task [6226699162806894371](https://jules.google.com/task/6226699162806894371) started by @pboachie*