### PR TITLE
Add de-identified evaluation microdata export

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -111,7 +111,6 @@ _All documentation tasks completed — see Recently Done._
 Scope is clear, just needs time. A session can pick these up without special approval.
 
 - [ ] Extract shared custom field utilities (form builder, save helper, context builder) to reduce duplication between staff and portal views — (REFACTOR2)
-- [ ] De-identified evaluation microdata export — new export tier for external evaluators with k-anonymity, pseudonymous IDs, generalised demographics, enhanced audit trail. DRR: `tasks/design-rationale/evaluation-microdata-export.md`. Session prompt: `tasks/session-prompt-evaluation-export.md` — (EVAL-EXPORT1)
 
 ## Parking Lot: Needs Review
 
@@ -127,6 +126,7 @@ Not yet clear we should build these, or the design isn't settled. May be too com
 
 ## Recently Done
 
+- [x] De-identified evaluation microdata export — 10-step de-identification pipeline with k-anonymity (k=5), pseudonymous IDs, generalised demographics, population thresholds, enhanced audit trail, preview/confirm flow, permission-gated nav — 2026-04-07 (EVAL-EXPORT1)
 - [x] Insights quality & language features — DQ1: practice signal contextual sentence + month count in summary bar; CONF1: raised theme auto-link threshold from 2→3 words; LANG1: EN/FR language detection on quotes, AI prompt language awareness, FR pills on mixed-language Insights pages — PR #595 — 2026-04-03 (INSIGHTS-DQ1, INSIGHTS-CONF1, INSIGHTS-LANG1)
 - [x] Dashboard & Insights enrichment — FHIR metadata features: program summary sentences, practice indicators, goal source distribution on Insights; stale episodes attention signal on Dashboard; batch query optimization; simplified both pages (removed funder stats, cohort comparison, cross-tab, dashboard bloat — 8 sections → 5 on Insights, ~20 rows → ~8 per program card) — PRs #529-#533 — 2026-03-16 (ENRICH1)
 - [x] Expand accessibility tests to cover portal flow (dashboard, journal, goals) and report/chart flow (outcome insights) — axe-core tests in test_a11y_ci.py — 2026-03-12 (REV26-A11Y1)

--- a/apps/auth_app/permissions.py
+++ b/apps/auth_app/permissions.py
@@ -70,6 +70,7 @@ PERMISSIONS = {
 
         "report.program_report": DENY,  # Managers generate, not front desk
         "report.funder_report": DENY,  # Managers/executives generate funder reports
+        "report.evaluation_export": DENY,  # Explicit grant only — admin or per-user
         "report.data_extract": DENY,
 
         "insights.view": DENY,  # Outcome insights — staff+ only
@@ -175,6 +176,7 @@ PERMISSIONS = {
 
         "report.program_report": DENY,
         "report.funder_report": DENY,  # Managers/executives generate funder reports
+        "report.evaluation_export": DENY,  # Explicit grant only — admin or per-user
         "report.data_extract": DENY,
 
         "insights.view": PROGRAM,  # Program-level outcome insights. Enforced by @requires_permission
@@ -287,6 +289,7 @@ PERMISSIONS = {
                                         # + _save_export_and_create_link()
         "report.funder_report": ALLOW,  # Managers generate funder reports for their programs.
                                         # Enforced by @requires_permission
+        "report.evaluation_export": DENY,  # Explicit grant only — admin or per-user
         "report.data_extract": ALLOW,  # PM handles PIPEDA data portability requests
 
         "insights.view": ALLOW,  # Program-level outcome insights. Enforced by @requires_permission
@@ -398,6 +401,7 @@ PERMISSIONS = {
         "report.program_report": ALLOW,  # View only (managers generate). Enforced by @requires_permission
         "report.funder_report": ALLOW,  # Executives can generate aggregate funder reports.
                                         # Enforced by @requires_permission
+        "report.evaluation_export": DENY,  # Explicit grant only — admin or per-user
         "report.data_extract": DENY,
 
         "insights.view": ALLOW,  # Aggregate outcome insights only (quotes suppressed).
@@ -570,6 +574,7 @@ def permission_to_plain_english(perm_key, perm_level):
 
         "report.program_report": "Generate program outcome reports",
         "report.funder_report": "Generate funder demographic reports",
+        "report.evaluation_export": "Generate de-identified evaluation exports for external evaluators",
         "report.data_extract": "Export client data extracts",
 
         "event.view": "View client events and timeline",

--- a/apps/clients/admin.py
+++ b/apps/clients/admin.py
@@ -137,7 +137,7 @@ class ClientAccessBlockAdmin(admin.ModelAdmin):
 
 @admin.register(CustomFieldGroup)
 class CustomFieldGroupAdmin(admin.ModelAdmin):
-    list_display = ("title", "sort_order", "collapsed_by_default")
+    list_display = ("title", "sort_order", "collapsed_by_default", "is_evaluation_exportable")
 
 
 @admin.register(CustomFieldDefinition)

--- a/apps/clients/forms.py
+++ b/apps/clients/forms.py
@@ -335,10 +335,11 @@ class ClientTransferForm(forms.Form):
 class CustomFieldGroupForm(forms.ModelForm):
     class Meta:
         model = CustomFieldGroup
-        fields = ["title", "sort_order", "collapsed_by_default", "status"]
+        fields = ["title", "sort_order", "collapsed_by_default", "is_evaluation_exportable", "status"]
         labels = {
             "sort_order": _("Display order"),
             "collapsed_by_default": _("Collapsed by default (display only — does not restrict access)"),
+            "is_evaluation_exportable": _("Available in evaluation exports"),
         }
 
     def __init__(self, *args, **kwargs):
@@ -346,7 +347,17 @@ class CustomFieldGroupForm(forms.ModelForm):
         self.fields["title"].help_text = _("Use groups to bundle related fields together, such as Intake, Demographics, or Accessibility.")
         self.fields["sort_order"].help_text = _("Lower numbers appear earlier on the participant file.")
         self.fields["collapsed_by_default"].help_text = _("This only affects whether the group starts open or closed on screen.")
+        self.fields["is_evaluation_exportable"].help_text = _("When enabled, fields in this group can be selected as demographic columns in evaluation exports. Only non-sensitive groups should be marked exportable.")
         self.fields["status"].help_text = _("Archived groups stay on old records but are hidden from new use.")
+
+    def clean_is_evaluation_exportable(self):
+        value = self.cleaned_data.get("is_evaluation_exportable", False)
+        if value and self.instance and self.instance.pk:
+            if self.instance.has_sensitive_fields:
+                raise forms.ValidationError(
+                    _("This group contains sensitive fields and cannot be marked as evaluation-exportable.")
+                )
+        return value
 
 
 class CustomFieldValuesForm(forms.Form):

--- a/apps/clients/migrations/0043_customfieldgroup_is_evaluation_exportable.py
+++ b/apps/clients/migrations/0043_customfieldgroup_is_evaluation_exportable.py
@@ -1,0 +1,23 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("clients", "0042_alter_customfieldgroup_collapsed_by_default"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="customfieldgroup",
+            name="is_evaluation_exportable",
+            field=models.BooleanField(
+                default=False,
+                help_text=(
+                    "When enabled, fields in this group can be selected as "
+                    "demographic columns in evaluation exports. Only non-sensitive "
+                    "groups should be marked exportable."
+                ),
+            ),
+        ),
+    ]

--- a/apps/clients/models.py
+++ b/apps/clients/models.py
@@ -725,6 +725,14 @@ class CustomFieldGroup(models.Model):
             "frontline workers do not need to see."
         ),
     )
+    is_evaluation_exportable = models.BooleanField(
+        default=False,
+        help_text=_(
+            "When enabled, fields in this group can be selected as "
+            "demographic columns in evaluation exports. Only non-sensitive "
+            "groups should be marked exportable."
+        ),
+    )
     status = models.CharField(
         max_length=20, default="active",
         choices=[("active", "Active"), ("archived", "Archived")],
@@ -738,6 +746,11 @@ class CustomFieldGroup(models.Model):
 
     def __str__(self):
         return self.title
+
+    @property
+    def has_sensitive_fields(self):
+        """True if any field in this group is marked sensitive."""
+        return self.fields.filter(is_sensitive=True).exists()
 
 
 class CustomFieldDefinition(models.Model):

--- a/apps/reports/deidentify.py
+++ b/apps/reports/deidentify.py
@@ -281,6 +281,19 @@ class DeidentificationPipeline:
             ).distinct().order_by("name")
         )
 
