### PR TITLE
🎨 Palette: Hide decorative HTML entities from screen readers

### DIFF
--- a/templates/403.html
+++ b/templates/403.html
@@ -42,7 +42,7 @@
 
     <footer class="error-actions">
         <a href="javascript:history.back()" role="button" class="outline">
-            &larr; {% trans "Go Back" %}
+            <span aria-hidden="true">&larr;</span> {% trans "Go Back" %}
         </a>
         <a href="/" role="button">
             {% trans "Home" %}

--- a/templates/404.html
+++ b/templates/404.html
@@ -26,7 +26,7 @@
 
     <footer class="error-actions">
         <a href="javascript:history.back()" role="button" class="outline">
-            &larr; {% trans "Go Back" %}
+            <span aria-hidden="true">&larr;</span> {% trans "Go Back" %}
         </a>
         <a href="/" role="button">
             {% trans "Home" %}

--- a/templates/500.html
+++ b/templates/500.html
@@ -162,7 +162,7 @@
 
             <footer class="error-actions">
                 <a href="javascript:history.back()" class="btn-back">
-                    &larr; {% trans "Go Back" %}
+                    <span aria-hidden="true">&larr;</span> {% trans "Go Back" %}
                 </a>
                 <a href="/" class="btn-home">
                     {% trans "Home" %}

--- a/templates/admin_settings/dashboard.html
+++ b/templates/admin_settings/dashboard.html
@@ -301,7 +301,7 @@
 </div>
 
 <nav class="settings-guide-footer" aria-label="{% trans 'Settings help' %}">
-    <p>{% trans "Need help with a setting?" %} <a href="{% url 'help' %}#admin-settings-guide">{% trans "Read the Settings Guide" %} &rarr;</a></p>
+    <p>{% trans "Need help with a setting?" %} <a href="{% url 'help' %}#admin-settings-guide">{% trans "Read the Settings Guide" %} <span aria-hidden="true">&rarr;</span></a></p>
 </nav>
 {% endblock %}
 

--- a/templates/admin_settings/diagnose_charts.html
+++ b/templates/admin_settings/diagnose_charts.html
@@ -111,5 +111,5 @@
     <li><strong>{% trans "Metric values" %}</strong> {% trans "must be recorded when creating full notes" %}</li>
 </ol>
 
-<p><a href="{% url 'admin_settings:dashboard' %}">&larr; {% trans "Back to Admin Settings" %}</a></p>
+<p><a href="{% url 'admin_settings:dashboard' %}"><span aria-hidden="true">&larr;</span> {% trans "Back to Admin Settings" %}</a></p>
 {% endblock %}

--- a/templates/admin_settings/dq_tuning.html
+++ b/templates/admin_settings/dq_tuning.html
@@ -108,5 +108,5 @@
 </article>
 {% endif %}
 
-<p><a href="{% url 'admin_settings:dashboard' %}">&larr; {% trans "Back to Admin Settings" %}</a></p>
+<p><a href="{% url 'admin_settings:dashboard' %}"><span aria-hidden="true">&larr;</span> {% trans "Back to Admin Settings" %}</a></p>
 {% endblock %}

--- a/templates/admin_settings/setup_wizard/custom_fields.html
+++ b/templates/admin_settings/setup_wizard/custom_fields.html
@@ -31,9 +31,9 @@
     <button type="button" class="add-btn" data-call-function="addGroup">+ {% trans "Add another group" %}</button>
 
     <div class="wizard-nav">
-        <a href="{% url 'admin_settings:setup_wizard_step' step='plan_templates' %}" role="button" class="outline">&larr; {% trans "Back" %}</a>
+        <a href="{% url 'admin_settings:setup_wizard_step' step='plan_templates' %}" role="button" class="outline"><span aria-hidden="true">&larr;</span> {% trans "Back" %}</a>
         <span class="spacer"></span>
-        <button type="submit">{% trans "Next: Review" %} &rarr;</button>
+        <button type="submit">{% trans "Next: Review" %} <span aria-hidden="true">&rarr;</span></button>
     </div>
 </form>
 {% endblock %}

--- a/templates/admin_settings/setup_wizard/features.html
+++ b/templates/admin_settings/setup_wizard/features.html
@@ -35,9 +35,9 @@
     </figure>
 
     <div class="wizard-nav">
