### PR TITLE
fix: prevent demo data from falling below report thresholds

### DIFF
--- a/apps/admin_settings/checks.py
+++ b/apps/admin_settings/checks.py
@@ -1,13 +1,14 @@
 """
-Django system checks for French translation completeness.
+Django system checks for translation completeness and demo data health.
 
 These run automatically with every manage.py command (runserver, migrate, etc.).
-They catch missing translations early — especially useful when Claude Code or
-other AI tools are the primary developer and will see the warnings.
+They catch issues early — especially useful when Claude Code or other AI tools
+are the primary developer and will see the warnings.
 
 Check IDs:
     KoNote.W010 — Translation gap detected (Warning)
     KoNote.W011 — .mo file missing or stale (Warning)
+    KoNote.W012 — Demo data below report suppression threshold (Warning)
 
 Run checks manually:
     python manage.py check
@@ -157,3 +158,55 @@ def _count_po_entries(po_path):
         i += 1
 
     return count
+
+
+@register()
+def check_demo_data_health(app_configs, **kwargs):
+    """W012: Warn if demo data exists but is below the report suppression threshold.
+
+    Only runs when DEMO_MODE is enabled.  Catches degraded demo data that
+    would cause reports to show "< 5" or empty results — whether from
+    low client counts, manual deletions, or migration side-effects.
+    """
+    warnings = []
+
+    if not getattr(settings, "DEMO_MODE", False):
+        return warnings
+
+    try:
+        from apps.clients.models import ClientFile, ClientProgramEnrolment
+        from apps.programs.models import Program
+        from apps.reports.suppression import SMALL_CELL_THRESHOLD
+    except Exception:
+        return warnings  # App not ready yet (e.g. during initial migrate)
+
+    # Only check if demo data exists at all
+    if not ClientFile.objects.filter(is_demo=True).exists():
+        return warnings
+
+    programs = Program.objects.filter(is_active=True)
+    low_programs = []
+
+    for prog in programs:
+        count = ClientProgramEnrolment.objects.filter(
+            program=prog, client_file__is_demo=True, status="active",
+        ).count()
+        if 0 < count < SMALL_CELL_THRESHOLD:
+            low_programs.append(f"{prog.name} ({count})")
+
+    if low_programs:
+        warnings.append(
+            Warning(
+                f"Demo data below suppression threshold in: "
+                f"{', '.join(low_programs)}. "
+                f"Reports will show '< {SMALL_CELL_THRESHOLD}' instead of "
+                f"actual counts.",
+                hint=(
+                    "Regenerate demo data: "
+                    "python manage.py generate_demo_data --force"
+                ),
+                id="KoNote.W012",
+            )
+        )
+
+    return warnings

--- a/apps/admin_settings/demo_engine.py
+++ b/apps/admin_settings/demo_engine.py
@@ -514,6 +514,13 @@ PORTAL_SURVEY_DEFINITIONS = [
 # The engine
 # ---------------------------------------------------------------------------
 
+# Minimum demo clients per program.  Must exceed the small-cell
+# suppression threshold (5) so that reports show real counts instead
+# of "< 5".  Import this constant wherever a default is needed —
+# never hardcode a number.
+DEMO_MIN_CLIENTS_PER_PROGRAM = 10
+
+
 class DemoDataEngine:
     """Generate configuration-aware demo data for any KoNote instance.
 
@@ -3355,29 +3362,43 @@ class DemoDataEngine:
         return descriptor_map.get(descriptor, "in_progress")
 
     @transaction.atomic
