### PR TITLE
Simplify eval export check and short-circuit demo seed

### DIFF
--- a/apps/admin_settings/management/commands/seed.py
+++ b/apps/admin_settings/management/commands/seed.py
@@ -35,11 +35,6 @@ class Command(BaseCommand):
             self._update_demo_client_fields()
             # Step 2: Top up each program to 20-30 clients with engine
             self._top_up_demo_data()
-            # Step 3: Set up the Evaluator Export demo (Supported Employment):
-            # adds extra participants, demographics, consent flags, discharges,
-            # plans, notes, marks Demographics group as exportable, and grants
-            # the evaluation_export permission to demo-worker-1, demo-manager
-            # and demo-executive so the end-to-end export flow can be tested.
             self._seed_eval_export_demo()
         self.stdout.write(self.style.SUCCESS("Seed complete."))
 

--- a/apps/auth_app/templatetags/permissions_tags.py
+++ b/apps/auth_app/templatetags/permissions_tags.py
@@ -57,7 +57,8 @@ def has_permission(context, permission_key):
     if level != DENY:
         return True
 
-    # Check per-user explicit grants for specific permissions
+    # Check per-user explicit grants for specific permissions.
+    # Mirrors apps.reports.utils.can_create_evaluation_export — keep in sync.
     if permission_key == "report.evaluation_export":
         return getattr(user, "evaluation_export_granted", False)
 

--- a/apps/reports/management/commands/seed_eval_export_demo.py
+++ b/apps/reports/management/commands/seed_eval_export_demo.py
@@ -51,6 +51,17 @@ NON_CONSENTING_COUNT = 3
 # How many participants should be discharged
 DISCHARGED_COUNT = 6
 
+# Demo users who receive the report.evaluation_export grant. Governance
+# model (tasks/eval-export-governance.md): per-user grant only, admins
+# are NOT auto-granted. Casey Worker is PM in Supported Employment (the
+# program the demo export is wired to), Morgan is PM elsewhere, and Eva
+# is the ED who authorises evaluations.
+EVAL_EXPORT_GRANTEES = [
+    ("demo-worker-1", "Casey Worker"),
+    ("demo-manager", "Morgan Manager"),
+    ("demo-executive", "Eva Executive"),
+]
+
 # Demographic distributions (counts, not percentages, for 35 people)
 GENDER_DISTRIBUTION = [
     ("Woman", 16),
@@ -162,6 +173,27 @@ class Command(BaseCommand):
             return
 
         self.stdout.write(f"Target program: {program.name} (id={program.pk})")
+
+        # Fast path: if the demo is already set up (target participants
+        # reached AND the permission grantees already hold the flag) skip
+        # the full idempotent sweep. This matters because `seed` runs on
+        # every container startup and the sweep otherwise does ~1-5 s of
+        # read + unconditional-write DB work.
+        enrolment_count = ClientProgramEnrolment.objects.filter(
+            program=program, client_file__is_demo=True,
+        ).count()
+        granted_count = User.objects.filter(
+            username__in=[u for u, _ in EVAL_EXPORT_GRANTEES],
+            evaluation_export_granted=True,
+        ).count()
+        if (
+            enrolment_count >= TARGET_PARTICIPANTS
+            and granted_count == len(EVAL_EXPORT_GRANTEES)
+        ):
+            self.stdout.write(
+                "  Evaluator Export demo already seeded — skipping."
+            )
+            return
 
         # 2. Find the PM worker for this program
         pm_role = UserProgramRole.objects.filter(
@@ -694,23 +726,8 @@ class Command(BaseCommand):
             ))
 
     def _grant_permission(self):
