### PR TITLE
Enforce per-user grant for Evaluator Export, add Team Members link, wire demo seed

### DIFF
--- a/apps/admin_settings/management/commands/seed.py
+++ b/apps/admin_settings/management/commands/seed.py
@@ -35,6 +35,12 @@ class Command(BaseCommand):
             self._update_demo_client_fields()
             # Step 2: Top up each program to 20-30 clients with engine
             self._top_up_demo_data()
+            # Step 3: Set up the Evaluator Export demo (Supported Employment):
+            # adds extra participants, demographics, consent flags, discharges,
+            # plans, notes, marks Demographics group as exportable, and grants
+            # the evaluation_export permission to demo-worker-1, demo-manager
+            # and demo-executive so the end-to-end export flow can be tested.
+            self._seed_eval_export_demo()
         self.stdout.write(self.style.SUCCESS("Seed complete."))
 
     def _generate_config_aware_demo_data(self, profile_path):
@@ -899,3 +905,22 @@ class Command(BaseCommand):
         from django.core.management import call_command
 
         call_command("update_demo_client_fields", stdout=self.stdout)
+
+    def _seed_eval_export_demo(self):
+        """Set up the Evaluator Export demo on Supported Employment.
+
+        Runs only when DEMO_MODE is on (the sub-command guards itself too).
+        Non-fatal if it fails — the app still starts, but the Evaluator
+        Export walkthrough won't have its extra participants or permission
+        grants.
+        """
+        from django.core.management import call_command
+
+        try:
+            call_command("seed_eval_export_demo", stdout=self.stdout)
+        except Exception as e:
+            self.stderr.write(f"  WARNING: seed_eval_export_demo failed: {e}")
+            self.stderr.write(
+                "  App will start but the Evaluator Export demo may be "
+                "incomplete."
+            )