-        <a href="{% url 'admin_settings:setup_wizard_step' step='terminology' %}" role="button" class="outline">&larr; {% trans "Back" %}</a>
+        <a href="{% url 'admin_settings:setup_wizard_step' step='terminology' %}" role="button" class="outline"><span aria-hidden="true">&larr;</span> {% trans "Back" %}</a>
         <span class="spacer"></span>
-        <button type="submit">{% trans "Next: Programs" %} &rarr;</button>
+        <button type="submit">{% trans "Next: Programs" %} <span aria-hidden="true">&rarr;</span></button>
     </div>
 </form>
 {% endblock %}

--- a/templates/admin_settings/setup_wizard/instance_settings.html
+++ b/templates/admin_settings/setup_wizard/instance_settings.html
@@ -59,7 +59,7 @@
 
     <div class="wizard-nav">
         <span class="spacer"></span>
-        <button type="submit">{% trans "Next: Terminology" %} &rarr;</button>
+        <button type="submit">{% trans "Next: Terminology" %} <span aria-hidden="true">&rarr;</span></button>
     </div>
 </form>
 {% endblock %}

--- a/templates/admin_settings/setup_wizard/metrics.html
+++ b/templates/admin_settings/setup_wizard/metrics.html
@@ -42,9 +42,9 @@
     </figure>
 
     <div class="wizard-nav">
-        <a href="{% url 'admin_settings:setup_wizard_step' step='programs' %}" role="button" class="outline">&larr; {% trans "Back" %}</a>
+        <a href="{% url 'admin_settings:setup_wizard_step' step='programs' %}" role="button" class="outline"><span aria-hidden="true">&larr;</span> {% trans "Back" %}</a>
         <span class="spacer"></span>
-        <button type="submit">{% trans "Next: Plan Templates" %} &rarr;</button>
+        <button type="submit">{% trans "Next: Plan Templates" %} <span aria-hidden="true">&rarr;</span></button>
     </div>
 </form>
 {% endblock %}

--- a/templates/admin_settings/setup_wizard/plan_templates.html
+++ b/templates/admin_settings/setup_wizard/plan_templates.html
@@ -37,9 +37,9 @@
     <button type="button" class="add-btn" data-call-function="addTemplate">+ {% trans "Add another template" %}</button>
 
     <div class="wizard-nav">
-        <a href="{% url 'admin_settings:setup_wizard_step' step='metrics' %}" role="button" class="outline">&larr; {% trans "Back" %}</a>
+        <a href="{% url 'admin_settings:setup_wizard_step' step='metrics' %}" role="button" class="outline"><span aria-hidden="true">&larr;</span> {% trans "Back" %}</a>
         <span class="spacer"></span>
-        <button type="submit">{% trans "Next: Custom Fields" %} &rarr;</button>
+        <button type="submit">{% trans "Next: Custom Fields" %} <span aria-hidden="true">&rarr;</span></button>
     </div>
 </form>
 {% endblock %}

--- a/templates/admin_settings/setup_wizard/programs.html
+++ b/templates/admin_settings/setup_wizard/programs.html
@@ -43,9 +43,9 @@
     <button type="button" class="add-btn" data-call-function="addProgram">+ {% trans "Add another program" %}</button>
 
     <div class="wizard-nav">
-        <a href="{% url 'admin_settings:setup_wizard_step' step='features' %}" role="button" class="outline">&larr; {% trans "Back" %}</a>
+        <a href="{% url 'admin_settings:setup_wizard_step' step='features' %}" role="button" class="outline"><span aria-hidden="true">&larr;</span> {% trans "Back" %}</a>
         <span class="spacer"></span>
-        <button type="submit">{% trans "Next: Metrics" %} &rarr;</button>
+        <button type="submit">{% trans "Next: Metrics" %} <span aria-hidden="true">&rarr;</span></button>
     </div>
 </form>
 {% endblock %}

--- a/templates/admin_settings/setup_wizard/review.html
+++ b/templates/admin_settings/setup_wizard/review.html
@@ -35,7 +35,7 @@
     {% csrf_token %}
 
     <div class="wizard-nav">
-        <a href="{% url 'admin_settings:setup_wizard_step' step='custom_fields' %}" role="button" class="outline">&larr; {% trans "Back" %}</a>
+        <a href="{% url 'admin_settings:setup_wizard_step' step='custom_fields' %}" role="button" class="outline"><span aria-hidden="true">&larr;</span> {% trans "Back" %}</a>
         <span class="spacer"></span>
         <button type="submit" class="contrast">{% trans "Apply Configuration" %}</button>
     </div>