-    def run(self, clients_per_program=10, days_span=180, profile_path=None,
+    def run(self, clients_per_program=None, days_span=180, profile_path=None,
             force=False):
         """Generate demo data matching the instance's current configuration.
 
         Args:
-            clients_per_program: Number of demo clients to create per program
-                (default 10 — must exceed the suppression threshold of 5 so
-                reports show real counts instead of "< 5").
+            clients_per_program: Number of demo clients to create per program.
+                Defaults to DEMO_MIN_CLIENTS_PER_PROGRAM (10).  Values below
+                the suppression threshold (5) are raised automatically with
+                a warning.
             days_span: Number of days of historical data to generate.
             profile_path: Optional path to a demo data profile JSON.
             force: If True, clear existing demo data before generating.
         """
+        if clients_per_program is None:
+            clients_per_program = DEMO_MIN_CLIENTS_PER_PROGRAM
+
         random.seed(42)  # Reproducible demo data
 
         profile = self.load_profile(profile_path)
         self.apply_feature_toggles(profile)
 
-        # Apply profile defaults
+        # Apply profile defaults (only when caller used the default)
         profile_defaults = profile.get("defaults", {})
-        if "clients_per_program" in profile_defaults and clients_per_program == 10:
+        if "clients_per_program" in profile_defaults and clients_per_program == DEMO_MIN_CLIENTS_PER_PROGRAM:
             clients_per_program = profile_defaults["clients_per_program"]
         if "days_span" in profile_defaults and days_span == 180:
             days_span = profile_defaults["days_span"]
+
+        # Guard: enforce minimum so reports are never suppressed
+        from apps.reports.suppression import SMALL_CELL_THRESHOLD
+        if clients_per_program < SMALL_CELL_THRESHOLD:
+            self.log(
+                f"  WARNING: clients_per_program={clients_per_program} is below "
+                f"the suppression threshold ({SMALL_CELL_THRESHOLD}). "
+                f"Raising to {DEMO_MIN_CLIENTS_PER_PROGRAM}.",
+            )
+            clients_per_program = DEMO_MIN_CLIENTS_PER_PROGRAM
 
         note_count_range = profile_defaults.get("note_count_range", [7, 12])
 

--- a/apps/admin_settings/demo_engine.py
+++ b/apps/admin_settings/demo_engine.py
@@ -29,6 +29,7 @@ from time import perf_counter
 
 from django.contrib.auth import get_user_model
 from django.db import transaction
+from django.db.models import Q
 from django.utils import timezone
 
 from apps.admin_settings.models import FeatureToggle
@@ -3598,12 +3599,68 @@ class DemoDataEngine:
                 f"  Demo data generated: {total_clients} clients across "
                 f"{len(programs)} programs."
             )
+
+            # Post-generation health check: verify data is usable for reports
+            self._validate_demo_data_health(programs)
+
             return True
         finally:
             if previous_skip_recompute is None:
                 os.environ.pop("KONOTE_SKIP_ACHIEVEMENT_RECOMPUTE", None)
             else:
                 os.environ["KONOTE_SKIP_ACHIEVEMENT_RECOMPUTE"] = previous_skip_recompute
+
+    def _validate_demo_data_health(self, programs):
+        """Check that generated demo data will produce usable reports.
+
+        Warns (does not fail) if any program has too few clients or if no
+        notes fall in the current fiscal year — these are the two conditions
+        that make reports show "no results" or "< 5".
+        """
+        from apps.reports.suppression import SMALL_CELL_THRESHOLD
+        from apps.reports.utils import get_current_fiscal_year, get_fiscal_year_range
+
+        issues = []
+
+        for prog in programs:
+            enrolled = ClientProgramEnrolment.objects.filter(
+                program=prog, client_file__is_demo=True, status="active",
+            ).count()
+            if enrolled < SMALL_CELL_THRESHOLD:
+                issues.append(
+                    f"  ⚠ {prog.name}: {enrolled} demo clients "
+                    f"(below suppression threshold of {SMALL_CELL_THRESHOLD})"
+                )
+
+        # Check that at least some notes fall in the current fiscal year
+        fy_start_year = get_current_fiscal_year()
+        date_from, date_to = get_fiscal_year_range(fy_start_year)
+
+        from datetime import datetime, time
+        date_from_dt = timezone.make_aware(datetime.combine(date_from, time.min))
+        date_to_dt = timezone.make_aware(datetime.combine(date_to, time.max))
+
+        current_fy_notes = ProgressNote.objects.filter(
+            client_file__is_demo=True,
+            status="default",
+        ).filter(
+            Q(backdate__range=(date_from_dt, date_to_dt))
+            | Q(backdate__isnull=True, created_at__range=(date_from_dt, date_to_dt))
+        ).count()
+
+        if current_fy_notes == 0:
+            issues.append(
+                f"  ⚠ No demo notes in current fiscal year "
+                f"(FY {fy_start_year}-{str(fy_start_year + 1)[-2:]}). "
+                f"Reports for this period will be empty."
+            )
+
+        if issues:
+            self.log_warning("  Demo data health check — potential report issues:")
+            for issue in issues:
+                self.log_warning(issue)
+        else:
+            self.log("  Demo data health check passed — reports should work.")
 
     def _recompute_achievement_statuses(self, plan_targets):
         """Recompute achievement statuses in batches after bulk demo generation."""

