### PR TITLE
🛡️ Sentinel: [HIGH] Fix missing rate limiting on invite_accept

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,7 @@
 **Vulnerability:** The `demo_portal_login` view was missing rate limiting, making it vulnerable to brute-force or DoS attacks.
 **Learning:** Even endpoints designed for demo purposes need to be protected. The `django-ratelimit` decorator with `block=True` should be applied uniformly to all authentication-related endpoints.
 **Prevention:** Always ensure the `@ratelimit(key="ip", rate="...", method="POST", block=True)` decorator is present on any view that processes login or authentication requests. Also make sure the import is present: `from django_ratelimit.decorators import ratelimit`.
+## 2026-04-07 - [Missing Rate Limiting on invite_accept Endpoint]
+**Vulnerability:** The `invite_accept` view in `apps/auth_app/invite_views.py` handles user registration and account creation but was missing rate limiting.
+**Learning:** Endpoints that consume one-time tokens or handle user registrations must be uniformly protected by the `@ratelimit` decorator to prevent brute-force attacks and spam account creation.
+**Prevention:** Always ensure the `@ratelimit(key="ip", rate="...", method="POST", block=True)` decorator is present on any view that processes user registration or consumes tokens.

--- a/apps/auth_app/invite_views.py
+++ b/apps/auth_app/invite_views.py
@@ -8,6 +8,7 @@ from django.http import Http404
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils import timezone
 from django.utils.translation import gettext as _
+from django_ratelimit.decorators import ratelimit
 
 from apps.programs.models import UserProgramRole
 
@@ -52,6 +53,7 @@ def invite_create(request):
     return render(request, "auth_app/invite_form.html", {"form": form})
 
 
+@ratelimit(key="ip", rate="10/h", method="POST", block=True)
 def invite_accept(request, code):
     """Public view — new user registers via invite link."""
     invite = get_object_or_404(Invite, code=code)


### PR DESCRIPTION
This PR addresses a missing rate limit on an endpoint that handles user registrations and token consumption. As a core part of the authentication boundary, it must be protected against brute-force and spam attacks.

---
*PR created automatically by Jules for task [7412199576968138267](https://jules.google.com/task/7412199576968138267) started by @pboachie*