--- a/templates/admin_settings/setup_wizard/terminology.html
+++ b/templates/admin_settings/setup_wizard/terminology.html
@@ -35,9 +35,9 @@
     </figure>
 
     <div class="wizard-nav">
-        <a href="{% url 'admin_settings:setup_wizard_step' step='instance_settings' %}" role="button" class="outline">&larr; {% trans "Back" %}</a>
+        <a href="{% url 'admin_settings:setup_wizard_step' step='instance_settings' %}" role="button" class="outline"><span aria-hidden="true">&larr;</span> {% trans "Back" %}</a>
         <span class="spacer"></span>
-        <button type="submit">{% trans "Next: Features" %} &rarr;</button>
+        <button type="submit">{% trans "Next: Features" %} <span aria-hidden="true">&rarr;</span></button>
     </div>
 </form>
 {% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -293,13 +293,13 @@
     <!-- HTMX error toast — shown by app.js on network/server errors -->
     <div id="htmx-error-toast" class="toast toast-error" role="alert" hidden>
         <span id="htmx-error-toast-message"></span>
-        <button type="button" id="htmx-error-toast-close" aria-label="{% trans 'Dismiss' %}" style="background:none;border:none;cursor:pointer;padding:0 0 0 1rem;font-size:1.2rem;color:inherit;">&times;</button>
+        <button type="button" id="htmx-error-toast-close" aria-label="{% trans 'Dismiss' %}" style="background:none;border:none;cursor:pointer;padding:0 0 0 1rem;font-size:1.2rem;color:inherit;"><span aria-hidden="true">&times;</span></button>
     </div>
 
     <!-- HTMX success toast — shown by app.js for async confirmations (UXP2 / WCAG 4.1.3) -->
     <div id="htmx-success-toast" class="toast toast-success" role="status" hidden>
         <span id="htmx-success-toast-message"></span>
-        <button type="button" id="htmx-success-toast-close" aria-label="{% trans 'Dismiss' %}" style="background:none;border:none;cursor:pointer;padding:0 0 0 1rem;font-size:1.2rem;color:inherit;">&times;</button>
+        <button type="button" id="htmx-success-toast-close" aria-label="{% trans 'Dismiss' %}" style="background:none;border:none;cursor:pointer;padding:0 0 0 1rem;font-size:1.2rem;color:inherit;"><span aria-hidden="true">&times;</span></button>
     </div>
 
     <footer class="container site-footer" role="contentinfo">
@@ -336,7 +336,7 @@
     <!-- Contextual page help modal -->
     <div class="modal-backdrop" id="page-help-backdrop" hidden></div>
     <div class="page-help-modal" id="page-help-modal" hidden role="dialog" aria-labelledby="page-help-title" aria-modal="true" tabindex="-1">
-        <button type="button" class="modal-close" id="close-page-help" aria-label="{% trans 'Close' %}">&times;</button>
+        <button type="button" class="modal-close" id="close-page-help" aria-label="{% trans 'Close' %}"><span aria-hidden="true">&times;</span></button>
         {% if page_help.is_default %}
         <h2 id="page-help-title">{% trans "Help" %}</h2>
         <p class="page-help-description">{% trans "Here are a few things you can do from anywhere in KoNote:" %}</p>
@@ -350,9 +350,9 @@
             {% endfor %}
         </ul>
         {% if page_help.help_section %}
-        <p class="page-help-more"><a href="{% url 'help' %}#{{ page_help.help_section }}">{% trans "Read more in the Help Guide" %} &rarr;</a></p>
+        <p class="page-help-more"><a href="{% url 'help' %}#{{ page_help.help_section }}">{% trans "Read more in the Help Guide" %} <span aria-hidden="true">&rarr;</span></a></p>
         {% else %}
-        <p class="page-help-more"><a href="{% url 'help' %}">{% trans "Open Help Guide" %} &rarr;</a></p>
+        <p class="page-help-more"><a href="{% url 'help' %}">{% trans "Open Help Guide" %} <span aria-hidden="true">&rarr;</span></a></p>
         {% endif %}
     </div>
 

--- a/templates/clients/_dashboard_executive_summary.html
+++ b/templates/clients/_dashboard_executive_summary.html
@@ -90,7 +90,7 @@
     {% endif %}
 
     <p class="exec-detail-link">
-        <a href="{% url 'clients:executive_dashboard' %}">{% trans "View full executive dashboard" %} &rarr;</a>
+        <a href="{% url 'clients:executive_dashboard' %}">{% trans "View full executive dashboard" %} <span aria-hidden="true">&rarr;</span></a>
     </p>
 </section>
 

--- a/templates/clients/alert_overview.html
+++ b/templates/clients/alert_overview.html
@@ -53,5 +53,5 @@
 <p>{% trans "No programs found." %}</p>
 {% endif %}
 
-<p><a href="{% url 'clients:executive_dashboard' %}">&larr; {% trans "Back to Executive Dashboard" %}</a></p>
+<p><a href="{% url 'clients:executive_dashboard' %}"><span aria-hidden="true">&larr;</span> {% trans "Back to Executive Dashboard" %}</a></p>
 {% endblock %}

--- a/templates/clients/executive_dashboard.html
+++ b/templates/clients/executive_dashboard.html
@@ -234,7 +234,7 @@
             <div class="stat-detail">{{ alert_oversight.pending_cancellation }} {% trans "pending review" %}</div>
             {% endif %}
             {% if alert_oversight.active > 0 %}
-            <a href="{% url 'clients:alert_overview' %}" class="stat-link">{% trans "View by program" %} &rarr;</a>
+            <a href="{% url 'clients:alert_overview' %}" class="stat-link">{% trans "View by program" %} <span aria-hidden="true">&rarr;</span></a>
             {% endif %}
         </article>
         {% endif %}
@@ -317,7 +317,7 @@
                 </ul>
                 {% if stat.theme_overflow > 0 %}
                 <div class="metric-row">
-                    <a href="{% url 'suggestion_themes:theme_list' %}?program={{ stat.program.pk }}" class="metric-link">+{{ stat.theme_overflow }} {% trans "more" %} &rarr;</a>
+                    <a href="{% url 'suggestion_themes:theme_list' %}?program={{ stat.program.pk }}" class="metric-link">+{{ stat.theme_overflow }} {% trans "more" %} <span aria-hidden="true">&rarr;</span></a>
                 </div>
                 {% endif %}
                 {% elif stat.suggestion_total > 0 %}
@@ -390,7 +390,7 @@
                     </div>
 
                     <div class="metric-row">
-                        <a href="{% url 'reports:program_insights' %}?program={{ stat.program.pk }}" class="metric-link">{% trans "View program learning" %} &rarr;</a>
+                        <a href="{% url 'reports:program_insights' %}?program={{ stat.program.pk }}" class="metric-link">{% trans "View program learning" %} <span aria-hidden="true">&rarr;</span></a>
                     </div>
                 </div>
                 {% endif %}

--- a/templates/clients/home.html
+++ b/templates/clients/home.html
@@ -20,14 +20,14 @@
 <article class="onboarding-banner" id="onboarding-banner" role="complementary" aria-label="{% trans 'Welcome banner' %}" hidden>
     <header>
         <strong>{% blocktrans with product_name=site.product_name|default:"KoNote" %}Welcome to {{ product_name }}! Need help getting started?{% endblocktrans %}</strong>
-        <button type="button" class="close-btn" id="dismiss-onboarding" aria-label="{% trans 'Dismiss welcome banner' %}">&times;</button>
+        <button type="button" class="close-btn" id="dismiss-onboarding" aria-label="{% trans 'Dismiss welcome banner' %}"><span aria-hidden="true">&times;</span></button>
     </header>
     <ul>
         <li>{% blocktrans with clients=term.client_plural|default:"participants" %}Use the search bar to find {{ clients }}, or the "+ New" button to register one{% endblocktrans %}</li>
         <li>{% blocktrans with client=term.client|default:"participant" %}Open a {{ client }} profile to view their plan, notes, and progress{% endblocktrans %}</li>
         <li>{% trans "Need help? Ask your program manager or administrator" %}</li>
     </ul>
-    <p class="onboarding-help-link"><a href="{% url 'help' %}">{% trans "View help guide" %} &rarr;</a></p>
+    <p class="onboarding-help-link"><a href="{% url 'help' %}">{% trans "View help guide" %} <span aria-hidden="true">&rarr;</span></a></p>
 </article>
 {% endif %}
 
@@ -276,7 +276,7 @@
         <p class="empty-message"><em>{% blocktrans with clients=term.client_plural|default:"participants" %}No recent {{ clients }} yet. Start by searching above.{% endblocktrans %}</em></p>
         {% endif %}
         <footer class="card-footer">
-            <a href="{% url 'clients:client_list' %}" class="outline" role="button">{% blocktrans with clients=term.client_plural|default:"participants" %}View all {{ clients }}{% endblocktrans %} &rarr;</a>
+            <a href="{% url 'clients:client_list' %}" class="outline" role="button">{% blocktrans with clients=term.client_plural|default:"participants" %}View all {{ clients }}{% endblocktrans %} <span aria-hidden="true">&rarr;</span></a>
         </footer>
     </article>
     {% endif %}

--- a/templates/clients/merge/merge_compare.html
+++ b/templates/clients/merge/merge_compare.html
@@ -7,7 +7,7 @@
 <h1>{% trans "Compare Records" %}</h1>
 
 <p>
-    <a href="{% url 'merge_candidates_list' %}">{% trans "&larr; Back to candidates list" %}</a>
+    <a href="{% url 'merge_candidates_list' %}"><span aria-hidden="true">&larr;</span> {% trans "Back to candidates list" %}</a>
 </p>
 
 {# Summary cards — creation dates and activity counts #}

--- a/templates/clients/search.html
+++ b/templates/clients/search.html
@@ -33,5 +33,5 @@
     {% include "clients/_search_results.html" %}
 </div>
 
-<p><a href="{% url 'clients:client_list' %}">{% blocktrans with clients=term.client_plural|default:"Participants" %}&larr; Back to {{ clients }} list{% endblocktrans %}</a></p>
+<p><a href="{% url 'clients:client_list' %}"><span aria-hidden="true">&larr;</span> {% blocktrans with clients=term.client_plural|default:"Participants" %}Back to {{ clients }} list{% endblocktrans %}</a></p>
 {% endblock %}

--- a/templates/events/_timeline_entries.html
+++ b/templates/events/_timeline_entries.html
@@ -64,7 +64,7 @@
             <summary>{{ entry.obj.notes_text|truncatechars:200 }}</summary>
             <div class="timeline-note-full">
                 <p>{{ entry.obj.notes_text }}</p>
-                <p class="timeline-note-link"><small><a href="{% url 'notes:note_detail' note_id=entry.obj.pk %}">{% trans "View in Notes" %} &rarr;</a></small></p>
+                <p class="timeline-note-link"><small><a href="{% url 'notes:note_detail' note_id=entry.obj.pk %}">{% trans "View in Notes" %} <span aria-hidden="true">&rarr;</span></a></small></p>
             </div>
         </details>
         {% endif %}

--- a/templates/groups/attendance_report.html
+++ b/templates/groups/attendance_report.html
@@ -5,9 +5,9 @@
 
 {% block content %}
 {% if show_attendance_navigation %}
-<p><a href="{% url 'groups:attendance_hub' %}" class="back-link">&larr; {% trans "Back to Attendance" %}</a></p>
+<p><a href="{% url 'groups:attendance_hub' %}" class="back-link"><span aria-hidden="true">&larr;</span> {% trans "Back to Attendance" %}</a></p>
 {% else %}
-<p><a href="{% url 'groups:group_detail' group_id=group.pk %}" class="back-link">&larr; {% blocktrans with name=group.name %}Back to {{ name }}{% endblocktrans %}</a></p>
+<p><a href="{% url 'groups:group_detail' group_id=group.pk %}" class="back-link"><span aria-hidden="true">&larr;</span> {% blocktrans with name=group.name %}Back to {{ name }}{% endblocktrans %}</a></p>
 {% endif %}
 
 <hgroup>

--- a/templates/plans/goal_form.html
+++ b/templates/plans/goal_form.html
@@ -177,7 +177,7 @@
             <details>
                 <summary>{% blocktrans with target=term.target|default:"target" %}Tips for writing a good {{ target }}{% endblocktrans %}</summary>
                 <p>{% blocktrans with target=term.target|default:"target" %}Try turning their words into a {{ target }} that is Specific, Measurable, Achievable, Relevant, and Time-bound (SMART).{% endblocktrans %}</p>
-                <p class="secondary">{% trans "For example:" %} <em>&ldquo;{% trans "Make a friend" %}&rdquo;</em> &rarr; <em>&ldquo;{% trans "Build one social connection outside of program activities within 3 months" %}&rdquo;</em></p>
+                <p class="secondary">{% trans "For example:" %} <em>&ldquo;{% trans "Make a friend" %}&rdquo;</em> <span aria-hidden="true">&rarr;</span> <em>&ldquo;{% trans "Build one social connection outside of program activities within 3 months" %}&rdquo;</em></p>
             </details>
         </aside>
         {% endif %}

--- a/templates/plans/template_apply.html
+++ b/templates/plans/template_apply.html
@@ -59,5 +59,5 @@
 <p>{% trans "No active templates available." %} <a href="{% url 'plan_templates:template_list' %}">{% trans "Create one first." %}</a></p>
 {% endif %}
 
-<p><a href="{% url 'plans:plan_view' client_id=client_file.pk %}">&larr; {% blocktrans with plan=term.plan|default:"Plan" %}Back to {{ plan }}{% endblocktrans %}</a></p>
+<p><a href="{% url 'plans:plan_view' client_id=client_file.pk %}"><span aria-hidden="true">&larr;</span> {% blocktrans with plan=term.plan|default:"Plan" %}Back to {{ plan }}{% endblocktrans %}</a></p>
 {% endblock %}

--- a/templates/programs/detail.html
+++ b/templates/programs/detail.html
@@ -32,7 +32,7 @@
     {% if is_admin %}
     <a href="{% url 'programs:program_edit' program_id=program.pk %}" role="button" class="outline">{% blocktrans with program=term.program|default:"Program" %}Edit {{ program }}{% endblocktrans %}</a>
     {% endif %}
-    <a href="{% url 'programs:program_list' %}" class="back-link">&larr; {% trans "Back to List" %}</a>
+    <a href="{% url 'programs:program_list' %}" class="back-link"><span aria-hidden="true">&larr;</span> {% trans "Back to List" %}</a>
 </div>
 
 <hr>
@@ -69,11 +69,11 @@
 
     <div role="group">
         <a href="{% url 'reports:program_insights' %}?program={{ program.pk }}&time_period=6m"
-           role="button" class="outline">{% trans "View Program Results" %} &rarr;</a>
+           role="button" class="outline">{% trans "View Program Results" %} <span aria-hidden="true">&rarr;</span></a>
         {% has_permission "report.program_report" as can_see_reports %}
         {% if can_see_reports or user.is_admin %}
         <a href="{% url 'reports:export_form' %}"
-           role="button" class="outline secondary">{% trans "Export Program Data" %} &rarr;</a>
+           role="button" class="outline secondary">{% trans "Export Program Data" %} <span aria-hidden="true">&rarr;</span></a>
         {% endif %}
     </div>
     {% else %}

--- a/templates/reports/_insights_basic.html
+++ b/templates/reports/_insights_basic.html
@@ -242,7 +242,7 @@
             {% endfor %}
         </tbody>
     </table>
-    <p><a href="{% url 'suggestion_themes:theme_list' %}">{% trans "View all themes" %} &rarr;</a></p>
+    <p><a href="{% url 'suggestion_themes:theme_list' %}">{% trans "View all themes" %} <span aria-hidden="true">&rarr;</span></a></p>
     {% endif %}
 
     {# Ungrouped suggestions #}

--- a/templates/reports/report_preview.html
+++ b/templates/reports/report_preview.html
@@ -618,9 +618,9 @@
 {# Back link #}
 <p class="preview-back-link no-print" style="margin-top: 1rem;">
     {% if preview_type == "template" %}
-    <a href="{% url 'reports:generate_report' %}">&larr; {% trans "Back to Standard Report" %}</a>
+    <a href="{% url 'reports:generate_report' %}"><span aria-hidden="true">&larr;</span> {% trans "Back to Standard Report" %}</a>
     {% else %}
-    <a href="{% url 'reports:export_form' %}">&larr; {% trans "Back to Build a Report" %}</a>
+    <a href="{% url 'reports:export_form' %}"><span aria-hidden="true">&larr;</span> {% trans "Back to Build a Report" %}</a>
     {% endif %}
 </p>
 {% endblock %}


### PR DESCRIPTION
Fixes accessibility issues where screen readers announce visual HTML entities like `&larr;` as "leftwards arrow". By wrapping them in `<span aria-hidden="true">`, we hide them from screen readers while preserving their visual appearance. 

This addresses the learning from `.Jules/palette.md` on `2024-05-24`. I also made sure to put the spans outside the Django translation tags to prevent localization breakage.

---
*PR created automatically by Jules for task [8968274270345601667](https://jules.google.com/task/8968274270345601667) started by @pboachie*