### PR TITLE
Rename Evaluation Export to Evaluator Export (Confidential)

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -157,7 +157,7 @@
                         {% endif %}
                         {% has_permission "report.evaluation_export" as can_see_eval_export %}
                         {% if can_see_eval_export or user.is_admin %}
-                        <li role="none"><a role="menuitem" href="{% url 'reports:evaluation_export' %}">{% trans "Evaluation Export" %}</a></li>
+                        <li role="none"><a role="menuitem" href="{% url 'reports:evaluation_export' %}">{% trans "Evaluator Export (Confidential)" %}</a></li>
                         {% endif %}
                         {% if can_see_compliance %}
                         <li role="none"><a role="menuitem" href="{% url 'audit:compliance_summary' %}">{% trans "Privacy & Access Audit" %}</a></li>

--- a/templates/reports/evaluation_export.html
+++ b/templates/reports/evaluation_export.html
@@ -1,11 +1,11 @@
 {% extends "base.html" %}
 {% load i18n %}
 
-{% block title %}{% trans "Evaluation Export" %} — {{ site.product_name|default:"KoNote" }}{% endblock %}
+{% block title %}{% trans "Evaluator Export (Confidential)" %} — {{ site.product_name|default:"KoNote" }}{% endblock %}
 
 {% block content %}
 <hgroup>
-    <h1>{% trans "De-Identified Evaluation Export" %}</h1>
+    <h1>{% trans "Evaluator Export (Confidential)" %}</h1>
     <p>{% trans "Generate a de-identified, participant-level CSV for an external program evaluator." %}</p>
 </hgroup>
 

--- a/templates/reports/evaluation_export_preview.html
+++ b/templates/reports/evaluation_export_preview.html
@@ -1,11 +1,11 @@
 {% extends "base.html" %}
 {% load i18n %}
 
-{% block title %}{% trans "Evaluation Export Preview" %} — {{ site.product_name|default:"KoNote" }}{% endblock %}
+{% block title %}{% trans "Evaluator Export Preview" %} — {{ site.product_name|default:"KoNote" }}{% endblock %}
 
 {% block content %}
 <hgroup>
-    <h1>{% trans "Evaluation Export Preview" %}</h1>
+    <h1>{% trans "Evaluator Export Preview" %}</h1>
     <p>{% trans "Review the de-identification results before generating the export." %}</p>
 </hgroup>
 


### PR DESCRIPTION
## Summary

Renames the menu item and page titles from "Evaluation Export" to "Evaluator Export (Confidential)" to differentiate from standard reports and signal that this contains sensitive de-identified data for an external evaluator.

- Menu: Reports → **Evaluator Export (Confidential)**
- Form page title: **Evaluator Export (Confidential)**
- Preview page title: **Evaluator Export Preview**

French translations will be picked up when `translate_strings` runs on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)