### PR TITLE
🛡️ Sentinel: [HIGH] Add rate limits to portal auth boundary endpoints

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,7 @@
 **Vulnerability:** The `demo_portal_login` view was missing rate limiting, making it vulnerable to brute-force or DoS attacks.
 **Learning:** Even endpoints designed for demo purposes need to be protected. The `django-ratelimit` decorator with `block=True` should be applied uniformly to all authentication-related endpoints.
 **Prevention:** Always ensure the `@ratelimit(key="ip", rate="...", method="POST", block=True)` decorator is present on any view that processes login or authentication requests. Also make sure the import is present: `from django_ratelimit.decorators import ratelimit`.
+## 2024-04-02 - [Missing Rate Limits on Authentication Boundaries]
+**Vulnerability:** Missing rate limits on `accept_invite` and `staff_assisted_login` endpoints in `apps/portal/views.py` allowed potential brute forcing of tokens or DoS.
+**Learning:** All endpoints that handle authentication or consume tokens must be consistently protected with rate limiting across both GET and POST requests, as both methods can be targeted by automated attacks.
+**Prevention:** Apply the `@ratelimit` decorator uniformly to all token-consuming and authentication-related endpoints, explicitly covering relevant HTTP methods and using `block=True`.

--- a/apps/portal/views.py
+++ b/apps/portal/views.py
@@ -333,6 +333,7 @@ def emergency_logout(request):
 
 
 @portal_feature_required
+@ratelimit(key="ip", rate="10/m", method=["GET", "POST"], block=True)
 def accept_invite(request, token):
     """Accept a portal invite — register a new ParticipantUser.
 
@@ -1020,6 +1021,7 @@ def password_reset_confirm(request):
 
 
 @portal_feature_required
+@ratelimit(key="ip", rate="10/m", method=["GET", "POST"], block=True)
 def staff_assisted_login(request, token):
     """Log a participant in via a staff-generated one-time token."""
     from apps.portal.models import StaffAssistedLoginToken


### PR DESCRIPTION
🛡️ **Sentinel: [HIGH] Missing Rate Limiting on Authentication Boundary Endpoints**

**🚨 Severity:** HIGH
**💡 Vulnerability:** The `accept_invite` and `staff_assisted_login` endpoints in `apps/portal/views.py` were missing rate limit protections. Both of these endpoints act as authentication boundaries (consuming one-time tokens to authenticate/register a user). 
**🎯 Impact:** Without rate limits, these endpoints are vulnerable to brute-force attacks against the one-time tokens, and potentially to Denial-of-Service (DoS) attacks.
**🔧 Fix:** Added the `@ratelimit(key="ip", rate="10/m", method=["GET", "POST"], block=True)` decorator to both endpoints to properly throttle incoming requests across both GET and POST HTTP methods. Also updated `.jules/sentinel.md` journal.
**✅ Verification:** Ran `tests/test_security.py` and `tests/test_portal_password_reset.py`, and `tests/test_portal_surveys.py` to ensure tests passed successfully.

---
*PR created automatically by Jules for task [1035599383756918889](https://jules.google.com/task/1035599383756918889) started by @pboachie*