--- a/apps/auth_app/permissions.py
+++ b/apps/auth_app/permissions.py
@@ -70,7 +70,7 @@ PERMISSIONS = {
 
         "report.program_report": DENY,  # Managers generate, not front desk
         "report.funder_report": DENY,  # Managers/executives generate funder reports
-        "report.evaluation_export": DENY,  # Explicit grant only — admin or per-user
+        "report.evaluation_export": DENY,  # Explicit per-user grant only — not tied to any role (admins must be granted too)
         "report.data_extract": DENY,
 
         "insights.view": DENY,  # Outcome insights — staff+ only
@@ -176,7 +176,7 @@ PERMISSIONS = {
 
         "report.program_report": DENY,
         "report.funder_report": DENY,  # Managers/executives generate funder reports
-        "report.evaluation_export": DENY,  # Explicit grant only — admin or per-user
+        "report.evaluation_export": DENY,  # Explicit per-user grant only — not tied to any role (admins must be granted too)
         "report.data_extract": DENY,
 
         "insights.view": PROGRAM,  # Program-level outcome insights. Enforced by @requires_permission
@@ -289,7 +289,7 @@ PERMISSIONS = {
                                         # + _save_export_and_create_link()
         "report.funder_report": ALLOW,  # Managers generate funder reports for their programs.
                                         # Enforced by @requires_permission
-        "report.evaluation_export": DENY,  # Explicit grant only — admin or per-user
+        "report.evaluation_export": DENY,  # Explicit per-user grant only — not tied to any role (admins must be granted too)
         "report.data_extract": ALLOW,  # PM handles PIPEDA data portability requests
 
         "insights.view": ALLOW,  # Program-level outcome insights. Enforced by @requires_permission
@@ -401,7 +401,7 @@ PERMISSIONS = {
         "report.program_report": ALLOW,  # View only (managers generate). Enforced by @requires_permission
         "report.funder_report": ALLOW,  # Executives can generate aggregate funder reports.
                                         # Enforced by @requires_permission
-        "report.evaluation_export": DENY,  # Explicit grant only — admin or per-user
+        "report.evaluation_export": DENY,  # Explicit per-user grant only — not tied to any role (admins must be granted too)
         "report.data_extract": DENY,
 
         "insights.view": ALLOW,  # Aggregate outcome insights only (quotes suppressed).

--- a/apps/reports/management/commands/seed_eval_export_demo.py
+++ b/apps/reports/management/commands/seed_eval_export_demo.py
@@ -694,30 +694,38 @@ class Command(BaseCommand):
             ))
 
     def _grant_permission(self):
-        """Grant evaluation export permission to demo-manager."""
-        manager = User.objects.filter(username="demo-manager").first()
-        if manager:
-            if not manager.evaluation_export_granted:
-                manager.evaluation_export_granted = True
-                manager.save(update_fields=["evaluation_export_granted"])
-                self.stdout.write(
-                    "  Granted evaluation export permission to demo-manager."
-                )
-            else:
-                self.stdout.write(
-                    "  demo-manager already has evaluation export permission."
-                )
-        else:
-            self.stdout.write(self.style.WARNING(
-                "  demo-manager user not found."
-            ))
+        """Grant evaluation export permission to demo users who should hold it.
 
-        # Also grant to demo-executive (ED can also export)
-        executive = User.objects.filter(username="demo-executive").first()
-        if executive:
-            if not executive.evaluation_export_granted:
-                executive.evaluation_export_granted = True
-                executive.save(update_fields=["evaluation_export_granted"])
+        Governance model (see tasks/eval-export-governance.md): the permission
+        is DENY for all roles by default and must be explicitly granted per
+        user. Admins do NOT auto-hold it — they grant it to operators. For
+        the demo we grant to:
+          - demo-executive (Eva, ED who authorises evaluations)
+          - demo-manager (Morgan, PM who executes exports)
+          - demo-worker-1 (Casey, PM in Supported Employment, the program
+            the demo export is wired up against)
+        """
+        grantees = [
+            ("demo-worker-1", "Casey Worker"),
+            ("demo-manager", "Morgan Manager"),
+            ("demo-executive", "Eva Executive"),
+        ]
+        for username, display_name in grantees:
+            user = User.objects.filter(username=username).first()
+            if not user:
+                self.stdout.write(self.style.WARNING(
+                    f"  {username} user not found."
+                ))
+                continue
+            if user.evaluation_export_granted:
                 self.stdout.write(
-                    "  Granted evaluation export permission to demo-executive."
+                    f"  {display_name} ({username}) already has "
+                    f"evaluation export permission."
                 )
+                continue
+            user.evaluation_export_granted = True
+            user.save(update_fields=["evaluation_export_granted"])
+            self.stdout.write(
+                f"  Granted evaluation export permission to "
+                f"{display_name} ({username})."
+            )

--- a/apps/reports/utils.py
+++ b/apps/reports/utils.py
@@ -61,17 +61,19 @@ def can_download_pii_export(user):
 def can_create_evaluation_export(user):
     """Check if this user can create evaluation microdata exports.
 
-    Evaluation exports are restricted to users with the explicit
-    report.evaluation_export permission or admin users. This is a
-    separate permission from report.program_report because evaluation
-    exports serve a different purpose (external sharing) with different
-    safeguards (evaluator details, enhanced audit).
+    Evaluation exports require the explicit report.evaluation_export
+    permission, which is DENY for all roles by default and must be
+    granted per-user. Admins do NOT automatically hold this permission:
+    the governance model (see tasks/eval-export-governance.md) separates
+    the permission granter (admin) from the operator, so an admin must
+    be explicitly granted the permission to generate exports themselves.
+    This is a separate permission from report.program_report because
+    evaluation exports serve a different purpose (external sharing) with
+    different safeguards (evaluator details, enhanced audit).
 
     Returns:
         True if the user can create evaluation exports.
     """
-    if user.is_admin:
-        return True
     # Check per-user explicit grant (set by admin via admin panel or seed)
     if getattr(user, "evaluation_export_granted", False):
         return True

--- a/templates/base.html
+++ b/templates/base.html
@@ -156,7 +156,7 @@
                         <li role="none"><a role="menuitem" href="{% url 'reports:export_form' %}">{% trans "Build a Report" %}</a></li>
                         {% endif %}
                         {% has_permission "report.evaluation_export" as can_see_eval_export %}
-                        {% if can_see_eval_export or user.is_admin %}
+                        {% if can_see_eval_export %}
                         <li role="none"><a role="menuitem" href="{% url 'reports:evaluation_export' %}">{% trans "Evaluator Export (Confidential)" %}</a></li>
                         {% endif %}
                         {% if can_see_compliance %}
@@ -189,6 +189,7 @@
                         <li role="none"><a role="menuitem" href="{% url 'admin_settings:dashboard' %}">{% trans "Settings" %}</a></li>
                         <li role="none"><a role="menuitem" href="{% url 'admin_settings:report_template_list' %}">{% trans "Report Templates" %}</a></li>
                         <li role="none"><a role="menuitem" href="{% url 'reports:oversight_list' %}">{% trans "Safety Oversight" %}</a></li>
+                        <li role="none"><a role="menuitem" href="{% url 'admin_users:user_list' %}">{% trans "Team Members" %}</a></li>
                         <li role="none"><a role="menuitem" href="{% url 'admin_users:invite_list' %}">{% trans "User Invites" %}</a></li>
                         <li role="none"><a role="menuitem" href="{% url 'audit:audit_log_list' %}">{% trans "Audit Log" %}</a></li>
                         <li role="none"><a role="menuitem" href="{% url 'merge_candidates_list' %}">{% trans "Merge Duplicates" %}</a></li>


### PR DESCRIPTION
## Summary

Three UX/governance bugs in the Evaluator Export (Confidential) flow, plus wiring the demo seed so the feature is testable on demo.konote.ca.

### Bugs fixed

1. **Admin could see and generate evaluator exports** — violated the governance model in [tasks/eval-export-governance.md](tasks/eval-export-governance.md). The permission is supposed to be DENY for all roles by default and explicitly granted per-user; admins are the *granters*, not the *operators*. Removed the \`is_admin\` bypass in two places:
   - [apps/reports/utils.py](apps/reports/utils.py) — \`can_create_evaluation_export\` view-level gate
   - [templates/base.html](templates/base.html) — Reports dropdown nav visibility
2. **No Team Members link in the admin menu** — admins had \`User Invites\` but no way to view or edit existing users. Added the missing \`admin_users:user_list\` link to the admin dropdown in [templates/base.html](templates/base.html).
3. **Stale comment** in [apps/auth_app/permissions.py](apps/auth_app/permissions.py) claimed the permission was granted to admins; updated to reflect the corrected model.

### Demo seed

- [apps/reports/management/commands/seed_eval_export_demo.py](apps/reports/management/commands/seed_eval_export_demo.py): grant \`evaluation_export_granted\` to Casey Worker (\`demo-worker-1\`, PM in Supported Employment — the program the demo export is wired up against) alongside Morgan Manager and Eva Executive.
- [apps/admin_settings/management/commands/seed.py](apps/admin_settings/management/commands/seed.py): wire \`seed_eval_export_demo\` into the main seed orchestrator. Previously the command existed but was never called on container startup, so the demo export walkthrough was missing its extra participants, demographics, consent flags, and permission grants.

### Governance source of truth

[tasks/eval-export-governance.md](tasks/eval-export-governance.md):

> Anyone with the \`report.evaluation_export\` permission. This permission is DENY for all roles by default — it must be explicitly granted per-user. [...] The Admin grants \`report.evaluation_export\` in the KoNote admin panel. [...] This is the two-person control: ED approves the evaluation engagement → Admin grants the permission.

## Test plan

- [ ] Deploy to \`demo-dev.konote.ca\` (dev branch) — confirm container starts and seeds run without errors
- [ ] Sign in as Alex Admin — confirm **Evaluator Export (Confidential)** is NOT in the Reports dropdown
- [ ] Confirm **Team Members** now appears in the Admin dropdown and opens the user list
- [ ] Sign in as Casey Worker — confirm **Evaluator Export (Confidential)** IS in the Reports dropdown and the form loads
- [ ] Sign in as Morgan Manager and Eva Executive — confirm the link is visible for both
- [ ] Admin hits \`/reports/evaluation-export/\` directly while NOT granted — confirm 403

## Follow-up (not in this PR)

EVAL-GOV1 — build a proper in-KoNote UI for granting \`report.evaluation_export\` (currently only settable via Django admin at \`/admin/auth_app/user/\`) with a mandatory reason field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)