+        # Guard against metric name collisions after slugification
+        # (e.g., "Well-being Score" and "Wellbeing Score" → same slug)
+        seen_slugs: dict[str, str] = {}
+        for md in self._metric_defs:
+            slug = self._sanitise_metric_name(md.name)
+            if slug in seen_slugs:
+                logger.warning(
+                    "Metric name collision: '%s' and '%s' both slugify to '%s'",
+                    seen_slugs[slug], md.name, slug,
+                )
+            else:
+                seen_slugs[slug] = md.name
+
         # Build raw records
         for client_id, (client, episode) in client_episodes.items():
             self._raw_records.append({
@@ -396,14 +409,21 @@ class DeidentificationPipeline:
         # Group by (client_id, metric_def_id)
         grouped: dict[tuple[int, int], list] = defaultdict(list)
         metric_name_map: dict[int, str] = {}
+        used_slugs: set[str] = set()
         for mv in all_values:
             cid = mv.progress_note_target.progress_note.client_file_id
             mid = mv.metric_def_id
             grouped[(cid, mid)].append(mv.value)
             if mid not in metric_name_map:
-                metric_name_map[mid] = self._sanitise_metric_name(
-                    mv.metric_def.name,
-                )
+                slug = self._sanitise_metric_name(mv.metric_def.name)
+                # Append suffix if slug collides with another metric
+                if slug in used_slugs:
+                    suffix = 2
+                    while f"{slug}_{suffix}" in used_slugs:
+                        suffix += 1
+                    slug = f"{slug}_{suffix}"
+                used_slugs.add(slug)
+                metric_name_map[mid] = slug
 
         result: dict[int, dict[str, dict[str, Any]]] = defaultdict(dict)
         for (cid, mid), values in grouped.items():

--- a/apps/reports/deidentify.py
+++ b/apps/reports/deidentify.py
@@ -1,0 +1,1282 @@
+"""De-identification pipeline for evaluation microdata export.
+
+Transforms identified participant data into de-identified, k-anonymous
+microdata suitable for external evaluators.  Follows the 10-step pipeline
+specified in the DRR (tasks/design-rationale/evaluation-microdata-export.md).
+
+Key privacy guarantees:
+- Direct identifiers (name, phone, email, exact birth date, record ID)
+  are stripped before any output is produced.
+- Quasi-identifiers (age, gender, geography) are generalised into bands.
+- k-anonymity (k >= 5) is enforced: every combination of quasi-identifier
+  values in the output must appear in at least 5 records.
+- Violations are resolved by widening age bands, suppressing geography,
+  and finally suppressing records entirely.
+- Export is blocked when the population is too small (< 15), the
+  suppression rate exceeds 15 %, or too many QI columns are requested
+  for the population size.
+
+Canadian spelling is used throughout (generalise, organisation, colour).
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+import logging
+import os
+import secrets
+import uuid
+from collections import Counter, defaultdict
+from dataclasses import dataclass, field
+from datetime import date
+from typing import Any
+
+from django.conf import settings
+from django.db.models import Q, Sum
+from django.utils import timezone
+
+from apps.audit.models import AuditLog
+from apps.clients.models import ClientDetailValue, ClientFile, ServiceEpisode
+from apps.notes.models import MetricValue, ProgressNote
+from apps.plans.models import MetricDefinition, PlanTarget, PlanTargetMetric
+from apps.reports.csv_utils import sanitise_csv_value
+from apps.reports.suppression import SMALL_CELL_THRESHOLD
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Age band definitions
+# ---------------------------------------------------------------------------
+
+# Standard 5-year grouping (DRR spec)
+EVAL_AGE_BANDS = [
+    (0, 17, "0-17"),
+    (18, 24, "18-24"),
+    (25, 29, "25-29"),
+    (30, 34, "30-34"),
+    (35, 39, "35-39"),
+    (40, 44, "40-44"),
+    (45, 49, "45-49"),
+    (50, 54, "50-54"),
+    (55, 59, "55-59"),
+    (60, 64, "60-64"),
+    (65, 999, "65+"),
+]
+
+# Widened age bands for k-anonymity resolution — used when 5-year bands
+# produce equivalence classes smaller than TARGET_K.
+WIDENED_AGE_BANDS = [
+    (0, 17, "0-17"),
+    (18, 29, "18-29"),
+    (30, 44, "30-44"),
+    (45, 64, "45-64"),
+    (65, 999, "65+"),
+]
+
+
+# ---------------------------------------------------------------------------
+# Pipeline constants
+# ---------------------------------------------------------------------------
+
+TARGET_K = 5                # minimum equivalence class size
+SUPPRESSION_CEILING = 0.15  # 15 % — block export if exceeded
+MIN_POPULATION = 15         # absolute minimum for any export
+QI_LIMIT_SMALL = 3          # max QI columns for 15 <= n < 30
+QI_LIMIT_LARGE = 5          # max QI columns for n >= 30
+QI_THRESHOLD_LARGE = 30     # population size threshold
+
+
+# ---------------------------------------------------------------------------
+# Result dataclasses
+# ---------------------------------------------------------------------------
+
+@dataclass
+class PreviewResult:
+    """Summary of what the pipeline would produce, without writing files."""
+
+    eligible_count: int
+    consented_count: int
+    exportable_count: int
+    suppressed_count: int
+    suppression_rate: float
+    effective_k: int
+    qi_columns_used: list[str]
+    generalizations_applied: list[dict[str, Any]]
+    suppression_details: list[dict[str, Any]]
+    blocked: bool
+    block_reason: str | None
+    tier: str  # "aggregate_only", "limited_qi", "full"
+
+
+@dataclass
+class GenerateResult:
+    """Output of a successful pipeline run."""
+
+    csv_path: str
+    suppression_report_path: str
+    preview: PreviewResult
+    linkage_blob: bytes  # encrypted JSON mapping study_id -> real client_id
+    audit_metadata: dict[str, Any]
+
+
+# ---------------------------------------------------------------------------
+# Pipeline
+# ---------------------------------------------------------------------------
+
+class DeidentificationPipeline:
+    """10-step pipeline that transforms identified participant data
+    into de-identified, k-anonymous microdata for evaluation export.
+
+    Each step is a separate method that logs to the audit trail.
+    The pipeline is run in preview mode (dry run) first to show the
+    user what will happen, then in generate mode to produce output.
+    """
+
+    def __init__(
+        self,
+        program,
+        period_start: date,
+        period_end: date,
+        qi_columns: list[str],
+        evaluator_info: dict[str, Any],
+        user,
+        request=None,
+    ):
+        self.program = program
+        self.period_start = period_start
+        self.period_end = period_end
+        self.qi_columns = list(qi_columns)
+        self.evaluator_info = evaluator_info
+        self.user = user
+        self.request = request
+
+        # Internal state populated by pipeline steps
+        self._raw_records: list[dict[str, Any]] = []
+        self._staged_records: list[dict[str, Any]] = []
+        self._consented_records: list[dict[str, Any]] = []
+        self._deidentified_records: list[dict[str, Any]] = []
+        self._linkage_table: dict[str, int] = {}
+        self._generalizations_applied: list[dict[str, Any]] = []
+        self._suppressed_records: list[dict[str, Any]] = []
+        self._suppression_reasons: list[dict[str, Any]] = []
+        self._blocked = False
+        self._block_reason: str | None = None
+        self._effective_k = 0
+        self._metric_defs: list[MetricDefinition] = []
+
+    # ------------------------------------------------------------------
+    # Public interface
+    # ------------------------------------------------------------------
+
+    def run_preview(self) -> PreviewResult:
+        """Execute steps 1-8 without generating output files."""
+        self._reset_state()
+
+        self._extract_raw_data()               # Step 1
+        self._decrypt_and_stage()              # Step 2
+        self._apply_consent_filter()           # Step 3
+        self._strip_direct_identifiers()       # Step 4
+        self._generalise_quasi_identifiers()   # Step 5
+
+        # Check population threshold BEFORE k-anonymity
+        tier = self._check_population_threshold()  # Step 8 (early)
+        if self._blocked:
+            return self._build_preview_result(tier)
+
+        self._compute_k_anonymity()            # Step 6
+        self._resolve_k_violations()           # Step 7
+
+        # Re-check after resolution (suppression may have shrunk population)
+        tier = self._check_population_threshold()  # Step 8
+        return self._build_preview_result(tier)
+
+    def run_generate(self) -> GenerateResult:
+        """Execute all 10 steps and produce CSV + suppression report.
+
+        Must only be called after run_preview() confirms the export is
+        not blocked.
+
+        Raises:
+            ValueError: If the export is blocked (population too small,
+                suppression rate exceeded, too many QI columns).
+        """
+        # Re-run preview steps to get fresh data
+        preview = self.run_preview()
+        if preview.blocked:
+            raise ValueError(f"Export blocked: {preview.block_reason}")
+
+        csv_path = self._generate_csv()                    # Step 9
+        report_path = self._generate_suppression_report()  # Step 10
+
+        # Encrypt the linkage table
+        from konote.encryption import encrypt_field
+        linkage_blob = encrypt_field(json.dumps(self._linkage_table))
+
+        audit_metadata = self._build_audit_metadata(preview)
+        self._log_audit("export", "Export generated", metadata=audit_metadata)
+
+        return GenerateResult(
+            csv_path=csv_path,
+            suppression_report_path=report_path,
+            preview=preview,
+            linkage_blob=linkage_blob,
+            audit_metadata=audit_metadata,
+        )
+
+    # ------------------------------------------------------------------
+    # Step 1: Extract raw data
+    # ------------------------------------------------------------------
+
+    def _extract_raw_data(self):
+        """Query database for all participants and metrics in the period.
+
+        Populates self._raw_records with one dict per participant,
+        containing the raw encrypted model instances (not yet decrypted).
+        """
+        self._log_audit("view", "Pipeline initiated — extracting raw data")
+
+        # Find service episodes that overlap the reporting period.
+        # An episode overlaps if it started on or before period_end AND
+        # has not ended before period_start (or has no end date).
+        episodes = ServiceEpisode.objects.filter(
+            program=self.program,
+            status__in=["active", "on_hold", "finished"],
+        ).filter(
+            Q(started_at__date__lte=self.period_end) | Q(started_at__isnull=True),
+        ).filter(
+            Q(ended_at__date__gte=self.period_start)
+            | Q(ended_at__isnull=True)
+        ).select_related("client_file")
+
+        # Deduplicate: a client may have multiple episodes — we want one
+        # record per client, keeping the most relevant episode.
+        client_episodes: dict[int, tuple[ClientFile, ServiceEpisode]] = {}
+        for ep in episodes:
+            client = ep.client_file
+            # Skip demo clients
+            if client.is_demo:
+                continue
+            # Keep the most recent episode if multiple exist
+            existing = client_episodes.get(client.pk)
+            if existing is None or (ep.started_at and (
+                not existing[1].started_at or ep.started_at > existing[1].started_at
+            )):
+                client_episodes[client.pk] = (client, ep)
+
+        # Collect client IDs for metric queries
+        client_ids = list(client_episodes.keys())
+
+        # Get all metric definitions used in this program via plan targets
+        self._metric_defs = list(
+            MetricDefinition.objects.filter(
+                plantargetmetric__plan_target__plan_section__client_file_id__in=client_ids,
+                plantargetmetric__plan_target__plan_section__program=self.program,
+            ).distinct().order_by("name")
+        )
+
+        # Build raw records
+        for client_id, (client, episode) in client_episodes.items():
+            self._raw_records.append({
+                "_client": client,
+                "_episode": episode,
+                "_client_id": client.pk,
+            })
+
+        logger.info(
+            "Step 1: Extracted %d raw records for program %s",
+            len(self._raw_records), self.program.pk,
+        )
+
+    # ------------------------------------------------------------------
+    # Step 2: Decrypt and stage
+    # ------------------------------------------------------------------
+
+    def _decrypt_and_stage(self):
+        """Decrypt PII fields and build working dicts.
+
+        Accesses encrypted property accessors (.birth_date, .first_name,
+        .last_name) for staging only — these values will be stripped in
+        Step 4.
+        """
+        self._log_audit("view", "Decrypting and staging records")
+
+        for raw in self._raw_records:
+            client: ClientFile = raw["_client"]
+            episode: ServiceEpisode = raw["_episode"]
+
+            # Count sessions (progress notes) in the period
+            note_qs = ProgressNote.objects.filter(
+                client_file=client,
+                created_at__date__range=(self.period_start, self.period_end),
+            )
+            sessions_count = note_qs.count()
+
+            # Sum duration minutes, convert to hours
+            duration_agg = note_qs.aggregate(
+                total_minutes=Sum("duration_minutes"),
+            )
+            total_minutes = duration_agg["total_minutes"] or 0
+            total_hours = round(total_minutes / 60, 1) if total_minutes else 0.0
+
+            # Get metric values (intake = earliest, latest = most recent)
+            metric_data = self._get_metric_data(client)
+
+            # Get custom field values for QI columns
+            custom_field_values = self._get_custom_field_values(client)
+
+            # Get postal code for geography derivation (if needed)
+            postal_code = self._get_postal_code(client)
+
+            # Build staged record
+            staged = {
+                "_client_id": client.pk,
+                "_episode": episode,
+                # PII fields — will be stripped in Step 4
+                "_first_name": client.first_name,
+                "_last_name": client.last_name,
+                "_birth_date": client.birth_date,
+                "_postal_code": postal_code,
+                # Consent flag
+                "_consent": episode.consent_to_aggregate_reporting,
+                # Non-PII operational data
+                "enrolment_date": (
+                    episode.started_at.date()
+                    if episode.started_at else None
+                ),
+                "exit_date": (
+                    episode.ended_at.date()
+                    if episode.ended_at else None
+                ),
+                "sessions_count": sessions_count,
+                "total_hours": total_hours,
+                "metrics": metric_data,
+                "custom_fields": custom_field_values,
+            }
+            self._staged_records.append(staged)
+
+        logger.info(
+            "Step 2: Staged %d records with decrypted fields",
+            len(self._staged_records),
+        )
+
+    def _get_metric_data(self, client: ClientFile) -> dict[str, dict[str, Any]]:
+        """Get intake and latest metric values for a client.
+
+        Returns a dict keyed by metric definition name, with intake and
+        latest values for each.
+        """
+        result: dict[str, dict[str, Any]] = {}
+
+        for metric_def in self._metric_defs:
+            values = MetricValue.objects.filter(
+                progress_note_target__progress_note__client_file=client,
+                progress_note_target__progress_note__created_at__date__range=(
+                    self.period_start, self.period_end,
+                ),
+                metric_def=metric_def,
+            ).select_related(
+                "progress_note_target__progress_note",
+            ).order_by("progress_note_target__progress_note__created_at")
+
+            if not values.exists():
+                continue
+
+            values_list = list(values)
+            intake_val = values_list[0].value if values_list else None
+            latest_val = values_list[-1].value if values_list else None
+
+            # Sanitise the metric name for use as a column header
+            safe_name = self._sanitise_metric_name(metric_def.name)
+            result[safe_name] = {
+                "intake": intake_val,
+                "latest": latest_val,
+            }
+
+        return result
+
+    def _get_custom_field_values(self, client: ClientFile) -> dict[str, str]:
+        """Get custom field values relevant to the selected QI columns.
+
+        Only fetches fields that are used as quasi-identifiers.
+        """
+        result: dict[str, str] = {}
+
+        # QI columns that correspond to custom fields (not age_group or geography)
+        custom_qi = [
+            col for col in self.qi_columns
+            if col not in ("age_group", "geography")
+        ]
+        if not custom_qi:
+            return result
+
+        # Query all ClientDetailValue records for this client
+        detail_values = ClientDetailValue.objects.filter(
+            client_file=client,
+            field_def__status="active",
+        ).select_related("field_def", "field_def__group")
+
+        for dv in detail_values:
+            field_name_lower = dv.field_def.name.lower().replace(" ", "_")
+            if field_name_lower in custom_qi:
+                raw_val = dv.get_value()
+                # For dropdown fields, resolve to the option label
+                if dv.field_def.input_type in ("select", "select_other"):
+                    raw_val = self._resolve_option_label(dv.field_def, raw_val)
+                result[field_name_lower] = raw_val or ""
+
+        return result
+
+    def _get_postal_code(self, client: ClientFile) -> str | None:
+        """Retrieve postal code from custom field values.
+
+        Looks for a field with validation_type="postal_code" or named
+        "Postal Code".
+        """
+        postal_dv = ClientDetailValue.objects.filter(
+            client_file=client,
+            field_def__status="active",
+        ).filter(
+            Q(field_def__validation_type="postal_code")
+            | Q(field_def__name__iexact="Postal Code")
+        ).select_related("field_def").first()
+
+        if postal_dv:
+            return postal_dv.get_value() or None
+        return None
+
+    def _resolve_option_label(self, field_def, raw_value: str) -> str:
+        """Resolve a dropdown value to its display label."""
+        if not field_def.options_json or not raw_value:
+            return raw_value or ""
+        for option in field_def.options_json:
+            if isinstance(option, dict):
+                if option.get("value", "") == raw_value:
+                    return option.get("label", raw_value)
+            elif option == raw_value:
+                return raw_value
+        return raw_value
+
+    @staticmethod
+    def _sanitise_metric_name(name: str) -> str:
+        """Convert a metric name to a safe column name slug.
+
+        Replaces spaces/special chars with underscores and lowercases.
+        """
+        import re
+        safe = re.sub(r"[^a-z0-9]+", "_", name.lower()).strip("_")
+        return safe or "metric"
+
+    # ------------------------------------------------------------------
+    # Step 3: Apply consent filter
+    # ------------------------------------------------------------------
+
+    def _apply_consent_filter(self):
+        """Remove records where the participant has not consented to
+        aggregate reporting for this program.
+        """
+        self._log_audit("view", "Applying consent filter")
+
+        excluded_count = 0
+        for record in self._staged_records:
+            if record.get("_consent", False):
+                self._consented_records.append(record)
+            else:
+                excluded_count += 1
+
+        logger.info(
+            "Step 3: %d consented, %d excluded (no consent)",
+            len(self._consented_records), excluded_count,
+        )
+
+    # ------------------------------------------------------------------
+    # Step 4: Strip direct identifiers
+    # ------------------------------------------------------------------
+
+    def _strip_direct_identifiers(self):
+        """Remove all direct identifiers and generate pseudonymous
+        study IDs.
+
+        Direct identifiers removed: first_name, last_name, exact
+        birth_date, postal_code, real client_id.
+        """
+        self._log_audit("view", "Stripping direct identifiers")
+
+        used_study_ids: set[str] = set()
+
+        for record in self._consented_records:
+            # Generate a unique study ID
+            study_id = self._generate_study_id(used_study_ids)
+            used_study_ids.add(study_id)
+
+            # Build linkage table entry
+            self._linkage_table[study_id] = record["_client_id"]
+
+            # Create de-identified record — carry forward only what's needed
+            deidentified = {
+                "study_id": study_id,
+                # Preserve birth_date temporarily for age generalisation
+                "_birth_date": record.get("_birth_date"),
+                # Preserve postal code temporarily for geography derivation
+                "_postal_code": record.get("_postal_code"),
+                # Non-PII fields pass through
+                "enrolment_date": record.get("enrolment_date"),
+                "exit_date": record.get("exit_date"),
+                "sessions_count": record.get("sessions_count", 0),
+                "total_hours": record.get("total_hours", 0.0),
+                "metrics": record.get("metrics", {}),
+                "custom_fields": record.get("custom_fields", {}),
+                # Suppression tracking
+                "_suppressed": False,
+            }
+            self._deidentified_records.append(deidentified)
+
+        logger.info(
+            "Step 4: Generated %d pseudonymous study IDs",
+            len(self._deidentified_records),
+        )
+
+    @staticmethod
+    def _generate_study_id(existing: set[str]) -> str:
+        """Generate a unique random study ID in format EVL-XXXXXX."""
+        for _ in range(1000):  # safety limit
+            candidate = f"EVL-{secrets.token_hex(3).upper()}"
+            if candidate not in existing:
+                return candidate
+        # Extremely unlikely fallback
+        return f"EVL-{uuid.uuid4().hex[:6].upper()}"
+
+    # ------------------------------------------------------------------
+    # Step 5: Generalise quasi-identifiers
+    # ------------------------------------------------------------------
+
+    def _generalise_quasi_identifiers(self):
+        """Generalise quasi-identifiers into broader categories.
+
+        - age_group: exact birth_date -> 5-year age band
+        - gender: pass through from custom field
+        - ethnicity: pass through from custom field
+        - geography: postal code FSA -> Urban/Rural
+        - Enrolment/exit dates -> quarter/year
+        """
+        self._log_audit("view", "Generalising quasi-identifiers")
+
+        for record in self._deidentified_records:
+            # Age generalisation
+            if "age_group" in self.qi_columns:
+                birth_date = record.pop("_birth_date", None)
+                age = self._compute_age(birth_date)
+                band = self._age_to_band(age, EVAL_AGE_BANDS)
+                record["age_group"] = band
+
+                if birth_date and band:
+                    self._generalizations_applied.append({
+                        "field": "age_group",
+                        "original": "exact birth date",
+                        "widened_to": band,
+                    })
+            else:
+                # Remove the temporary field if not used
+                record.pop("_birth_date", None)
+
+            # Geography generalisation (Urban/Rural from postal code FSA)
+            if "geography" in self.qi_columns:
+                postal_code = record.pop("_postal_code", None)
+                geo = self._postal_code_to_geography(postal_code)
+                record["geography"] = geo
+
+                if postal_code and geo:
+                    self._generalizations_applied.append({
+                        "field": "geography",
+                        "original": "postal code",
+                        "widened_to": geo,
+                    })
+            else:
+                record.pop("_postal_code", None)
+
+            # Custom field QI columns (gender, ethnicity, etc.)
+            custom_fields = record.get("custom_fields", {})
+            for col in self.qi_columns:
+                if col not in ("age_group", "geography"):
+                    record[col] = custom_fields.get(col, None)
+
+            # Generalise dates to quarters
+            record["enrolment_quarter"] = self._date_to_quarter(
+                record.pop("enrolment_date", None),
+            )
+            record["exit_quarter"] = self._date_to_quarter(
+                record.pop("exit_date", None),
+            )
+
+        # Deduplicate generalisation log entries
+        seen = set()
+        unique_generalizations = []
+        for g in self._generalizations_applied:
+            key = (g["field"], g["widened_to"])
+            if key not in seen:
+                seen.add(key)
+                unique_generalizations.append(g)
+        self._generalizations_applied = unique_generalizations
+
+        logger.info(
+            "Step 5: Applied %d generalisations",
+            len(self._generalizations_applied),
+        )
+
+    @staticmethod
+    def _postal_code_to_geography(postal_code: str | None) -> str | None:
+        """Derive Urban/Rural from a Canadian postal code FSA.
+
+        In Canadian postal codes, the second character of the FSA
+        (Forward Sortation Area) indicates urban vs. rural:
+        - 0 = rural delivery area
+        - 1-9 = urban delivery area
+        """
+        if not postal_code or len(postal_code) < 2:
+            return None
+
+        # Clean up — remove spaces, uppercase
+        cleaned = postal_code.strip().upper().replace(" ", "")
+        if len(cleaned) < 2:
+            return None
+
+        second_char = cleaned[1]
+        if not second_char.isdigit():
+            return None
+
+        if second_char == "0":
+            return "Rural"
+        return "Urban"
+
+    # ------------------------------------------------------------------
+    # Step 6: Compute k-anonymity
+    # ------------------------------------------------------------------
+
+    def _compute_k_anonymity(self):
+        """Compute the effective k-anonymity of the current dataset.
+
+        Groups records by their QI column values (equivalence classes)
+        and finds the minimum class size.
+        """
+        self._log_audit("view", "Computing k-anonymity")
+
+        active_records = [
+            r for r in self._deidentified_records if not r.get("_suppressed")
+        ]
+
+        if not active_records:
+            self._effective_k = 0
+            return
+
+        eq_classes = self._build_equivalence_classes(active_records)
+        self._effective_k = min(eq_classes.values()) if eq_classes else 0
+
+        logger.info(
+            "Step 6: Effective k = %d across %d equivalence classes",
+            self._effective_k, len(eq_classes),
+        )
+
+    def _build_equivalence_classes(
+        self, records: list[dict[str, Any]],
+    ) -> dict[tuple, int]:
+        """Group records by their QI tuple and return class sizes."""
+        eq_classes: dict[tuple, int] = Counter()
+
+        for record in records:
+            qi_tuple = self._qi_tuple(record)
+            eq_classes[qi_tuple] += 1
+
+        return dict(eq_classes)
+
+    def _qi_tuple(self, record: dict[str, Any]) -> tuple:
+        """Build a tuple of QI values for a record."""
+        values = []
+        for col in self.qi_columns:
+            values.append(record.get(col))
+        return tuple(values)
+
+    # ------------------------------------------------------------------
+    # Step 7: Resolve k-anonymity violations
+    # ------------------------------------------------------------------
+
+    def _resolve_k_violations(self):
+        """Resolve equivalence classes smaller than TARGET_K.
+
+        Resolution strategy (in order):
+        1. Widen age bands from 5-year to coarser bands
+        2. Suppress geography (set to null)
+        3. Suppress the entire record
+
+        After each step, re-check k-anonymity. Stop when all classes
+        meet the threshold.
+        """
+        self._log_audit("view", "Resolving k-anonymity violations")
+
+        active_records = [
+            r for r in self._deidentified_records if not r.get("_suppressed")
+        ]
+        if not active_records:
+            return
+
+        eq_classes = self._build_equivalence_classes(active_records)
+        min_k = min(eq_classes.values()) if eq_classes else 0
+
+        if min_k >= TARGET_K:
+            self._effective_k = min_k
+            return
+
+        # Strategy 1: Widen age bands
+        if "age_group" in self.qi_columns:
+            widened = self._try_widen_age_bands(active_records)
+            if widened:
+                self._generalizations_applied.append({
+                    "field": "age_group",
+                    "original": "5-year bands",
+                    "widened_to": "coarser bands (0-17, 18-29, 30-44, 45-64, 65+)",
+                })
+                # Re-check
+                eq_classes = self._build_equivalence_classes(active_records)
+                min_k = min(eq_classes.values()) if eq_classes else 0
+                if min_k >= TARGET_K:
+                    self._effective_k = min_k
+                    return
+
+        # Strategy 2: Suppress geography (set to null for small classes)
+        if "geography" in self.qi_columns:
+            geography_suppressed = self._try_suppress_geography(active_records)
+            if geography_suppressed:
+                self._suppression_reasons.append({
+                    "reason": "geography_suppressed",
+                    "count": geography_suppressed,
+                    "description": (
+                        f"Geography set to null for {geography_suppressed} "
+                        f"records in small equivalence classes"
+                    ),
+                })
+                # Re-check
+                eq_classes = self._build_equivalence_classes(active_records)
+                min_k = min(eq_classes.values()) if eq_classes else 0
+                if min_k >= TARGET_K:
+                    self._effective_k = min_k
+                    return
+
+        # Strategy 3: Suppress records in classes still below threshold
+        suppressed_count = self._suppress_small_classes(active_records)
+        if suppressed_count:
+            self._suppression_reasons.append({
+                "reason": "record_suppressed",
+                "count": suppressed_count,
+                "description": (
+                    f"{suppressed_count} records suppressed — equivalence "
+                    f"class too small even after generalisation"
+                ),
+            })
+
+        # Final k computation on remaining records
+        remaining = [
+            r for r in self._deidentified_records if not r.get("_suppressed")
+        ]
+        if remaining:
+            eq_classes = self._build_equivalence_classes(remaining)
+            self._effective_k = min(eq_classes.values()) if eq_classes else 0
+        else:
+            self._effective_k = 0
+
+        # Check suppression rate
+        total = len(self._deidentified_records)
+        suppressed_total = sum(
+            1 for r in self._deidentified_records if r.get("_suppressed")
+        )
+        if total > 0:
+            suppression_rate = suppressed_total / total
+            if suppression_rate > SUPPRESSION_CEILING:
+                self._blocked = True
+                self._block_reason = "suppression_rate_exceeded"
+                logger.warning(
+                    "Step 7: Suppression rate %.1f%% exceeds ceiling %.1f%%",
+                    suppression_rate * 100, SUPPRESSION_CEILING * 100,
+                )
+
+        logger.info(
+            "Step 7: Resolved violations — effective k = %d, "
+            "%d records suppressed",
+            self._effective_k, suppressed_total,
+        )
+
+    def _try_widen_age_bands(self, records: list[dict[str, Any]]) -> bool:
+        """Re-map age_group from 5-year bands to wider bands.
+
+        Returns True if any records were re-mapped.
+        """
+        changed = False
+        for record in records:
+            if record.get("_suppressed"):
+                continue
+            current = record.get("age_group")
+            if current is None:
+                continue
+            # Find which widened band this falls into
+            widened = self._remap_to_widened_band(current)
+            if widened and widened != current:
+                record["age_group"] = widened
+                changed = True
+        return changed
+
+    @staticmethod
+    def _remap_to_widened_band(narrow_band: str) -> str | None:
+        """Map a 5-year band label to the corresponding widened band."""
+        # Parse the narrow band to extract age range
+        narrow_to_wide = {
+            "0-17": "0-17",
+            "18-24": "18-29",
+            "25-29": "18-29",
+            "30-34": "30-44",
+            "35-39": "30-44",
+            "40-44": "30-44",
+            "45-49": "45-64",
+            "50-54": "45-64",
+            "55-59": "45-64",
+            "60-64": "45-64",
+            "65+": "65+",
+        }
+        return narrow_to_wide.get(narrow_band, narrow_band)
+
+    def _try_suppress_geography(
+        self, records: list[dict[str, Any]],
+    ) -> int:
+        """Set geography to None for records in small equivalence classes.
+
+        Returns the number of records affected.
+        """
+        eq_classes = self._build_equivalence_classes(
+            [r for r in records if not r.get("_suppressed")]
+        )
+        # Identify QI tuples with class size < TARGET_K
+        small_tuples = {
+            qt for qt, count in eq_classes.items() if count < TARGET_K
+        }
+        if not small_tuples:
+            return 0
+
+        affected = 0
+        for record in records:
+            if record.get("_suppressed"):
+                continue
+            qt = self._qi_tuple(record)
+            if qt in small_tuples and record.get("geography") is not None:
+                record["geography"] = None
+                affected += 1
+
+        return affected
+
+    def _suppress_small_classes(
+        self, records: list[dict[str, Any]],
+    ) -> int:
+        """Suppress (mark) records in equivalence classes still below
+        TARGET_K after generalisation.
+
+        Returns the count of newly suppressed records.
+        """
+        active = [r for r in records if not r.get("_suppressed")]
+        eq_classes = self._build_equivalence_classes(active)
+        small_tuples = {
+            qt for qt, count in eq_classes.items() if count < TARGET_K
+        }
+        if not small_tuples:
+            return 0
+
+        suppressed_count = 0
+        for record in self._deidentified_records:
+            if record.get("_suppressed"):
+                continue
+            qt = self._qi_tuple(record)
+            if qt in small_tuples:
+                record["_suppressed"] = True
+                suppressed_count += 1
+
+        return suppressed_count
+
+    # ------------------------------------------------------------------
+    # Step 8: Check population threshold
+    # ------------------------------------------------------------------
+
+    def _check_population_threshold(self) -> str:
+        """Determine the export tier based on population size and
+        QI column count.
+
+        Tiers:
+        - "aggregate_only": n < 15, export blocked
+        - "limited_qi": 15 <= n < 30, max 3 QI columns
+        - "full": n >= 30, max 5 QI columns
+
+        Returns the tier string.
+        """
+        exportable = [
+            r for r in self._deidentified_records
+            if not r.get("_suppressed")
+        ]
+        n = len(exportable)
+        qi_count = len(self.qi_columns)
+
+        if n < MIN_POPULATION:
+            self._blocked = True
+            self._block_reason = "population_too_small"
+            logger.warning(
+                "Step 8: Population %d < minimum %d — export blocked",
+                n, MIN_POPULATION,
+            )
+            return "aggregate_only"
+
+        if n < QI_THRESHOLD_LARGE:
+            if qi_count > QI_LIMIT_SMALL:
+                self._blocked = True
+                self._block_reason = "too_many_qi_columns"
+                logger.warning(
+                    "Step 8: %d QI columns exceeds limit of %d for "
+                    "population %d (< %d)",
+                    qi_count, QI_LIMIT_SMALL, n, QI_THRESHOLD_LARGE,
+                )
+            return "limited_qi"
+
+        # n >= QI_THRESHOLD_LARGE
+        if qi_count > QI_LIMIT_LARGE:
+            self._blocked = True
+            self._block_reason = "too_many_qi_columns"
+            logger.warning(
+                "Step 8: %d QI columns exceeds limit of %d for "
+                "population %d",
+                qi_count, QI_LIMIT_LARGE, n,
+            )
+        return "full"
+
+    # ------------------------------------------------------------------
+    # Step 9: Generate CSV
+    # ------------------------------------------------------------------
+
+    def _generate_csv(self) -> str:
+        """Write de-identified data as CSV with metadata header.
+
+        Returns the absolute path to the generated file.
+        """
+        self._log_audit("export", "Generating CSV file")
+
+        export_dir = getattr(
+            settings, "SECURE_EXPORT_DIR", "/tmp/konote_exports",
+        )
+        os.makedirs(export_dir, exist_ok=True)
+
+        timestamp = timezone.now().strftime("%Y%m%d_%H%M%S")
+        filename = f"eval_microdata_{self.program.pk}_{timestamp}.csv"
+        filepath = os.path.join(export_dir, filename)
+
+        exportable = [
+            r for r in self._deidentified_records
+            if not r.get("_suppressed")
+        ]
+
+        # Build column headers
+        columns = self._build_csv_columns()
+
+        with open(filepath, "w", newline="", encoding="utf-8-sig") as f:
+            # Metadata header (comment lines)
+            f.write(f"# KoNote Evaluation Microdata Export\n")
+            f.write(f"# Program: {sanitise_csv_value(self.program.name)}\n")
+            f.write(f"# Period: {self.period_start} to {self.period_end}\n")
+            f.write(f"# Generated: {timezone.now().isoformat()}\n")
+            f.write(f"# Records: {len(exportable)}\n")
+            f.write(f"# Effective k: {self._effective_k}\n")
+            f.write(f"# QI columns: {', '.join(self.qi_columns)}\n")
+            f.write(f"#\n")
+
+            writer = csv.writer(f)
+            writer.writerow([sanitise_csv_value(c) for c in columns])
+
+            for record in exportable:
+                row = self._record_to_row(record, columns)
+                writer.writerow([sanitise_csv_value(v) for v in row])
+
+        logger.info("Step 9: CSV written to %s (%d rows)", filepath, len(exportable))
+        return filepath
+
+    def _build_csv_columns(self) -> list[str]:
+        """Build the ordered list of CSV column headers."""
+        columns = ["study_id"]
+
+        # QI columns
+        for col in self.qi_columns:
+            columns.append(col)
+
+        # Temporal columns
+        columns.extend(["enrolment_quarter", "exit_quarter"])
+
+        # Service columns
+        columns.extend(["sessions_count", "total_hours"])
+
+        # Metric columns (intake and latest for each metric)
+        for metric_def in self._metric_defs:
+            safe_name = self._sanitise_metric_name(metric_def.name)
+            columns.append(f"metric_{safe_name}_intake")
+            columns.append(f"metric_{safe_name}_latest")
+
+        return columns
+
+    def _record_to_row(
+        self,
+        record: dict[str, Any],
+        columns: list[str],
+    ) -> list[Any]:
+        """Convert a de-identified record dict to a CSV row."""
+        row = []
+        metrics = record.get("metrics", {})
+
+        for col in columns:
+            if col == "study_id":
+                row.append(record.get("study_id", ""))
+            elif col in self.qi_columns:
+                row.append(record.get(col, ""))
+            elif col == "enrolment_quarter":
+                row.append(record.get("enrolment_quarter", ""))
+            elif col == "exit_quarter":
+                row.append(record.get("exit_quarter", ""))
+            elif col == "sessions_count":
+                row.append(record.get("sessions_count", 0))
+            elif col == "total_hours":
+                row.append(record.get("total_hours", 0.0))
+            elif col.startswith("metric_") and col.endswith("_intake"):
+                metric_key = col[len("metric_"):-len("_intake")]
+                metric_data = metrics.get(metric_key, {})
+                row.append(metric_data.get("intake", ""))
+            elif col.startswith("metric_") and col.endswith("_latest"):
+                metric_key = col[len("metric_"):-len("_latest")]
+                metric_data = metrics.get(metric_key, {})
+                row.append(metric_data.get("latest", ""))
+            else:
+                row.append("")
+
+        return row
+
+    # ------------------------------------------------------------------
+    # Step 10: Generate suppression report
+    # ------------------------------------------------------------------
+
+    def _generate_suppression_report(self) -> str:
+        """Write a JSON suppression report alongside the CSV.
+
+        The report documents what was suppressed and why, for audit
+        and transparency.
+        """
+        self._log_audit("export", "Generating suppression report")
+
+        export_dir = getattr(
+            settings, "SECURE_EXPORT_DIR", "/tmp/konote_exports",
+        )
+        os.makedirs(export_dir, exist_ok=True)
+
+        timestamp = timezone.now().strftime("%Y%m%d_%H%M%S")
+        filename = f"eval_suppression_report_{self.program.pk}_{timestamp}.json"
+        filepath = os.path.join(export_dir, filename)
+
+        exportable = [
+            r for r in self._deidentified_records
+            if not r.get("_suppressed")
+        ]
+        suppressed = [
+            r for r in self._deidentified_records
+            if r.get("_suppressed")
+        ]
+
+        report = {
+            "generated_at": timezone.now().isoformat(),
+            "program_id": self.program.pk,
+            "program_name": self.program.name,
+            "period": {
+                "start": str(self.period_start),
+                "end": str(self.period_end),
+            },
+            "population": {
+                "eligible": len(self._raw_records),
+                "consented": len(self._consented_records),
+                "exportable": len(exportable),
+                "suppressed": len(suppressed),
+            },
+            "privacy": {
+                "target_k": TARGET_K,
+                "effective_k": self._effective_k,
+                "suppression_rate": round(
+                    len(suppressed) / (len(exportable) + len(suppressed))
+                    if (len(exportable) + len(suppressed)) > 0
+                    else 0.0,
+                    3,
+                ),
+                "suppression_ceiling": SUPPRESSION_CEILING,
+                "qi_columns": self.qi_columns,
+            },
+            "generalizations": self._generalizations_applied,
+            "suppression_reasons": self._suppression_reasons,
+            "evaluator": {
+                "name": self.evaluator_info.get("name", ""),
+                "organisation": self.evaluator_info.get("organisation", ""),
+                "purpose": self.evaluator_info.get("purpose", ""),
+            },
+        }
+
+        with open(filepath, "w", encoding="utf-8") as f:
+            json.dump(report, f, indent=2, ensure_ascii=False, default=str)
+
+        logger.info("Step 10: Suppression report written to %s", filepath)
+        return filepath
+
+    # ------------------------------------------------------------------
+    # Helper methods
+    # ------------------------------------------------------------------
+
+    def _reset_state(self):
+        """Clear all internal state for a fresh pipeline run."""
+        self._raw_records = []
+        self._staged_records = []
+        self._consented_records = []
+        self._deidentified_records = []
+        self._linkage_table = {}
+        self._generalizations_applied = []
+        self._suppressed_records = []
+        self._suppression_reasons = []
+        self._blocked = False
+        self._block_reason = None
+        self._effective_k = 0
+        self._metric_defs = []
+
+    def _log_audit(self, action: str, description: str, metadata=None):
+        """Log a pipeline step to the audit trail."""
+        from konote.utils import get_client_ip
+
+        try:
+            AuditLog.objects.using("audit").create(
+                event_timestamp=timezone.now(),
+                user_id=self.user.pk,
+                user_display=str(self.user),
+                ip_address=(
+                    get_client_ip(self.request) if self.request else None
+                ),
+                action=action,
+                resource_type="export",
+                program_id=self.program.pk,
+                metadata={
+                    "pipeline_step": description,
+                    "export_category": "evaluation_microdata",
+                    **(metadata or {}),
+                },
+            )
+        except Exception:
+            # Audit failure should not crash the pipeline — log and continue.
+            # The audit database might be temporarily unreachable.
+            logger.exception("Failed to write audit log: %s", description)
+
+    def _date_to_quarter(self, d) -> str | None:
+        """Convert a date to quarter/year string like Q3-2025."""
+        if not d:
+            return None
+        if isinstance(d, str):
+            try:
+                d = date.fromisoformat(d)
+            except (ValueError, TypeError):
+                return None
+        quarter = (d.month - 1) // 3 + 1
+        return f"Q{quarter}-{d.year}"
+
+    def _compute_age(
+        self,
+        birth_date,
+        as_of_date: date | None = None,
+    ) -> int | None:
+        """Compute age from birth date.
+
+        Args:
+            birth_date: Date of birth (date object or ISO string).
+            as_of_date: Calculate age as of this date (default: period_end).
+
+        Returns:
+            Integer age, or None if birth_date is missing/invalid.
+        """
+        if not birth_date:
+            return None
+        if isinstance(birth_date, str):
+            try:
+                birth_date = date.fromisoformat(birth_date)
+            except (ValueError, TypeError):
+                return None
+        if as_of_date is None:
+            as_of_date = self.period_end
+        age = as_of_date.year - birth_date.year
+        if (as_of_date.month, as_of_date.day) < (birth_date.month, birth_date.day):
+            age -= 1
+        return age
+
+    @staticmethod
+    def _age_to_band(age: int | None, bands=None) -> str | None:
+        """Map an integer age to an age band label."""
+        if age is None:
+            return None
+        if bands is None:
+            bands = EVAL_AGE_BANDS
+        for min_age, max_age, label in bands:
+            if min_age <= age <= max_age:
+                return label
+        return None
+
+    def _build_preview_result(self, tier: str) -> PreviewResult:
+        """Construct a PreviewResult from current pipeline state."""
+        exportable = [
+            r for r in self._deidentified_records
+            if not r.get("_suppressed")
+        ]
+        suppressed = [
+            r for r in self._deidentified_records
+            if r.get("_suppressed")
+        ]
+        total = len(exportable) + len(suppressed)
+
+        return PreviewResult(
+            eligible_count=len(self._raw_records),
+            consented_count=len(self._consented_records),
+            exportable_count=len(exportable),
+            suppressed_count=len(suppressed),
+            suppression_rate=len(suppressed) / total if total > 0 else 0.0,
+            effective_k=self._effective_k,
+            qi_columns_used=list(self.qi_columns),
+            generalizations_applied=list(self._generalizations_applied),
+            suppression_details=list(self._suppression_reasons),
+            blocked=self._blocked,
+            block_reason=self._block_reason,
+            tier=tier,
+        )
+
+    def _build_audit_metadata(self, preview: PreviewResult) -> dict[str, Any]:
+        """Build the full audit metadata blob for the export."""
+        return {
+            "export_category": "evaluation_microdata",
+            "evaluator_email": self.evaluator_info.get("email", ""),
+            "evaluator_name": self.evaluator_info.get("name", ""),
+            "evaluator_organisation": self.evaluator_info.get(
+                "organisation", "",
+            ),
+            "evaluation_purpose": self.evaluator_info.get("purpose", ""),
+            "data_sharing_agreement_expiry": str(
+                self.evaluator_info.get("agreement_expiry", ""),
+            ),
+            "program_id": self.program.pk,
+            "program_name": self.program.name,
+            "period_start": str(self.period_start),
+            "period_end": str(self.period_end),
+            "pipeline_summary": {
+                "eligible_count": preview.eligible_count,
+                "consented_count": preview.consented_count,
+                "exported_count": preview.exportable_count,
+                "suppressed_count": preview.suppressed_count,
+                "suppression_rate": round(preview.suppression_rate, 3),
+                "effective_k": preview.effective_k,
+                "qi_columns": preview.qi_columns_used,
+                "generalizations_applied": preview.generalizations_applied,
+            },
+        }

--- a/apps/reports/deidentify.py
+++ b/apps/reports/deidentify.py
@@ -26,6 +26,7 @@ import io
 import json
 import logging
 import os
+import re
 import secrets
 import uuid
 from collections import Counter, defaultdict
@@ -34,7 +35,7 @@ from datetime import date
 from typing import Any
 
 from django.conf import settings
-from django.db.models import Q, Sum
+from django.db.models import Count, Q, Sum
 from django.utils import timezone
 
 from apps.audit.models import AuditLog
@@ -42,7 +43,6 @@ from apps.clients.models import ClientDetailValue, ClientFile, ServiceEpisode
 from apps.notes.models import MetricValue, ProgressNote
 from apps.plans.models import MetricDefinition, PlanTarget, PlanTargetMetric
 from apps.reports.csv_utils import sanitise_csv_value
-from apps.reports.suppression import SMALL_CELL_THRESHOLD
 
 logger = logging.getLogger(__name__)
 
@@ -160,12 +160,16 @@ class DeidentificationPipeline:
         self._deidentified_records: list[dict[str, Any]] = []
         self._linkage_table: dict[str, int] = {}
         self._generalizations_applied: list[dict[str, Any]] = []
-        self._suppressed_records: list[dict[str, Any]] = []
         self._suppression_reasons: list[dict[str, Any]] = []
         self._blocked = False
         self._block_reason: str | None = None
         self._effective_k = 0
         self._metric_defs: list[MetricDefinition] = []
+
+    @property
+    def _active_records(self) -> list[dict[str, Any]]:
+        """Records not suppressed by k-anonymity resolution."""
+        return [r for r in self._deidentified_records if not r.get("_suppressed")]
 
     # ------------------------------------------------------------------
     # Public interface
@@ -300,48 +304,60 @@ class DeidentificationPipeline:
         Accesses encrypted property accessors (.birth_date, .first_name,
         .last_name) for staging only — these values will be stripped in
         Step 4.
+
+        Uses bulk queries to avoid N+1 patterns — all ProgressNote,
+        MetricValue, and ClientDetailValue data is fetched in a handful
+        of queries rather than per-client.
         """
         self._log_audit("view", "Decrypting and staging records")
+
+        client_ids = [raw["_client_id"] for raw in self._raw_records]
+
+        # Bulk fetch: session counts and total hours per client
+        note_stats = dict(
+            ProgressNote.objects.filter(
+                client_file_id__in=client_ids,
+                created_at__date__range=(self.period_start, self.period_end),
+            ).values("client_file_id").annotate(
+                count=Count("id"),
+                total_minutes=Sum("duration_minutes"),
+            ).values_list("client_file_id", "count", "total_minutes")
+        # Convert to {client_id: (count, total_minutes)}
+        )
+        note_stats_map: dict[int, tuple[int, int]] = {}
+        for row in ProgressNote.objects.filter(
+            client_file_id__in=client_ids,
+            created_at__date__range=(self.period_start, self.period_end),
+        ).values("client_file_id").annotate(
+            count=Count("id"),
+            total_minutes=Sum("duration_minutes"),
+        ):
+            note_stats_map[row["client_file_id"]] = (
+                row["count"], row["total_minutes"] or 0,
+            )
+
+        # Bulk fetch: all metric values for all clients
+        metric_data_map = self._bulk_get_metric_data(client_ids)
+
+        # Bulk fetch: custom field values and postal codes
+        custom_field_map, postal_code_map = self._bulk_get_field_data(client_ids)
 
         for raw in self._raw_records:
             client: ClientFile = raw["_client"]
             episode: ServiceEpisode = raw["_episode"]
+            cid = client.pk
 
-            # Count sessions (progress notes) in the period
-            note_qs = ProgressNote.objects.filter(
-                client_file=client,
-                created_at__date__range=(self.period_start, self.period_end),
-            )
-            sessions_count = note_qs.count()
-
-            # Sum duration minutes, convert to hours
-            duration_agg = note_qs.aggregate(
-                total_minutes=Sum("duration_minutes"),
-            )
-            total_minutes = duration_agg["total_minutes"] or 0
+            sessions_count, total_minutes = note_stats_map.get(cid, (0, 0))
             total_hours = round(total_minutes / 60, 1) if total_minutes else 0.0
 
-            # Get metric values (intake = earliest, latest = most recent)
-            metric_data = self._get_metric_data(client)
-
-            # Get custom field values for QI columns
-            custom_field_values = self._get_custom_field_values(client)
-
-            # Get postal code for geography derivation (if needed)
-            postal_code = self._get_postal_code(client)
-
-            # Build staged record
             staged = {
-                "_client_id": client.pk,
+                "_client_id": cid,
                 "_episode": episode,
-                # PII fields — will be stripped in Step 4
                 "_first_name": client.first_name,
                 "_last_name": client.last_name,
                 "_birth_date": client.birth_date,
-                "_postal_code": postal_code,
-                # Consent flag
+                "_postal_code": postal_code_map.get(cid),
                 "_consent": episode.consent_to_aggregate_reporting,
-                # Non-PII operational data
                 "enrolment_date": (
                     episode.started_at.date()
                     if episode.started_at else None
@@ -352,8 +368,8 @@ class DeidentificationPipeline:
                 ),
                 "sessions_count": sessions_count,
                 "total_hours": total_hours,
-                "metrics": metric_data,
-                "custom_fields": custom_field_values,
+                "metrics": metric_data_map.get(cid, {}),
+                "custom_fields": custom_field_map.get(cid, {}),
             }
             self._staged_records.append(staged)
 
@@ -362,90 +378,101 @@ class DeidentificationPipeline:
             len(self._staged_records),
         )
 
-    def _get_metric_data(self, client: ClientFile) -> dict[str, dict[str, Any]]:
-        """Get intake and latest metric values for a client.
+    def _bulk_get_metric_data(
+        self, client_ids: list[int],
+    ) -> dict[int, dict[str, dict[str, Any]]]:
+        """Bulk-fetch intake and latest metric values for all clients.
 
-        Returns a dict keyed by metric definition name, with intake and
-        latest values for each.
+        Returns {client_id: {metric_slug: {"intake": v, "latest": v}}}.
         """
-        result: dict[str, dict[str, Any]] = {}
+        if not self._metric_defs:
+            return {}
 
-        for metric_def in self._metric_defs:
-            values = MetricValue.objects.filter(
-                progress_note_target__progress_note__client_file=client,
+        all_values = (
+            MetricValue.objects.filter(
+                metric_def__in=self._metric_defs,
+                progress_note_target__progress_note__client_file_id__in=client_ids,
                 progress_note_target__progress_note__created_at__date__range=(
                     self.period_start, self.period_end,
                 ),
-                metric_def=metric_def,
-            ).select_related(
+            )
+            .select_related(
+                "metric_def",
                 "progress_note_target__progress_note",
-            ).order_by("progress_note_target__progress_note__created_at")
+            )
+            .order_by("progress_note_target__progress_note__created_at")
+        )
 
-            if not values.exists():
-                continue
+        # Group by (client_id, metric_def_id)
+        grouped: dict[tuple[int, int], list] = defaultdict(list)
+        metric_name_map: dict[int, str] = {}
+        for mv in all_values:
+            cid = mv.progress_note_target.progress_note.client_file_id
+            mid = mv.metric_def_id
+            grouped[(cid, mid)].append(mv.value)
+            if mid not in metric_name_map:
+                metric_name_map[mid] = self._sanitise_metric_name(
+                    mv.metric_def.name,
+                )
 
-            values_list = list(values)
-            intake_val = values_list[0].value if values_list else None
-            latest_val = values_list[-1].value if values_list else None
-
-            # Sanitise the metric name for use as a column header
-            safe_name = self._sanitise_metric_name(metric_def.name)
-            result[safe_name] = {
-                "intake": intake_val,
-                "latest": latest_val,
+        result: dict[int, dict[str, dict[str, Any]]] = defaultdict(dict)
+        for (cid, mid), values in grouped.items():
+            safe_name = metric_name_map[mid]
+            result[cid][safe_name] = {
+                "intake": values[0] if values else None,
+                "latest": values[-1] if values else None,
             }
 
-        return result
+        return dict(result)
 
-    def _get_custom_field_values(self, client: ClientFile) -> dict[str, str]:
-        """Get custom field values relevant to the selected QI columns.
+    def _bulk_get_field_data(
+        self, client_ids: list[int],
+    ) -> tuple[dict[int, dict[str, str]], dict[int, str | None]]:
+        """Bulk-fetch custom field values and postal codes for all clients.
 
-        Only fetches fields that are used as quasi-identifiers.
+        Returns (custom_field_map, postal_code_map) where:
+        - custom_field_map: {client_id: {qi_col: value}}
+        - postal_code_map: {client_id: postal_code_or_None}
         """
-        result: dict[str, str] = {}
-
-        # QI columns that correspond to custom fields (not age_group or geography)
         custom_qi = [
             col for col in self.qi_columns
             if col not in ("age_group", "geography")
         ]
-        if not custom_qi:
-            return result
 
-        # Query all ClientDetailValue records for this client
-        detail_values = ClientDetailValue.objects.filter(
-            client_file=client,
+        custom_field_map: dict[int, dict[str, str]] = defaultdict(dict)
+        postal_code_map: dict[int, str | None] = {}
+
+        # Single query for all custom field values across all clients
+        all_details = ClientDetailValue.objects.filter(
+            client_file_id__in=client_ids,
             field_def__status="active",
         ).select_related("field_def", "field_def__group")
 
-        for dv in detail_values:
-            field_name_lower = dv.field_def.name.lower().replace(" ", "_")
-            if field_name_lower in custom_qi:
-                raw_val = dv.get_value()
-                # For dropdown fields, resolve to the option label
-                if dv.field_def.input_type in ("select", "select_other"):
-                    raw_val = self._resolve_option_label(dv.field_def, raw_val)
-                result[field_name_lower] = raw_val or ""
+        for dv in all_details:
+            cid = dv.client_file_id
 
-        return result
+            # Check for postal code fields
+            fd = dv.field_def
+            if (
+                cid not in postal_code_map
+                and "geography" in self.qi_columns
+                and (
+                    getattr(fd, "validation_type", None) == "postal_code"
+                    or fd.name.lower() == "postal code"
+                )
+            ):
+                postal_code_map[cid] = dv.get_value() or None
 
-    def _get_postal_code(self, client: ClientFile) -> str | None:
-        """Retrieve postal code from custom field values.
+            # Check for QI custom fields
+            if custom_qi:
+                field_name_lower = fd.name.lower().replace(" ", "_")
+                if field_name_lower in custom_qi:
+                    raw_val = dv.get_value()
+                    if fd.input_type in ("select", "select_other"):
+                        raw_val = self._resolve_option_label(fd, raw_val)
+                    custom_field_map[cid][field_name_lower] = raw_val or ""
 
-        Looks for a field with validation_type="postal_code" or named
-        "Postal Code".
-        """
-        postal_dv = ClientDetailValue.objects.filter(
-            client_file=client,
-            field_def__status="active",
-        ).filter(
-            Q(field_def__validation_type="postal_code")
-            | Q(field_def__name__iexact="Postal Code")
-        ).select_related("field_def").first()
-
-        if postal_dv:
-            return postal_dv.get_value() or None
-        return None
+        return dict(custom_field_map), postal_code_map
 
     def _resolve_option_label(self, field_def, raw_value: str) -> str:
         """Resolve a dropdown value to its display label."""
@@ -461,11 +488,7 @@ class DeidentificationPipeline:
 
     @staticmethod
     def _sanitise_metric_name(name: str) -> str:
-        """Convert a metric name to a safe column name slug.
-
-        Replaces spaces/special chars with underscores and lowercases.
-        """
-        import re
+        """Convert a metric name to a safe column name slug."""
         safe = re.sub(r"[^a-z0-9]+", "_", name.lower()).strip("_")
         return safe or "metric"
 
@@ -662,9 +685,7 @@ class DeidentificationPipeline:
         """
         self._log_audit("view", "Computing k-anonymity")
 
-        active_records = [
-            r for r in self._deidentified_records if not r.get("_suppressed")
-        ]
+        active_records = self._active_records
 
         if not active_records:
             self._effective_k = 0
@@ -714,9 +735,7 @@ class DeidentificationPipeline:
         """
         self._log_audit("view", "Resolving k-anonymity violations")
 
-        active_records = [
-            r for r in self._deidentified_records if not r.get("_suppressed")
-        ]
+        active_records = self._active_records
         if not active_records:
             return
 
@@ -775,9 +794,7 @@ class DeidentificationPipeline:
             })
 
         # Final k computation on remaining records
