### PR TITLE
fix: demo reports show no results and under-five suppression

### DIFF
--- a/apps/admin_settings/demo_engine.py
+++ b/apps/admin_settings/demo_engine.py
@@ -2443,9 +2443,11 @@ class DemoDataEngine:
         # Client words pool
         client_words = prog_profile.get("client_words_pool", CLIENT_WORDS_POOL)
 
-        # Spread notes over the time span
+        # Spread notes over the time span.
+        # Include recent notes (0-4 days ago) so reports for the current
+        # fiscal year always have data, even right after a year boundary.
         note_days = sorted(
-            [random.randint(5, days_span - 5) for _ in range(note_count)],
+            [random.randint(0, days_span - 5) for _ in range(note_count)],
             reverse=True,
         )
 
@@ -3353,12 +3355,14 @@ class DemoDataEngine:
         return descriptor_map.get(descriptor, "in_progress")
 
     @transaction.atomic
-    def run(self, clients_per_program=3, days_span=180, profile_path=None,
+    def run(self, clients_per_program=10, days_span=180, profile_path=None,
             force=False):
         """Generate demo data matching the instance's current configuration.
 
         Args:
-            clients_per_program: Number of demo clients to create per program.
+            clients_per_program: Number of demo clients to create per program
+                (default 10 — must exceed the suppression threshold of 5 so
+                reports show real counts instead of "< 5").
             days_span: Number of days of historical data to generate.
             profile_path: Optional path to a demo data profile JSON.
             force: If True, clear existing demo data before generating.
@@ -3370,7 +3374,7 @@ class DemoDataEngine:
 
         # Apply profile defaults
         profile_defaults = profile.get("defaults", {})
-        if "clients_per_program" in profile_defaults and clients_per_program == 3:
+        if "clients_per_program" in profile_defaults and clients_per_program == 10:
             clients_per_program = profile_defaults["clients_per_program"]
         if "days_span" in profile_defaults and days_span == 180:
             days_span = profile_defaults["days_span"]

--- a/apps/reports/funder_report.py
+++ b/apps/reports/funder_report.py
@@ -26,7 +26,7 @@ from apps.clients.models import ClientFile, ClientProgramEnrolment
 from apps.notes.models import MetricValue, ProgressNote
 
 from .achievements import get_achievement_summary
-from .aggregations import count_clients_by_program, count_contacts_by_outcome, count_notes_by_program
+from .aggregations import count_contacts_by_outcome, count_notes_by_program
 from .demographics import get_age_range, group_clients_by_age, group_clients_by_custom_field
 from .utils import get_fiscal_year_range
 
@@ -292,13 +292,25 @@ def generate_funder_report_data(
             accessible_ids = set(ClientFile.objects.real().values_list("pk", flat=True))
         enrolled_client_ids = [cid for cid in enrolled_client_ids if cid in accessible_ids]
 
-    # Count unique clients with activity in the period
-    total_individuals_served = count_clients_by_program(
-        program,
-        date_from=date_from,
-        date_to=date_to,
-        active_only=True,
+    # Build date-range boundaries for note queries
+    from datetime import datetime, time
+    date_from_dt = timezone.make_aware(datetime.combine(date_from, time.min))
+    date_to_dt = timezone.make_aware(datetime.combine(date_to, time.max))
+
+    # Get clients who had activity in the period.
+    # Uses enrolled_client_ids (already filtered by demo/real status above)
+    # so the count is consistent with the rest of the report.
+    active_client_ids = list(
+        ProgressNote.objects.filter(
+            client_file_id__in=enrolled_client_ids,
+            status="default",
+        ).filter(
+            Q(backdate__range=(date_from_dt, date_to_dt))
+            | Q(backdate__isnull=True, created_at__range=(date_from_dt, date_to_dt))
+        ).values_list("client_file_id", flat=True).distinct()
     )
+
+    total_individuals_served = len(active_client_ids)
 
     # Count new clients enrolled in the period
     new_clients = get_new_clients_count(program, date_from, date_to)
@@ -315,22 +327,6 @@ def generate_funder_report_data(
         program,
         date_from=date_from,
         date_to=date_to,
-    )
-
-    # Get clients who had activity in the period for demographics
-    # (use same logic as count_clients_by_program but get IDs)
-    from datetime import datetime, time
-    date_from_dt = timezone.make_aware(datetime.combine(date_from, time.min))
-    date_to_dt = timezone.make_aware(datetime.combine(date_to, time.max))
-
-    active_client_ids = list(
-        ProgressNote.objects.filter(
-            client_file_id__in=enrolled_client_ids,
-            status="default",
-        ).filter(
-            Q(backdate__range=(date_from_dt, date_to_dt))
-            | Q(backdate__isnull=True, created_at__range=(date_from_dt, date_to_dt))
-        ).values_list("client_file_id", flat=True).distinct()
     )
 
     # Age demographics

--- a/seeds/demo_data_profile_example.json
+++ b/seeds/demo_data_profile_example.json
@@ -2,7 +2,7 @@
   "_comment": "Demo data profile for KoNote. Place alongside your setup_config.json. Programs not listed here will get auto-generated demo data.",
   "description": "Example demo data profile — customise for your agency",
   "defaults": {
-    "clients_per_program": 3,
+    "clients_per_program": 10,
     "days_span": 180,
     "note_count_range": [7, 12]
   },


### PR DESCRIPTION
## Summary

- **Demo notes never landed in the current fiscal year.** Notes were backdated 5–175 days; right after a fiscal year boundary (April 1), every note fell in the previous FY. Changed minimum backdate from 5 to 0 so some notes always appear in the current period.
- **Too few demo clients for reports.** Default was 3 per program, below the suppression threshold of 5. Increased to 10 so reports show real counts instead of "< 5".
- **Participant count ignored demo/real filtering.** `generate_funder_report_data()` filtered enrolled clients by demo status but then called `count_clients_by_program()` which re-queried without that filter. Now uses the already-filtered `active_client_ids` for the count — one source of truth.

## Test plan

- [ ] Regenerate demo data on VPS (`seed --demo`) and verify > 5 clients per program
- [ ] Generate standard report for "All Programs" as Eva Executive — verify participant counts appear (not "< 5")
- [ ] Generate report for FY 2026-27 (current) — verify notes exist in this period
- [ ] Generate report for FY 2025-26 (previous) — verify data still appears
- [ ] Run `pytest tests/test_reports.py tests/test_exports.py` on VPS

🤖 Generated with [Claude Code](https://claude.com/claude-code)