-        """Grant evaluation export permission to demo users who should hold it.
-
-        Governance model (see tasks/eval-export-governance.md): the permission
-        is DENY for all roles by default and must be explicitly granted per
-        user. Admins do NOT auto-hold it — they grant it to operators. For
-        the demo we grant to:
-          - demo-executive (Eva, ED who authorises evaluations)
-          - demo-manager (Morgan, PM who executes exports)
-          - demo-worker-1 (Casey, PM in Supported Employment, the program
-            the demo export is wired up against)
-        """
-        grantees = [
-            ("demo-worker-1", "Casey Worker"),
-            ("demo-manager", "Morgan Manager"),
-            ("demo-executive", "Eva Executive"),
-        ]
-        for username, display_name in grantees:
+        """Grant report.evaluation_export to each user in EVAL_EXPORT_GRANTEES."""
+        for username, display_name in EVAL_EXPORT_GRANTEES:
             user = User.objects.filter(username=username).first()
             if not user:
                 self.stdout.write(self.style.WARNING(

--- a/apps/reports/utils.py
+++ b/apps/reports/utils.py
@@ -59,35 +59,14 @@ def can_download_pii_export(user):
 
 
 def can_create_evaluation_export(user):
-    """Check if this user can create evaluation microdata exports.
+    """Return True if this user holds the per-user evaluation_export grant.
 
-    Evaluation exports require the explicit report.evaluation_export
-    permission, which is DENY for all roles by default and must be
-    granted per-user. Admins do NOT automatically hold this permission:
-    the governance model (see tasks/eval-export-governance.md) separates
-    the permission granter (admin) from the operator, so an admin must
-    be explicitly granted the permission to generate exports themselves.
-    This is a separate permission from report.program_report because
-    evaluation exports serve a different purpose (external sharing) with
-    different safeguards (evaluator details, enhanced audit).
-
-    Returns:
-        True if the user can create evaluation exports.
+    Per-user only — not tied to any role, not auto-granted to admins. See
+    tasks/eval-export-governance.md. The nav-level check in
+    apps/auth_app/templatetags/permissions_tags.py mirrors this rule; keep
+    them in sync.
     """
-    # Check per-user explicit grant (set by admin via admin panel or seed)
-    if getattr(user, "evaluation_export_granted", False):
-        return True
-    # Check if user has the evaluation_export permission via their role
-    from apps.auth_app.permissions import DENY, can_access
-    from apps.programs.models import UserProgramRole
-
-    roles = UserProgramRole.objects.filter(
-        user=user, status="active"
-    ).values_list("role", flat=True).distinct()
-    for role in roles:
-        if can_access(role, "report.evaluation_export") != DENY:
-            return True
-    return False
+    return getattr(user, "evaluation_export_granted", False)
 
 
 def can_create_export(user, export_type, program=None):


### PR DESCRIPTION
## Summary

Follow-up to #617 addressing findings from a `/simplify` review:

- **Delete dead role loop** in \`can_create_evaluation_export\` (apps/reports/utils.py). All four roles have \`DENY\` for \`report.evaluation_export\` in apps/auth_app/permissions.py, so the trailing role loop could never return \`True\` — and worse, it would have silently bypassed the per-user governance if a role were ever flipped to \`ALLOW\`. The function is now a one-line attribute read, matching the template tag's fast path. Also collapses the 8-line docstring that was narrating the governance doc.
- **Cross-reference comment** in apps/auth_app/templatetags/permissions_tags.py so the two per-user evaluation_export_granted checks don't silently drift.
- **Fast-path short-circuit** in seed_eval_export_demo.\_run(). The seed runs on every container startup (wired via the main orchestrator) and previously did ~1-5s of read + unconditional-write DB work even when the demo was already fully seeded. Two cheap indexed queries now let us skip the whole sweep when enrolments are at target and all grantees already hold the permission.
- **Hoist grantees to EVAL_EXPORT_GRANTEES** module-level constant shared between the fast-path check and \`_grant_permission\` so the two callers can't drift.
- **Delete 5-line narrating comment** in seed.py — the method name self-documents and the comment just restated the sub-command's own docstring.

## Test plan

- [ ] Deploy to dev — confirm first startup runs the seed normally, second startup prints "Evaluator Export demo already seeded — skipping."
- [ ] Sign in as Alex Admin — still no Evaluator Export link (behaviour unchanged from #617)
- [ ] Sign in as Casey Worker — Evaluator Export link still present and form still loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)