### PR TITLE
🛡️ Sentinel: [MEDIUM] Add missing rate limit to goal builder save endpoint

### DIFF
--- a/konote/ai_views.py
+++ b/konote/ai_views.py
@@ -685,6 +685,7 @@ def goal_builder_chat(request, client_id):
 
 @login_required
 @require_POST
+@ratelimit(key="user", rate="20/h", method="POST", block=False)
 def goal_builder_save(request, client_id):
     """Save a goal from the Goal Builder — POST creates target + metric + section.
 
@@ -692,6 +693,8 @@ def goal_builder_save(request, client_id):
     + metric creation. Custom metric creation (from AI) is handled here before
     calling the helper.
     """
+    if getattr(request, "limited", False):
+        return ai_rate_limited_response(request, template_name="plans/_goal_builder.html")
 
     from apps.clients.models import ClientFile
     from apps.plans.models import MetricDefinition, PlanSection


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The `goal_builder_save` endpoint in `konote/ai_views.py` processes POST requests and makes database writes (including target, section, and metric creation) but lacked a rate limit, making it susceptible to abuse or potential denial of service if flooded.
🎯 Impact: An authenticated user could spam the endpoint, leading to rapid creation of database objects and potential exhaustion of system resources.
🔧 Fix: Applied the `@ratelimit(key="user", rate="20/h", method="POST", block=False)` decorator and added the required `request.limited` check to return a standardized HTMX-friendly 429 response.
✅ Verification: Ran `pytest tests/test_security.py` and the full test suite to ensure the application still functions correctly and no regressions were introduced.

---
*PR created automatically by Jules for task [17697340462108120659](https://jules.google.com/task/17697340462108120659) started by @pboachie*