--- a/apps/admin_settings/forms.py
+++ b/apps/admin_settings/forms.py
@@ -524,10 +524,11 @@ class DemoDataForm(forms.Form):
     """Form for the demo data generation action."""
 
     clients_per_program = forms.IntegerField(
-        min_value=1,
+        min_value=5,
         max_value=50,
-        initial=3,
+        initial=10,
         label=_("Participants per program"),
+        help_text=_("Minimum 5 (report suppression threshold). Recommended: 10–20."),
     )
     days_span = forms.IntegerField(
         min_value=30,

--- a/apps/admin_settings/management/commands/generate_demo_data.py
+++ b/apps/admin_settings/management/commands/generate_demo_data.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from django.conf import settings
 from django.core.management.base import BaseCommand
 
-from apps.admin_settings.demo_engine import DemoDataEngine
+from apps.admin_settings.demo_engine import DEMO_MIN_CLIENTS_PER_PROGRAM, DemoDataEngine
 
 
 class Command(BaseCommand):
@@ -50,8 +50,12 @@ class Command(BaseCommand):
         parser.add_argument(
             "--clients-per-program",
             type=int,
-            default=20,
-            help="Number of demo clients to create per program (default: 20).",
+            default=DEMO_MIN_CLIENTS_PER_PROGRAM,
+            help=(
+                f"Number of demo clients to create per program "
+                f"(default: {DEMO_MIN_CLIENTS_PER_PROGRAM}, "
+                f"minimum enforced by engine: 5)."
+            ),
         )
         parser.add_argument(
             "--days",

--- a/apps/admin_settings/management/commands/seed.py
+++ b/apps/admin_settings/management/commands/seed.py
@@ -65,10 +65,10 @@ class Command(BaseCommand):
             self._update_demo_client_fields()
 
     def _top_up_demo_data(self):
-        """Top up demo data to 20-30 clients per program using the engine."""
+        """Top up demo data to target clients per program using the engine."""
         import os
 
-        from apps.admin_settings.demo_engine import DemoDataEngine
+        from apps.admin_settings.demo_engine import DEMO_MIN_CLIENTS_PER_PROGRAM, DemoDataEngine
 
         demo_profile = os.environ.get("DEMO_DATA_PROFILE", "")
         self.stdout.write("  Topping up demo data with config-aware engine...")
@@ -76,7 +76,7 @@ class Command(BaseCommand):
 
         try:
             success = engine.run(
-                clients_per_program=20,
+                clients_per_program=DEMO_MIN_CLIENTS_PER_PROGRAM,
                 profile_path=demo_profile if demo_profile else None,
                 force=False,
             )


### PR DESCRIPTION
## Summary

Root cause fix for recurring issue where demo data produces empty or suppressed reports. The underlying problem was that five entry points each hardcoded a different default for `clients_per_program` (3, 10, 20), and there was no validation that generated data would actually work in reports.

**Three layers of defence:**

- **Single constant** (`DEMO_MIN_CLIENTS_PER_PROGRAM = 10`) imported by all entry points — CLI, admin UI, seed command, engine default. The engine enforces a floor at the suppression threshold (5) with a warning if any caller tries to go below.
- **Post-generation health check** — after generating, the engine validates that each program has enough clients and that notes exist in the current fiscal year. Warns immediately if reports would be empty.
- **Django system check (W012)** — runs at every container startup in DEMO_MODE. Catches demo data degradation from manual deletions, migrations, or any other path. Operators see the warning in their logs.

## Changes

| File | What |
|------|------|
| `demo_engine.py` | Added `DEMO_MIN_CLIENTS_PER_PROGRAM` constant, floor enforcement in `run()`, `_validate_demo_data_health()` method |
| `forms.py` | Admin UI form: `initial` 3→10, `min_value` 1→5, added help text |
| `generate_demo_data.py` | CLI default uses constant instead of hardcoded 20 |
| `seed.py` | Top-up target uses constant instead of hardcoded 20 |
| `checks.py` | New `check_demo_data_health()` system check (W012) |

## Test plan

- [ ] Run `python manage.py check` on VPS — verify W012 doesn't fire when data is healthy
- [ ] Generate demo data with `--clients-per-program 2` — verify warning is raised and count is raised to 10
- [ ] Clear demo data, regenerate via admin UI — verify form defaults to 10 and help text shows
- [ ] Verify post-generation log shows "health check passed"
- [ ] Run `pytest tests/test_reports.py tests/test_exports.py` on VPS

🤖 Generated with [Claude Code](https://claude.com/claude-code)