### PR TITLE
🛡️ Sentinel: [HIGH] Add rate limiting to goal_builder_save view

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** The `demo_portal_login` view was missing rate limiting, making it vulnerable to brute-force or DoS attacks.
 **Learning:** Even endpoints designed for demo purposes need to be protected. The `django-ratelimit` decorator with `block=True` should be applied uniformly to all authentication-related endpoints.
 **Prevention:** Always ensure the `@ratelimit(key="ip", rate="...", method="POST", block=True)` decorator is present on any view that processes login or authentication requests. Also make sure the import is present: `from django_ratelimit.decorators import ratelimit`.
+
+## 2024-03-05 - [Missing Rate Limiting on Goal Builder Save]
+**Vulnerability:** The `goal_builder_save` view in `konote/ai_views.py` was missing rate limiting, exposing the AI-powered endpoint to potential abuse and resource exhaustion (costly AI API calls).
+**Learning:** Endpoints that handle AI operations or custom metric creation need protection against DoS and financial exhaustion, even if they are authenticated.
+**Prevention:** Ensure the `@ratelimit(key="user", rate="...", method="POST", block=False)` decorator and manual check `if getattr(request, "limited", False): return ai_rate_limited_response(...)` are applied to all AI-powered endpoints.

--- a/konote/ai_views.py
+++ b/konote/ai_views.py
@@ -685,6 +685,7 @@ def goal_builder_chat(request, client_id):
 
 @login_required
 @require_POST
+@ratelimit(key="user", rate="20/h", method="POST", block=False)
 def goal_builder_save(request, client_id):
     """Save a goal from the Goal Builder — POST creates target + metric + section.
 
@@ -692,6 +693,8 @@ def goal_builder_save(request, client_id):
     + metric creation. Custom metric creation (from AI) is handled here before
     calling the helper.
     """
+    if getattr(request, "limited", False):
+        return ai_rate_limited_response(request, template_name="plans/_goal_builder.html")
 
     from apps.clients.models import ClientFile
     from apps.plans.models import MetricDefinition, PlanSection


### PR DESCRIPTION
Added rate limiting to the `goal_builder_save` view to protect against DoS and financial exhaustion of AI resources.

---
*PR created automatically by Jules for task [2021302405277054154](https://jules.google.com/task/2021302405277054154) started by @pboachie*