### PR TITLE
🛡️ Sentinel: [HIGH] Add missing rate limiting to authentication boundaries

### DIFF
--- a/apps/portal/views.py
+++ b/apps/portal/views.py
@@ -333,6 +333,7 @@ def emergency_logout(request):
 
 
 @portal_feature_required
+@ratelimit(key="ip", rate="10/m", method=["GET", "POST"], block=True)
 def accept_invite(request, token):
     """Accept a portal invite — register a new ParticipantUser.
 
@@ -1020,6 +1021,7 @@ def password_reset_confirm(request):
 
 
 @portal_feature_required
+@ratelimit(key="ip", rate="10/m", method=["GET", "POST"], block=True)
 def staff_assisted_login(request, token):
     """Log a participant in via a staff-generated one-time token."""
     from apps.portal.models import StaffAssistedLoginToken

--- a/apps/registration/views.py
+++ b/apps/registration/views.py
@@ -8,6 +8,7 @@ from django.http import Http404
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils import timezone
 from django.views.decorators.http import require_http_methods
+from django_ratelimit.decorators import ratelimit
 
 from apps.clients.models import CustomFieldDefinition
 
@@ -104,6 +105,7 @@ def _get_grouped_custom_fields(registration_link):
 
 
 @require_http_methods(["GET", "POST"])
+@ratelimit(key="ip", rate="10/m", method=["POST"], block=True)
 def public_registration_form(request, slug):
     """Display the public registration form for a registration link.
 


### PR DESCRIPTION
Added missing rate limiting to endpoints that consume one-time tokens or handle user registrations (`accept_invite`, `staff_assisted_login`, and `public_registration_form`) to prevent brute-force or DoS attacks.

---
*PR created automatically by Jules for task [5855948281100952022](https://jules.google.com/task/5855948281100952022) started by @pboachie*