### PR TITLE
🎨 Palette: Add aria-labels to progress bars

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -16,3 +16,6 @@
 ## 2025-03-11 - Add Empty State Styles with A11y to Portal
 **Learning:** Many pages in the portal application render empty states inside `<article class="portal-empty-state">` blocks. However, the corresponding styling for `.portal-empty-state` was completely missing from `portal.css`. Also, when using CSS pseudo-elements to add an emoji icon (like `content: "\1F4CB"`), screen readers will try to read it. Using the `/ ""` syntax (`content: "\1F4CB" / ""`) ensures it stays decorative and prevents it from being read aloud.
 **Action:** When adding empty state CSS with emojis or icons using `::before`, always include `/ ""` to avoid screen readers announcing decorative visuals.
+## 2024-03-24 - [ARIA labels for progress bars]
+**Learning:** Progress bars (`<progress>`) used to track metrics need descriptive `aria-label`s to be fully accessible for screen readers (WCAG 4.1.2).
+**Action:** When adding or updating `<progress>` tags in templates, always ensure they include an appropriate `aria-label` describing the metric being tracked.

--- a/templates/programs/evaluation/framework_detail.html
+++ b/templates/programs/evaluation/framework_detail.html
@@ -21,7 +21,7 @@
 <section>
     <h2>{% trans "CIDS Class Coverage" %}</h2>
     <p>{{ cids_coverage|length }} / {{ total_cids_classes }} {% trans "classes mapped" %} ({{ coverage_pct }}%)</p>
-    <progress value="{{ cids_coverage|length }}" max="{{ total_cids_classes }}"></progress>
+    <progress value="{{ cids_coverage|length }}" max="{{ total_cids_classes }}" aria-label="{% trans 'CIDS class coverage' %}"></progress>
 
     {% if framework.is_attested %}
     <article>

--- a/templates/reports/cids_coverage_dashboard.html
+++ b/templates/reports/cids_coverage_dashboard.html
@@ -13,7 +13,7 @@
     <article>
         <header>{% trans "Agency Coverage" %}</header>
         <p><strong>{{ all_classes_count }} / {{ total_classes }}</strong> {% trans "CIDS classes" %}</p>
-        <progress value="{{ all_classes_count }}" max="{{ total_classes }}"></progress>
+        <progress value="{{ all_classes_count }}" max="{{ total_classes }}" aria-label="{% trans 'Agency coverage' %}"></progress>
     </article>
     <article>
         <header>{% trans "Programs" %}</header>
@@ -35,7 +35,7 @@
                 <strong>{{ summary.program.name }}</strong>
                 <span>{{ summary.present }} / {{ summary.total }} ({{ summary.pct }}%)</span>
             </div>
-            <progress value="{{ summary.present }}" max="{{ summary.total }}"></progress>
+            <progress value="{{ summary.present }}" max="{{ summary.total }}" aria-label="{% blocktrans with name=summary.program.name %}Coverage for {{ name }}{% endblocktrans %}"></progress>
         </header>
         <figure>
         <table role="grid">

--- a/templates/reports/cids_export_status.html
+++ b/templates/reports/cids_export_status.html
@@ -9,7 +9,7 @@
     <p>{{ program.name }} — {{ present }} / {{ total }} {% trans "classes" %} ({{ pct }}%)</p>
 </hgroup>
 
-<progress value="{{ present }}" max="{{ total }}"></progress>
+<progress value="{{ present }}" max="{{ total }}" aria-label="{% trans 'CIDS export status progress' %}"></progress>
 
 {% if framework %}
 <article>


### PR DESCRIPTION
💡 **What:** Added descriptive `aria-label` attributes to `<progress>` tags in the CIDS coverage dashboard, CIDS export status, and framework detail templates. Also logged a new entry in the `.Jules/palette.md` journal.
🎯 **Why:** Progress bars are used to track specific metrics in these templates. Without `aria-label`s, screen readers do not provide users with context about what the progress bar represents, which is an accessibility issue (WCAG 4.1.2). Adding these labels makes the application more accessible and inclusive.
♿ **Accessibility:** Added appropriate aria-labels so screen readers announce "Agency coverage", "Coverage for [Program Name]", "CIDS export status progress", and "CIDS class coverage" respectively when reading the progress bars.

---
*PR created automatically by Jules for task [1250371354758950888](https://jules.google.com/task/1250371354758950888) started by @pboachie*