### PR TITLE
🛡️ Sentinel: [HIGH] Fix missing rate limits on auth endpoints

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -7,3 +7,8 @@
 **Vulnerability:** The `demo_portal_login` view was missing rate limiting, making it vulnerable to brute-force or DoS attacks.
 **Learning:** Even endpoints designed for demo purposes need to be protected. The `django-ratelimit` decorator with `block=True` should be applied uniformly to all authentication-related endpoints.
 **Prevention:** Always ensure the `@ratelimit(key="ip", rate="...", method="POST", block=True)` decorator is present on any view that processes login or authentication requests. Also make sure the import is present: `from django_ratelimit.decorators import ratelimit`.
+
+## 2025-04-08 - [Missing Rate Limiting on Authentication Boundary Endpoints]
+**Vulnerability:** Endpoints that consume one-time tokens or handle user registrations (like `invite_accept` in `apps/auth_app/invite_views.py` and `staff_assisted_login` in `apps/portal/views.py`) were not rate-limited.
+**Learning:** These endpoints act as authentication boundaries. Without rate limits, they are vulnerable to brute-force attacks on the tokens or DoS attacks via repeated requests.
+**Prevention:** All authentication-related endpoints, including those consuming one-time tokens or handling user registrations (e.g., invite accept links, staff-assisted tokens), must be uniformly protected by the `@ratelimit(key="ip", rate="...", method=["GET", "POST"], block=True)` decorator. Both GET and POST should be protected where applicable to prevent abuse.

--- a/apps/auth_app/invite_views.py
+++ b/apps/auth_app/invite_views.py
@@ -8,6 +8,7 @@ from django.http import Http404
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils import timezone
 from django.utils.translation import gettext as _
+from django_ratelimit.decorators import ratelimit
 
 from apps.programs.models import UserProgramRole
 
@@ -52,6 +53,7 @@ def invite_create(request):
     return render(request, "auth_app/invite_form.html", {"form": form})
 
 
+@ratelimit(key="ip", rate="10/m", method=["GET", "POST"], block=True)
 def invite_accept(request, code):
     """Public view — new user registers via invite link."""
     invite = get_object_or_404(Invite, code=code)

--- a/apps/portal/views.py
+++ b/apps/portal/views.py
@@ -1020,6 +1020,7 @@ def password_reset_confirm(request):
 
 
 @portal_feature_required
+@ratelimit(key="ip", rate="10/m", method=["GET", "POST"], block=True)
 def staff_assisted_login(request, token):
     """Log a participant in via a staff-generated one-time token."""
     from apps.portal.models import StaffAssistedLoginToken


### PR DESCRIPTION
Added rate limiting decorators to `invite_accept` and `staff_assisted_login` endpoints to prevent abuse and brute-force attacks on authentication boundaries. Also updated the Sentinel Journal with this learning.

---
*PR created automatically by Jules for task [6189298195654663343](https://jules.google.com/task/6189298195654663343) started by @pboachie*