### PR TITLE
TODO: record Evaluator Export bypass fix and link EVAL-GOV1 prompt

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -105,7 +105,7 @@ Step-by-step commands for each task are in [tasks/recurring-tasks.md](tasks/recu
 ### Phase: Evaluation Export Governance & Documentation (see tasks/eval-export-governance.md)
 
 **Code & UI:**
-- [ ] Add reason field to evaluation export permission grant — free-text logged when `report.evaluation_export` is granted (EVAL-GOV1)
+- [ ] Add reason field to evaluation export permission grant — free-text logged when `report.evaluation_export` is granted. Detailed implementation prompt in [tasks/phase-eval-gov1-prompt.md](tasks/phase-eval-gov1-prompt.md) — a new session can pick this up cold (EVAL-GOV1)
 - [ ] Admin dashboard card for evaluation export — shows N authorised users, last export date, click-through to permission list (EVAL-GOV2)
 - [ ] Permission audit list page — who has the permission, granted by whom, when, why, last used, revoke button (EVAL-GOV3)
 - [ ] Export history view — past evaluation exports with program, evaluator, counts, status (EVAL-GOV4)
@@ -143,6 +143,7 @@ Not yet clear we should build these, or the design isn't settled. May be too com
 
 ## Recently Done
 
+- [x] Close Evaluator Export admin bypass — removed `is_admin` bypass in `can_create_evaluation_export` + nav check, added missing Team Members link to admin menu, wired `seed_eval_export_demo` into container-startup orchestrator with Casey/Morgan/Eva granted, added fast-path short-circuit, hoisted `EVAL_EXPORT_GRANTEES` constant, added regression tests (`EvaluatorExportPermissionTest` in `tests/test_export_permissions.py`), wrote EVAL-GOV1 implementation prompt — PRs #617, #622, #623, #624 — 2026-04-09 (EVAL-GOV-BYPASS1)
 - [x] De-identified evaluation microdata export — 10-step de-identification pipeline with k-anonymity (k=5), pseudonymous IDs, generalised demographics, population thresholds, enhanced audit trail, preview/confirm flow, permission-gated nav — 2026-04-07 (EVAL-EXPORT1)
 - [x] Insights quality & language features — DQ1: practice signal contextual sentence + month count in summary bar; CONF1: raised theme auto-link threshold from 2→3 words; LANG1: EN/FR language detection on quotes, AI prompt language awareness, FR pills on mixed-language Insights pages — PR #595 — 2026-04-03 (INSIGHTS-DQ1, INSIGHTS-CONF1, INSIGHTS-LANG1)
 - [x] Dashboard & Insights enrichment — FHIR metadata features: program summary sentences, practice indicators, goal source distribution on Insights; stale episodes attention signal on Dashboard; batch query optimization; simplified both pages (removed funder stats, cohort comparison, cross-tab, dashboard bloat — 8 sections → 5 on Insights, ~20 rows → ~8 per program card) — PRs #529-#533 — 2026-03-16 (ENRICH1)


### PR DESCRIPTION
## Summary

Housekeeping after the governance fix session:

- Adds a **Recently Done** entry bundling PRs #617, #622, #623, #624 as \`EVAL-GOV-BYPASS1\`
- Adds a pointer on the EVAL-GOV1 line to \`tasks/phase-eval-gov1-prompt.md\` so a future session can pick it up cold without re-reading the /review-session thread

No code changes. Doc-only PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)