### PR TITLE
🎨 Palette: Fix screen reader output for empty states

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -1766,7 +1766,8 @@ button.outline.secondary:hover {
 }
 /* Static icon above empty state text */
 .empty-state::before {
-    content: "\1F4CB";  /* clipboard emoji — renders as text glyph */
+    content: "\1F4CB";  /* fallback for older browsers */
+    content: "\1F4CB" / "";  /* clipboard emoji — renders as text glyph, screen reader hidden */
     display: block;
     font-size: 2rem;
     line-height: 1;


### PR DESCRIPTION
💡 **What:** Added `content: "\1F4CB" / ""` to `.empty-state::before` alongside a fallback property for older browsers.
🎯 **Why:** To prevent screen readers from announcing decorative emojis (like "clipboard") out of context when visually impaired users navigate empty states.
📸 **Before/After:** The visual layout is unchanged. 
♿ **Accessibility:** Fixes confusing screen reader output for `.empty-state` icons.

---
*PR created automatically by Jules for task [1801778407944451749](https://jules.google.com/task/1801778407944451749) started by @pboachie*