### PR TITLE
🎨 Palette: Fix empty-state decorative icon for screen readers

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -1766,7 +1766,8 @@ button.outline.secondary:hover {
 }
 /* Static icon above empty state text */
 .empty-state::before {
-    content: "\1F4CB";  /* clipboard emoji — renders as text glyph */
+    content: "\1F4CB";  /* fallback for older browsers */
+    content: "\1F4CB" / ""; /* modern syntax for a11y */
     display: block;
     font-size: 2rem;
     line-height: 1;


### PR DESCRIPTION
💡 What: Added modern CSS alt-text syntax to `.empty-state::before` to provide an empty description to screen readers.
🎯 Why: Decorative elements generated with CSS `content:` are read aloud by screen readers. The clipboard emoji was unhelpfully being announced without context, providing no value to visually impaired users.
♿ Accessibility: The addition of `/ ""` ensures that screen readers treat the decorative visual glyph as truly empty text. A fallback for legacy browsers is maintained.

---
*PR created automatically by Jules for task [1576344182424808189](https://jules.google.com/task/1576344182424808189) started by @pboachie*