### PR TITLE
🎨 Palette: Add aria-hidden to decorative HTML entities

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -16,3 +16,7 @@
 ## 2025-03-11 - Add Empty State Styles with A11y to Portal
 **Learning:** Many pages in the portal application render empty states inside `<article class="portal-empty-state">` blocks. However, the corresponding styling for `.portal-empty-state` was completely missing from `portal.css`. Also, when using CSS pseudo-elements to add an emoji icon (like `content: "\1F4CB"`), screen readers will try to read it. Using the `/ ""` syntax (`content: "\1F4CB" / ""`) ensures it stays decorative and prevents it from being read aloud.
 **Action:** When adding empty state CSS with emojis or icons using `::before`, always include `/ ""` to avoid screen readers announcing decorative visuals.
+
+## 2025-03-12 - Screen Reader Compatibility for Close Buttons
+**Learning:** Decorative HTML entities like `&times;` (multiply/close icon) are often used in modal and toast close buttons. Screen readers read these aloud (e.g., "multiply"), creating confusing navigation text instead of just "Close".
+**Action:** Always wrap decorative HTML entities in a `<span aria-hidden="true">` to hide them from assistive technologies while keeping them visible on screen, and rely on `aria-label` on the parent button to provide context.

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -23924,3 +23924,6 @@ msgstr "Début du service"
 
 msgid "You do not have access to this %(group_label)s."
 msgstr "Vous n’avez pas accès à ce %(group_label)s."
+
+msgid "Print report"
+msgstr ""

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -202,7 +202,7 @@ document.body.addEventListener("htmx:configRequest", function (event) {
         closeBtn.type = "button";
         closeBtn.className = "message-close";
         closeBtn.setAttribute("aria-label", t("dismissMessage", "Dismiss message"));
-        closeBtn.innerHTML = "&times;";
+        closeBtn.innerHTML = '<span aria-hidden="true">&times;</span>';
         closeBtn.addEventListener("click", function () {
             dismissMessage(messageEl);
         });

--- a/templates/base.html
+++ b/templates/base.html
@@ -293,13 +293,13 @@
     <!-- HTMX error toast — shown by app.js on network/server errors -->
     <div id="htmx-error-toast" class="toast toast-error" role="alert" hidden>
         <span id="htmx-error-toast-message"></span>
-        <button type="button" id="htmx-error-toast-close" aria-label="{% trans 'Dismiss' %}" style="background:none;border:none;cursor:pointer;padding:0 0 0 1rem;font-size:1.2rem;color:inherit;">&times;</button>
+        <button type="button" id="htmx-error-toast-close" aria-label="{% trans 'Dismiss' %}" style="background:none;border:none;cursor:pointer;padding:0 0 0 1rem;font-size:1.2rem;color:inherit;"><span aria-hidden="true">&times;</span></button>
     </div>
 
     <!-- HTMX success toast — shown by app.js for async confirmations (UXP2 / WCAG 4.1.3) -->
     <div id="htmx-success-toast" class="toast toast-success" role="status" hidden>
         <span id="htmx-success-toast-message"></span>
-        <button type="button" id="htmx-success-toast-close" aria-label="{% trans 'Dismiss' %}" style="background:none;border:none;cursor:pointer;padding:0 0 0 1rem;font-size:1.2rem;color:inherit;">&times;</button>
+        <button type="button" id="htmx-success-toast-close" aria-label="{% trans 'Dismiss' %}" style="background:none;border:none;cursor:pointer;padding:0 0 0 1rem;font-size:1.2rem;color:inherit;"><span aria-hidden="true">&times;</span></button>
     </div>
 
     <footer class="container site-footer" role="contentinfo">
@@ -336,7 +336,7 @@
     <!-- Contextual page help modal -->
     <div class="modal-backdrop" id="page-help-backdrop" hidden></div>
     <div class="page-help-modal" id="page-help-modal" hidden role="dialog" aria-labelledby="page-help-title" aria-modal="true" tabindex="-1">
-        <button type="button" class="modal-close" id="close-page-help" aria-label="{% trans 'Close' %}">&times;</button>
+        <button type="button" class="modal-close" id="close-page-help" aria-label="{% trans 'Close' %}"><span aria-hidden="true">&times;</span></button>
         {% if page_help.is_default %}
         <h2 id="page-help-title">{% trans "Help" %}</h2>
         <p class="page-help-description">{% trans "Here are a few things you can do from anywhere in KoNote:" %}</p>

--- a/templates/clients/home.html
+++ b/templates/clients/home.html
@@ -20,7 +20,7 @@
 <article class="onboarding-banner" id="onboarding-banner" role="complementary" aria-label="{% trans 'Welcome banner' %}" hidden>
     <header>
         <strong>{% blocktrans with product_name=site.product_name|default:"KoNote" %}Welcome to {{ product_name }}! Need help getting started?{% endblocktrans %}</strong>
-        <button type="button" class="close-btn" id="dismiss-onboarding" aria-label="{% trans 'Dismiss welcome banner' %}">&times;</button>
+        <button type="button" class="close-btn" id="dismiss-onboarding" aria-label="{% trans 'Dismiss welcome banner' %}"><span aria-hidden="true">&times;</span></button>
     </header>
     <ul>
         <li>{% blocktrans with clients=term.client_plural|default:"participants" %}Use the search bar to find {{ clients }}, or the "+ New" button to register one{% endblocktrans %}</li>


### PR DESCRIPTION
💡 What: The UX enhancement added: `aria-hidden="true"` wrapped around decorative HTML entities like `&times;` (close icon).
🎯 Why: The user problem it solves: screen readers would read these aloud to users leading to confusing navigation text (e.g. "multiply").
📸 Before/After: Visual changes were validated via an automated end-to-end screenshot script to ensure the visual rendering of the close button remained exactly the same.
♿ Accessibility: Better screen reader accessibility. Included a journal critical learning.

---
*PR created automatically by Jules for task [5892345562284232681](https://jules.google.com/task/5892345562284232681) started by @pboachie*