### PR TITLE
🛡️ Sentinel: [HIGH] Fix missing rate limit on portal auth endpoints

### DIFF
--- a/apps/portal/views.py
+++ b/apps/portal/views.py
@@ -333,6 +333,7 @@ def emergency_logout(request):
 
 
 @portal_feature_required
+@ratelimit(key="ip", rate="10/m", method=["GET", "POST"], block=True)
 def accept_invite(request, token):
     """Accept a portal invite — register a new ParticipantUser.
 
@@ -1020,6 +1021,7 @@ def password_reset_confirm(request):
 
 
 @portal_feature_required
+@ratelimit(key="ip", rate="10/m", method=["GET", "POST"], block=True)
 def staff_assisted_login(request, token):
     """Log a participant in via a staff-generated one-time token."""
     from apps.portal.models import StaffAssistedLoginToken


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `accept_invite` and `staff_assisted_login` endpoints in the participant portal lacked rate limiting. Both endpoints process one-time tokens and handle sensitive authentication/registration flows. 
🎯 Impact: Without rate limiting, these endpoints were vulnerable to brute-force attacks (attempting to guess valid tokens) and DoS attacks.
🔧 Fix: Applied the `@ratelimit(key="ip", rate="10/m", method=["GET", "POST"], block=True)` decorator to both endpoints to enforce rate limiting on both GET (form rendering/token validation) and POST (submission) requests.
✅ Verification: Tested locally by verifying syntax and test configurations. The `ratelimit` decorator is applied correctly and the import is present.

---
*PR created automatically by Jules for task [16364228293880060238](https://jules.google.com/task/16364228293880060238) started by @pboachie*