-        remaining = [
-            r for r in self._deidentified_records if not r.get("_suppressed")
-        ]
+        remaining = self._active_records
         if remaining:
             eq_classes = self._build_equivalence_classes(remaining)
             self._effective_k = min(eq_classes.values()) if eq_classes else 0
@@ -913,10 +930,7 @@ class DeidentificationPipeline:
 
         Returns the tier string.
         """
-        exportable = [
-            r for r in self._deidentified_records
-            if not r.get("_suppressed")
-        ]
+        exportable = self._active_records
         n = len(exportable)
         qi_count = len(self.qi_columns)
 
@@ -962,19 +976,14 @@ class DeidentificationPipeline:
         """
         self._log_audit("export", "Generating CSV file")
 
-        export_dir = getattr(
-            settings, "SECURE_EXPORT_DIR", "/tmp/konote_exports",
-        )
+        export_dir = settings.SECURE_EXPORT_DIR
         os.makedirs(export_dir, exist_ok=True)
 
         timestamp = timezone.now().strftime("%Y%m%d_%H%M%S")
         filename = f"eval_microdata_{self.program.pk}_{timestamp}.csv"
         filepath = os.path.join(export_dir, filename)
 
-        exportable = [
-            r for r in self._deidentified_records
-            if not r.get("_suppressed")
-        ]
+        exportable = self._active_records
 
         # Build column headers
         columns = self._build_csv_columns()
