### PR TITLE
🛡️ Sentinel: [HIGH] Fix missing rate limiting on staff-assisted login

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** The `demo_portal_login` view was missing rate limiting, making it vulnerable to brute-force or DoS attacks.
 **Learning:** Even endpoints designed for demo purposes need to be protected. The `django-ratelimit` decorator with `block=True` should be applied uniformly to all authentication-related endpoints.
 **Prevention:** Always ensure the `@ratelimit(key="ip", rate="...", method="POST", block=True)` decorator is present on any view that processes login or authentication requests. Also make sure the import is present: `from django_ratelimit.decorators import ratelimit`.
+
+## 2024-03-05 - [Missing Rate Limiting on Staff-Assisted Login]
+**Vulnerability:** The `staff_assisted_login` endpoint (which authenticates users via a one-time token and sets session cookies) lacked rate-limiting, making it vulnerable to brute-force attacks against the token and potentially DoS attacks.
+**Learning:** All authentication boundaries, including GET requests that consume one-time tokens, must be rate-limited.
+**Prevention:** Apply `@ratelimit(key="ip", rate="10/m", method=["GET", "POST"], block=True)` to all authentication entry points, ensuring `django_ratelimit.decorators` is imported.

--- a/apps/portal/views.py
+++ b/apps/portal/views.py
@@ -1020,6 +1020,7 @@ def password_reset_confirm(request):
 
 
 @portal_feature_required
+@ratelimit(key="ip", rate="10/m", method=["GET", "POST"], block=True)
 def staff_assisted_login(request, token):
     """Log a participant in via a staff-generated one-time token."""
     from apps.portal.models import StaffAssistedLoginToken


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The `staff_assisted_login` endpoint was missing rate-limiting. This endpoint consumes one-time tokens and logs users in, making it a critical authentication boundary.
🎯 **Impact:** Vulnerability to brute-force guessing of active staff-assisted login tokens or Denial-of-Service (DoS) attacks against the authentication system.
🔧 **Fix:** Added the `@ratelimit` decorator with a rate limit of 10 requests per minute per IP for both GET and POST methods, with `block=True` to reject excess requests.
✅ **Verification:** Ran tests (`test_security.py` and `test_permissions_enforcement.py`) and confirmed all pass. Checked that the rate limiting logic successfully wraps the view logic and the `ratelimit` utility is correctly imported.

---
*PR created automatically by Jules for task [14003573186587965961](https://jules.google.com/task/14003573186587965961) started by @pboachie*