### PR TITLE
fix: separate demo target (20) from demo minimum (10)

### DIFF
--- a/apps/admin_settings/demo_engine.py
+++ b/apps/admin_settings/demo_engine.py
@@ -517,9 +517,13 @@ PORTAL_SURVEY_DEFINITIONS = [
 
 # Minimum demo clients per program.  Must exceed the small-cell
 # suppression threshold (5) so that reports show real counts instead
-# of "< 5".  Import this constant wherever a default is needed —
-# never hardcode a number.
+# of "< 5".  Used for floor enforcement and admin UI default.
 DEMO_MIN_CLIENTS_PER_PROGRAM = 10
+
+# Target demo clients for rich demos (presentations, funder meetings).
+# Higher than the minimum to produce convincing charts, demographics,
+# and outcome summaries.  Used by CLI and seed top-up.
+DEMO_TARGET_CLIENTS_PER_PROGRAM = 20
 
 
 class DemoDataEngine:

--- a/apps/admin_settings/management/commands/generate_demo_data.py
+++ b/apps/admin_settings/management/commands/generate_demo_data.py
@@ -15,7 +15,7 @@ from pathlib import Path
 from django.conf import settings
 from django.core.management.base import BaseCommand
 
-from apps.admin_settings.demo_engine import DEMO_MIN_CLIENTS_PER_PROGRAM, DemoDataEngine
+from apps.admin_settings.demo_engine import DEMO_TARGET_CLIENTS_PER_PROGRAM, DemoDataEngine
 
 
 class Command(BaseCommand):
@@ -50,10 +50,10 @@ class Command(BaseCommand):
         parser.add_argument(
             "--clients-per-program",
             type=int,
-            default=DEMO_MIN_CLIENTS_PER_PROGRAM,
+            default=DEMO_TARGET_CLIENTS_PER_PROGRAM,
             help=(
                 f"Number of demo clients to create per program "
-                f"(default: {DEMO_MIN_CLIENTS_PER_PROGRAM}, "
+                f"(default: {DEMO_TARGET_CLIENTS_PER_PROGRAM}, "
                 f"minimum enforced by engine: 5)."
             ),
         )

--- a/apps/admin_settings/management/commands/seed.py
+++ b/apps/admin_settings/management/commands/seed.py
@@ -68,7 +68,7 @@ class Command(BaseCommand):
         """Top up demo data to target clients per program using the engine."""
         import os
 
-        from apps.admin_settings.demo_engine import DEMO_MIN_CLIENTS_PER_PROGRAM, DemoDataEngine
+        from apps.admin_settings.demo_engine import DEMO_TARGET_CLIENTS_PER_PROGRAM, DemoDataEngine
 
         demo_profile = os.environ.get("DEMO_DATA_PROFILE", "")
         self.stdout.write("  Topping up demo data with config-aware engine...")
@@ -76,7 +76,7 @@ class Command(BaseCommand):
 
         try:
             success = engine.run(
-                clients_per_program=DEMO_MIN_CLIENTS_PER_PROGRAM,
+                clients_per_program=DEMO_TARGET_CLIENTS_PER_PROGRAM,
                 profile_path=demo_profile if demo_profile else None,
                 force=False,
             )


### PR DESCRIPTION
## Summary

PR #588 unified all entry points to use `DEMO_MIN_CLIENTS_PER_PROGRAM` (10), but this accidentally halved the CLI and seed top-up target from 20 to 10. The minimum (safety floor for reports) and the target (rich data for demos) are different concerns that should evolve independently.

- Added `DEMO_TARGET_CLIENTS_PER_PROGRAM = 20` for CLI default and seed top-up
- `DEMO_MIN_CLIENTS_PER_PROGRAM = 10` remains for admin UI default and engine floor enforcement

## Test plan

- [ ] `generate_demo_data --help` shows default of 20
- [ ] `generate_demo_data --clients-per-program 2` still triggers floor warning and raises to 10
- [ ] Admin UI form still defaults to 10

🤖 Generated with [Claude Code](https://claude.com/claude-code)