### PR TITLE
🎨 Palette: Add screen reader accessibility to empty state emojis

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -1767,6 +1767,7 @@ button.outline.secondary:hover {
 /* Static icon above empty state text */
 .empty-state::before {
     content: "\1F4CB";  /* clipboard emoji — renders as text glyph */
+    content: "\1F4CB" / "";
     display: block;
     font-size: 2rem;
     line-height: 1;


### PR DESCRIPTION
Added screen reader accessibility for empty state pseudo-elements in `main.css`.

---
*PR created automatically by Jules for task [8653857009959774296](https://jules.google.com/task/8653857009959774296) started by @pboachie*