### PR TITLE
Implement insights DQ1, CONF1, and LANG1

### DIFF
--- a/apps/notes/tests/test_theme_engine.py
+++ b/apps/notes/tests/test_theme_engine.py
@@ -74,7 +74,7 @@ class Tier1AutoLinkTests(TestCase):
         )
 
     def test_auto_link_matches_by_keywords(self):
-        note = self._make_note("I wish there were evening sessions available")
+        note = self._make_note("I wish there were evening sessions on a better schedule")
         linked = try_auto_link_suggestion(note)
         self.assertEqual(len(linked), 1)
         self.assertEqual(linked[0].pk, self.theme.pk)
@@ -82,10 +82,16 @@ class Tier1AutoLinkTests(TestCase):
             SuggestionLink.objects.filter(theme=self.theme, progress_note=note).exists()
         )
 
-    def test_auto_link_requires_2_word_overlap(self):
+    def test_auto_link_requires_3_word_overlap(self):
         note = self._make_note("The evening was nice")
         linked = try_auto_link_suggestion(note)
         # "evening" overlaps but only 1 content word — should NOT link
+        self.assertEqual(len(linked), 0)
+
+    def test_auto_link_rejects_2_word_overlap(self):
+        note = self._make_note("I wish there were evening sessions available")
+        linked = try_auto_link_suggestion(note)
+        # "evening" + "sessions" = 2 words — below 3-word threshold
         self.assertEqual(len(linked), 0)
 
     def test_auto_link_skips_addressed_themes(self):
@@ -106,7 +112,7 @@ class Tier1AutoLinkTests(TestCase):
 
     def test_auto_link_recalculates_priority(self):
         self.assertEqual(self.theme.priority, "noted")
-        note = self._make_note("Evening sessions urgently needed", priority="urgent")
+        note = self._make_note("Evening sessions urgently needed on the schedule", priority="urgent")
         try_auto_link_suggestion(note)
         self.theme.refresh_from_db()
         self.assertEqual(self.theme.priority, "urgent")
@@ -177,7 +183,7 @@ class Tier1PrivacyGateTests(TestCase):
             note_type="full",
             author=self.user,
             author_program=self.program,
-            participant_suggestion="Evening sessions would help with schedule",
+            participant_suggestion="Evening sessions during better hours would help",
             suggestion_priority="noted",
         )
         linked = try_auto_link_suggestion(note)
@@ -400,3 +406,38 @@ class FindNoteIdTests(TestCase):
     def test_no_match_returns_none(self):
         qsm = {"something else entirely": 42}
         self.assertIsNone(_find_note_id("no match", qsm))
+
+
+# ── Language Detection Tests ──────────────────────────────────────────
+
+
+class DetectLanguageTests(TestCase):
+    """Test detect_language() EN/FR heuristic."""
+
+    def test_english_text(self):
+        from apps.reports.insights import detect_language
+        text = "I really appreciate the support I have been getting from the program"
+        self.assertEqual(detect_language(text), "en")
+
+    def test_french_text(self):
+        from apps.reports.insights import detect_language
+        text = "Je suis très content du programme et je voudrais continuer avec les sessions"
+        self.assertEqual(detect_language(text), "fr")
+
+    def test_short_text_defaults_to_english(self):
+        from apps.reports.insights import detect_language
+        self.assertEqual(detect_language("merci"), "en")
+
+    def test_empty_text_defaults_to_english(self):
+        from apps.reports.insights import detect_language
+        self.assertEqual(detect_language(""), "en")
+
+    def test_mixed_but_mostly_french(self):
+        from apps.reports.insights import detect_language
+        text = "Le programme est très bien mais il faut plus de sessions le soir"
+        self.assertEqual(detect_language(text), "fr")
+
+    def test_english_with_french_loanwords(self):
+        from apps.reports.insights import detect_language
+        text = "The program has a certain je ne sais quoi but overall it works well for me"
+        self.assertEqual(detect_language(text), "en")

--- a/apps/notes/theme_engine.py
+++ b/apps/notes/theme_engine.py
@@ -131,7 +131,7 @@ def try_auto_link_suggestion(note):
         theme_words = _extract_content_words(theme_text)
 
         overlap = suggestion_words & theme_words
