### PR TITLE
🛡️ Sentinel: [HIGH] Add rate limiting to token and registration endpoints

### DIFF
--- a/apps/auth_app/invite_views.py
+++ b/apps/auth_app/invite_views.py
@@ -8,6 +8,7 @@ from django.http import Http404
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils import timezone
 from django.utils.translation import gettext as _
+from django_ratelimit.decorators import ratelimit
 
 from apps.programs.models import UserProgramRole
 
@@ -52,6 +53,7 @@ def invite_create(request):
     return render(request, "auth_app/invite_form.html", {"form": form})
 
 
+@ratelimit(key="ip", rate="10/m", method=["GET", "POST"], block=True)
 def invite_accept(request, code):
     """Public view — new user registers via invite link."""
     invite = get_object_or_404(Invite, code=code)

--- a/apps/portal/views.py
+++ b/apps/portal/views.py
@@ -333,6 +333,7 @@ def emergency_logout(request):
 
 
 @portal_feature_required
+@ratelimit(key="ip", rate="10/m", method=["GET", "POST"], block=True)
 def accept_invite(request, token):
     """Accept a portal invite — register a new ParticipantUser.
 
@@ -1020,6 +1021,7 @@ def password_reset_confirm(request):
 
 
 @portal_feature_required
+@ratelimit(key="ip", rate="10/m", method=["GET", "POST"], block=True)
 def staff_assisted_login(request, token):
     """Log a participant in via a staff-generated one-time token."""
     from apps.portal.models import StaffAssistedLoginToken

--- a/apps/registration/views.py
+++ b/apps/registration/views.py
@@ -8,6 +8,7 @@ from django.http import Http404
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils import timezone
 from django.views.decorators.http import require_http_methods
+from django_ratelimit.decorators import ratelimit
 
 from apps.clients.models import CustomFieldDefinition
 
@@ -104,6 +105,7 @@ def _get_grouped_custom_fields(registration_link):
 
 
 @require_http_methods(["GET", "POST"])
+@ratelimit(key="ip", rate="10/m", method=["GET", "POST"], block=True)
 def public_registration_form(request, slug):
     """Display the public registration form for a registration link.
 


### PR DESCRIPTION
Added `@ratelimit` missing from sensitive token and registration endpoints in `apps/auth_app/invite_views.py`, `apps/portal/views.py`, and `apps/registration/views.py`.

---
*PR created automatically by Jules for task [1973232519079662083](https://jules.google.com/task/1973232519079662083) started by @pboachie*