### PR TITLE
chore: add report preview HTML files

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -1,0 +1,172 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>KoNote Demo Reports</title>
+  <style>
+    :root {
+      --kn-primary: #3176aa;
+      --kn-primary-dark: #245d8a;
+      --kn-bg: #f8f9fa;
+      --kn-card-bg: #ffffff;
+      --kn-border: #dee2e6;
+      --kn-text: #212529;
+      --kn-text-secondary: #555;
+      --kn-muted: #6c757d;
+      --kn-radius: 8px;
+    }
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      background: var(--kn-bg);
+      color: var(--kn-text);
+      line-height: 1.5;
+    }
+    .header {
+      background: linear-gradient(135deg, var(--kn-primary) 0%, var(--kn-primary-dark) 100%);
+      color: white;
+      padding: 2rem 2rem 1.5rem;
+      text-align: center;
+    }
+    .header h1 { font-size: 1.6rem; font-weight: 700; margin-bottom: 0.25rem; }
+    .header p { opacity: 0.85; font-size: 0.95rem; }
+    .container {
+      max-width: 900px;
+      margin: 0 auto;
+      padding: 2rem 1.5rem;
+    }
+    .category {
+      margin-bottom: 2rem;
+    }
+    .category h2 {
+      font-size: 1.1rem;
+      color: var(--kn-primary-dark);
+      padding-bottom: 0.4rem;
+      border-bottom: 2px solid var(--kn-primary);
+      margin-bottom: 1rem;
+    }
+    .card-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 1rem;
+    }
+    .card {
+      background: var(--kn-card-bg);
+      border: 1px solid var(--kn-border);
+      border-radius: var(--kn-radius);
+      padding: 1.25rem;
+      text-decoration: none;
+      color: var(--kn-text);
+      transition: border-color 0.15s, box-shadow 0.15s;
+      display: flex;
+      flex-direction: column;
+    }
+    .card:hover {
+      border-color: var(--kn-primary);
+      box-shadow: 0 2px 8px rgba(49, 118, 170, 0.15);
+    }
+    .card h3 {
+      font-size: 1rem;
+      font-weight: 600;
+      color: var(--kn-primary);
+      margin-bottom: 0.4rem;
+    }
+    .card p {
+      font-size: 0.85rem;
+      color: var(--kn-text-secondary);
+      flex: 1;
+    }
+    .card .tag {
+      display: inline-block;
+      margin-top: 0.75rem;
+      padding: 0.15rem 0.5rem;
+      border-radius: 10px;
+      font-size: 0.7rem;
+      font-weight: 500;
+      align-self: flex-start;
+    }
+    .tag-funder { background: #e3f2fd; color: #1565c0; }
+    .tag-agency { background: #e8f5e9; color: #2e7d32; }
+    .tag-wireframe { background: #f3e5f5; color: #6a1b9a; }
+    .tag-cids { background: #fff3e0; color: #e65100; }
+
+    .footer {
+      text-align: center;
+      padding: 1.5rem;
+      color: var(--kn-muted);
+      font-size: 0.8rem;
+      border-top: 1px solid var(--kn-border);
+      margin-top: 1rem;
+    }
+
+    @media (max-width: 600px) {
+      .card-grid { grid-template-columns: 1fr; }
+    }
+  </style>
+</head>
+<body>
+
+<div class="header">
+  <h1>KoNote Demo Reports</h1>
+  <p>Open this page before a presentation. All demo materials in one place.</p>
+</div>
+
+<div class="container">
+
+  <div class="category">
+    <h2>Funder Portfolio View</h2>
+    <div class="card-grid">
+      <a class="card" href="preview_funder_portfolio_dashboard.html">
+        <h3>Funder Portfolio Dashboard</h3>
+        <p>United Way looking across 32 agencies and 87 programs. Shows how CIDS enables cross-agency outcome aggregation. The "why CIDS matters" demo.</p>
+        <span class="tag tag-funder">Funder view</span>
+      </a>
+      <a class="card" href="preview_multi_program_report.html">
+        <h3>Multi-Program Outcome Report</h3>
+        <p>Agency-level report covering 3 programs with metrics, demographics, CIDS alignment, and achievement summaries. What an agency submits to a funder.</p>
+        <span class="tag tag-agency">Agency report</span>
+      </a>
+    </div>
+  </div>
+
+  <div class="category">
+    <h2>Single Program Reports</h2>
+    <div class="card-grid">
+      <a class="card" href="tasks/wireframes/funder-outcome-dashboard.html">
+        <h3>Program Outcome Dashboard</h3>
+        <p>CIDS Full Tier export for one program: theory of change, headline outcomes, counterfactual, impact risks, stakeholders, and evaluator attestation.</p>
+        <span class="tag tag-cids">CIDS Full Tier</span>
+      </a>
+      <a class="card" href="preview_funder_outcome_report.html">
+        <h3>Program Outcome Report (PDF-style)</h3>
+        <p>Single-program funder report with service stats, metrics table, demographics, narrative, and CIDS alignment. Print-ready format.</p>
+        <span class="tag tag-agency">Agency report</span>
+      </a>
+    </div>
+  </div>
+
+  <div class="category">
+    <h2>Configuration &amp; Standards</h2>
+    <div class="card-grid">
+      <a class="card" href="tasks/wireframes/evaluation-framework-editor.html">
+        <h3>Evaluation Framework Editor</h3>
+        <p>Where agencies define their program's evaluation framework: indicators, measurement tools, targets, and CIDS code mappings.</p>
+        <span class="tag tag-wireframe">Wireframe</span>
+      </a>
+      <a class="card" href="tasks/wireframes/common-approach-working-document.html">
+        <h3>CIDS Implementation Working Document</h3>
+        <p>Technical overview of how KoNote implements the Common Impact Data Standard. For conversations with Common Approach.</p>
+        <span class="tag tag-cids">CIDS reference</span>
+      </a>
+    </div>
+  </div>
+
+</div>
+
+<div class="footer">
+  KoNote Demo Materials &middot; Not for distribution &middot; <a href="https://www.konote.ca" style="color: var(--kn-muted);">www.konote.ca</a>
+</div>
+
+</body>
+</html>

--- a/preview_funder_outcome_report.html
+++ b/preview_funder_outcome_report.html
@@ -1,0 +1,441 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Program Outcome Report — Youth Wellness Initiative</title>
+    <style>
+/* === Base styles (pdf_base.html) === */
+@page {
+    size: letter;
+    margin: 2cm 1.5cm;
+    @bottom-right {
+        content: "Page " counter(page) " of " counter(pages);
+        font-size: 9pt;
+        color: #718096;
+    }
+}
+* { box-sizing: border-box; }
+body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    font-size: 11pt;
+    line-height: 1.5;
+    color: #1a202c;
+    margin: 0;
+    padding: 2rem;
+    max-width: 900px;
+    margin-left: auto;
+    margin-right: auto;
+    background-color: #ffffff;
+}
+.pdf-header {
+    border-bottom: 3px solid #3176aa;
+    padding-bottom: 0.4cm;
+    margin-bottom: 0.6cm;
+}
+.pdf-header h1 {
+    font-size: 18pt;
+    margin: 0 0 0.15cm 0;
+    color: #3176aa;
+}
+.pdf-header .subtitle {
+    font-size: 13pt;
+    color: #4a5568;
+    margin-bottom: 0.3cm;
+}
+.pdf-header .meta-grid {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 0.05cm 0.4cm;
+    font-size: 9pt;
+    color: #718096;
+}
+.pdf-header .meta-grid dt {
+    font-weight: 600;
+    color: #4a5568;
+}
+.pdf-header .meta-grid dd {
+    margin: 0;
+}
+.pdf-header .draft-notice {
+    margin-top: 0.3cm;
+    padding: 0.2cm 0.4cm;
+    background-color: #fef3c7;
+    border-radius: 3px;
+    font-size: 9pt;
+}
+h2 {
+    font-size: 16pt;
+    color: #3176aa;
+    border-bottom: 2px solid #3176aa;
+    padding-bottom: 0.3cm;
+    margin-top: 1cm;
+}
+h3 {
+    font-size: 13pt;
+    color: #1a202c;
+    margin-top: 0.8cm;
+}
+h4 {
+    margin-top: 0.5cm;
+}
+table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 0.5cm 0;
+    font-size: 10pt;
+}
+thead th {
+    background-color: #3176aa;
+    color: #ffffff;
+    padding: 6px 10px;
+    text-align: left;
+    font-weight: 600;
+}
+tbody td {
+    padding: 5px 10px;
+    border-bottom: 1px solid #e5e7eb;
+}
+tbody tr:nth-child(even) {
+    background-color: #f7f8fa;
+}
+dl {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 0.2cm 1cm;
+    margin: 0.5cm 0;
+}
+dt {
+    font-weight: 600;
+    color: #4a5568;
+}
+dd { margin: 0; }
+.page-break { page-break-after: always; }
+.avoid-break { page-break-inside: avoid; }
+.summary-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.5cm;
+    margin: 0.5cm 0;
+}
+.summary-card {
+    border: 1px solid #d1d5db;
+    border-radius: 4px;
+    padding: 0.4cm;
+    text-align: center;
+}
+.summary-card .number {
+    font-size: 20pt;
+    font-weight: 700;
+    color: #3176aa;
+}
+.summary-card .label {
+    font-size: 9pt;
+    color: #718096;
+}
+
+/* === Funder outcome report styles === */
+.report-header {
+    background-color: #3176aa;
+    color: #ffffff;
+    padding: 0.3cm 0.5cm;
+    margin-top: 1cm;
+    font-size: 12pt;
+    font-weight: 600;
+}
+.stat-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr 1fr;
+    gap: 0.4cm;
+    margin: 0.5cm 0;
+}
+.stat-box {
+    border: 1px solid #d1d5db;
+    border-radius: 4px;
+    padding: 0.3cm;
+    text-align: center;
+}
+.stat-box .value {
+    font-size: 18pt;
+    font-weight: 700;
+    color: #3176aa;
+}
+.stat-box .label {
+    font-size: 9pt;
+    color: #718096;
+    margin-top: 0.1cm;
+}
+.outcome-card {
+    border: 2px solid #3176aa;
+    border-radius: 4px;
+    padding: 0.4cm;
+    margin: 0.3cm 0;
+}
+.outcome-card h4 {
+    margin: 0 0 0.2cm 0;
+    color: #3176aa;
+    font-size: 11pt;
+}
+.outcome-card .rate {
+    font-size: 24pt;
+    font-weight: 700;
+    color: #3176aa;
+}
+.outcome-card .details {
+    font-size: 9pt;
+    color: #4a5568;
+    margin-top: 0.2cm;
+}
+.demo-row {
+    display: grid;
+    grid-template-columns: 1fr 80px 80px;
+    padding: 4px 10px;
+    border-bottom: 1px solid #e5e7eb;
+}
+.demo-row.header {
+    background-color: #f7f8fa;
+    font-weight: 600;
+}
+.demo-bar {
+    background-color: #e5e7eb;
+    height: 8px;
+    border-radius: 4px;
+    margin-top: 4px;
+    overflow: hidden;
+}
+.demo-bar-fill {
+    background-color: #3176aa;
+    height: 100%;
+    border-radius: 4px;
+}
+.metrics-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 0.5cm 0;
+}
+.metrics-table th, .metrics-table td {
+    border: 1px solid #d1d5db;
+    padding: 6px 10px;
+    text-align: right;
+    font-size: 10pt;
+}
+.metrics-table th:first-child, .metrics-table td:first-child {
+    text-align: left;
+}
+.metrics-table thead th {
+    background-color: #f7f8fa;
+    font-weight: 600;
+}
+.narrative-section {
+    border-left: 4px solid #3176aa;
+    padding: 0.4cm 0.5cm;
+    margin: 0.5cm 0;
+    background-color: #f7f8fa;
+}
+.narrative-section .placeholder {
+    font-style: italic;
+    color: #718096;
+}
+.footer-note {
+    font-size: 9pt;
+    color: #718096;
+    font-style: italic;
+    margin-top: 1cm;
+    padding-top: 0.3cm;
+    border-top: 1px solid #e5e7eb;
+}
+    </style>
+</head>
+<body>
+<!-- Report Header -->
+<div class="pdf-header">
+    <h1>Program Outcome Report</h1>
+    <div class="subtitle">Youth Wellness Initiative</div>
+    <dl class="meta-grid">
+        <dt>Organisation</dt>
+        <dd>Eastside Community Services</dd>
+        <dt>Program</dt>
+        <dd>Youth Wellness Initiative</dd>
+        <dt>Description</dt>
+        <dd>Supporting youth ages 13–24 through individual and group-based wellness programming, including mental health support, life skills, and community engagement.</dd>
+        <dt>Period</dt>
+        <dd>January 1 – March 31, 2026</dd>
+        <dt>Generated</dt>
+        <dd>2026-04-02 by Gillian Kerr</dd>
+    </dl>
+    <div class="draft-notice">
+        <strong>Draft Template:</strong> Verify this format matches the specific reporting requirements before submission.
+    </div>
+</div>
+
+<!-- Service Statistics -->
+<div class="report-header">Service Statistics</div>
+<div class="stat-grid">
+    <div class="stat-box">
+        <div class="value">112</div>
+        <div class="label">Total Individuals Served</div>
+    </div>
+    <div class="stat-box">
+        <div class="value">18</div>
+        <div class="label">New Participants This Period</div>
+    </div>
+    <div class="stat-box">
+        <div class="value">486</div>
+        <div class="label">Total Service Contacts</div>
+    </div>
+</div>
+
+<!-- Outcome Metrics -->
+<div class="report-header">Outcome Metrics</div>
+<table class="metrics-table">
+    <thead>
+        <tr>
+            <th scope="col">Metric</th>
+            <th scope="col">All Participants</th>
+            <th scope="col">Youth (13–18)</th>
+            <th scope="col">Young Adults (19–24)</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>Self-reported wellbeing improvement</td>
+            <td>72%</td>
+            <td>68%</td>
+            <td>78%</td>
+        </tr>
+        <tr>
+            <td>Goal completion rate</td>
+            <td>61%</td>
+            <td>55%</td>
+            <td>69%</td>
+        </tr>
+        <tr>
+            <td>Average sessions attended</td>
+            <td>8.4</td>
+            <td>7.2</td>
+            <td>9.8</td>
+        </tr>
+    </tbody>
+</table>
+
+<!-- Age Demographics -->
+<div class="report-header">Age Demographics</div>
+<div style="margin: 0.5cm 0;">
+    <div class="demo-row header">
+        <div>Age Group</div>
+        <div style="text-align: right;">Count</div>
+        <div style="text-align: right;">Percentage</div>
+    </div>
+    <div class="demo-row">
+        <div>
+            13–15
+            <div class="demo-bar">
+                <div class="demo-bar-fill" style="width: 27%;"></div>
+            </div>
+        </div>
+        <div style="text-align: right;">30</div>
+        <div style="text-align: right;">27%</div>
+    </div>
+    <div class="demo-row">
+        <div>
+            16–18
+            <div class="demo-bar">
+                <div class="demo-bar-fill" style="width: 38%;"></div>
+            </div>
+        </div>
+        <div style="text-align: right;">43</div>
+        <div style="text-align: right;">38%</div>
+    </div>
+    <div class="demo-row">
+        <div>
+            19–24
+            <div class="demo-bar">
+                <div class="demo-bar-fill" style="width: 35%;"></div>
+            </div>
+        </div>
+        <div style="text-align: right;">39</div>
+        <div style="text-align: right;">35%</div>
+    </div>
+    <div class="demo-row header">
+        <div>Total</div>
+        <div style="text-align: right;">112</div>
+        <div style="text-align: right;">100%</div>
+    </div>
+</div>
+
+<!-- Narrative -->
+<div class="report-header">Program Narrative</div>
+<div class="narrative-section">
+    <p>Describe programme highlights, challenges, and key learnings from this period.</p>
+    <p class="placeholder">[To be added during review]</p>
+</div>
+
+<!-- CIDS Standards Alignment -->
+<div class="report-header">Standards Alignment</div>
+<p style="font-size: 9pt; color: #718096; margin-bottom: 0.5cm;">
+    Aligned with Common Impact Data Standard (CIDS) v3.2.0.
+</p>
+<p><strong>Reporting Lens:</strong> United Way Outcomes</p>
+<p><strong>Sector:</strong> Youth Services</p>
+<p><strong>Funder Program Code:</strong> UW-YTH-2026-041</p>
+
+<table class="metrics-table">
+    <thead>
+        <tr>
+            <th scope="col">Indicator</th>
+            <th scope="col">Selected Code</th>
+            <th scope="col">Selected Label</th>
+            <th scope="col">Code List</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>Self-reported wellbeing improvement</td>
+            <td>OC-WB-01</td>
+            <td>Improved personal wellbeing</td>
+            <td>Common Outcomes</td>
+        </tr>
+        <tr>
+            <td>Goal completion rate</td>
+            <td>OC-GC-03</td>
+            <td>Goal attainment</td>
+            <td>Common Outcomes</td>
+        </tr>
+        <tr>
+            <td>Average sessions attended</td>
+            <td>ACT-SA-02</td>
+            <td>Service participation level</td>
+            <td>Common Activities</td>
+        </tr>
+    </tbody>
+</table>
+<p style="font-size: 9pt; color: #718096;">
+    3 of 3 indicators mapped for the selected reporting lens.
+</p>
+
+<h4 style="margin-top: 0.5cm;">United Way Outcomes Summary</h4>
+<ul>
+    <li>Improved personal wellbeing: 72% achievement</li>
+    <li>Goal attainment: 61% achievement</li>
+    <li>Service participation: 8.4 avg sessions</li>
+</ul>
+
+<!-- Overall Summary -->
+<div class="report-header">Overall Summary</div>
+<div class="summary-grid">
+    <div class="summary-card">
+        <div class="number">72%</div>
+        <div class="label">Overall Achievement Rate</div>
+    </div>
+    <div class="summary-card">
+        <div class="number">81 / 112</div>
+        <div class="label">Participants Met at Least One Target</div>
+    </div>
+</div>
+
+<div class="footer-note">
+    <strong>Draft Template:</strong> This report was generated using KoNote's Program Outcome Report Template.
+    Verify this format matches the specific reporting requirements before submission.
+    Data reflects client outcomes recorded during the January 1 – March 31, 2026 reporting period.
+</div>
+</body>
+</html>

