### PR TITLE
🎨 Palette: Add aria-label to progress elements for a11y

### DIFF
--- a/templates/programs/evaluation/framework_detail.html
+++ b/templates/programs/evaluation/framework_detail.html
@@ -21,7 +21,7 @@
 <section>
     <h2>{% trans "CIDS Class Coverage" %}</h2>
     <p>{{ cids_coverage|length }} / {{ total_cids_classes }} {% trans "classes mapped" %} ({{ coverage_pct }}%)</p>
-    <progress value="{{ cids_coverage|length }}" max="{{ total_cids_classes }}"></progress>
+    <progress value="{{ cids_coverage|length }}" max="{{ total_cids_classes }}" aria-label="{% trans 'CIDS Class Coverage' %}"></progress>
 
     {% if framework.is_attested %}
     <article>

--- a/templates/reports/cids_coverage_dashboard.html
+++ b/templates/reports/cids_coverage_dashboard.html
@@ -13,7 +13,7 @@
     <article>
         <header>{% trans "Agency Coverage" %}</header>
         <p><strong>{{ all_classes_count }} / {{ total_classes }}</strong> {% trans "CIDS classes" %}</p>
-        <progress value="{{ all_classes_count }}" max="{{ total_classes }}"></progress>
+        <progress value="{{ all_classes_count }}" max="{{ total_classes }}" aria-label="{% trans 'Agency Coverage' %}"></progress>
     </article>
     <article>
         <header>{% trans "Programs" %}</header>
@@ -35,7 +35,7 @@
                 <strong>{{ summary.program.name }}</strong>
                 <span>{{ summary.present }} / {{ summary.total }} ({{ summary.pct }}%)</span>
             </div>
-            <progress value="{{ summary.present }}" max="{{ summary.total }}"></progress>
+            <progress value="{{ summary.present }}" max="{{ summary.total }}" aria-label="{% blocktrans with name=summary.program.name %}{{ name }} Coverage{% endblocktrans %}"></progress>
         </header>
         <figure>
         <table role="grid">

--- a/templates/reports/cids_export_status.html
+++ b/templates/reports/cids_export_status.html
@@ -9,7 +9,7 @@
     <p>{{ program.name }} — {{ present }} / {{ total }} {% trans "classes" %} ({{ pct }}%)</p>
 </hgroup>
 
-<progress value="{{ present }}" max="{{ total }}"></progress>
+<progress value="{{ present }}" max="{{ total }}" aria-label="{% trans 'Export Status' %}"></progress>
 
 {% if framework %}
 <article>


### PR DESCRIPTION
**What:** Added descriptive `aria-label` attributes to the `<progress>` elements on the CIDS coverage dashboard, export status, and framework detail pages.
**Why:** Improves accessibility for screen reader users by providing context to the tracked metrics on these progress bars. Without these labels, screen readers may announce generic, unhelpful information.
**Accessibility:** Ensures compliance with WCAG 4.1.2 by describing what each `<progress>` element specifically tracks.

---
*PR created automatically by Jules for task [10579422738322081602](https://jules.google.com/task/10579422738322081602) started by @pboachie*