@@ -1069,23 +1078,15 @@ class DeidentificationPipeline:
         """
         self._log_audit("export", "Generating suppression report")
 
-        export_dir = getattr(
-            settings, "SECURE_EXPORT_DIR", "/tmp/konote_exports",
-        )
+        export_dir = settings.SECURE_EXPORT_DIR
         os.makedirs(export_dir, exist_ok=True)
 
         timestamp = timezone.now().strftime("%Y%m%d_%H%M%S")
         filename = f"eval_suppression_report_{self.program.pk}_{timestamp}.json"
         filepath = os.path.join(export_dir, filename)
 
-        exportable = [
-            r for r in self._deidentified_records
-            if not r.get("_suppressed")
-        ]
-        suppressed = [
-            r for r in self._deidentified_records
-            if r.get("_suppressed")
-        ]
+        exportable = self._active_records
+        suppressed_count = len(self._deidentified_records) - len(exportable)
 
         report = {
             "generated_at": timezone.now().isoformat(),
@@ -1099,14 +1100,14 @@ class DeidentificationPipeline:
                 "eligible": len(self._raw_records),
                 "consented": len(self._consented_records),
                 "exportable": len(exportable),
-                "suppressed": len(suppressed),
+                "suppressed": suppressed_count,
             },
             "privacy": {
                 "target_k": TARGET_K,
                 "effective_k": self._effective_k,
                 "suppression_rate": round(
-                    len(suppressed) / (len(exportable) + len(suppressed))
-                    if (len(exportable) + len(suppressed)) > 0
+                    suppressed_count / (len(exportable) + suppressed_count)
+                    if (len(exportable) + suppressed_count) > 0
                     else 0.0,
                     3,
                 ),
@@ -1140,7 +1141,6 @@ class DeidentificationPipeline:
         self._deidentified_records = []
         self._linkage_table = {}
         self._generalizations_applied = []
-        self._suppressed_records = []
         self._suppression_reasons = []
         self._blocked = False
         self._block_reason = None
@@ -1227,22 +1227,16 @@ class DeidentificationPipeline:
 
     def _build_preview_result(self, tier: str) -> PreviewResult:
         """Construct a PreviewResult from current pipeline state."""
-        exportable = [
-            r for r in self._deidentified_records
-            if not r.get("_suppressed")
-        ]
-        suppressed = [
-            r for r in self._deidentified_records
-            if r.get("_suppressed")
-        ]
-        total = len(exportable) + len(suppressed)
+        exportable = self._active_records
+        suppressed_count = len(self._deidentified_records) - len(exportable)
+        total = len(self._deidentified_records)
 
         return PreviewResult(
             eligible_count=len(self._raw_records),
             consented_count=len(self._consented_records),
             exportable_count=len(exportable),
-            suppressed_count=len(suppressed),
-            suppression_rate=len(suppressed) / total if total > 0 else 0.0,
+            suppressed_count=suppressed_count,
+            suppression_rate=suppressed_count / total if total > 0 else 0.0,
             effective_k=self._effective_k,
             qi_columns_used=list(self.qi_columns),
             generalizations_applied=list(self._generalizations_applied),

--- a/apps/reports/deidentify.py
+++ b/apps/reports/deidentify.py
@@ -30,7 +30,7 @@ import re
 import secrets
 import uuid
 from collections import Counter, defaultdict
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import date
 from typing import Any
 
@@ -41,7 +41,7 @@ from django.utils import timezone
 from apps.audit.models import AuditLog
 from apps.clients.models import ClientDetailValue, ClientFile, ServiceEpisode
 from apps.notes.models import MetricValue, ProgressNote
-from apps.plans.models import MetricDefinition, PlanTarget, PlanTargetMetric
+from apps.plans.models import MetricDefinition, PlanTargetMetric
 from apps.reports.csv_utils import sanitise_csv_value
 
 logger = logging.getLogger(__name__)
@@ -314,16 +314,6 @@ class DeidentificationPipeline:
         client_ids = [raw["_client_id"] for raw in self._raw_records]
 
         # Bulk fetch: session counts and total hours per client
-        note_stats = dict(
-            ProgressNote.objects.filter(
-                client_file_id__in=client_ids,
-                created_at__date__range=(self.period_start, self.period_end),
-            ).values("client_file_id").annotate(
-                count=Count("id"),
-                total_minutes=Sum("duration_minutes"),
-            ).values_list("client_file_id", "count", "total_minutes")
-        # Convert to {client_id: (count, total_minutes)}
-        )
         note_stats_map: dict[int, tuple[int, int]] = {}
         for row in ProgressNote.objects.filter(
             client_file_id__in=client_ids,
@@ -442,10 +432,16 @@ class DeidentificationPipeline:
         custom_field_map: dict[int, dict[str, str]] = defaultdict(dict)
         postal_code_map: dict[int, str | None] = {}
 
-        # Single query for all custom field values across all clients
+        # Single query for all custom field values across all clients.
+        # Only include fields from groups marked as evaluation-exportable
+        # (plus postal code fields needed for geography derivation).
         all_details = ClientDetailValue.objects.filter(
             client_file_id__in=client_ids,
             field_def__status="active",
+        ).filter(
+            Q(field_def__group__is_evaluation_exportable=True)
+            | Q(field_def__validation_type="postal_code")
+            | Q(field_def__name__iexact="Postal Code")
         ).select_related("field_def", "field_def__group")
 
         for dv in all_details:

--- a/apps/reports/forms.py
+++ b/apps/reports/forms.py
@@ -1200,7 +1200,7 @@ class FunderReportApprovalForm(forms.Form):
 # ---------------------------------------------------------------------------
 
 
-class EvaluationExportForm(forms.Form):
+class EvaluationExportForm(ProgramSelectionMixin, forms.Form):
     """Form for generating de-identified evaluation microdata exports.
 
     Captures: program, reporting period, evaluator details (for audit),
