### PR TITLE
🛡️ Sentinel: [HIGH] Add rate limiting to portal invite acceptance endpoint

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,7 @@
 **Vulnerability:** The `demo_portal_login` view was missing rate limiting, making it vulnerable to brute-force or DoS attacks.
 **Learning:** Even endpoints designed for demo purposes need to be protected. The `django-ratelimit` decorator with `block=True` should be applied uniformly to all authentication-related endpoints.
 **Prevention:** Always ensure the `@ratelimit(key="ip", rate="...", method="POST", block=True)` decorator is present on any view that processes login or authentication requests. Also make sure the import is present: `from django_ratelimit.decorators import ratelimit`.
+## 2025-05-14 - [Missing Rate Limiting on Invite Acceptance]
+**Vulnerability:** The `accept_invite` endpoint in `apps/portal/views.py`, which is an authentication boundary that consumes one-time tokens and registers new users, was missing the `@ratelimit` decorator. This left it vulnerable to brute-force and DoS attacks.
+**Learning:** Authentication boundaries, including endpoints handling invites, tokens, and registration, must uniformly use `@ratelimit` to prevent token brute-forcing and resource exhaustion.
+**Prevention:** Ensure `@ratelimit` with `block=True` is consistently applied across all authentication and registration-related view functions.

--- a/apps/portal/views.py
+++ b/apps/portal/views.py
@@ -332,6 +332,7 @@ def emergency_logout(request):
     return HttpResponse(status=204)
 
 
+@ratelimit(key="ip", rate="10/m", method=["GET", "POST"], block=True)
 @portal_feature_required
 def accept_invite(request, token):
     """Accept a portal invite — register a new ParticipantUser.


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `accept_invite` endpoint in `apps/portal/views.py` processes one-time tokens and registers new users but was missing the `@ratelimit` decorator.
🎯 Impact: This omission made the portal registration flow vulnerable to token brute-forcing and resource exhaustion (DoS) attacks.
🔧 Fix: Added `@ratelimit(key="ip", rate="10/m", method=["GET", "POST"], block=True)` to the `accept_invite` function.
✅ Verification: Ran `python -m pytest apps/portal/tests/` and confirmed all 88 tests pass.

---
*PR created automatically by Jules for task [12128344848507262646](https://jules.google.com/task/12128344848507262646) started by @pboachie*