### PR TITLE
Fix browser title showing agency name instead of KoNote

### DIFF
--- a/konote/context_processors.py
+++ b/konote/context_processors.py
@@ -110,11 +110,17 @@ def instance_settings(request):
         settings_dict = InstanceSetting.get_all()
         cache.set("instance_settings", settings_dict, 300)
 
+    # Copy before mutating so the cached dict stays clean
+    settings_dict = dict(settings_dict)
+
     # Resolve bilingual organization name based on current language
     lang = get_language() or "en"
     if lang.startswith("fr") and settings_dict.get("organization_name_fr"):
-        settings_dict = dict(settings_dict)  # copy to avoid mutating cache
         settings_dict["organization_name"] = settings_dict["organization_name_fr"]
+
+    # product_name is always "KoNote" — the legacy key was replaced by
+    # organization_name, but templates still reference site.product_name.
+    settings_dict["product_name"] = "KoNote"
 
     return {"site": settings_dict}
 


### PR DESCRIPTION
## Summary
- The legacy `product_name` instance setting (renamed to `organization_name` in the admin form) was still persisting in the DB on some instances
- Templates use `{{ site.product_name|default:"KoNote" }}` for `<title>` tags, so the default never kicked in when the old key existed
- Fix: the `instance_settings` context processor now always sets `product_name = "KoNote"` since the product name is constant — the agency name is available separately as `organization_name`

## Test plan
- [ ] Visit demo.konote.ca, bookmark the sign-in page — title should show "Sign In — KoNote"
- [ ] Navigate to any page after login — browser tab should show "Page — KoNote"

🤖 Generated with [Claude Code](https://claude.com/claude-code)