@@ -1276,34 +1276,17 @@ class EvaluationExportForm(forms.Form):
     def __init__(self, *args, **kwargs):
         user = kwargs.pop("user", None)
         super().__init__(*args, **kwargs)
+        # Use mixin's program setup but without "All Programs" option
         self._user = user
-
-        # Build program choices — only programs user can access
         if user:
             from .utils import get_manageable_programs
             programs = get_manageable_programs(user)
         else:
             programs = Program.objects.filter(status="active")
-
         program_choices = [("", _("\u2014 Select a program \u2014"))]
         for p in programs.order_by("name"):
             program_choices.append((str(p.pk), str(p)))
         self.fields["program"].choices = program_choices
-
-    def clean_program(self):
-        value = self.cleaned_data.get("program", "")
-        if not value:
-            raise forms.ValidationError(_("Please select a program."))
-        try:
-            program = Program.objects.get(pk=int(value), status="active")
-        except (Program.DoesNotExist, ValueError, TypeError):
-            raise forms.ValidationError(_("Invalid program selection."))
-        # RBAC: verify user has access
-        if self._user:
-            from .utils import get_manageable_programs
-            if not get_manageable_programs(self._user).filter(pk=program.pk).exists():
-                raise forms.ValidationError(_("You do not have access to this program."))
-        return program
 
     def clean(self):
         cleaned = super().clean()

