### PR TITLE
fix: test date filters and perm map entry

### DIFF
--- a/tests/test_exports.py
+++ b/tests/test_exports.py
@@ -12,7 +12,7 @@ Covers CHART-TIME1: client_analysis timeframe filter.
 Covers IMPROVE-4: get_quarter_range() and get_quarter_choices() utility functions.
 """
 import json
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta
 from unittest.mock import patch
 
 from cryptography.fernet import Fernet
@@ -532,6 +532,7 @@ class FunderReportTemplateMetricFilterTest(TestCase):
         # Create a note with values for both metrics
         note = ProgressNote.objects.create(
             client_file=self.client_file, author=self.user,
+            backdate=timezone.make_aware(datetime(2025, 6, 15, 10, 0)),
         )
         pnt = ProgressNoteTarget.objects.create(
             progress_note=note, plan_target=target,

--- a/tests/test_permissions_enforcement.py
+++ b/tests/test_permissions_enforcement.py
@@ -116,6 +116,7 @@ PERMISSION_URL_MAP = {
     "report.program_report": {"url": "/reports/export/"},
     "report.funder_report": {"url": "/reports/export/"},
     "report.data_extract": {"url": "/reports/participant/{client_id}/export/"},
+    "report.evaluation_export": {"url": "/reports/evaluation-export/"},
 
     # Insights
     "insights.view": {"url": "/reports/insights/"},

--- a/tests/test_reports.py
+++ b/tests/test_reports.py
@@ -1607,7 +1607,7 @@ class GenerateFunderReportDataTests(TestCase):
             client_file=client,
             note_type="quick",
             author=self.user,
-            created_at=timezone.make_aware(datetime(2025, 6, 15, 10, 0)),
+            backdate=timezone.make_aware(datetime(2025, 6, 15, 10, 0)),
         )
 
         report_data = generate_funder_report_data(
@@ -1636,16 +1636,19 @@ class GenerateFunderReportDataTests(TestCase):
             client_file=client, note_type="quick",
             interaction_type="phone", outcome="reached",
             author=self.user, notes_text="Reached them.",
+            backdate=timezone.make_aware(datetime(2025, 6, 15, 10, 0)),
         )
         ProgressNote.objects.create(
             client_file=client, note_type="quick",
             interaction_type="phone", outcome="no_answer",
             author=self.user, notes_text="No answer.",
+            backdate=timezone.make_aware(datetime(2025, 7, 10, 10, 0)),
         )
         ProgressNote.objects.create(
             client_file=client, note_type="quick",
             interaction_type="sms", outcome="left_message",
             author=self.user, notes_text="Left message.",
+            backdate=timezone.make_aware(datetime(2025, 8, 5, 10, 0)),
         )
 
         report_data = generate_funder_report_data(
@@ -3071,7 +3074,7 @@ class ExportWarningDialogTests(TestCase):
             client_file=self.client_file,
             note_type="full",
             author=self.admin,
-            created_at=timezone.make_aware(datetime(2025, 6, 15, 10, 0)),
+            backdate=timezone.make_aware(datetime(2025, 6, 15, 10, 0)),
         )
         pnt = ProgressNoteTarget.objects.create(
             progress_note=note,


### PR DESCRIPTION
## Summary
- Use `backdate` instead of `created_at` in test fixtures — `auto_now_add=True` ignores explicit values, and today (2026-04-09) is past the hardcoded fiscal year end (2026-03-31)
- Add missing `report.evaluation_export` entry to `PERMISSION_URL_MAP`

## Test plan
- [x] All 8 previously failing tests pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)