### PR TITLE
Add DRR for de-identified evaluation microdata export

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -258,6 +258,7 @@ Current DRRs (all in `tasks/design-rationale/` — see `README.md` there for the
 - `data-access-residency-policy.md` — Canadian residency by data access level
 - `document-integration.md` — SharePoint + Google Drive integration
 - `encryption-key-rotation.md` — Key rotation procedures and custody
+- `evaluation-microdata-export.md` — De-identified microdata export for external evaluators, k-anonymity pipeline
 - `executive-dashboard-redesign.md` — Dashboard UX with accessibility focus
 - `fhir-informed-modelling.md` — FHIR concepts without FHIR compliance
 - `funder-reporting-profiles.md` — Template-based funder reporting (Parking Lot)

--- a/tasks/design-rationale/README.md
+++ b/tasks/design-rationale/README.md
@@ -59,6 +59,7 @@ These are detailed decisions with expert panel findings and anti-patterns. Group
 | Document | Status | Scope | See also |
 |---|---|---|---|
 | [reporting-architecture.md](reporting-architecture.md) | Decided | Template-driven vs. ad-hoc reporting | Sovereignty |
+| [evaluation-microdata-export.md](evaluation-microdata-export.md) | Decided | De-identified microdata export for external evaluators, k-anonymity pipeline | Sovereignty, Security |
 | [funder-reporting-profiles.md](funder-reporting-profiles.md) | Parking Lot | Template-based funder reporting configuration | |
 | [executive-dashboard-redesign.md](executive-dashboard-redesign.md) | Approved | Dashboard UX with accessibility focus | Collab |
 | [cids-batch-classification-workflow.md](cids-batch-classification-workflow.md) | Draft | Batch AI classification for reporting taxonomies | |

--- a/tasks/design-rationale/evaluation-microdata-export.md
+++ b/tasks/design-rationale/evaluation-microdata-export.md
@@ -1,0 +1,261 @@
+# De-Identified Microdata Export for Program Evaluation
+
+**Date:** 2026-04-07
+**Status:** Decided — GK
+**Panels:** 1 expert panel (program evaluator, privacy/data governance, nonprofit program manager, health informatics), 3 rounds
+
+---
+
+## What Was Requested
+
+External program evaluators need participant-level outcome data with demographic breakdowns to do rigorous evaluation — trajectory analysis, equity disaggregation, dose-response modelling, attrition analysis. KoNote currently offers aggregate-only template reports (which can't support individual-level analysis) and PII-containing individual exports (which include names and are too sensitive to hand to an external party). There is no middle option.
+
+## The Decision
+
+Build a **de-identified microdata export** — individual rows with pseudonymous IDs, generalised demographics, and outcome metric values, with all direct identifiers removed. Deliver as CSV via the existing SecureExportLink infrastructure.
+
+This is a new export tier sitting between template reports and individual exports:
+
+| Tier | What | Who | Contains PII |
+|---|---|---|---|
+| Template reports | Aggregate metrics by demographic group | PM, Executive | No |
+| **Evaluation export (new)** | **De-identified individual rows with generalised demographics** | **ED / designated user** | **No (de-identified)** |
+| Individual client export | Full client record including names | PM | Yes |
+| Full agency export | Encrypted dump of everything | CLI / KoNote team | Yes |
+
+### What Evaluators Get
+
+- One row per participant (or per participant-per-time-point for longitudinal data)
+- Pseudonymous study ID (random, not derived from real record ID)
+- Demographic quasi-identifiers: age group, gender, ethnicity, geography (urban/rural) — subject to k-anonymity gating
+- Program enrollment and exit (quarter/year, not exact dates)
+- Service intensity: session count, total hours
+- Outcome metric values at each measurement point
+
+### What Evaluators Do NOT Get
+
+- Names, birth dates, contact information, exact addresses
+- Real record IDs
+- Clinical note text
+- Any direct identifier
+
+## Why This Approach
+
+### Why not just give evaluators the aggregate reports?
+
+Aggregate reports answer "did the average participant improve?" They cannot answer:
+- "Did outcomes differ by subgroup?" (equity analysis)
+- "Did participants who attended more sessions have better outcomes?" (dose-response)
+- "Who dropped out, and are they different from completers?" (attrition bias)
+- "Did individual trajectories vary, or did everyone improve at the same rate?" (heterogeneity)
+
+A weak evaluation harms participants — it fails to identify whether the program actually helps them, or whether it helps some groups and not others.
+
+### Why not just remove names and hand over the file?
+
+With small nonprofit populations (20-200 participants per program), demographic combinations become quasi-identifiers. A 67-year-old Indigenous woman in a rural program of 12 people is identifiable without a name. Removing direct identifiers is necessary but not sufficient.
+
+### Why not a container / secure analysis environment?
+
+Evaluated by the expert panel and rejected for KoNote's context:
+- Every evaluator has different tools, workflows, and analysis needs — KoNote can't anticipate or support all of them
+- Adds infrastructure complexity and cost disproportionate to the nonprofit market
+- Agencies need to interview evaluators about their data analysis process regardless — KoNote providing an environment doesn't remove that responsibility
+- The de-identification pipeline with k-anonymity enforcement makes the CSV safe enough to export
+
+### Why not synthetic data?
+
+Deferred to a future phase. Synthetic data preserves statistical distributions without mapping to real people, but:
+- Requires validation that synthetic data preserves the analytical properties evaluators need
+- Can distort the subgroup patterns that equity analysis aims to detect
+- More complex to implement and explain to non-technical users
+- Should be validated as a research project before being offered as a feature
+
+## De-Identification Pipeline
+
+The export runs a 10-step pipeline. Every step writes to the audit log.
+
+### Step 1: Extract
+
+Query raw data from PostgreSQL: ClientFile (encrypted PII), ServiceEpisode (enrollment/consent), ClientDetailValue (demographics), ProgressNote metrics, PlanTarget outcomes.
+
+### Step 2: Decrypt & Stage
+
+Decrypt PII fields in memory (never written to disk decrypted). Build a working recordset with all fields needed for the export. Names are decrypted only to build the exclusion list for output scanning — they are never included in output.
+
+### Step 3: Consent Filter
+
+Remove participants where `ServiceEpisode.consent_to_aggregate_reporting = False`. Consent language should be broadened to cover de-identified evaluation use: "I consent to my de-identified information being included in program reports and evaluations. No personally identifying information (name, date of birth, contact details) will be shared." No new database field needed — the existing boolean covers both aggregate and de-identified microdata.
+
+### Step 4: Strip Direct Identifiers
+
+Drop all direct identifiers: names, phone, email, exact birth date, real record ID. Assign pseudonymous study IDs (random, not sequential from record ID — no ordinal leakage). Store a linkage table (real ID ↔ study ID) encrypted and accessible only to agency admin, for the sole purpose of participant withdrawal requests ("remove my data from the evaluation"). Stored as encrypted JSON on the SecureExportLink record; destroyed when the link expires.
+
+### Step 5: Generalise Quasi-Identifiers
+
+Apply generalisation rules to reduce the specificity of demographic fields:
+
+| Field | Generalisation |
+|---|---|
+| Age (from DOB) | 5-year bands (18-24, 25-29, 30-34, ...) |
+| Geography (FSA) | Urban / Rural (derived from Stats Canada FSA classification) |
+| Enrolment date | Quarter/Year (Q3-2025) |
+| Exit date | Quarter/Year |
+| Ethnicity | As collected (already categorical) |
+| Gender | As collected (already categorical) |
+
+Generalisation levels are configurable per export — tighter for smaller populations, looser for larger ones. The system enforces minimum generalisation.
+
+### Step 6: K-Anonymity Check
+
+For each record, compute its equivalence class (the set of records sharing identical quasi-identifier values). Report the minimum k across all classes. Target k = 5, consistent with KoNote's existing small-cell suppression threshold and CIHI Pan-Canadian De-Identification Guidelines.
+
+### Step 7: Resolve K Violations
+
+For each equivalence class where k < 5, apply a cascading resolution strategy:
+
+1. **Widen** the most granular quasi-identifier (e.g., age 55-59 → 45+, merging adjacent bands until k is met)
+2. If still below k after widening, **suppress** the field value (replace with null)
+3. If the record is still unique after all QI generalisation, **suppress the entire record**
+
+Constraints:
+- Never widen to fewer than 2 categories (defeats the analytical purpose)
+- If more than 15% of records would need suppression, **block the export** and advise fewer QI columns — the population is too small for this level of demographic detail
+
+### Step 8: Population Threshold Gate
+
+System-enforced minimums based on population size after consent filtering and suppression:
+
+| Population (n) | Available Export Types |
+|---|---|
+| n < 15 | **Blocked.** Aggregate reports only. |
+| 15 ≤ n < 30 | Microdata with maximum 3 quasi-identifier columns, k=5 enforced |
+| n ≥ 30 | Full microdata with k=5 enforced, up to 5 quasi-identifier columns |
+
+These thresholds align with Statistics Canada small-area data practices and IPC minimum cell size guidance.
+
+### Step 9: Generate Output
+
+Write CSV with metadata header containing: report name, program, period, generated date/by, evaluator details, population counts, suppression summary, effective k, quasi-identifiers used, generalisations applied. Create SecureExportLink with `export_type = "evaluation_microdata"`, `contains_pii = False`, `is_elevated = True` (always elevated for evaluation exports). Deliver via existing 24-hour download link.
+
+### Step 10: Suppression Report
+
+Generate a companion JSON file documenting: total eligible, consented, exported, suppressed counts; suppression reasons by field; generalisations applied; effective k. This file is downloadable alongside the CSV — evaluators need it to understand what was excluded and adjust their analysis accordingly.
+
+## Access Control
+
+### Who Can Generate Evaluation Exports
+
+A new permission: `report.evaluation_export`. Not tied to any existing role by default — must be explicitly granted. Typically granted to the Executive Director or a designated privacy officer.
+
+**Why not reuse the `executive` role directly?** Not every executive should generate evaluation exports. In a large agency, the board treasurer has the executive role but shouldn't be exporting de-identified microdata. A specific permission lets the agency grant it to exactly the right person.
+
+**Why not Program Managers?** PMs can generate ad-hoc exports with PII for their own programs. Evaluation exports serve a different purpose (external sharing) with different safeguards (evaluator details, enhanced audit). Separating the permission clarifies the intent and audit trail.
+
+### Evaluator Details (Mandatory for Audit)
+
+The export form requires evaluator details before generation. These are stored in the audit log, not in a separate model:
+
+- Evaluator name (required)
+- Evaluator email (required)
+- Evaluator organisation (required)
+- Evaluation purpose (required)
+- Data sharing agreement expiry date (required)
+
+KoNote does not email the evaluator, create an evaluator account, or store/enforce the data sharing agreement document. These are metadata for the audit trail. The agency manages the evaluator relationship and agreement outside KoNote.
+
+### What's NOT in KoNote's Scope
+
+- **Sending the file to the evaluator** — the ED downloads it and delivers it via their own secure channel
+- **Data sharing agreement management** — the expiry date is captured for audit; the agency manages the actual agreement
+- **Evaluator accounts** — evaluators don't log into KoNote
+- **Controlling what the evaluator does with the data** — that's governed by the data sharing agreement, not by software
+
+## Enhanced Audit Trail
+
+Standard report exports log a generic metadata blob. Evaluation exports log structured, detailed metadata because the data is more sensitive (de-identified individual rows vs. aggregate statistics):
+
+```json
+{
+    "export_category": "evaluation_microdata",
+    "evaluator_email": "dr.martinez@llewelyn.ca",
+    "evaluator_name": "Dr. Ana Martinez",
+    "evaluator_organisation": "Llewelyn Consulting",
+    "evaluation_purpose": "Youth Employment outcome evaluation 2025-26",
+    "data_sharing_agreement_expiry": "2026-04-30",
+    "program_id": 7,
+    "program_name": "Youth Employment",
+    "period_start": "2025-09-01",
+    "period_end": "2026-03-31",
+    "pipeline_summary": {
+        "eligible_count": 47,
+        "consented_count": 42,
+        "exported_count": 41,
+        "suppressed_count": 1,
+        "suppression_rate": 0.024,
+        "effective_k": 5,
+        "qi_columns": ["age_group", "gender", "geography"],
+        "generalizations_applied": [
+            {"field": "age_group", "original": "55-59", "widened_to": "45+"}
+        ]
+    }
+}
+```
+
+The audit log is immutable (append-only, enforced at Django and PostgreSQL levels). If there is ever a privacy complaint, the audit entry answers: who exported what, for whom, with what de-identification applied, and under what authority.
+
+## CSV Output Format
+
+```csv
+# Evaluation Export — Youth Employment Program
+# Period: 2025-09 to 2026-03
+# Generated: 2026-04-07 by Jane Admin
+# Evaluator: Dr. Ana Martinez (dr.martinez@llewelyn.ca), Llewelyn Consulting
+# Purpose: Youth Employment outcome evaluation 2025-26
+# Agreement expiry: 2026-04-30
+# Population: 47 eligible, 42 consented, 41 exported, 1 suppressed (k<5)
+# Effective k-anonymity: 5
+# Quasi-identifiers: age_group, gender, geography
+# Generalizations: age_group 55-59 widened to 45+
+#
+study_id,age_group,gender,geography,enrolment_quarter,exit_quarter,sessions_count,total_hours,metric_wellbeing_intake,metric_wellbeing_exit,metric_housing_intake,metric_housing_exit
+EVL-001,25-29,Woman,Urban,Q3-2025,,12,18.5,3,6,2,4
+EVL-002,25-29,Woman,Urban,Q3-2025,Q1-2026,8,12.0,4,5,3,5
+```
+
+## Anti-Patterns — Do Not Build
+
+| Anti-pattern | Why |
+|---|---|
+| **Evaluator login to KoNote** | Violates the principle that external users don't access the system. Export is file-based, mediated by agency staff. |
+| **Container / secure analysis environment** | Every evaluator has different tools and workflows. Adds infrastructure complexity disproportionate to nonprofit budgets. Agencies must manage the evaluator relationship regardless. |
+| **Automatic evaluator notification** | KoNote should not email the evaluator or manage the delivery channel. The ED controls how and when data is shared. |
+| **Reusing real record IDs as pseudonyms** | Linkable to other KoNote data. Pseudonymous IDs must be random with no derivable relationship to real IDs. |
+| **Hashing record IDs as pseudonyms** | Hashes are reversible when the input space is small (sequential integers). Use random UUIDs or random short codes. |
+| **Skipping k-anonymity for "trusted" evaluators** | Trust doesn't prevent laptop theft. De-identification protects against all downstream risks, not just the evaluator's intent. |
+| **Advisory-only population thresholds** | Funders will pressure agencies to override warnings. System-enforced blocks protect the program manager from having to argue. |
+| **Separate consent flag for evaluation** | Creates consent fatigue at intake, introduces selection bias. Broaden existing consent language instead. |
+| **Synthetic data as default** | Can distort subgroup patterns that equity analysis aims to detect. Defer until validated. |
+
+## What This DRR Does NOT Restrict
+
+- **Template-driven aggregate reports** — unchanged, still the primary reporting path
+- **Ad-hoc exports by PMs** — unchanged, still available for internal program management
+- **Individual client exports** — unchanged, still available for PIPEDA requests
+- **CIDS JSON-LD aggregate exports** — unchanged, governed by reporting architecture DRR
+
+## Future Considerations
+
+1. **Synthetic data option** — for programs with n < 15 where aggregate reports are insufficient. Requires validation research before implementation.
+2. **Longitudinal export format** — one row per participant-per-measurement-point instead of one row per participant. More useful for trajectory analysis but increases re-identification risk (more rows = more combinatorial surface). Design separately.
+3. **Cross-program evaluation export** — spanning multiple programs in one export. Raises consent complexity (different programs may have different consent rates). Defer until single-program exports are proven.
+4. **Data sharing agreement tracking model** — if many agencies need to track multiple concurrent evaluations, a lightweight `EvaluationAgreement` model could be useful. Not needed for Phase 1 — the audit log metadata is sufficient.
+
+## Related Documents
+
+- `tasks/design-rationale/no-live-api-individual-data.md` — the two-tier export model this extends
+- `tasks/design-rationale/reporting-architecture.md` — template-driven reporting (aggregate path)
+- `tasks/design-rationale/phipa-consent-enforcement.md` — consent model and enforcement
+- `tasks/design-rationale/data-access-residency-policy.md` — data access tiers
+- `tasks/design-rationale/multi-tenancy.md` — suppression thresholds, consortium sharing
+- `tasks/phase-evaluation-export-prompt.md` — implementation prompt for this feature

--- a/tasks/phase-evaluation-export-prompt.md
+++ b/tasks/phase-evaluation-export-prompt.md
@@ -1,0 +1,414 @@
+# Phase: De-Identified Evaluation Microdata Export
+
+## Goal
+
+Build a new export type that produces de-identified, participant-level CSV files for external program evaluators. The CSV contains pseudonymous IDs, generalised demographics, and outcome metric values — with all direct identifiers removed and k-anonymity enforced. This sits between the existing aggregate template reports and PII-containing individual exports.
+
+**Read before starting:** `tasks/design-rationale/evaluation-microdata-export.md` — contains the full rationale, anti-patterns, and decisions. Do not deviate from that DRR without explicit user approval.
+
+## Prerequisites
+
+Before starting, verify:
+- You have read and understood the DRR
+- You understand how `SecureExportLink` works (see `apps/reports/models.py`)
+- You understand the existing export flow in `apps/reports/views.py` (the `generate_report_form` and `export_form` views)
+- You understand the permission model in `apps/auth_app/permissions.py` and `apps/reports/utils.py`
+- You understand how `AuditLog` works (see `apps/audit/models.py`, uses `.using("audit")`)
+- You understand the demographic/age grouping in `apps/reports/demographics.py`
+- You understand the suppression logic in `apps/reports/suppression.py`
+
+## Tasks (in dependency order)
+
+### Task 1: EVAL-PERM1 — Add Evaluation Export Permission
+
+**What:** Add a new permission `report.evaluation_export` that is not granted to any role by default. Must be explicitly granted to specific users (typically the Executive Director).
+
+**Changes to `apps/auth_app/permissions.py`:**
+- Add `evaluation_export` to the `report` permission group
+- Default: DENY for all roles (executive, PM, staff, receptionist)
+- Admins (is_admin=True) can always access (consistent with other admin overrides)
+
+**Changes to `apps/auth_app/models.py` or admin views:**
+- Ensure there's a way for admins to grant this permission to specific users via the admin UI
+- Check how other permissions are granted — follow the same pattern
+
+**Changes to `apps/reports/utils.py`:**
+- Add `can_create_evaluation_export(user)` — returns True if user has the `report.evaluation_export` permission or is admin
+
+**Tests (`tests/test_reports.py` or new `tests/test_evaluation_export.py`):**
+- Test: user without permission cannot access the evaluation export view (403)
+- Test: user with permission can access the view
+- Test: admin can always access the view
+- Test: PM and executive without explicit permission cannot access (403)
+
+---
+
+### Task 2: EVAL-PIPE1 — De-Identification Pipeline Engine
+
+**What:** Create the core de-identification pipeline as a standalone module. This is the heart of the feature — it transforms raw identified data into de-identified, k-anonymous microdata.
+
+**New file: `apps/reports/deidentify.py`**
+
+This module should contain:
+
+#### Class: `DeidentificationPipeline`
+
+```python
+class DeidentificationPipeline:
+    """
+    10-step pipeline that transforms identified participant data
+    into de-identified, k-anonymous microdata for evaluation export.
+    
+    Each step is a separate method that logs to the audit trail.
+    The pipeline is run in preview mode (dry run) first to show
+    the user what will happen, then in generate mode to produce output.
+    """
+    
+    def __init__(self, program, period_start, period_end, 
+                 qi_columns, evaluator_info, user):
+        """
+        Args:
+            program: Program instance
+            period_start: date
+            period_end: date
+            qi_columns: list of quasi-identifier column names 
+                        (e.g., ["age_group", "gender", "geography"])
+            evaluator_info: dict with keys: name, email, organisation, 
+                           purpose, agreement_expiry
+            user: User initiating the export
+        """
+    
+    def run_preview(self):
+        """
+        Execute steps 1-8 without generating output.
+        Returns a PreviewResult with counts, suppression details,
+        and whether the export is permitted.
+        """
+    
+    def run_generate(self):
+        """
+        Execute all 10 steps and produce the CSV + suppression report.
+        Returns a GenerateResult with file paths.
+        Must only be called after run_preview() has been shown to the user.
+        """
+```
+
+#### Step Methods (called by run_preview and run_generate)
+
+**Step 1: `_extract_raw_data()`**
+- Query ClientFile records for the program within the period
+- Query ServiceEpisode for enrollment data
+- Query ClientDetailValue for demographic custom fields
+- Query MetricValue / ProgressNote for outcome measurements
+- Return: list of raw record dicts
+- Audit: log job initiation with eligible count
+
+**Step 2: `_decrypt_and_stage()`**
+- Decrypt birth_date (for age calculation) and names (for exclusion list only)
+- Build working recordset in memory — never write decrypted data to disk
+- Return: list of staged record dicts
+- Audit: log fields decrypted and record count
+
+**Step 3: `_apply_consent_filter()`**
+- Remove records where `ServiceEpisode.consent_to_aggregate_reporting = False`
+- Return: filtered list, count of excluded
+- Audit: log consent exclusion count
+
+**Step 4: `_strip_direct_identifiers()`**
+- Drop: names, phone, email, exact birth_date, real record_id
+- Generate pseudonymous study IDs: random short codes (e.g., EVL-001)
+  - Use `secrets.token_hex(4)` or similar — NOT sequential, NOT derived from record_id
+  - Ensure uniqueness within the export
+- Build linkage table: `{study_id: real_record_id}` — encrypt with Fernet, store later on SecureExportLink
+- Return: de-identified records, encrypted linkage blob
+- Audit: log identifier stripping and pseudonym assignment
+
+**Step 5: `_generalise_quasi_identifiers()`**
+- Age (from decrypted birth_date): compute age, map to 5-year bands (18-24, 25-29, 30-34, 35-39, 40-44, 45-49, 50-54, 55-59, 60-64, 65+)
+- Geography: if FSA (first 3 of postal code) is available, map to Urban/Rural using Stats Canada classification. If no postal code, set to null.
+- Enrolment date: round to quarter/year (Q1-2026, Q2-2026, etc.)
+- Exit date: round to quarter/year (null if still enrolled)
+- Gender, ethnicity: pass through as-is (already categorical)
+- Return: generalised records, list of generalisations applied
+- Audit: log generalisation rules applied
+
+**Step 6: `_compute_k_anonymity()`**
+- For each record, compute its equivalence class: the set of records sharing identical values across all selected QI columns
+- Compute minimum k (smallest equivalence class size)
+- Return: dict mapping equivalence class tuple → count, minimum k
+- Audit: log QI columns, equivalence class count, minimum k
+
+**Step 7: `_resolve_k_violations(target_k=5)`**
+- For each equivalence class where count < target_k:
+  1. **Widen** the most granular QI. Priority order for widening: age_group (merge adjacent bands), geography (suppress to null), enrolment_quarter (widen to half-year)
+  2. Recompute equivalence classes after widening
+  3. If still below k, **suppress** the smallest QI field value (set to null)
+  4. If record is still unique after all QI generalisation, **suppress the entire record**
+- Track suppressed records and reasons
+- If suppression rate > 15%, set `blocked = True` with message recommending fewer QI columns
+- Return: resolved records, suppressed records with reasons, final minimum k, blocked flag
+- Audit: log resolution actions, suppression count, final k
+
+**Step 8: `_check_population_threshold()`**
+- After consent filter + suppression, count remaining records
+- Apply tier rules:
+  - n < 15: blocked, aggregate only
+  - 15 ≤ n < 30: max 3 QI columns (if more were selected, block and advise)
+  - n ≥ 30: max 5 QI columns
+- Return: pass/block, tier applied, population count
+- Audit: log threshold check result
+
+**Step 9: `_generate_csv(records)`**
+- Build CSV with metadata header (see DRR for exact format)
+- Include: study_id, selected QI columns, enrolment_quarter, exit_quarter, sessions_count, total_hours, metric columns (intake and latest values per metric)
+- Apply CSV injection prevention from `apps/reports/csv_utils.py`
+- Write to SECURE_EXPORT_DIR (same as existing exports)
+- Return: file path
+- Audit: log output generation, file path
+
+**Step 10: `_generate_suppression_report()`**
+- Build JSON companion file documenting:
+  - Total eligible, consented, exported, suppressed
+  - Suppression reasons by field
+  - Generalisations applied (original → widened)
+  - Effective k
+  - QI columns used
+- Write alongside CSV in SECURE_EXPORT_DIR
+- Return: file path
+- Audit: log completion with full pipeline summary
+
+#### Data Classes for Results
+
+```python
+@dataclass
+class PreviewResult:
+    eligible_count: int
+    consented_count: int
+    exportable_count: int
+    suppressed_count: int
+    suppression_rate: float
+    effective_k: int
+    qi_columns_used: list[str]
+    generalizations_applied: list[dict]  # [{"field": ..., "original": ..., "widened_to": ...}]
+    suppression_details: list[dict]  # [{"reason": ..., "count": ...}]
+    blocked: bool
+    block_reason: str | None  # "population_too_small", "suppression_rate_exceeded", "too_many_qi_columns"
+    tier: str  # "aggregate_only", "limited_qi", "full"
+
+@dataclass
+class GenerateResult:
+    csv_path: str
+    suppression_report_path: str
+    preview: PreviewResult
+    linkage_blob: bytes  # encrypted
+    audit_metadata: dict  # the full metadata blob for the audit log
+```
+
+**Tests (`tests/test_evaluation_export.py`):**
+
+Use Django's `TestCase` with factory-created test data. You'll need:
+- A program with ~30 test participants with varied demographics
+- A program with ~10 test participants (to test the n<15 block)
+- Participants with and without consent
+
+Test cases:
+- Pipeline runs end-to-end on a program with 30+ consented participants
+- Consent filter correctly excludes non-consenting participants
+- Direct identifiers (names, email, phone, birth_date, record_id) are absent from output
+- Pseudonymous IDs are random (not sequential, not derived from record_id)
+- Age generalisation produces correct 5-year bands
+- Date generalisation produces correct quarter/year
+- K-anonymity is computed correctly (create a scenario with a known unique combination)
+- K violations are resolved by widening (check that bands were merged)
+- K violations are resolved by suppression when widening is insufficient
+- Export is blocked when suppression rate exceeds 15%
+- Export is blocked when n < 15
+- QI column limit is enforced for populations 15-29 (max 3)
+- QI column limit is enforced for populations 30+ (max 5)
+- CSV output matches the expected format (metadata header, column order, data values)
+- Suppression report JSON contains correct counts
+- Linkage table is encrypted and contains correct mappings
+- Each pipeline step creates an audit log entry
+
+---
+
+### Task 3: EVAL-FORM1 — Export Form and View
+
+**What:** Create the web form and view for the evaluation export. The form has two stages: configuration (program, period, evaluator details, QI columns) and preview/confirm.
+
+**New form: `apps/reports/forms.py`**
+
+```python
+class EvaluationExportForm(forms.Form):
+    program = forms.ModelChoiceField(...)  # Programs user has access to
+    period_start = forms.DateField(widget=forms.DateInput(attrs={"type": "date"}))
+    period_end = forms.DateField(widget=forms.DateInput(attrs={"type": "date"}))
+    
+    # Evaluator details (all required)
+    evaluator_name = forms.CharField(max_length=200)
+    evaluator_email = forms.EmailField()
+    evaluator_organisation = forms.CharField(max_length=200)
+    evaluation_purpose = forms.CharField(widget=forms.Textarea(attrs={"rows": 3}))
+    agreement_expiry = forms.DateField(
+        widget=forms.DateInput(attrs={"type": "date"}),
+        help_text="When does the data sharing agreement with this evaluator expire?"
+    )
+    
+    # QI column selection (checkboxes)
+    include_age_group = forms.BooleanField(required=False, initial=True)
+    include_gender = forms.BooleanField(required=False, initial=True)
+    include_ethnicity = forms.BooleanField(required=False)
+    include_geography = forms.BooleanField(required=False)
+    # Additional custom field groups marked as evaluation-exportable
+    # (dynamically populated in __init__)
+```
+
+**New view: `apps/reports/views.py`**
+
+Add `evaluation_export_form()`:
+
+1. **GET**: Render the form. Check `can_create_evaluation_export(user)` — 403 if not.
+2. **POST with action=preview**: Validate form, run `pipeline.run_preview()`, render preview template showing counts, suppressions, and generalisations. Include a hidden form with all original values plus a confirm button.
+3. **POST with action=generate**: Run `pipeline.run_generate()`, create SecureExportLink:
+   - `export_type = "evaluation_microdata"`
+   - `contains_pii = False`
+   - `is_elevated = True` (always — evaluation exports are always elevated)
+   - `recipient = evaluator_email`
+   - `client_count = exportable_count`
+   - Store encrypted linkage blob (add a new field or use `filters_json`)
+4. Create AuditLog entry with full metadata blob
+5. Redirect to the SecureExportLink download page (existing flow handles the elevated delay)
+
+**URL: `apps/reports/urls.py`**
+- `path("evaluation-export/", views.evaluation_export_form, name="evaluation_export")`
+
+**Templates:**
+
+`templates/reports/evaluation_export.html`:
+- Standard form layout using `{% include "includes/_form_field.html" %}` for all fields
+- Evaluator details section with clear heading: "Evaluator Information (required for audit trail)"
+- QI column checkboxes with population-size warning (shown via HTMX after program selection, or as static text)
+- Warning banner: "This export contains de-identified individual-level data. All details will be recorded in the audit log."
+
+`templates/reports/evaluation_export_preview.html`:
+- Summary table: eligible → consented → exportable → suppressed
+- Effective k-anonymity value
+- Generalisations applied (list)
+- Suppression details (if any records were suppressed, explain why)
+- If blocked: red banner explaining why (population too small, too many QI columns, suppression rate too high) with no generate button
+- If permitted: confirm button, cancel button
+- The evaluator details echoed back for confirmation
+
+**Navigation:**
+- Add "Evaluation Export" link to the reports navigation menu
+- Only visible to users with `report.evaluation_export` permission
+
+**Tests:**
+- Test: GET renders form for authorised user
+- Test: GET returns 403 for unauthorised user
+- Test: POST with action=preview returns preview with correct counts
+- Test: POST with action=preview for blocked export shows block reason, no generate button
+- Test: POST with action=generate creates SecureExportLink with correct fields
+- Test: POST with action=generate creates AuditLog entry with correct metadata structure
+- Test: evaluator fields are all required (form validation)
+- Test: email field validates as email
+
+---
+
+### Task 4: EVAL-NAV1 — Navigation and SecureExportLink Integration
+
+**What:** Wire the evaluation export into the existing navigation, reports landing page, and export link management.
+
+**Changes:**
+
+1. **Reports nav** — add "Evaluation Export" link, permission-gated
+2. **SecureExportLink** — add `"evaluation_microdata"` to `export_type` choices. If the model uses a choices tuple, add the new value.
+3. **Export links management page** (`/reports/export-links/`) — evaluation exports should appear here alongside other exports, with the evaluator email shown in the recipient column
+4. **SecureExportLink model** — consider adding a `linkage_key_encrypted` field (TextField, nullable) for storing the encrypted linkage blob. Alternative: store in `filters_json`. Check which is cleaner.
+
+**Translations:**
+- Run `python manage.py translate_strings` after template changes
+- Add French translations for all new UI strings:
+  - "Evaluation Export" → "Exportation pour l'évaluation"
+  - "Evaluator Information" → "Information sur l'évaluateur"
+  - "Data sharing agreement expiry" → "Expiration de l'entente de partage de données"
+  - "This export contains de-identified individual-level data" → "Cette exportation contient des données individuelles dépersonnalisées"
+  - etc.
+
+**Tests:**
+- Test: navigation link appears for authorised user
+- Test: navigation link hidden for unauthorised user
+- Test: evaluation export appears in export links management page
+- Test: evaluator email shows in recipient column
+
+---
+
+### Task 5: EVAL-ADMIN1 — Admin Configuration for Exportable Custom Fields
+
+**What:** Allow admins to mark which custom field groups are available as quasi-identifiers in evaluation exports.
+
+**Model change: `apps/clients/models.py`**
+- Add `is_evaluation_exportable` BooleanField to `CustomFieldGroup` (default=False)
+- Help text: "When enabled, fields in this group can be selected as demographic columns in evaluation exports."
+- Only non-sensitive field groups should be marked exportable (enforce: if `is_sensitive=True` on any field in the group, block marking the group as exportable)
+
+**Admin change:**
+- Add checkbox to CustomFieldGroup admin form
+- Validation: warn if group contains sensitive fields
+
+**Pipeline integration:**
+- In `EvaluationExportForm.__init__()`, dynamically add checkboxes for custom field groups where `is_evaluation_exportable=True`
+- In `DeidentificationPipeline._extract_raw_data()`, include values from selected exportable custom field groups
+- In `_generalise_quasi_identifiers()`, pass custom field values through as-is (they're already categorical)
+- In `_compute_k_anonymity()`, include custom field values in QI tuple
+
+**Migration:** One new field on CustomFieldGroup.
+
+**Tests:**
+- Test: custom field group marked exportable appears as checkbox in evaluation export form
+- Test: custom field group not marked does not appear
+- Test: sensitive field group cannot be marked exportable
+- Test: custom field values included in k-anonymity computation
+
+---
+
+## Implementation Notes
+
+### What to reuse (do not rebuild)
+
+- `SecureExportLink` model and download flow — just add the new export_type
+- Elevated export delay and admin notification — works as-is for evaluation exports
+- `apps/reports/csv_utils.py` — CSV injection prevention
+- `apps/reports/demographics.py` — age grouping logic (may need to adjust band sizes)
+- `apps/reports/suppression.py` — small-cell suppression logic (adapt from cell-level to row-level)
+- `AuditLog` model — no schema change needed, use the existing `metadata` JSONField
+- `apps/reports/utils.py` — permission checking patterns
+
+### What is new
+
+- `apps/reports/deidentify.py` — the pipeline module (Task 2)
+- `report.evaluation_export` permission (Task 1)
+- `EvaluationExportForm` (Task 3)
+- `evaluation_export_form` view (Task 3)
+- `evaluation_export.html` and `evaluation_export_preview.html` templates (Task 3)
+- `is_evaluation_exportable` field on CustomFieldGroup (Task 5)
+
+### Order matters
+
+Tasks 1 and 2 are independent and can be built in parallel. Task 3 depends on both 1 and 2. Task 4 depends on 3. Task 5 can be built after Task 2 (pipeline) but its integration into the form requires Task 3.
+
+```
+Task 1 (permission) ─────┐
+                          ├──→ Task 3 (form/view) ──→ Task 4 (nav/integration)
+Task 2 (pipeline) ───────┘                                    │
+       │                                                       │
+       └──→ Task 5 (admin config) ─── integrates into ────────┘
+```
+
+### Testing strategy
+
+Run tests for each task as you complete it:
+- `pytest tests/test_evaluation_export.py` (new file, covers Tasks 1-5)
+- After Task 3, also run `pytest tests/test_reports.py` to ensure existing export tests still pass
+
+Do NOT run the full test suite until all 5 tasks are complete.


### PR DESCRIPTION
## Summary
- New Design Rationale Record for de-identified microdata exports for external program evaluators
- Documents the 10-step de-identification pipeline with k-anonymity enforcement, pseudonymous IDs, generalised demographics, and population threshold gates
- Includes implementation prompt with 5 tasks in dependency order for a future session
- Expert panel deliberation (evaluator, privacy specialist, nonprofit PM, health informatics) — container approach evaluated and rejected in favour of CSV export with enhanced audit logging

## Files
- `tasks/design-rationale/evaluation-microdata-export.md` — the DRR
- `tasks/phase-evaluation-export-prompt.md` — implementation prompt
- `tasks/design-rationale/README.md` — updated index
- `CLAUDE.md` — updated DRR reference list

## Test plan
- [ ] DRR is listed in `tasks/design-rationale/README.md` under Evaluation & Reporting
- [ ] DRR is listed in `CLAUDE.md` DRR reference list (alphabetical order)
- [ ] Implementation prompt references the DRR correctly
- [ ] No code changes — documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)