--- a/apps/reports/forms.py
+++ b/apps/reports/forms.py
@@ -1288,6 +1288,21 @@ class EvaluationExportForm(ProgramSelectionMixin, forms.Form):
             program_choices.append((str(p.pk), str(p)))
         self.fields["program"].choices = program_choices
 
+    def clean_program(self):
+        """Override mixin: evaluation exports require a single program."""
+        value = self.cleaned_data.get("program", "")
+        if not value or value == self.ALL_PROGRAMS_VALUE:
+            raise forms.ValidationError(_("Please select a program."))
+        try:
+            program = Program.objects.get(pk=int(value), status="active")
+        except (Program.DoesNotExist, ValueError, TypeError):
+            raise forms.ValidationError(_("Invalid program selection."))
+        if self._user:
+            from .utils import get_manageable_programs
+            if not get_manageable_programs(self._user).filter(pk=program.pk).exists():
+                raise forms.ValidationError(_("You do not have access to this program."))
+        return program
+
     def clean(self):
         cleaned = super().clean()
         period_start = cleaned.get("period_start")

--- a/apps/reports/forms.py
+++ b/apps/reports/forms.py
@@ -1193,3 +1193,145 @@ class FunderReportApprovalForm(forms.Form):
             "placeholder": _("e.g., Q1 debt figures include a large legal settlement for one participant. This is accurate, not a data entry error."),
         }),
     )
+
+
+# ---------------------------------------------------------------------------
+# Evaluation Microdata Export (DRR: evaluation-microdata-export.md)
+# ---------------------------------------------------------------------------
+
+
+class EvaluationExportForm(forms.Form):
+    """Form for generating de-identified evaluation microdata exports.
+
+    Captures: program, reporting period, evaluator details (for audit),
+    and quasi-identifier column selection.  All evaluator fields are
+    required — they are stored in the immutable audit log, not in a
+    separate model.
+
+    Access is restricted to users with the report.evaluation_export
+    permission (checked in the view, not the form).
+    """
+
+    program = forms.ChoiceField(
+        required=True,
+        label=_("Program"),
+    )
+
+    period_start = forms.DateField(
+        required=True,
+        label=_("Period start"),
+        widget=forms.DateInput(attrs={"type": "date"}),
+    )
+    period_end = forms.DateField(
+        required=True,
+        label=_("Period end"),
+        widget=forms.DateInput(attrs={"type": "date"}),
+    )
+
+    # Evaluator details — all required for audit trail
+    evaluator_name = forms.CharField(
+        max_length=200,
+        label=_("Evaluator name"),
+    )
+    evaluator_email = forms.EmailField(
+        label=_("Evaluator email"),
+    )
+    evaluator_organisation = forms.CharField(
+        max_length=200,
+        label=_("Evaluator organisation"),
+    )
+    evaluation_purpose = forms.CharField(
+        widget=forms.Textarea(attrs={"rows": 3}),
+        label=_("Evaluation purpose"),
+        help_text=_("Describe the evaluation and how the data will be used."),
+    )
+    agreement_expiry = forms.DateField(
+        widget=forms.DateInput(attrs={"type": "date"}),
+        label=_("Data sharing agreement expiry"),
+        help_text=_("When does the data sharing agreement with this evaluator expire?"),
+    )
+
+    # Quasi-identifier column selection (checkboxes)
+    include_age_group = forms.BooleanField(
+        required=False,
+        initial=True,
+        label=_("Age group"),
+        help_text=_("5-year age bands (e.g., 25-29, 30-34)"),
+    )
+    include_gender = forms.BooleanField(
+        required=False,
+        initial=True,
+        label=_("Gender"),
+    )
+    include_ethnicity = forms.BooleanField(
+        required=False,
+        label=_("Ethnicity"),
+    )
+    include_geography = forms.BooleanField(
+        required=False,
+        label=_("Geography"),
+        help_text=_("Urban / Rural (derived from postal code)"),
+    )
+
+    def __init__(self, *args, **kwargs):
+        user = kwargs.pop("user", None)
+        super().__init__(*args, **kwargs)
+        self._user = user
+
+        # Build program choices — only programs user can access
+        if user:
+            from .utils import get_manageable_programs
+            programs = get_manageable_programs(user)
+        else:
+            programs = Program.objects.filter(status="active")
+
+        program_choices = [("", _("\u2014 Select a program \u2014"))]
+        for p in programs.order_by("name"):
+            program_choices.append((str(p.pk), str(p)))
+        self.fields["program"].choices = program_choices
+
+    def clean_program(self):
+        value = self.cleaned_data.get("program", "")
+        if not value:
+            raise forms.ValidationError(_("Please select a program."))
+        try:
+            program = Program.objects.get(pk=int(value), status="active")
+        except (Program.DoesNotExist, ValueError, TypeError):
+            raise forms.ValidationError(_("Invalid program selection."))
+        # RBAC: verify user has access
+        if self._user:
+            from .utils import get_manageable_programs
+            if not get_manageable_programs(self._user).filter(pk=program.pk).exists():
+                raise forms.ValidationError(_("You do not have access to this program."))
+        return program
+
+    def clean(self):
+        cleaned = super().clean()
+        period_start = cleaned.get("period_start")
+        period_end = cleaned.get("period_end")
+        if period_start and period_end and period_start > period_end:
+            raise forms.ValidationError(_("Period start must be before period end."))
+        return cleaned
+
+    def get_qi_columns(self):
+        """Return the list of selected quasi-identifier column names."""
+        qi = []
+        if self.cleaned_data.get("include_age_group"):
+            qi.append("age_group")
+        if self.cleaned_data.get("include_gender"):
+            qi.append("gender")
+        if self.cleaned_data.get("include_ethnicity"):
+            qi.append("ethnicity")
+        if self.cleaned_data.get("include_geography"):
+            qi.append("geography")
+        return qi
+
+    def get_evaluator_info(self):
+        """Return evaluator details as a dict for the pipeline."""
+        return {
+            "name": self.cleaned_data.get("evaluator_name", ""),
+            "email": self.cleaned_data.get("evaluator_email", ""),
+            "organisation": self.cleaned_data.get("evaluator_organisation", ""),
+            "purpose": self.cleaned_data.get("evaluation_purpose", ""),
+            "agreement_expiry": self.cleaned_data.get("agreement_expiry"),
+        }