--- a/preview_funder_portfolio_dashboard.html
+++ b/preview_funder_portfolio_dashboard.html
@@ -1,0 +1,968 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Funder Portfolio Dashboard — United Way Greater Toronto</title>
+  <style>
+    :root {
+      --kn-primary: #3176aa;
+      --kn-primary-dark: #245d8a;
+      --kn-success: #2e7d32;
+      --kn-success-light: #e8f5e9;
+      --kn-warning: #f57f17;
+      --kn-warning-light: #fff8e1;
+      --kn-info: #1565c0;
+      --kn-info-light: #e3f2fd;
+      --kn-danger: #c62828;
+      --kn-danger-light: #ffebee;
+      --kn-muted: #6c757d;
+      --kn-bg: #f8f9fa;
+      --kn-card-bg: #ffffff;
+      --kn-border: #dee2e6;
+      --kn-text: #212529;
+      --kn-text-secondary: #555;
+      --kn-radius: 8px;
+    }
+
+    * { box-sizing: border-box; margin: 0; padding: 0; }
+
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      background: var(--kn-bg);
+      color: var(--kn-text);
+      line-height: 1.5;
+    }
+
+    /* Header */
+    .header {
+      background: linear-gradient(135deg, var(--kn-primary) 0%, var(--kn-primary-dark) 100%);
+      color: white;
+      padding: 2rem 2rem 1.5rem;
+    }
+    .header-top {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      margin-bottom: 0.5rem;
+    }
+    .header h1 { font-size: 1.6rem; font-weight: 700; }
+    .header .subtitle { opacity: 0.9; font-size: 1rem; margin-bottom: 0.75rem; }
+    .header-meta {
+      display: flex; gap: 2rem; margin-top: 0.75rem;
+      font-size: 0.85rem; opacity: 0.8;
+    }
+    .cids-badge {
+      background: rgba(255,255,255,0.2);
+      padding: 0.3rem 0.75rem;
+      border-radius: 20px;
+      font-size: 0.8rem;
+      font-weight: 500;
+      white-space: nowrap;
+    }
+
+    .container { max-width: 1100px; margin: 0 auto; padding: 1.5rem; }
+
+    /* Explanation banner */
+    .explainer {
+      background: var(--kn-info-light);
+      border: 1px solid #90caf9;
+      border-radius: var(--kn-radius);
+      padding: 1rem 1.25rem;
+      margin-bottom: 1.5rem;
+      font-size: 0.9rem;
+      color: var(--kn-info);
+    }
+    .explainer strong { color: var(--kn-primary-dark); }
+
+    /* Portfolio summary row */
+    .portfolio-row {
+      display: grid;
+      grid-template-columns: repeat(5, 1fr);
+      gap: 1rem;
+      margin-bottom: 1.5rem;
+    }
+    .portfolio-card {
+      background: var(--kn-card-bg);
+      border: 1px solid var(--kn-border);
+      border-radius: var(--kn-radius);
+      padding: 1.25rem;
+      text-align: center;
+    }
+    .portfolio-card .big-number {
+      font-size: 2.2rem;
+      font-weight: 700;
+      color: var(--kn-primary);
+      line-height: 1.1;
+    }
+    .portfolio-card .card-label {
+      font-size: 0.8rem;
+      color: var(--kn-muted);
+      margin-top: 0.3rem;
+    }
+
+    /* Section headings */
+    .section { margin-bottom: 2rem; }
+    .section h2 {
+      font-size: 1.2rem;
+      color: var(--kn-primary-dark);
+      margin-bottom: 0.75rem;
+      padding-bottom: 0.5rem;
+      border-bottom: 2px solid var(--kn-primary);
+    }
+    .section-desc {
+      font-size: 0.9rem;
+      color: var(--kn-text-secondary);
+      margin-bottom: 1rem;
+    }
+
+    /* Outcome aggregation cards */
+    .outcome-group {
+      background: var(--kn-card-bg);
+      border: 1px solid var(--kn-border);
+      border-radius: var(--kn-radius);
+      margin-bottom: 1.25rem;
+      overflow: hidden;
+    }
+    .outcome-group-header {
+      background: #f1f3f5;
+      padding: 0.75rem 1.25rem;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+    .outcome-group-header h3 {
+      font-size: 1rem;
+      font-weight: 600;
+      color: var(--kn-text);
+    }
+    .cids-code {
+      font-family: "SF Mono", Monaco, Consolas, monospace;
+      font-size: 0.75rem;
+      background: var(--kn-info-light);
+      color: var(--kn-info);
+      padding: 0.15rem 0.5rem;
+      border-radius: 4px;
+      font-weight: 600;
+    }
+    .outcome-group-body {
+      padding: 1.25rem;
+    }
+    .outcome-stats {
+      display: grid;
+      grid-template-columns: repeat(4, 1fr);
+      gap: 1rem;
+      margin-bottom: 1rem;
+    }
+    .outcome-stat {
+      text-align: center;
+    }
+    .outcome-stat .stat-value {
+      font-size: 1.6rem;
+      font-weight: 700;
+    }
+    .outcome-stat .stat-label {
+      font-size: 0.75rem;
+      color: var(--kn-muted);
+    }
+    .val-green { color: var(--kn-success); }
+    .val-blue { color: var(--kn-info); }
+    .val-amber { color: var(--kn-warning); }
+
+    /* Progress bar */
+    .progress-bar-container {
+      width: 100%;
+      height: 8px;
+      background: #e9ecef;
+      border-radius: 4px;
+      overflow: hidden;
+    }
+    .progress-bar-fill {
+      height: 100%;
+      border-radius: 4px;
+    }
+
+    /* Agency breakdown table */
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      font-size: 0.85rem;
+    }
+    thead { background: #f8f9fa; }
+    th {
+      text-align: left;
+      padding: 0.5rem 0.75rem;
+      font-weight: 600;
+      color: var(--kn-text-secondary);
+      font-size: 0.75rem;
+      text-transform: uppercase;
+      letter-spacing: 0.03em;
+      border-bottom: 2px solid var(--kn-border);
+    }
+    td {
+      padding: 0.5rem 0.75rem;
+      border-bottom: 1px solid #f0f0f0;
+    }
+    tr:hover td { background: #f8f9fa; }
+    .status-dot {
+      display: inline-block;
+      width: 8px; height: 8px;
+      border-radius: 50%;
+      margin-right: 0.3rem;
+      vertical-align: middle;
+    }
+    .status-received { background: var(--kn-success); }
+    .status-pending { background: var(--kn-warning); }
+    .status-overdue { background: var(--kn-danger); }
+    .bar-cell {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+    }
+    .bar-cell .progress-bar-container {
+      width: 80px;
+      flex-shrink: 0;
+    }
+
+    /* Tags */
+    .tag {
+      display: inline-block;
+      padding: 0.15rem 0.5rem;
+      border-radius: 10px;
+      font-size: 0.7rem;
+      font-weight: 500;
+    }
+    .tag-sector { background: #f3e5f5; color: #6a1b9a; }
+    .tag-sdg { background: #fce4ec; color: #c62828; }
+    .tag-theme { background: #e3f2fd; color: #1565c0; }
+
+    /* Reporting status summary */
+    .status-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr 1fr;
+      gap: 1rem;
+      margin-bottom: 1rem;
+    }
+    .status-card {
+      background: var(--kn-card-bg);
+      border: 1px solid var(--kn-border);
+      border-radius: var(--kn-radius);
+      padding: 1rem;
+      text-align: center;
+    }
+    .status-card .count {
+      font-size: 2rem;
+      font-weight: 700;
+    }
+    .status-card .status-label {
+      font-size: 0.8rem;
+      color: var(--kn-muted);
+    }
+
+    /* Comparison highlight */
+    .comparison-banner {
+      background: var(--kn-card-bg);
+      border: 1px solid var(--kn-border);
+      border-left: 4px solid var(--kn-primary);
+      border-radius: var(--kn-radius);
+      padding: 1rem 1.25rem;
+      margin-bottom: 1.5rem;
+    }
+    .comparison-banner h3 {
+      font-size: 0.95rem;
+      color: var(--kn-primary-dark);
+      margin-bottom: 0.5rem;
+    }
+    .comparison-banner p {
+      font-size: 0.9rem;
+      color: var(--kn-text-secondary);
+    }
+
+    /* Taxonomy lens summary */
+    .lens-grid {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 1rem;
+    }
+    .lens-card {
+      background: var(--kn-card-bg);
+      border: 1px solid var(--kn-border);
+      border-radius: var(--kn-radius);
+      padding: 1rem;
+    }
+    .lens-card h4 {
+      font-size: 0.9rem;
+      margin-bottom: 0.5rem;
+      color: var(--kn-primary-dark);
+    }
+    .lens-bar-row {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      margin-bottom: 0.4rem;
+      font-size: 0.85rem;
+    }
+    .lens-bar-label {
+      width: 140px;
+      flex-shrink: 0;
+      color: var(--kn-text-secondary);
+    }
+    .lens-bar-container {
+      flex: 1;
+      height: 14px;
+      background: #e9ecef;
+      border-radius: 4px;
+      overflow: hidden;
+    }
+    .lens-bar-fill {
+      height: 100%;
+      border-radius: 4px;
+    }
+    .lens-bar-value {
+      width: 50px;
+      text-align: right;
+      font-weight: 600;
+      font-size: 0.8rem;
+    }
+
+    /* Footer */
+    .footer {
+      text-align: center;
+      padding: 1.5rem;
+      color: var(--kn-muted);
+      font-size: 0.8rem;
+      border-top: 1px solid var(--kn-border);
+      margin-top: 1rem;
+    }
+
+    /* Attestation */
+    .attestation {
+      background: var(--kn-success-light);
+      border: 1px solid #a5d6a7;
+      border-radius: var(--kn-radius);
+      padding: 1rem 1.25rem;
+      margin-top: 1.5rem;
+    }
+    .attestation h4 { color: var(--kn-success); font-size: 0.9rem; margin-bottom: 0.5rem; }
+    .attestation p { font-size: 0.85rem; color: var(--kn-text-secondary); }
+
+    @media print {
+      .header { -webkit-print-color-adjust: exact; print-color-adjust: exact; }
+      body { background: white; }
+    }
+
+    @media (max-width: 800px) {
+      .portfolio-row { grid-template-columns: repeat(3, 1fr); }
+      .outcome-stats { grid-template-columns: repeat(2, 1fr); }
+      .status-grid { grid-template-columns: 1fr; }
+      .lens-grid { grid-template-columns: 1fr; }
+      .header-meta { flex-direction: column; gap: 0.25rem; }
+    }
+  </style>
+</head>
+<body>
+
+<div class="header">
+  <div class="header-top">
+    <div>
+      <h1>Funder Portfolio Dashboard</h1>
+      <div class="subtitle">United Way Greater Toronto &mdash; Q1 2026 Outcome Report</div>
+    </div>
+    <span class="cids-badge">CIDS v3.2.0 &middot; Common Approach</span>
+  </div>
+  <div class="header-meta">
+    <span>Reporting period: January &ndash; March 2026</span>
+    <span>Generated: April 2, 2026</span>
+    <span>32 agencies &middot; 87 programs</span>
+  </div>
+</div>
+
+<div class="container">
+
+  <!-- Why this works -->
+  <div class="explainer">
+    <strong>How does this work?</strong> Each agency uses KoNote to track outcomes using their own language. When they export a funder report, KoNote maps their indicators to <strong>Common Impact Data Standard (CIDS)</strong> codes. Because every agency maps to the same standard, this dashboard can aggregate results across programs that measure the same things &mdash; even if they call them different names.
+  </div>
+
+  <!-- Portfolio overview -->
+  <div class="portfolio-row">
+    <div class="portfolio-card">
+      <div class="big-number">32</div>
+      <div class="card-label">Funded Agencies</div>
+    </div>
+    <div class="portfolio-card">
+      <div class="big-number">87</div>
+      <div class="card-label">Active Programs</div>
+    </div>
+    <div class="portfolio-card">
+      <div class="big-number">4,218</div>
+      <div class="card-label">Participants Served</div>
+    </div>
+    <div class="portfolio-card">
+      <div class="big-number">23,491</div>
+      <div class="card-label">Service Contacts</div>
+    </div>
+    <div class="portfolio-card">
+      <div class="big-number">71%</div>
+      <div class="card-label">Avg. Achievement Rate</div>
+    </div>
+  </div>
+
+  <!-- Reporting status -->
+  <div class="section">
+    <h2>Reporting Status</h2>
+    <div class="status-grid">
+      <div class="status-card">
+        <div class="count val-green">26</div>
+        <div class="status-label"><span class="status-dot status-received"></span> Reports Received</div>
+      </div>
+      <div class="status-card">
+        <div class="count val-amber">4</div>
+        <div class="status-label"><span class="status-dot status-pending"></span> Pending (due Apr 15)</div>
+      </div>
+      <div class="status-card">
+        <div class="count" style="color: var(--kn-danger);">2</div>
+        <div class="status-label"><span class="status-dot status-overdue"></span> Overdue</div>
+      </div>
+    </div>
+  </div>
+
+  <!-- =============================== -->
+  <!-- AGGREGATED OUTCOMES BY CIDS CODE -->
+  <!-- =============================== -->
+  <div class="section">
+    <h2>Aggregated Outcomes by CIDS Indicator</h2>
+    <p class="section-desc">Because agencies map their metrics to CIDS codes, we can compare and aggregate across programs that track the same outcomes &mdash; even when they use different instruments or terminology.</p>
+
+    <!-- Outcome 1: Employment -->
+    <div class="outcome-group">
+      <div class="outcome-group-header">
+        <h3>Employment Attainment</h3>
+        <span class="cids-code">OC-EM-01</span>
+      </div>
+      <div class="outcome-group-body">
+        <div class="outcome-stats">
+          <div class="outcome-stat">
+            <div class="stat-value val-green">68%</div>
+            <div class="stat-label">Avg. Achievement</div>
+          </div>
+          <div class="outcome-stat">
+            <div class="stat-value val-blue">14</div>
+            <div class="stat-label">Programs Reporting</div>
+          </div>
+          <div class="outcome-stat">
+            <div class="stat-value">892</div>
+            <div class="stat-label">Participants Measured</div>
+          </div>
+          <div class="outcome-stat">
+            <div class="stat-value val-green">607</div>
+            <div class="stat-label">Achieved Target</div>
+          </div>
+        </div>
+        <table>
+          <thead>
+            <tr>
+              <th>Agency</th>
+              <th>Program</th>
+              <th>Participants</th>
+              <th>Achievement</th>
+              <th>Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Bright Futures Community Services</td>
+              <td>Youth Employment Services</td>
+              <td>112</td>
+              <td>
+                <div class="bar-cell">
+                  <span>78%</span>
+                  <div class="progress-bar-container">
+                    <div class="progress-bar-fill" style="width:78%; background: var(--kn-success);"></div>
+                  </div>
+                </div>
+              </td>
+              <td><span class="status-dot status-received"></span> Received</td>
+            </tr>
+            <tr>
+              <td>Eastside Settlement Services</td>
+              <td>Newcomer Job Readiness</td>
+              <td>84</td>
+              <td>
+                <div class="bar-cell">
+                  <span>72%</span>
+                  <div class="progress-bar-container">
+                    <div class="progress-bar-fill" style="width:72%; background: var(--kn-success);"></div>
+                  </div>
+                </div>
+              </td>
+              <td><span class="status-dot status-received"></span> Received</td>
+            </tr>
+            <tr>
+              <td>Northern Youth Alliance</td>
+              <td>Trades Apprenticeship Pathway</td>
+              <td>56</td>
+              <td>
+                <div class="bar-cell">
+                  <span>82%</span>
+                  <div class="progress-bar-container">
+                    <div class="progress-bar-fill" style="width:82%; background: var(--kn-success);"></div>
+                  </div>
+                </div>
+              </td>
+              <td><span class="status-dot status-received"></span> Received</td>
+            </tr>
+            <tr>
+              <td>Community Action Network</td>
+              <td>Second Career Support</td>
+              <td>138</td>
+              <td>
+                <div class="bar-cell">
+                  <span>61%</span>
+                  <div class="progress-bar-container">
+                    <div class="progress-bar-fill" style="width:61%; background: var(--kn-info);"></div>
+                  </div>
+                </div>
+              </td>
+              <td><span class="status-dot status-received"></span> Received</td>
+            </tr>
+            <tr>
+              <td>Horizon Centre for Women</td>
+              <td>Women in Skilled Trades</td>
+              <td>42</td>
+              <td>
+                <div class="bar-cell">
+                  <span>74%</span>
+                  <div class="progress-bar-container">
+                    <div class="progress-bar-fill" style="width:74%; background: var(--kn-success);"></div>
+                  </div>
+                </div>
+              </td>
+              <td><span class="status-dot status-received"></span> Received</td>
+            </tr>
+            <tr>
+              <td colspan="2" style="color: var(--kn-muted); font-style: italic;">+ 9 more programs reporting on this indicator</td>
+              <td>460</td>
+              <td>
+                <div class="bar-cell">
+                  <span>63%</span>
+                  <div class="progress-bar-container">
+                    <div class="progress-bar-fill" style="width:63%; background: var(--kn-info);"></div>
+                  </div>
+                </div>
+              </td>
+              <td></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <!-- Outcome 2: Wellbeing -->
+    <div class="outcome-group">
+      <div class="outcome-group-header">
+        <h3>Improved Personal Wellbeing</h3>
+        <span class="cids-code">OC-WB-01</span>
+      </div>
+      <div class="outcome-group-body">
+        <div class="outcome-stats">
+          <div class="outcome-stat">
+            <div class="stat-value val-green">74%</div>
+            <div class="stat-label">Avg. Achievement</div>
+          </div>
+          <div class="outcome-stat">
+            <div class="stat-value val-blue">21</div>
+            <div class="stat-label">Programs Reporting</div>
+          </div>
+          <div class="outcome-stat">
+            <div class="stat-value">1,547</div>
+            <div class="stat-label">Participants Measured</div>
+          </div>
+          <div class="outcome-stat">
+            <div class="stat-value val-green">1,145</div>
+            <div class="stat-label">Achieved Target</div>
+          </div>
+        </div>
+        <table>
+          <thead>
+            <tr>
+              <th>Agency</th>
+              <th>Program</th>
+              <th>Participants</th>
+              <th>Achievement</th>
+              <th>Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Riverdale Mental Health Centre</td>
+              <td>Peer Support Network</td>
+              <td>215</td>
+              <td>
+                <div class="bar-cell">
+                  <span>81%</span>
+                  <div class="progress-bar-container">
+                    <div class="progress-bar-fill" style="width:81%; background: var(--kn-success);"></div>
+                  </div>
+                </div>
+              </td>
+              <td><span class="status-dot status-received"></span> Received</td>
+            </tr>
+            <tr>
+              <td>South Asian Family Services</td>
+              <td>Culturally-Responsive Counselling</td>
+              <td>178</td>
+              <td>
+                <div class="bar-cell">
+                  <span>76%</span>
+                  <div class="progress-bar-container">
+                    <div class="progress-bar-fill" style="width:76%; background: var(--kn-success);"></div>
+                  </div>
+                </div>
+              </td>
+              <td><span class="status-dot status-received"></span> Received</td>
+            </tr>
+            <tr>
+              <td>Indigenous Wellness Collective</td>
+              <td>Land-Based Healing</td>
+              <td>64</td>
+              <td>
+                <div class="bar-cell">
+                  <span>88%</span>
+                  <div class="progress-bar-container">
+                    <div class="progress-bar-fill" style="width:88%; background: var(--kn-success);"></div>
+                  </div>
+                </div>
+              </td>
+              <td><span class="status-dot status-received"></span> Received</td>
+            </tr>
+            <tr>
+              <td>Scarborough Youth Collective</td>
+              <td>Youth Wellness Drop-In</td>
+              <td>142</td>
+              <td>
+                <div class="bar-cell">
+                  <span>69%</span>
+                  <div class="progress-bar-container">
+                    <div class="progress-bar-fill" style="width:69%; background: var(--kn-info);"></div>
+                  </div>
+                </div>
+              </td>
+              <td><span class="status-dot status-received"></span> Received</td>
+            </tr>
+            <tr>
+              <td>Newcomer Health Alliance</td>
+              <td>Refugee Wellness Program</td>
+              <td>93</td>
+              <td>
+                <div class="bar-cell">
+                  <span>71%</span>
+                  <div class="progress-bar-container">
+                    <div class="progress-bar-fill" style="width:71%; background: var(--kn-success);"></div>
+                  </div>
+                </div>
+              </td>
+              <td><span class="status-dot status-pending"></span> Pending</td>
+            </tr>
+            <tr>
+              <td colspan="2" style="color: var(--kn-muted); font-style: italic;">+ 16 more programs reporting on this indicator</td>
+              <td>855</td>
+              <td>
+                <div class="bar-cell">
+                  <span>73%</span>
+                  <div class="progress-bar-container">
+                    <div class="progress-bar-fill" style="width:73%; background: var(--kn-success);"></div>
+                  </div>
+                </div>
+              </td>
+              <td></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <!-- Outcome 3: Financial Literacy -->
+    <div class="outcome-group">
+      <div class="outcome-group-header">
+        <h3>Improved Financial Literacy</h3>
+        <span class="cids-code">OC-FL-01</span>
+      </div>
+      <div class="outcome-group-body">
+        <div class="outcome-stats">
+          <div class="outcome-stat">
+            <div class="stat-value val-green">66%</div>
+            <div class="stat-label">Avg. Achievement</div>
+          </div>
+          <div class="outcome-stat">
+            <div class="stat-value val-blue">9</div>
+            <div class="stat-label">Programs Reporting</div>
+          </div>
+          <div class="outcome-stat">
+            <div class="stat-value">623</div>
+            <div class="stat-label">Participants Measured</div>
+          </div>
+          <div class="outcome-stat">
+            <div class="stat-value val-green">411</div>
+            <div class="stat-label">Achieved Target</div>
+          </div>
+        </div>
+        <table>
+          <thead>
+            <tr>
+              <th>Agency</th>
+              <th>Program</th>
+              <th>Participants</th>
+              <th>Achievement</th>
+              <th>Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Eastside Community Services</td>
+              <td>Family Financial Literacy</td>
+              <td>85</td>
+              <td>
+                <div class="bar-cell">
+                  <span>65%</span>
+                  <div class="progress-bar-container">
+                    <div class="progress-bar-fill" style="width:65%; background: var(--kn-info);"></div>
+                  </div>
+                </div>
+              </td>
+              <td><span class="status-dot status-received"></span> Received</td>
+            </tr>
+            <tr>
+              <td>Parkdale Financial Empowerment</td>
+              <td>Tax Clinic &amp; Benefits Access</td>
+              <td>312</td>
+              <td>
+                <div class="bar-cell">
+                  <span>71%</span>
+                  <div class="progress-bar-container">
+                    <div class="progress-bar-fill" style="width:71%; background: var(--kn-success);"></div>
+                  </div>
+                </div>
+              </td>
+              <td><span class="status-dot status-received"></span> Received</td>
+            </tr>
+            <tr>
+              <td>North York Newcomer Centre</td>
+              <td>Financial Foundations for Newcomers</td>
+              <td>98</td>
+              <td>
+                <div class="bar-cell">
+                  <span>58%</span>
+                  <div class="progress-bar-container">
+                    <div class="progress-bar-fill" style="width:58%; background: var(--kn-info);"></div>
+                  </div>
+                </div>
+              </td>
+              <td><span class="status-dot status-received"></span> Received</td>
+            </tr>
+            <tr>
+              <td colspan="2" style="color: var(--kn-muted); font-style: italic;">+ 6 more programs reporting on this indicator</td>
+              <td>128</td>
+              <td>
+                <div class="bar-cell">
+                  <span>64%</span>
+                  <div class="progress-bar-container">
+                    <div class="progress-bar-fill" style="width:64%; background: var(--kn-info);"></div>
+                  </div>
+                </div>
+              </td>
+              <td></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <!-- Outcome 4: Housing Stability -->
+    <div class="outcome-group">
+      <div class="outcome-group-header">
+        <h3>Housing Stability</h3>
+        <span class="cids-code">OC-HS-01</span>
+      </div>
+      <div class="outcome-group-body">
+        <div class="outcome-stats">
+          <div class="outcome-stat">
+            <div class="stat-value val-amber">52%</div>
+            <div class="stat-label">Avg. Achievement</div>
+          </div>
+          <div class="outcome-stat">
+            <div class="stat-value val-blue">7</div>
+            <div class="stat-label">Programs Reporting</div>
+          </div>
+          <div class="outcome-stat">
+            <div class="stat-value">489</div>
+            <div class="stat-label">Participants Measured</div>
+          </div>
+          <div class="outcome-stat">
+            <div class="stat-value val-amber">254</div>
+            <div class="stat-label">Achieved Target</div>
+          </div>
+        </div>
+        <table>
+          <thead>
+            <tr>
+              <th>Agency</th>
+              <th>Program</th>
+              <th>Participants</th>
+              <th>Achievement</th>
+              <th>Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td>Covenant House Toronto</td>
+              <td>Youth Transitional Housing</td>
+              <td>89</td>
+              <td>
+                <div class="bar-cell">
+                  <span>61%</span>
+                  <div class="progress-bar-container">
+                    <div class="progress-bar-fill" style="width:61%; background: var(--kn-info);"></div>
+                  </div>
+                </div>
+              </td>
+              <td><span class="status-dot status-received"></span> Received</td>
+            </tr>
+            <tr>
+              <td>Dixon Hall</td>
+              <td>Rapid Rehousing</td>
+              <td>156</td>
+              <td>
+                <div class="bar-cell">
+                  <span>48%</span>
+                  <div class="progress-bar-container">
+                    <div class="progress-bar-fill" style="width:48%; background: var(--kn-warning);"></div>
+                  </div>
+                </div>
+              </td>
+              <td><span class="status-dot status-received"></span> Received</td>
+            </tr>
+            <tr>
+              <td>Women's Habitat</td>
+              <td>Safe Housing Transition</td>
+              <td>72</td>
+              <td>
+                <div class="bar-cell">
+                  <span>56%</span>
+                  <div class="progress-bar-container">
+                    <div class="progress-bar-fill" style="width:56%; background: var(--kn-info);"></div>
+                  </div>
+                </div>
+              </td>
+              <td><span class="status-dot status-pending"></span> Pending</td>
+            </tr>
+            <tr>
+              <td colspan="2" style="color: var(--kn-muted); font-style: italic;">+ 4 more programs reporting on this indicator</td>
+              <td>172</td>
+              <td>
+                <div class="bar-cell">
+                  <span>47%</span>
+                  <div class="progress-bar-container">
+                    <div class="progress-bar-fill" style="width:47%; background: var(--kn-warning);"></div>
+                  </div>
+                </div>
+              </td>
+              <td></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+
+  <!-- CIDS Taxonomy Lens -->
+  <div class="section">
+    <h2>Portfolio by CIDS Taxonomy</h2>
+    <p class="section-desc">How funded programs distribute across Common Approach classification codes.</p>
+    <div class="lens-grid">
+      <div class="lens-card">
+        <h4>By Sector (ICNPO)</h4>
+        <div class="lens-bar-row">
+          <span class="lens-bar-label">Social Services</span>
+          <div class="lens-bar-container"><div class="lens-bar-fill" style="width:38%; background: var(--kn-primary);"></div></div>
+          <span class="lens-bar-value">33 pgms</span>
+        </div>
+        <div class="lens-bar-row">
+          <span class="lens-bar-label">Health</span>
+          <div class="lens-bar-container"><div class="lens-bar-fill" style="width:24%; background: var(--kn-primary);"></div></div>
+          <span class="lens-bar-value">21 pgms</span>
+        </div>
+        <div class="lens-bar-row">
+          <span class="lens-bar-label">Education</span>
+          <div class="lens-bar-container"><div class="lens-bar-fill" style="width:18%; background: var(--kn-primary);"></div></div>
+          <span class="lens-bar-value">16 pgms</span>
+        </div>
+        <div class="lens-bar-row">
+          <span class="lens-bar-label">Housing</span>
+          <div class="lens-bar-container"><div class="lens-bar-fill" style="width:12%; background: var(--kn-primary);"></div></div>
+          <span class="lens-bar-value">10 pgms</span>
+        </div>
+        <div class="lens-bar-row">
+          <span class="lens-bar-label">Other</span>
+          <div class="lens-bar-container"><div class="lens-bar-fill" style="width:8%; background: var(--kn-muted);"></div></div>
+          <span class="lens-bar-value">7 pgms</span>
+        </div>
+      </div>
+      <div class="lens-card">
+        <h4>By SDG Alignment</h4>
+        <div class="lens-bar-row">
+          <span class="lens-bar-label">SDG 3: Good Health</span>
+          <div class="lens-bar-container"><div class="lens-bar-fill" style="width:34%; background: #4caf50;"></div></div>
+          <span class="lens-bar-value">30 pgms</span>
+        </div>
+        <div class="lens-bar-row">
+          <span class="lens-bar-label">SDG 8: Decent Work</span>
+          <div class="lens-bar-container"><div class="lens-bar-fill" style="width:28%; background: #9c27b0;"></div></div>
+          <span class="lens-bar-value">24 pgms</span>
+        </div>
+        <div class="lens-bar-row">
+          <span class="lens-bar-label">SDG 10: Reduced Ineq.</span>
+          <div class="lens-bar-container"><div class="lens-bar-fill" style="width:22%; background: #e91e63;"></div></div>
+          <span class="lens-bar-value">19 pgms</span>
+        </div>
+        <div class="lens-bar-row">
+          <span class="lens-bar-label">SDG 11: Sust. Cities</span>
+          <div class="lens-bar-container"><div class="lens-bar-fill" style="width:10%; background: #ff9800;"></div></div>
+          <span class="lens-bar-value">9 pgms</span>
+        </div>
+        <div class="lens-bar-row">
+          <span class="lens-bar-label">Other SDGs</span>
+          <div class="lens-bar-container"><div class="lens-bar-fill" style="width:6%; background: var(--kn-muted);"></div></div>
+          <span class="lens-bar-value">5 pgms</span>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Why CIDS matters -->
+  <div class="comparison-banner">
+    <h3>Why This Dashboard Is Possible</h3>
+    <p>
+      Without a common standard, each agency reports in its own format &mdash; different indicator names, different scales, different definitions of "success." A funder reviewing 87 programs would receive 87 incompatible spreadsheets.
+    </p>
+    <p style="margin-top: 0.5rem;">
+      With <strong>CIDS</strong>, each agency keeps its own terminology and measurement tools, but maps outcomes to shared codes at export time. The funder receives structured, comparable data &mdash; enabling the portfolio view above. The agency's workflow doesn't change; only the export gains a common language.
+    </p>
+  </div>
+
+  <!-- Data integrity note -->
+  <div class="attestation">
+    <h4>Data Integrity</h4>
+    <p>All data is <strong>aggregate</strong>. No individual participant information is included in this dashboard. Each agency's data was approved by their designated report approver before submission. 24 of 26 received reports include evaluator attestation.</p>
+  </div>
+
+</div>
+
+<div class="footer">
+  Generated from CIDS-mapped KoNote exports &middot; Common Impact Data Standard v3.2.0<br>
+  All data is aggregate. No individual participant information is included.<br>
+  Powered by KoNote &middot; <a href="https://www.konote.ca" style="color: var(--kn-muted);">www.konote.ca</a>
+</div>
+
+</body>
+</html>

--- a/preview_multi_program_report.html
+++ b/preview_multi_program_report.html
@@ -1,0 +1,829 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Multi-Program Outcome Report — Eastside Community Services</title>
+    <style>
+/* === Shared report styles (_report_styles.html) === */
+* { box-sizing: border-box; }
+body {
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    font-size: 14px;
+    line-height: 1.6;
+    color: #1a202c;
+    margin: 0;
+    padding: 2rem;
+    max-width: 900px;
+    margin-left: auto;
+    margin-right: auto;
+    background-color: #ffffff;
+}
+.sr-only {
+    position: absolute; width: 1px; height: 1px;
+    padding: 0; margin: -1px; overflow: hidden;
+    clip: rect(0, 0, 0, 0); white-space: nowrap; border: 0;
+}
+details { margin-top: 1.5rem; }
+summary.report-header-bar {
+    list-style: none;
+    cursor: pointer;
+    user-select: none;
+}
+summary.report-header-bar::-webkit-details-marker { display: none; }
+summary.report-header-bar::marker { display: none; }
+summary.report-header-bar::after {
+    content: " \25BE";
+    float: right;
+    transition: transform 0.2s;
+}
+details:not([open]) > summary.report-header-bar::after {
+    transform: rotate(-90deg);
+    display: inline-block;
+}
+.report-header-bar {
+    background-color: #3176aa;
+    color: #ffffff;
+    padding: 0.4rem 0.8rem;
+    margin-top: 1.5rem;
+    font-size: 14px;
+    font-weight: 600;
+    border-radius: 4px 4px 0 0;
+}
+.pdf-header {
+    border-bottom: 3px solid #3176aa;
+    padding-bottom: 0.6rem;
+    margin-bottom: 1rem;
+}
+.pdf-header h1 {
+    font-size: 1.5rem;
+    margin: 0 0 0.25rem 0;
+    color: #3176aa;
+}
+.pdf-header .subtitle {
+    font-size: 1.1rem;
+    color: #4a5568;
+    margin-bottom: 0.5rem;
+}
+.pdf-header .meta-grid {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 0.1rem 0.8rem;
+    font-size: 0.85rem;
+    color: #718096;
+}
+.pdf-header .meta-grid dt {
+    font-weight: 600;
+    color: #4a5568;
+}
+.pdf-header .meta-grid dd { margin: 0; }
+.report-toc {
+    margin: 1rem 0;
+    padding: 0.6rem 1rem;
+    background-color: #f7f8fa;
+    border-radius: 4px;
+    font-size: 0.85rem;
+}
+.report-toc h2 {
+    font-size: 0.9rem;
+    margin: 0 0 0.3rem 0;
+    border: none;
+    color: #4a5568;
+}
+.report-toc ol {
+    margin: 0;
+    padding-left: 1.5rem;
+}
+.report-toc li { margin-bottom: 0.15rem; }
+.report-toc a {
+    color: #3176aa;
+    text-decoration: none;
+}
+.report-toc a:hover { text-decoration: underline; }
+h2 {
+    font-size: 1.3rem;
+    color: #3176aa;
+    border-bottom: 2px solid #3176aa;
+    padding-bottom: 0.3rem;
+    margin-top: 1.5rem;
+}
+h3 {
+    font-size: 1.1rem;
+    color: #1a202c;
+    margin-top: 1rem;
+}
+table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 0.8rem 0;
+    font-size: 0.9rem;
+}
+thead th {
+    background-color: #3176aa;
+    color: #ffffff;
+    padding: 8px 12px;
+    text-align: left;
+    font-weight: 600;
+}
+tbody td {
+    padding: 6px 12px;
+    border-bottom: 1px solid #e5e7eb;
+}
+tbody tr:nth-child(even) { background-color: #f7f8fa; }
+.stat-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 0.8rem;
+    margin: 0.8rem 0;
+}
+.stat-box {
+    border: 1px solid #d1d5db;
+    border-radius: 6px;
+    padding: 1rem;
+    text-align: center;
+}
+.stat-box .value {
+    font-size: 1.8rem;
+    font-weight: 700;
+    color: #3176aa;
+}
+.stat-box .label {
+    font-size: 0.8rem;
+    color: #718096;
+    margin-top: 0.2rem;
+}
+.stat-box .change {
+    font-size: 0.75rem;
+    color: #4a5568;
+    margin-top: 0.15rem;
+}
+.outcome-card {
+    border: 2px solid #3176aa;
+    border-radius: 6px;
+    padding: 1rem;
+    margin: 0.5rem 0;
+}
+.outcome-card h4 {
+    margin: 0 0 0.3rem 0;
+    color: #3176aa;
+}
+.outcome-card .rate {
+    font-size: 2rem;
+    font-weight: 700;
+    color: #3176aa;
+}
+.outcome-card .details {
+    font-size: 0.85rem;
+    color: #4a5568;
+    margin-top: 0.3rem;
+}
+.achievement-bar {
+    background-color: #e5e7eb;
+    height: 10px;
+    border-radius: 5px;
+    margin-top: 0.4rem;
+    overflow: hidden;
+}
+.achievement-bar-fill {
+    background-color: #3176aa;
+    height: 100%;
+    border-radius: 5px;
+    transition: width 0.3s;
+}
+td .achievement-bar {
+    height: 6px;
+    margin-top: 2px;
+    min-width: 60px;
+}
+.demo-row {
+    display: grid;
+    grid-template-columns: 1fr 80px 80px;
+    padding: 6px 12px;
+    border-bottom: 1px solid #e5e7eb;
+}
+.demo-row.header {
+    background-color: #f7f8fa;
+    font-weight: 600;
+}
+.demo-bar {
+    background-color: #e5e7eb;
+    height: 8px;
+    border-radius: 4px;
+    margin-top: 4px;
+    overflow: hidden;
+}
+.demo-bar-fill {
+    background-color: #3176aa;
+    height: 100%;
+    border-radius: 4px;
+}
+.summary-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0.8rem;
+    margin: 0.8rem 0;
+}
+.summary-card {
+    border: 1px solid #d1d5db;
+    border-radius: 6px;
+    padding: 1rem;
+    text-align: center;
+}
+.summary-card .number {
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: #3176aa;
+}
+.summary-card .label {
+    font-size: 0.8rem;
+    color: #718096;
+}
+.footer-note {
+    font-size: 0.85rem;
+    color: #718096;
+    font-style: italic;
+    margin-top: 2rem;
+    padding-top: 0.5rem;
+    border-top: 1px solid #e5e7eb;
+}
+.generated-by {
+    font-size: 0.8rem;
+    color: #a0aec0;
+    margin-top: 1rem;
+    text-align: right;
+}
+
+/* === Multi-program extras === */
+.metrics-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 0.8rem 0;
+}
+.metrics-table th, .metrics-table td {
+    border: 1px solid #d1d5db;
+    padding: 8px 12px;
+    text-align: right;
+}
+.metrics-table th:first-child, .metrics-table td:first-child {
+    text-align: left;
+}
+.metrics-table thead th {
+    background-color: #f7f8fa;
+    font-weight: 600;
+    color: #1a202c;
+}
+.narrative-section {
+    border-left: 4px solid #3176aa;
+    padding: 0.8rem 1rem;
+    margin: 0.8rem 0;
+    background-color: #f7f8fa;
+}
+.narrative-section .placeholder {
+    font-style: italic;
+    color: #718096;
+}
+.program-section {
+    margin-top: 2rem;
+    border-top: 3px solid #3176aa;
+    padding-top: 1rem;
+}
+.program-section:first-of-type {
+    border-top: none;
+    margin-top: 1rem;
+}
+.program-section-title {
+    font-size: 1.2rem;
+    font-weight: 700;
+    color: #3176aa;
+    margin-bottom: 0.5rem;
+    margin-top: 0;
+    border-bottom: none;
+    padding-bottom: 0;
+}
+
+@media print {
+    body { padding: 0; max-width: none; }
+    .no-print { display: none; }
+    details > summary { display: none; }
+    details > *:not(summary) { display: block !important; }
+    .program-section { page-break-before: always; }
+    .program-section:first-of-type { page-break-before: auto; }
+}
+    </style>
+</head>
+<body>
+<!-- Report Header -->
+<div class="pdf-header">
+    <h1>Multi-Program Outcome Report</h1>
+    <div class="subtitle">Eastside Community Services — Quarterly Funder Report</div>
+    <dl class="meta-grid">
+        <dt>Partner</dt>
+        <dd>Eastside Community Services</dd>
+        <dt>Period</dt>
+        <dd>January 1 – March 31, 2026</dd>
+        <dt>Programs Included</dt>
+        <dd>3</dd>
+        <dt>Generated</dt>
+        <dd>2026-04-02 by Gillian Kerr</dd>
+    </dl>
+</div>
+
+<!-- Organisation-wide summary -->
+<div class="report-header-bar">Organisation Summary</div>
+<div class="stat-grid">
+    <div class="stat-box">
+        <div class="value">247</div>
+        <div class="label">Total Individuals Served</div>
+    </div>
+    <div class="stat-box">
+        <div class="value">38</div>
+        <div class="label">New Participants This Period</div>
+    </div>
+    <div class="stat-box">
+        <div class="value">1,024</div>
+        <div class="label">Total Service Contacts</div>
+    </div>
+    <div class="stat-box">
+        <div class="value">3</div>
+        <div class="label">Programs</div>
+    </div>
+</div>
+
+<!-- Table of contents -->
+<nav class="report-toc no-print" aria-label="Programs in this report">
+    <h2>Programs</h2>
+    <ol>
+        <li><a href="#program-1">Youth Wellness Initiative</a></li>
+        <li><a href="#program-2">Family Financial Literacy</a></li>
+        <li><a href="#program-3">Employment Readiness</a></li>
+    </ol>
+</nav>
+
+<!-- ==================== PROGRAM 1 ==================== -->
+<div class="program-section" id="program-1">
+    <h2 class="program-section-title">Youth Wellness Initiative</h2>
+
+    <div class="stat-grid">
+        <div class="stat-box">
+            <div class="value">112</div>
+            <div class="label">Total Individuals Served</div>
+            <div class="change">
+                <span aria-hidden="true">&#9650;</span>
+                <span class="sr-only">Increased</span>
+                from 98 previous period
+            </div>
+        </div>
+        <div class="stat-box">
+            <div class="value">18</div>
+            <div class="label">New Participants This Period</div>
+        </div>
+        <div class="stat-box">
+            <div class="value">486</div>
+            <div class="label">Total Service Contacts</div>
+        </div>
+    </div>
+
+    <!-- Metrics -->
+    <details open>
+    <summary class="report-header-bar">Outcome Metrics</summary>
+    <table class="metrics-table">
+        <thead>
+            <tr>
+                <th scope="col">Metric</th>
+                <th scope="col">All Participants</th>
+                <th scope="col">Youth (13–18)</th>
+                <th scope="col">Young Adults (19–24)</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>Self-reported wellbeing improvement</td>
+                <td>
+                    72%
+                    <div class="achievement-bar" role="progressbar" aria-valuenow="72" aria-valuemin="0" aria-valuemax="100">
+                        <div class="achievement-bar-fill" style="width: 72%;"></div>
+                    </div>
+                </td>
+                <td>
+                    68%
+                    <div class="achievement-bar" role="progressbar" aria-valuenow="68" aria-valuemin="0" aria-valuemax="100">
+                        <div class="achievement-bar-fill" style="width: 68%;"></div>
+                    </div>
+                </td>
+                <td>
+                    78%
+                    <div class="achievement-bar" role="progressbar" aria-valuenow="78" aria-valuemin="0" aria-valuemax="100">
+                        <div class="achievement-bar-fill" style="width: 78%;"></div>
+                    </div>
+                </td>
+            </tr>
+            <tr>
+                <td>Goal completion rate</td>
+                <td>
+                    61%
+                    <div class="achievement-bar" role="progressbar" aria-valuenow="61" aria-valuemin="0" aria-valuemax="100">
+                        <div class="achievement-bar-fill" style="width: 61%;"></div>
+                    </div>
+                </td>
+                <td>
+                    55%
+                    <div class="achievement-bar" role="progressbar" aria-valuenow="55" aria-valuemin="0" aria-valuemax="100">
+                        <div class="achievement-bar-fill" style="width: 55%;"></div>
+                    </div>
+                </td>
+                <td>
+                    69%
+                    <div class="achievement-bar" role="progressbar" aria-valuenow="69" aria-valuemin="0" aria-valuemax="100">
+                        <div class="achievement-bar-fill" style="width: 69%;"></div>
+                    </div>
+                </td>
+            </tr>
+            <tr>
+                <td>Average sessions attended</td>
+                <td>8.4</td>
+                <td>7.2</td>
+                <td>9.8</td>
+            </tr>
+        </tbody>
+    </table>
+    </details>
+
+    <!-- Age Demographics -->
+    <details open>
+    <summary class="report-header-bar">Age Demographics &mdash; 112 participants</summary>
+    <div style="margin: 0.8rem 0;">
+        <div class="demo-row header">
+            <div>Age Group</div>
+            <div style="text-align: right;">Count</div>
+            <div style="text-align: right;">Percentage</div>
+        </div>
+        <div class="demo-row">
+            <div>
+                13–15
+                <div class="demo-bar" role="progressbar" aria-valuenow="27" aria-valuemin="0" aria-valuemax="100" aria-label="13–15">
+                    <div class="demo-bar-fill" style="width: 27%;"></div>
+                </div>
+            </div>
+            <div style="text-align: right;">30</div>
+            <div style="text-align: right;">27%</div>
+        </div>
+        <div class="demo-row">
+            <div>
+                16–18
+                <div class="demo-bar" role="progressbar" aria-valuenow="38" aria-valuemin="0" aria-valuemax="100" aria-label="16–18">
+                    <div class="demo-bar-fill" style="width: 38%;"></div>
+                </div>
+            </div>
+            <div style="text-align: right;">43</div>
+            <div style="text-align: right;">38%</div>
+        </div>
+        <div class="demo-row">
+            <div>
+                19–24
+                <div class="demo-bar" role="progressbar" aria-valuenow="35" aria-valuemin="0" aria-valuemax="100" aria-label="19–24">
+                    <div class="demo-bar-fill" style="width: 35%;"></div>
+                </div>
+            </div>
+            <div style="text-align: right;">39</div>
+            <div style="text-align: right;">35%</div>
+        </div>
+        <div class="demo-row header">
+            <div>Total</div>
+            <div style="text-align: right;">112</div>
+            <div style="text-align: right;">100%</div>
+        </div>
+    </div>
+    </details>
+
+    <!-- CIDS Standards Alignment -->
+    <details id="program-1-standards">
+    <summary class="report-header-bar">Standards Alignment</summary>
+    <p style="font-size: 0.85rem; color: #718096; margin-bottom: 0.8rem;">
+        Aligned with Common Impact Data Standard (CIDS) v3.2.0.
+    </p>
+    <p><strong>Reporting Lens:</strong> United Way Outcomes</p>
+    <p><strong>Sector:</strong> Youth Services</p>
+    <table class="metrics-table">
+        <thead>
+            <tr>
+                <th scope="col">Indicator</th>
+                <th scope="col">Selected Code</th>
+                <th scope="col">Selected Label</th>
+                <th scope="col">Code List</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>Self-reported wellbeing improvement</td>
+                <td>OC-WB-01</td>
+                <td>Improved personal wellbeing</td>
+                <td>Common Outcomes</td>
+            </tr>
+            <tr>
+                <td>Goal completion rate</td>
+                <td>OC-GC-03</td>
+                <td>Goal attainment</td>
+                <td>Common Outcomes</td>
+            </tr>
+            <tr>
+                <td>Average sessions attended</td>
+                <td>ACT-SA-02</td>
+                <td>Service participation level</td>
+                <td>Common Activities</td>
+            </tr>
+        </tbody>
+    </table>
+    <p style="font-size: 0.85rem; color: #718096;">
+        3 of 3 indicators mapped for the selected reporting lens.
+    </p>
+    </details>
+
+    <!-- Program Summary -->
+    <div class="report-header-bar">Program Summary</div>
+    <div class="summary-grid">
+        <div class="summary-card">
+            <div class="number">72%</div>
+            <div class="achievement-bar" role="progressbar" aria-valuenow="72" aria-valuemin="0" aria-valuemax="100" aria-label="Overall achievement rate">
+                <div class="achievement-bar-fill" style="width: 72%;"></div>
+            </div>
+            <div class="label">Overall Achievement Rate</div>
+        </div>
+        <div class="summary-card">
+            <div class="number">81 / 112</div>
+            <div class="label">Participants Met at Least One Target</div>
+        </div>
+    </div>
+</div>
+
+<!-- ==================== PROGRAM 2 ==================== -->
+<div class="program-section" id="program-2">
+    <h2 class="program-section-title">Family Financial Literacy</h2>
+
+    <div class="stat-grid">
+        <div class="stat-box">
+            <div class="value">85</div>
+            <div class="label">Total Individuals Served</div>
+            <div class="change">
+                <span aria-hidden="true">&#9650;</span>
+                <span class="sr-only">Increased</span>
+                from 72 previous period
+            </div>
+        </div>
+        <div class="stat-box">
+            <div class="value">12</div>
+            <div class="label">New Participants This Period</div>
+        </div>
+        <div class="stat-box">
+            <div class="value">340</div>
+            <div class="label">Total Service Contacts</div>
+        </div>
+    </div>
+
+    <details open>
+    <summary class="report-header-bar">Outcome Metrics</summary>
+    <table class="metrics-table">
+        <thead>
+            <tr>
+                <th scope="col">Metric</th>
+                <th scope="col">All Participants</th>
+                <th scope="col">Single Parents</th>
+                <th scope="col">Two-Parent Families</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>Budgeting confidence score increase</td>
+                <td>
+                    65%
+                    <div class="achievement-bar" role="progressbar" aria-valuenow="65" aria-valuemin="0" aria-valuemax="100">
+                        <div class="achievement-bar-fill" style="width: 65%;"></div>
+                    </div>
+                </td>
+                <td>
+                    60%
+                    <div class="achievement-bar" role="progressbar" aria-valuenow="60" aria-valuemin="0" aria-valuemax="100">
+                        <div class="achievement-bar-fill" style="width: 60%;"></div>
+                    </div>
+                </td>
+                <td>
+                    71%
+                    <div class="achievement-bar" role="progressbar" aria-valuenow="71" aria-valuemin="0" aria-valuemax="100">
+                        <div class="achievement-bar-fill" style="width: 71%;"></div>
+                    </div>
+                </td>
+            </tr>
+            <tr>
+                <td>Completed savings plan</td>
+                <td>
+                    48%
+                    <div class="achievement-bar" role="progressbar" aria-valuenow="48" aria-valuemin="0" aria-valuemax="100">
+                        <div class="achievement-bar-fill" style="width: 48%;"></div>
+                    </div>
+                </td>
+                <td>
+                    42%
+                    <div class="achievement-bar" role="progressbar" aria-valuenow="42" aria-valuemin="0" aria-valuemax="100">
+                        <div class="achievement-bar-fill" style="width: 42%;"></div>
+                    </div>
+                </td>
+                <td>
+                    55%
+                    <div class="achievement-bar" role="progressbar" aria-valuenow="55" aria-valuemin="0" aria-valuemax="100">
+                        <div class="achievement-bar-fill" style="width: 55%;"></div>
+                    </div>
+                </td>
+            </tr>
+        </tbody>
+    </table>
+    </details>
+
+    <details>
+    <summary class="report-header-bar">Standards Alignment</summary>
+    <p style="font-size: 0.85rem; color: #718096; margin-bottom: 0.8rem;">
+        Aligned with Common Impact Data Standard (CIDS) v3.2.0.
+    </p>
+    <p><strong>Reporting Lens:</strong> United Way Outcomes</p>
+    <table class="metrics-table">
+        <thead>
+            <tr>
+                <th scope="col">Indicator</th>
+                <th scope="col">Selected Code</th>
+                <th scope="col">Selected Label</th>
+                <th scope="col">Code List</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>Budgeting confidence score increase</td>
+                <td>OC-FL-01</td>
+                <td>Improved financial literacy</td>
+                <td>Common Outcomes</td>
+            </tr>
+            <tr>
+                <td>Completed savings plan</td>
+                <td>OC-FL-04</td>
+                <td>Financial planning behaviour</td>
+                <td>Common Outcomes</td>
+            </tr>
+        </tbody>
+    </table>
+    <p style="font-size: 0.85rem; color: #718096;">
+        2 of 2 indicators mapped for the selected reporting lens.
+    </p>
+    </details>
+
+    <div class="report-header-bar">Program Summary</div>
+    <div class="summary-grid">
+        <div class="summary-card">
+            <div class="number">65%</div>
+            <div class="achievement-bar" role="progressbar" aria-valuenow="65" aria-valuemin="0" aria-valuemax="100" aria-label="Overall achievement rate">
+                <div class="achievement-bar-fill" style="width: 65%;"></div>
+            </div>
+            <div class="label">Overall Achievement Rate</div>
+        </div>
+        <div class="summary-card">
+            <div class="number">55 / 85</div>
+            <div class="label">Participants Met at Least One Target</div>
+        </div>
+    </div>
+</div>
+
+<!-- ==================== PROGRAM 3 ==================== -->
+<div class="program-section" id="program-3">
+    <h2 class="program-section-title">Employment Readiness</h2>
+
+    <div class="stat-grid">
+        <div class="stat-box">
+            <div class="value">50</div>
+            <div class="label">Total Individuals Served</div>
+        </div>
+        <div class="stat-box">
+            <div class="value">8</div>
+            <div class="label">New Participants This Period</div>
+        </div>
+        <div class="stat-box">
+            <div class="value">198</div>
+            <div class="label">Total Service Contacts</div>
+        </div>
+    </div>
+
+    <details open>
+    <summary class="report-header-bar">Outcome Metrics</summary>
+    <table class="metrics-table">
+        <thead>
+            <tr>
+                <th scope="col">Metric</th>
+                <th scope="col">All Participants</th>
+                <th scope="col">Age 25–44</th>
+                <th scope="col">Age 45+</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>Job placement within 90 days</td>
+                <td>
+                    54%
+                    <div class="achievement-bar" role="progressbar" aria-valuenow="54" aria-valuemin="0" aria-valuemax="100">
+                        <div class="achievement-bar-fill" style="width: 54%;"></div>
+                    </div>
+                </td>
+                <td>
+                    62%
+                    <div class="achievement-bar" role="progressbar" aria-valuenow="62" aria-valuemin="0" aria-valuemax="100">
+                        <div class="achievement-bar-fill" style="width: 62%;"></div>
+                    </div>
+                </td>
+                <td>
+                    41%
+                    <div class="achievement-bar" role="progressbar" aria-valuenow="41" aria-valuemin="0" aria-valuemax="100">
+                        <div class="achievement-bar-fill" style="width: 41%;"></div>
+                    </div>
+                </td>
+            </tr>
+            <tr>
+                <td>Resume and interview readiness</td>
+                <td>
+                    88%
+                    <div class="achievement-bar" role="progressbar" aria-valuenow="88" aria-valuemin="0" aria-valuemax="100">
+                        <div class="achievement-bar-fill" style="width: 88%;"></div>
+                    </div>
+                </td>
+                <td>
+                    90%
+                    <div class="achievement-bar" role="progressbar" aria-valuenow="90" aria-valuemin="0" aria-valuemax="100">
+                        <div class="achievement-bar-fill" style="width: 90%;"></div>
+                    </div>
+                </td>
+                <td>
+                    84%
+                    <div class="achievement-bar" role="progressbar" aria-valuenow="84" aria-valuemin="0" aria-valuemax="100">
+                        <div class="achievement-bar-fill" style="width: 84%;"></div>
+                    </div>
+                </td>
+            </tr>
+        </tbody>
+    </table>
+    </details>
+
+    <details>
+    <summary class="report-header-bar">Standards Alignment</summary>
+    <p style="font-size: 0.85rem; color: #718096; margin-bottom: 0.8rem;">
+        Aligned with Common Impact Data Standard (CIDS) v3.2.0.
+    </p>
+    <p><strong>Reporting Lens:</strong> United Way Outcomes</p>
+    <table class="metrics-table">
+        <thead>
+            <tr>
+                <th scope="col">Indicator</th>
+                <th scope="col">Selected Code</th>
+                <th scope="col">Selected Label</th>
+                <th scope="col">Code List</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>Job placement within 90 days</td>
+                <td>OC-EM-01</td>
+                <td>Employment attainment</td>
+                <td>Common Outcomes</td>
+            </tr>
+            <tr>
+                <td>Resume and interview readiness</td>
+                <td>OC-EM-05</td>
+                <td>Employment skills development</td>
+                <td>Common Outcomes</td>
+            </tr>
+        </tbody>
+    </table>
+    <p style="font-size: 0.85rem; color: #718096;">
+        2 of 2 indicators mapped for the selected reporting lens.
+    </p>
+    </details>
+
+    <div class="report-header-bar">Program Summary</div>
+    <div class="summary-grid">
+        <div class="summary-card">
+            <div class="number">54%</div>
+            <div class="achievement-bar" role="progressbar" aria-valuenow="54" aria-valuemin="0" aria-valuemax="100" aria-label="Overall achievement rate">
+                <div class="achievement-bar-fill" style="width: 54%;"></div>
+            </div>
+            <div class="label">Overall Achievement Rate</div>
+        </div>
+        <div class="summary-card">
+            <div class="number">27 / 50</div>
+            <div class="label">Participants Met at Least One Target</div>
+        </div>
+    </div>
+</div>
+
+<div class="footer-note">
+    This report was generated using KoNote's Multi-Program Outcome Report Template.
+    Data reflects client outcomes recorded during the January 1 – March 31, 2026 reporting period.
+    Includes data from 3 program(s).
+</div>
+
+<div class="generated-by">
+    Generated by KoNote
+</div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Adds 4 static HTML preview files used for local design review of report layouts
- `demo.html` — general demo page
- `preview_funder_outcome_report.html` — funder outcome report layout
- `preview_funder_portfolio_dashboard.html` — funder portfolio dashboard layout
- `preview_multi_program_report.html` — multi-program report layout

## Test plan
- [ ] Open each file in a browser to verify rendering

🤖 Generated with [Claude Code](https://claude.com/claude-code)