-        if len(overlap) >= 2:
+        if len(overlap) >= 3:
             _, created = SuggestionLink.objects.get_or_create(
                 theme=theme,
                 progress_note=note,

--- a/apps/reports/insights.py
+++ b/apps/reports/insights.py
@@ -13,6 +13,7 @@ be queried in SQL. Descriptor and engagement fields are plaintext, so we
 aggregate those in the database for speed and unlimited scale.
 """
 import logging
+import re
 from collections import Counter, defaultdict
 from datetime import date
 
@@ -24,6 +25,39 @@ from apps.clients.models import ClientProgramEnrolment
 from apps.notes.models import ProgressNote, ProgressNoteTarget
 
 logger = logging.getLogger(__name__)
+
+# ── Language detection (EN/FR heuristic) ─────────────────────────────
+# Common French function words that rarely appear in English text.
+# Threshold: if >= 20% of the first 30 words match, classify as French.
+_FR_MARKERS = frozenset({
+    "je", "tu", "il", "elle", "nous", "vous", "ils", "elles",
+    "le", "la", "les", "un", "une", "des", "du", "dans", "pour",
+    "avec", "sur", "par", "est", "sont", "ont", "cette", "ces",
+    "mon", "ton", "son", "mes", "ses", "mais", "donc", "car",
+    "que", "qui", "où", "quand", "ne", "pas", "plus", "très",
+    "bien", "aussi", "tout", "tous", "comme", "être", "avoir",
+    "faire", "dire", "aller", "voir", "savoir", "pouvoir",
+    "vouloir", "falloir", "croire", "mettre", "prendre",
+    "ai", "suis", "était", "avait", "fait", "dit",
+})
+
+_WORD_SPLIT_RE = re.compile(r"[a-zàâçéèêëîïôùûüÿœæ]+", re.IGNORECASE)
+
+_FR_THRESHOLD = 0.20  # 20% of sampled words must be French markers
+_SAMPLE_SIZE = 30     # Check first 30 words (enough for reliable detection)
+
+
+def detect_language(text):
+    """Detect whether text is French or English using function-word heuristic.
+
+    Returns "fr" or "en". Defaults to "en" if uncertain.
+    """
+    words = _WORD_SPLIT_RE.findall(text.lower())[:_SAMPLE_SIZE]
+    if len(words) < 5:
+        return "en"
+    fr_count = sum(1 for w in words if w in _FR_MARKERS)
+    return "fr" if fr_count / len(words) >= _FR_THRESHOLD else "en"
+
 
 # Minimum number of active participants for program-level quote display.
 # Below this threshold, individual quotes risk re-identification.
@@ -295,6 +329,7 @@ def collect_quotes(program=None, client_file=None, date_from=None, date_to=None,
             "text": text,
             "target_name": target_name,
             "note_id": entry.progress_note_id,
+            "lang": detect_language(text),
         }
         if include_dates:
             quote["date"] = entry.progress_note.effective_date
@@ -336,6 +371,7 @@ def collect_quotes(program=None, client_file=None, date_from=None, date_to=None,
                         "text": text,
                         "target_name": "",
                         "note_id": note.pk,
+                        "lang": detect_language(text),
                     }
                     if include_dates:
                         quote["date"] = note.effective_date
@@ -358,6 +394,7 @@ def collect_quotes(program=None, client_file=None, date_from=None, date_to=None,
                         "source": "suggestion",
                         "priority": priority,
                         "note_id": note.pk,
+                        "lang": detect_language(suggestion),
                     }
                     if include_dates:
                         quote["date"] = note.effective_date

--- a/apps/reports/insights_fhir.py
+++ b/apps/reports/insights_fhir.py
@@ -235,6 +235,8 @@ def get_practice_health(program, date_from=None, date_to=None,
             "label": _("participant voice recorded"),
             "level": level,
             "show": True,
+            "with_voice": with_voice,
+            "total_full": total_full,
         }
     else:
         indicators["participant_voice"] = {"show": False}

--- a/apps/reports/insights_views.py
+++ b/apps/reports/insights_views.py
@@ -228,12 +228,15 @@ def program_insights(request):
         # Separate suggestions from other quotes so they display under their own heading
         suggestions = []
         other_quotes = []
+        quote_langs = set()
         for q in quotes:
+            quote_langs.add(q.get("lang", "en"))
             if q.get("source") == "suggestion":
                 q["priority_label"] = _PRIORITY_LABELS.get(q.get("priority", ""), "")
                 suggestions.append(q)
             elif not is_executive_only:
                 other_quotes.append(q)
+        has_mixed_languages = len(quote_langs) > 1
 
         # Active suggestion themes for this program (deduplicated by name)
         active_themes = deduplicate_themes(list(
@@ -366,6 +369,7 @@ def program_insights(request):
             "min_participants": MIN_PARTICIPANTS_FOR_QUOTES,
             "chart_data_json": structured["descriptor_trend"],
             "show_results": True,
+            "has_mixed_languages": has_mixed_languages,
             # New metric distribution data
             "metric_distributions": metric_distributions,
             "achievement_rates": achievement_rates_data,
@@ -527,12 +531,15 @@ def client_insights_partial(request, client_id):
     # Separate suggestions from other quotes
     suggestions = []
     other_quotes = []
+    quote_langs = set()
     for q in quotes:
+        quote_langs.add(q.get("lang", "en"))
         if q.get("source") == "suggestion":
             q["priority_label"] = _PRIORITY_LABELS.get(q.get("priority", ""), "")
             suggestions.append(q)
         else:
             other_quotes.append(q)
+    has_mixed_languages = len(quote_langs) > 1
 
     # Plain-language interpretations (only when enough data)
     interp = {}
@@ -557,6 +564,7 @@ def client_insights_partial(request, client_id):
         "data_tier": data_tier,
         "chart_data_json": structured["descriptor_trend"],
         "ai_enabled": ai_enabled,
+        "has_mixed_languages": has_mixed_languages,
         "scope": "client",
         **interp,
     }

--- a/konote/ai.py
+++ b/konote/ai.py
@@ -586,7 +586,11 @@ def generate_outcome_insights(
         "- Rank themes by frequency. Only report the top 3.\n"
         "- If the most frequent theme appears in fewer than 3 quotes, "
         "say 'no dominant themes emerged.'\n"
-        "- Use Canadian English spelling (colour, centre).\n\n"
+        "- Use Canadian English spelling (colour, centre).\n"
+        "- Some quotes may be in French. Analyse French quotes in French — "
+        "do not translate them. When citing a French quote, keep it verbatim. "
+        "If a theme is supported only by French quotes, note '(FR)' after "
+        "the theme name.\n\n"
         "PARTICIPANT FEEDBACK — this is critical:\n"
         "Read the quotes carefully for actionable feedback. Categorise what "
         "participants are saying into these categories:\n"
@@ -649,9 +653,21 @@ def generate_outcome_insights(
     )
 
     theme_names = existing_theme_names or []
+
+    # Language distribution for bilingual awareness
+    lang_counts = {}
+    for q in quotes:
+        lang = q.get("lang", "en")
+        lang_counts[lang] = lang_counts.get(lang, 0) + 1
+    lang_line = ""
+    if len(lang_counts) > 1:
+        parts = [f"{count} {lang.upper()}" for lang, count in sorted(lang_counts.items())]
+        lang_line = f"Language mix: {', '.join(parts)}\n"
+
     user_msg = (
         f"Program: {program_name}\n"
-        f"Period: {date_range}\n\n"
+        f"Period: {date_range}\n"
+        f"{lang_line}\n"
         f"Descriptor trends (percentages by month):\n"
         f"{json.dumps(structured_data.get('descriptor_trend', []), indent=2)}\n\n"
         f"Current descriptor distribution:\n"

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -23924,3 +23924,17 @@ msgstr "Début du service"
 
 msgid "You do not have access to this %(group_label)s."
 msgstr "Vous n’avez pas accès à ce %(group_label)s."
+
+#: templates/reports/_insights_basic.html
+msgid "%(months)s month"
+msgid_plural "%(months)s months"
+msgstr[0] "%(months)s mois"
+msgstr[1] "%(months)s mois"
+
+#: templates/reports/_insights_basic.html
+msgid ""
+"Participant reflections were recorded in %(with_voice)s of %(total)s "
+"sessions."
+msgstr ""
+"Les réflexions des participants ont été enregistrées dans %(with_voice)s "
+"des %(total)s sessions."

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -4311,9 +4311,11 @@ article[aria-label="notification"].fading-out {
 }
 .pill--descriptor { background: var(--kn-primary-subtle, #e8f0fe); color: var(--kn-primary, #2c3e50); }
 .pill--engagement { background: var(--kn-success-subtle, #e8f5e9); color: var(--kn-success-fg, #27ae60); }
+.pill--lang { background: var(--kn-info-subtle, #e3f2fd); color: var(--kn-info-fg, #1565c0); font-size: 0.75em; }
 @media (prefers-color-scheme: dark) {
     .pill--descriptor { color: #5cc8cc; }
     .pill--engagement { color: var(--kn-success-fg); }
+    .pill--lang { color: var(--kn-info-fg, #64b5f6); }
 }
 /* Insight quotes */
 .insight-quote {

--- a/templates/reports/_insights_basic.html
+++ b/templates/reports/_insights_basic.html
@@ -9,6 +9,9 @@
 <div class="insights-summary-bar">
     <strong>{{ structured.note_count }}</strong> {% trans "notes" %} &middot;
     <strong>{{ structured.participant_count }}</strong> {% trans "participants" %}
+    {% if structured.month_count %}
+    &middot; {% blocktrans with months=structured.month_count count counter=structured.month_count %}{{ months }} month{% plural %}{{ months }} months{% endblocktrans %}
+    {% endif %}
     {% if date_from and date_to %}
     &middot; {{ date_from }} {% trans "to" %} {{ date_to }}
     {% endif %}
@@ -184,6 +187,19 @@
         {% endif %}
     </summary>
 
+    {% if practice_health.participant_voice.show and practice_health.participant_voice.level == "low" %}
+    <p class="insight-interpretation">
+        {% blocktrans with with_voice=practice_health.participant_voice.with_voice total=practice_health.participant_voice.total_full %}Participant reflections were recorded in {{ with_voice }} of {{ total }} sessions.{% endblocktrans %}
+    </p>
+    {% endif %}
+
+    {# ── Practice signal: voice coverage ── #}
+    {% if practice_health.participant_voice.show and practice_health.participant_voice.level == "low" %}
+    <p class="insight-interpretation">
+        {% blocktrans with voice=practice_health.participant_voice.with_voice total=practice_health.participant_voice.total_full %}Participant reflections were recorded in {{ voice }} of {{ total }} sessions.{% endblocktrans %}
+    </p>
+    {% endif %}
+
     {# ── Participant Feedback section ── #}
     {% if structured.suggestion_total or active_themes %}
     <section class="feedback-section" aria-labelledby="feedback-heading">
@@ -243,9 +259,10 @@
         </summary>
         <p class="muted">{% trans "Not yet linked to a theme." %}</p>
         {% for s in unlinked_suggestions %}
-        <blockquote class="insight-quote">
+        <blockquote class="insight-quote" {% if s.lang == "fr" %}lang="fr"{% endif %}>
             <p>&ldquo;{{ s.text }}&rdquo;</p>
             <cite>
+                {% if has_mixed_languages and s.lang == "fr" %}<span class="pill pill--lang">FR</span> {% endif %}
                 {% if s.priority_label %}<span class="pill pill--engagement">{{ s.priority_label }}</span>{% if can_view_notes %} &middot; {% endif %}{% endif %}
                 {% if s.date %}{{ s.date }} &middot; {% endif %}
                 {% if can_view_notes %}<a href="{% url 'notes:note_detail' note_id=s.note_id %}">{% trans "View note" %}</a>{% endif %}
@@ -255,9 +272,10 @@
     </details>
     {% elif not active_themes and suggestions %}
     {% for s in suggestions %}
-    <blockquote class="insight-quote">
+    <blockquote class="insight-quote" {% if s.lang == "fr" %}lang="fr"{% endif %}>
         <p>&ldquo;{{ s.text }}&rdquo;</p>
         <cite>
+            {% if has_mixed_languages and s.lang == "fr" %}<span class="pill pill--lang">FR</span> {% endif %}
             {% if s.priority_label %}<span class="pill pill--engagement">{{ s.priority_label }}</span>{% if can_view_notes %} &middot; {% endif %}{% endif %}
             {% if s.date %}{{ s.date }} &middot; {% endif %}
             {% if can_view_notes %}<a href="{% url 'notes:note_detail' note_id=s.note_id %}">{% trans "View note" %}</a>{% endif %}
@@ -290,9 +308,10 @@
     {% if quotes %}
     <h3>{% trans "What participants are saying" %}</h3>
     {% for quote in quotes %}
-    <blockquote class="insight-quote">
+    <blockquote class="insight-quote" {% if quote.lang == "fr" %}lang="fr"{% endif %}>
         <p>&ldquo;{{ quote.text }}&rdquo;</p>
         <cite>
+            {% if has_mixed_languages and quote.lang == "fr" %}<span class="pill pill--lang">FR</span> {% endif %}
             {% if quote.target_name %}
             {% blocktrans with target=quote.target_name %}On their {{ target }} goal{% endblocktrans %} &middot;
             {% endif %}

--- a/templates/reports/_insights_client.html
+++ b/templates/reports/_insights_client.html
@@ -78,9 +78,10 @@
 {% if suggestions %}
 <h3>{% trans "Their Suggestions" %}</h3>
 {% for s in suggestions|slice:":5" %}
-<blockquote class="insight-quote">
+<blockquote class="insight-quote" {% if s.lang == "fr" %}lang="fr"{% endif %}>
     <p>&ldquo;{{ s.text }}&rdquo;</p>
     <cite>
+        {% if has_mixed_languages and s.lang == "fr" %}<span class="pill pill--lang">FR</span> {% endif %}
         {% if s.priority_label %}<span class="pill pill--engagement">{{ s.priority_label }}</span> &middot; {% endif %}
         {% if s.date %}{{ s.date }} &middot; {% endif %}
         <a href="{% url 'notes:note_detail' note_id=s.note_id %}">{% trans "View note" %}</a>
@@ -93,9 +94,10 @@
 {% if quotes %}
 <h3>{% trans "In their words" %}</h3>
 {% for quote in quotes|slice:":5" %}
-<blockquote class="insight-quote">
+<blockquote class="insight-quote" {% if quote.lang == "fr" %}lang="fr"{% endif %}>
     <p>&ldquo;{{ quote.text }}&rdquo;</p>
     <cite>
+        {% if has_mixed_languages and quote.lang == "fr" %}<span class="pill pill--lang">FR</span> {% endif %}
         {% if quote.target_name %}
         {% blocktrans with target=quote.target_name %}On their {{ target }} goal{% endblocktrans %} &middot;
         {% endif %}


### PR DESCRIPTION
## Summary
- **INSIGHTS-DQ1**: Practice signal — summary bar now shows month count; contextual sentence appears above Participant Voice section when voice coverage < 30% ("Participant reflections were recorded in X of Y sessions")
- **INSIGHTS-CONF1**: Raised theme auto-link threshold from 2 to 3 word overlap — reduces false positives without adding a review queue
- **INSIGHTS-LANG1 Phase 1**: Language-aware quote collection — heuristic EN/FR detection on each quote, language distribution included in AI prompts, FR pills shown on quotes only when mixed-language content is present, `lang="fr"` attribute on French blockquotes for accessibility

## Test plan
- [x] 31 theme engine tests pass (6 new: language detection + 2-word rejection)
- [ ] Verify FR pill only appears on bilingual program Insights page (not monolingual)
- [ ] Verify contextual sentence appears when voice coverage is low
- [ ] Verify summary bar shows month count
- [ ] Run `translate_strings` when env is available to compile new .po entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)