--- a/apps/reports/models.py
+++ b/apps/reports/models.py
@@ -476,6 +476,7 @@ class SecureExportLink(models.Model):
         ("standard_report", _("Standard Report")),
         ("individual_client", _("Individual Client Export")),
         ("session_report", _("Session Report")),
+        ("evaluation_microdata", _("Evaluation Microdata")),
     ]
 
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)

--- a/apps/reports/urls.py
+++ b/apps/reports/urls.py
@@ -45,6 +45,8 @@ urlpatterns = [
     path("oversight/<int:report_id>/pdf/", oversight_views.oversight_report_pdf, name="oversight_pdf"),
     # Sessions by Participant report (REP-SESS1)
     path("sessions/", views.session_report_form, name="session_report"),
+    # Evaluation microdata export (DRR: evaluation-microdata-export.md)
+    path("evaluation-export/", views.evaluation_export_form, name="evaluation_export"),
     # Report Schedules
     path("schedules/", oversight_views.report_schedule_list, name="schedule_list"),
     path("schedules/create/", oversight_views.report_schedule_create, name="schedule_create"),

--- a/apps/reports/utils.py
+++ b/apps/reports/utils.py
@@ -58,6 +58,33 @@ def can_download_pii_export(user):
     ).exists()
 
 
+def can_create_evaluation_export(user):
+    """Check if this user can create evaluation microdata exports.
+
+    Evaluation exports are restricted to users with the explicit
+    report.evaluation_export permission or admin users. This is a
+    separate permission from report.program_report because evaluation
+    exports serve a different purpose (external sharing) with different
+    safeguards (evaluator details, enhanced audit).
+
+    Returns:
+        True if the user can create evaluation exports.
+    """
+    if user.is_admin:
+        return True
+    # Check if user has the evaluation_export permission via their role
+    from apps.auth_app.permissions import DENY, can_access
+    from apps.programs.models import UserProgramRole
+
+    roles = UserProgramRole.objects.filter(
+        user=user, status="active"
+    ).values_list("role", flat=True).distinct()
+    for role in roles:
+        if can_access(role, "report.evaluation_export") != DENY:
+            return True
+    return False
+
+
 def can_create_export(user, export_type, program=None):
     """
     Check if a user can create an export of the given type.

--- a/apps/reports/views.py
+++ b/apps/reports/views.py
@@ -2329,3 +2329,146 @@ def session_report_form(request):
         % {"count": client_count, "sessions": report_data["summary"]["total_sessions"]},
     )
     return redirect("reports:download_export", link_id=link.pk)
+
+
+# ---------------------------------------------------------------------------
+# Evaluation Microdata Export (DRR: evaluation-microdata-export.md)
+# ---------------------------------------------------------------------------
+
+
+@login_required
+def evaluation_export_form(request):
+    """View for generating de-identified evaluation microdata exports.
+
+    Two-step flow:
+    1. GET or POST with action=preview — show form or run preview
+    2. POST with action=generate — produce the CSV and SecureExportLink
+
+    Access restricted to users with report.evaluation_export permission.
+    """
+    from .forms import EvaluationExportForm
+    from .deidentify import DeidentificationPipeline
+    from .utils import can_create_evaluation_export
+
+    if not can_create_evaluation_export(request.user):
+        return HttpResponseForbidden(
+            _("Access denied. You do not have permission to create evaluation exports.")
+        )
+
+    if request.method == "GET":
+        form = EvaluationExportForm(user=request.user)
+        return render(request, "reports/evaluation_export.html", {
+            "form": form,
+            "nav_active": "reports",
+        })
+
+    # POST — either preview or generate
+    action = request.POST.get("action", "preview")
+    form = EvaluationExportForm(request.POST, user=request.user)
+
+    if not form.is_valid():
+        return render(request, "reports/evaluation_export.html", {
+            "form": form,
+            "nav_active": "reports",
+        })
+
+    program = form.cleaned_data["program"]
+    period_start = form.cleaned_data["period_start"]
+    period_end = form.cleaned_data["period_end"]
+    qi_columns = form.get_qi_columns()
+    evaluator_info = form.get_evaluator_info()
+
+    pipeline = DeidentificationPipeline(
+        program=program,
+        period_start=period_start,
+        period_end=period_end,
+        qi_columns=qi_columns,
+        evaluator_info=evaluator_info,
+        user=request.user,
+        request=request,
+    )
+
+    if action == "preview":
+        preview = pipeline.run_preview()
+        return render(request, "reports/evaluation_export_preview.html", {
+            "form": form,
+            "preview": preview,
+            "program": program,
+            "period_start": period_start,
+            "period_end": period_end,
+            "evaluator_info": evaluator_info,
+            "qi_columns": qi_columns,
+            "nav_active": "reports",
+        })
+
+    # action == "generate"
+    try:
+        result = pipeline.run_generate()
+    except ValueError as exc:
+        from django.contrib import messages as django_messages
+        django_messages.error(request, str(exc))
+        return render(request, "reports/evaluation_export.html", {
+            "form": form,
+            "nav_active": "reports",
+        })
+
+    # Read the CSV file content for SecureExportLink storage
+    with open(result.csv_path, "r", encoding="utf-8-sig") as f:
+        csv_content = f.read()
+
+    filename = os.path.basename(result.csv_path)
+    link = _save_export_and_create_link(
+        request=request,
+        content=csv_content,
+        filename=filename,
+        export_type="evaluation_microdata",
+        client_count=result.preview.exportable_count,
+        includes_notes=False,
+        recipient=f"{evaluator_info['name']} ({evaluator_info['email']}), {evaluator_info['organisation']}",
+        filters_dict={
+            "program_id": program.pk,
+            "period_start": str(period_start),
+            "period_end": str(period_end),
+            "qi_columns": qi_columns,
+            "evaluator": evaluator_info,
+        },
+        contains_pii=False,
+    )
+
+    # Force elevated for evaluation exports (regardless of client count)
+    if not link.is_elevated:
+        SecureExportLink.objects.filter(pk=link.pk).update(
+            is_elevated=True,
+        )
+        _notify_admins_elevated_export(link, request)
+
+    # Store encrypted linkage blob
+    SecureExportLink.objects.filter(pk=link.pk).update(
+        filters_json=json.dumps({
+            **json.loads(link.filters_json),
+            "linkage_key_encrypted": result.linkage_blob.hex()
+            if isinstance(result.linkage_blob, bytes)
+            else str(result.linkage_blob),
+        }),
+    )
+
+    # Full audit log entry with structured metadata
+    AuditLog.objects.using("audit").create(
+        event_timestamp=timezone.now(),
+        user_id=request.user.pk,
+        user_display=request.user.display_name,
+        action="export",
+        resource_type="export",
+        program_id=program.pk,
+        ip_address=_get_client_ip(request),
+        is_demo_context=getattr(request.user, "is_demo", False),
+        metadata=result.audit_metadata,
+    )
+
+    from django.contrib import messages as django_messages
+    django_messages.success(
+        request,
+        _("Evaluation export generated. %(count)d de-identified records.")
+        % {"count": result.preview.exportable_count},
+    )
+    return redirect("reports:download_export", link_id=link.pk)

--- a/apps/reports/views.py
+++ b/apps/reports/views.py
@@ -2452,18 +2452,8 @@ def evaluation_export_form(request):
         }),
     )
 
-    # Full audit log entry with structured metadata
-    AuditLog.objects.using("audit").create(
-        event_timestamp=timezone.now(),
-        user_id=request.user.pk,
-        user_display=request.user.display_name,
-        action="export",
-        resource_type="export",
-        program_id=program.pk,
-        ip_address=_get_client_ip(request),
-        is_demo_context=getattr(request.user, "is_demo", False),
-        metadata=result.audit_metadata,
-    )
+    # Audit logging is handled by the pipeline's run_generate() — no
+    # duplicate entry needed here.
 
     from django.contrib import messages as django_messages
     django_messages.success(

--- a/apps/reports/views.py
+++ b/apps/reports/views.py
@@ -2435,22 +2435,21 @@ def evaluation_export_form(request):
         contains_pii=False,
     )
 
-    # Force elevated for evaluation exports (regardless of client count)
-    if not link.is_elevated:
-        SecureExportLink.objects.filter(pk=link.pk).update(
-            is_elevated=True,
-        )
-        _notify_admins_elevated_export(link, request)
-
-    # Store encrypted linkage blob
-    SecureExportLink.objects.filter(pk=link.pk).update(
-        filters_json=json.dumps({
-            **json.loads(link.filters_json),
-            "linkage_key_encrypted": result.linkage_blob.hex()
-            if isinstance(result.linkage_blob, bytes)
-            else str(result.linkage_blob),
-        }),
+    # Force elevated + store encrypted linkage blob in one update
+    link.refresh_from_db()
+    updated_filters = json.loads(link.filters_json)
+    updated_filters["linkage_key_encrypted"] = (
+        result.linkage_blob.hex()
+        if isinstance(result.linkage_blob, bytes)
+        else str(result.linkage_blob)
     )
+    SecureExportLink.objects.filter(pk=link.pk).update(
+        is_elevated=True,
+        filters_json=json.dumps(updated_filters),
+    )
+    if not link.is_elevated:
+        link.refresh_from_db()
+        _notify_admins_elevated_export(link, request)
 
     # Audit logging is handled by the pipeline's run_generate() — no
     # duplicate entry needed here.

--- a/templates/base.html
+++ b/templates/base.html
@@ -155,6 +155,10 @@
                         <li role="none"><a role="menuitem" href="{% url 'reports:generate_report' %}">{% trans "Standard Report" %}</a></li>
                         <li role="none"><a role="menuitem" href="{% url 'reports:export_form' %}">{% trans "Build a Report" %}</a></li>
                         {% endif %}
+                        {% has_permission "report.evaluation_export" as can_see_eval_export %}
+                        {% if can_see_eval_export or user.is_admin %}
+                        <li role="none"><a role="menuitem" href="{% url 'reports:evaluation_export' %}">{% trans "Evaluation Export" %}</a></li>
+                        {% endif %}
                         {% if can_see_compliance %}
                         <li role="none"><a role="menuitem" href="{% url 'audit:compliance_summary' %}">{% trans "Privacy & Access Audit" %}</a></li>
                         {% endif %}

--- a/templates/reports/evaluation_export.html
+++ b/templates/reports/evaluation_export.html
@@ -1,0 +1,73 @@
+{% extends "base.html" %}
+{% load i18n %}
+
+{% block title %}{% trans "Evaluation Export" %} — {{ site.product_name|default:"KoNote" }}{% endblock %}
+
+{% block content %}
+<hgroup>
+    <h1>{% trans "De-Identified Evaluation Export" %}</h1>
+    <p>{% trans "Generate a de-identified, participant-level CSV for an external program evaluator." %}</p>
+</hgroup>
+
+<article aria-label="{% trans 'About this export' %}" style="margin-bottom: 1.5rem;">
+    <strong>{% trans "What this export contains" %}</strong>
+    <p>{% trans "Each row represents one participant with pseudonymous IDs, generalised demographics, and outcome metric values. All direct identifiers (names, contact information, exact dates) are removed." %}</p>
+    <ul style="margin-bottom: 0.5rem;">
+        <li>{% trans "Pseudonymous study IDs (random, not linked to real record IDs)" %}</li>
+        <li>{% trans "Generalised demographics (age bands, urban/rural)" %}</li>
+        <li>{% trans "Outcome metric values (intake and latest)" %}</li>
+        <li>{% trans "Service intensity (session count, total hours)" %}</li>
+    </ul>
+    <p style="margin-bottom: 0;">
+        {% trans "K-anonymity (k=5) is enforced: every combination of demographic values must appear in at least 5 records. Exports with fewer than 15 participants are blocked." %}
+    </p>
+</article>
+
+<article aria-label="{% trans 'Audit notice' %}" role="alert" style="background: var(--kn-warning-bg); border-left: 4px solid var(--kn-warning-fg); padding: 1rem; margin-bottom: 1.5rem;">
+    <strong>{% trans "All details are recorded in the audit log" %}</strong>
+    <p style="margin-bottom: 0;">
+        {% trans "This export is always elevated — administrators will be notified and a delay will be applied before download. Evaluator information, export parameters, and de-identification details are recorded in the immutable audit trail." %}
+    </p>
+</article>
+
+<form method="post" action="{% url 'reports:evaluation_export' %}">
+    {% csrf_token %}
+    <input type="hidden" name="action" value="preview">
+
+    {% if form.non_field_errors %}
+    <article role="alert" style="background: var(--kn-error-bg, #fef2f2); border-left: 4px solid var(--kn-error-fg, #dc2626); padding: 1rem; margin-bottom: 1.5rem;">
+        {% for error in form.non_field_errors %}
+        <p style="margin-bottom: 0;">{{ error }}</p>
+        {% endfor %}
+    </article>
+    {% endif %}
+
+    <fieldset>
+        <legend>{% trans "Program and Period" %}</legend>
+        {% include "includes/_form_field.html" with field=form.program %}
+        {% include "includes/_form_field.html" with field=form.period_start %}
+        {% include "includes/_form_field.html" with field=form.period_end %}
+    </fieldset>
+
+    <fieldset>
+        <legend>{% trans "Evaluator Information" %}</legend>
+        <small style="display: block; margin-bottom: 1rem;">{% trans "Required for audit trail. KoNote does not email or create accounts for evaluators." %}</small>
+        {% include "includes/_form_field.html" with field=form.evaluator_name %}
+        {% include "includes/_form_field.html" with field=form.evaluator_email %}
+        {% include "includes/_form_field.html" with field=form.evaluator_organisation %}
+        {% include "includes/_form_field.html" with field=form.evaluation_purpose %}
+        {% include "includes/_form_field.html" with field=form.agreement_expiry %}
+    </fieldset>
+
+    <fieldset>
+        <legend>{% trans "Demographic Columns (Quasi-Identifiers)" %}</legend>
+        <small style="display: block; margin-bottom: 1rem;">{% trans "Select which demographic columns to include. More columns provide richer analysis but increase re-identification risk. The system will block the export if the population is too small for the selected columns." %}</small>
+        {% include "includes/_form_field.html" with field=form.include_age_group %}
+        {% include "includes/_form_field.html" with field=form.include_gender %}
+        {% include "includes/_form_field.html" with field=form.include_ethnicity %}
+        {% include "includes/_form_field.html" with field=form.include_geography %}
+    </fieldset>
+
+    <button type="submit">{% trans "Preview Export" %}</button>
+</form>
+{% endblock %}

--- a/templates/reports/evaluation_export_preview.html
+++ b/templates/reports/evaluation_export_preview.html
@@ -1,0 +1,138 @@
+{% extends "base.html" %}
+{% load i18n %}
+
+{% block title %}{% trans "Evaluation Export Preview" %} — {{ site.product_name|default:"KoNote" }}{% endblock %}
+
+{% block content %}
+<hgroup>
+    <h1>{% trans "Evaluation Export Preview" %}</h1>
+    <p>{% trans "Review the de-identification results before generating the export." %}</p>
+</hgroup>
+
+{% if preview.blocked %}
+<article role="alert" style="background: var(--kn-error-bg, #fef2f2); border-left: 4px solid var(--kn-error-fg, #dc2626); padding: 1rem; margin-bottom: 1.5rem;">
+    <strong>{% trans "Export Blocked" %}</strong>
+    {% if preview.block_reason == "population_too_small" %}
+    <p>{% blocktrans with count=preview.consented_count %}The consented population ({{ count }} participants) is too small for a de-identified export. A minimum of 15 participants is required. Use aggregate reports instead.{% endblocktrans %}</p>
+    {% elif preview.block_reason == "suppression_rate_exceeded" %}
+    <p>{% blocktrans with rate=preview.suppression_rate %}The suppression rate ({{ rate|floatformat:0 }}%) exceeds the 15% ceiling. Too many records would need to be removed to maintain k-anonymity. Try selecting fewer demographic columns.{% endblocktrans %}</p>
+    {% elif preview.block_reason == "too_many_qi_columns" %}
+    <p>{% blocktrans with count=preview.qi_columns_used|length tier=preview.tier %}Too many demographic columns selected for the population size. The "{{ tier }}" tier limits the number of columns. Reduce the number of selected columns and try again.{% endblocktrans %}</p>
+    {% else %}
+    <p>{{ preview.block_reason }}</p>
+    {% endif %}
+    <p style="margin-bottom: 0;">
+        <a href="{% url 'reports:evaluation_export' %}" role="button" class="secondary">{% trans "Back to Form" %}</a>
+    </p>
+</article>
+{% endif %}
+
+<article aria-label="{% trans 'Pipeline summary' %}">
+    <header><strong>{% trans "Population Summary" %}</strong></header>
+    <table role="grid">
+        <tbody>
+            <tr>
+                <td>{% trans "Eligible participants" %}</td>
+                <td><strong>{{ preview.eligible_count }}</strong></td>
+            </tr>
+            <tr>
+                <td>{% trans "With consent" %}</td>
+                <td><strong>{{ preview.consented_count }}</strong></td>
+            </tr>
+            <tr>
+                <td>{% trans "Exportable (after de-identification)" %}</td>
+                <td><strong>{{ preview.exportable_count }}</strong></td>
+            </tr>
+            {% if preview.suppressed_count %}
+            <tr>
+                <td>{% trans "Suppressed (k-anonymity)" %}</td>
+                <td><strong>{{ preview.suppressed_count }}</strong></td>
+            </tr>
+            {% endif %}
+            <tr>
+                <td>{% trans "Effective k-anonymity" %}</td>
+                <td><strong>{{ preview.effective_k }}</strong></td>
+            </tr>
+            <tr>
+                <td>{% trans "Export tier" %}</td>
+                <td><strong>{{ preview.tier }}</strong></td>
+            </tr>
+        </tbody>
+    </table>
+</article>
+
+{% if preview.generalizations_applied %}
+<article aria-label="{% trans 'Generalisations applied' %}">
+    <header><strong>{% trans "Generalisations Applied" %}</strong></header>
+    <ul>
+        {% for g in preview.generalizations_applied %}
+        <li><strong>{{ g.field }}</strong>: {{ g.original }} &rarr; {{ g.widened_to }}</li>
+        {% endfor %}
+    </ul>
+</article>
+{% endif %}
+
+{% if preview.suppression_details %}
+<article aria-label="{% trans 'Suppression details' %}">
+    <header><strong>{% trans "Suppression Details" %}</strong></header>
+    <ul>
+        {% for s in preview.suppression_details %}
+        <li>{{ s.description }} ({{ s.count }} records)</li>
+        {% endfor %}
+    </ul>
+</article>
+{% endif %}
+
+<article aria-label="{% trans 'Evaluator confirmation' %}">
+    <header><strong>{% trans "Evaluator Details" %}</strong></header>
+    <table role="grid">
+        <tbody>
+            <tr>
+                <td>{% trans "Name" %}</td>
+                <td>{{ evaluator_info.name }}</td>
+            </tr>
+            <tr>
+                <td>{% trans "Email" %}</td>
+                <td>{{ evaluator_info.email }}</td>
+            </tr>
+            <tr>
+                <td>{% trans "Organisation" %}</td>
+                <td>{{ evaluator_info.organisation }}</td>
+            </tr>
+            <tr>
+                <td>{% trans "Purpose" %}</td>
+                <td>{{ evaluator_info.purpose }}</td>
+            </tr>
+            <tr>
+                <td>{% trans "Agreement expiry" %}</td>
+                <td>{{ evaluator_info.agreement_expiry }}</td>
+            </tr>
+        </tbody>
+    </table>
+</article>
+
+{% if not preview.blocked %}
+<form method="post" action="{% url 'reports:evaluation_export' %}">
+    {% csrf_token %}
+    <input type="hidden" name="action" value="generate">
+    {# Pass through all original form values #}
+    <input type="hidden" name="program" value="{{ form.program.value }}">
+    <input type="hidden" name="period_start" value="{{ form.period_start.value }}">
+    <input type="hidden" name="period_end" value="{{ form.period_end.value }}">
+    <input type="hidden" name="evaluator_name" value="{{ form.evaluator_name.value }}">
+    <input type="hidden" name="evaluator_email" value="{{ form.evaluator_email.value }}">
+    <input type="hidden" name="evaluator_organisation" value="{{ form.evaluator_organisation.value }}">
+    <input type="hidden" name="evaluation_purpose" value="{{ form.evaluation_purpose.value }}">
+    <input type="hidden" name="agreement_expiry" value="{{ form.agreement_expiry.value }}">
+    {% if form.include_age_group.value %}<input type="hidden" name="include_age_group" value="on">{% endif %}
+    {% if form.include_gender.value %}<input type="hidden" name="include_gender" value="on">{% endif %}
+    {% if form.include_ethnicity.value %}<input type="hidden" name="include_ethnicity" value="on">{% endif %}
+    {% if form.include_geography.value %}<input type="hidden" name="include_geography" value="on">{% endif %}
+
+    <div style="display: flex; gap: 1rem; align-items: center;">
+        <button type="submit">{% trans "Generate Export" %}</button>
+        <a href="{% url 'reports:evaluation_export' %}" role="button" class="secondary outline">{% trans "Cancel" %}</a>
+    </div>
+</form>
+{% endif %}
+{% endblock %}

--- a/templates/reports/evaluation_export_preview.html
+++ b/templates/reports/evaluation_export_preview.html
@@ -15,9 +15,9 @@
     {% if preview.block_reason == "population_too_small" %}
     <p>{% blocktrans with count=preview.consented_count %}The consented population ({{ count }} participants) is too small for a de-identified export. A minimum of 15 participants is required. Use aggregate reports instead.{% endblocktrans %}</p>
     {% elif preview.block_reason == "suppression_rate_exceeded" %}
-    <p>{% blocktrans with rate=preview.suppression_rate %}The suppression rate ({{ rate|floatformat:0 }}%) exceeds the 15% ceiling. Too many records would need to be removed to maintain k-anonymity. Try selecting fewer demographic columns.{% endblocktrans %}</p>
+    <p>{% blocktrans with rate=preview.suppression_rate|floatformat:0 %}The suppression rate ({{ rate }}%) exceeds the 15% ceiling. Too many records would need to be removed to maintain k-anonymity. Try selecting fewer demographic columns.{% endblocktrans %}</p>
     {% elif preview.block_reason == "too_many_qi_columns" %}
-    <p>{% blocktrans with count=preview.qi_columns_used|length tier=preview.tier %}Too many demographic columns selected for the population size. The "{{ tier }}" tier limits the number of columns. Reduce the number of selected columns and try again.{% endblocktrans %}</p>
+    <p>{% blocktrans with qi_count=preview.qi_columns_used|length tier=preview.tier %}Too many demographic columns ({{ qi_count }}) selected for the population size. The "{{ tier }}" tier limits the number of columns. Reduce the number of selected columns and try again.{% endblocktrans %}</p>
     {% else %}
     <p>{{ preview.block_reason }}</p>
     {% endif %}


### PR DESCRIPTION
## Summary

- New export type producing de-identified, participant-level CSV for external program evaluators
- 10-step de-identification pipeline: extract → decrypt → consent filter → strip PII → generalise QIs → k-anonymity (k=5) → resolve violations → population gate → generate CSV → suppression report
- Permission-gated (`report.evaluation_export`) with two-step preview/confirm flow
- Enhanced audit trail with evaluator details, pipeline summary, and suppression metadata
- Admin config: `is_evaluation_exportable` on CustomFieldGroup controls which demographics are available as quasi-identifiers

## Key Design Decisions (from DRR)

- **k=5** aligned with CIHI Pan-Canadian De-Identification Guidelines
- **Population thresholds**: n<15 blocked, 15-29 max 3 QI columns, 30+ max 5
- **Suppression ceiling**: 15% — blocks export if too many records need suppression
- **Pseudonymous IDs**: random short codes (EVL-XXXXXX), not sequential or derived
- **Always elevated**: 10-minute delay + admin notification for all evaluation exports
- **Consent**: uses existing `consent_to_aggregate_reporting` field

## New Files

- `apps/reports/deidentify.py` — pipeline engine (~1,250 lines)
- `templates/reports/evaluation_export.html` — form template
- `templates/reports/evaluation_export_preview.html` — preview/confirm template
- `apps/clients/migrations/0043_customfieldgroup_is_evaluation_exportable.py`

## Post-Merge Tasks

- [ ] Run migration on VPS: `docker compose exec web python manage.py migrate`
- [ ] Run `translate_strings` and add French translations for new template strings
- [ ] Add tests on VPS (permission 403, form validation, pipeline smoke test)
- [ ] Update `konote-qa-scenarios` page inventory with new route
- [ ] Update consent form wording to cover de-identified evaluation use (operational)

## Test Plan

- [ ] Verify migration applies cleanly on dev VPS
- [ ] Verify admin can access evaluation export form
- [ ] Verify non-admin user gets 403
- [ ] Verify preview shows correct population counts with demo data
- [ ] Verify blocked export (population too small) shows correct error
- [ ] Verify CSV output has correct format with metadata header
- [ ] Verify audit log entries are created for each pipeline step
- [ ] Verify nav link only appears for users with permission / admins

🤖 Generated with [Claude Code](https://claude.com/claude-code)