### PR TITLE
Add LTE tier DRR and implementation prompt

### DIFF
--- a/.claude/skills/design-rationale/drr-index.md
+++ b/.claude/skills/design-rationale/drr-index.md
@@ -25,7 +25,7 @@ For any proposal, **always check the relevant foundation first**, then drill int
 | **Consent, PHIPA, cross-program notes, clinical note visibility** | `phipa-consent-enforcement.md`, `access-tiers.md` |
 | **AI, LLM, machine learning, suggestions, scoring, prompts** | `ai-feature-toggles.md`, `self-hosted-llm-infrastructure.md` |
 | **Encryption, key rotation, PII, decryption, Fernet** | `encryption-key-rotation.md`, `no-live-api-individual-data.md` |
-| **Reports, dashboards, funder reporting, executive view, exports** | `reporting-architecture.md`, `insights-metric-distributions.md`, `funder-reporting-profiles.md`, `executive-dashboard-redesign.md` |
+| **Reports, dashboards, funder reporting, executive view, exports** | `reporting-architecture.md`, `insights-metric-distributions.md`, `funder-reporting-profiles.md`, `executive-dashboard-redesign.md`, `evaluation-microdata-export.md` |
 | **CIDS, Common Approach, indicators, taxonomy, classification** | `cids-privacy-architecture.md`, `cids-batch-classification-workflow.md`, `cids-metadata-assignment.md`, `funder-reporting-profiles.md` |
 | **Surveys, questionnaires, instruments, PHQ-9, standardised tools** | `survey-metric-unification.md`, `insights-metric-distributions.md` |
 | **Offline, field work, mobile, ODK, data collection** | `offline-field-collection.md` |
@@ -34,7 +34,8 @@ For any proposal, **always check the relevant foundation first**, then drill int
 | **Accessibility, WCAG, a11y, screen reader, keyboard navigation** | `foundation-collaborative-practice.md` |
 | **EGAP, Black data governance, Black communities, anti-Black racism** | `foundation-data-sovereignty.md`, `multi-tenancy.md` |
 | **Documents, SharePoint, Google Drive, file storage, attachments** | `document-integration.md` |
-| **Data export, data portability, migration, offboarding** | `no-live-api-individual-data.md`, `cids-privacy-architecture.md` |
+| **Data export, data portability, migration, offboarding** | `no-live-api-individual-data.md`, `cids-privacy-architecture.md`, `evaluation-microdata-export.md` |
+| **Program evaluation, evaluator access, de-identified microdata, k-anonymity, REB, longitudinal trajectories** | `evaluation-microdata-export.md`, `reporting-architecture.md`, `foundation-data-sovereignty.md` |
 | **Data residency, Canadian hosting, foreign access, subpoena risk** | `data-access-residency-policy.md`, `ovhcloud-deployment.md` |
 | **Metrics, outcomes, progress notes, scoring, measurement** | `survey-metric-unification.md`, `insights-metric-distributions.md`, `cids-metadata-assignment.md` |
 | **Data sovereignty, OCAP, Indigenous data, community ownership** | `foundation-data-sovereignty.md`, `multi-tenancy.md`, `no-live-api-individual-data.md` |
@@ -52,7 +53,7 @@ For any proposal, **always check the relevant foundation first**, then drill int
 | **Draft** | Under development. Decisions may change — still read before building. |
 | **Parking Lot** | Not yet clear we should build. Do not implement without explicit approval. |
 
-## Full DRR Inventory (26 files)
+## Full DRR Inventory (27 files)
 
 ### Foundation Principles (4)
 
@@ -63,7 +64,7 @@ For any proposal, **always check the relevant foundation first**, then drill int
 | `foundation-security-by-default.md` | High security for non-technical operators — encryption, RBAC, immutable audit, fail-closed |
 | `foundation-nonprofit-sustainability.md` | Affordable tech stack, self-healing ops, evaluation-driven configuration |
 
-### Implementation Decisions (22)
+### Implementation Decisions (23)
 
 | File | Status | Scope |
 |---|---|---|
@@ -77,6 +78,7 @@ For any proposal, **always check the relevant foundation first**, then drill int
 | `data-access-residency-policy.md` | Decided | Canadian residency by data access level |
 | `document-integration.md` | Decided | SharePoint + Google Drive integration |
 | `encryption-key-rotation.md` | Decided | Master/tenant key rotation procedures |
+| `evaluation-microdata-export.md` | Decided | Two-tier de-identified evaluation export — EME (demographic microdata, n ≥ 15, k ≥ 5) + LTE (longitudinal trajectories, no demographics, n ≥ 10, REB + community governance) |
 | `executive-dashboard-redesign.md` | Approved | Dashboard UX with accessibility focus |
 | `fhir-informed-modelling.md` | Decided | FHIR concepts without FHIR compliance |
 | `funder-reporting-profiles.md` | Parking Lot | Template-based funder reporting |

--- a/TODO.md
+++ b/TODO.md
@@ -119,6 +119,23 @@ Step-by-step commands for each task are in [tasks/recurring-tasks.md](tasks/recu
 - [ ] Add evaluation export section to user guide — `docs/help.md` (EVAL-DOC3)
 - [ ] ED-facing one-page evaluation export reference — `docs/evaluation-export-guide.md` (EVAL-DOC4)
 
+### Phase: Longitudinal Trajectory Export (LTE) — see tasks/phase-lte-prompt.md
+
+DRR approved by GK after two expert panel rounds — `tasks/design-rationale/evaluation-microdata-export.md`. LTE is a second, structurally separate export tier for small-population evaluation (10 ≤ n < 15, or n ≥ 15 for OCAP/EGAP-governed programs). It drops demographics entirely and substitutes fuzzed longitudinal trajectories. New permission, separate form, reused pipeline base, distinct audit category, review-and-cancel window, distributed admin oversight, post-hoc privacy officer review. GK reviews on completion before merge.
+
+- [ ] LTE permission + "no designated privacy officer = no LTE" enforcement — new `report.evaluation_export_small_population` permission, settings check, form unavailable if unassigned (LTE-PERM1)
+- [ ] LTE form with structured preconditions — REB number/name/date, DSA expiry, structured evaluator credentials (degree/years/prior programs), destruction window, community governance flags (OCAP/EGAP/other), purpose statement, acknowledgement checkbox (LTE-FORM1)
+- [ ] LTE pipeline — reuse EME pipeline base, strip all demographic fields, round metric values to scale unit, band session count to 5 and hours to 0.5, generate pseudonymous study_id, trivial k check (LTE-PIPE1)
+- [ ] Review-and-cancel window — 5 business days, countdown visible on submitter history and privacy officer dashboard, withdrawal-during-window invalidation, population snapshot at submission, auto-cancel if population drops below floor (LTE-WINDOW1)
+- [ ] Distributed oversight — admin notification email at submission time with "flag concerns" link; any admin may cancel during the window; cancellation discards (LTE-OVERSIGHT1)
+- [ ] Post-hoc privacy officer review task + agency-wide rate limit — auto-created at submission, blocks next LTE agency-wide until resolved (LTE-REVIEW1)
+- [ ] Distinct audit category + enhanced metadata — `longitudinal_trajectory_export`, structured credential fields, community governance flags, window timestamps, destruction attestation (LTE-AUDIT1)
+- [ ] LTE CSV output — metadata header with "for program evaluation, not research" warning, rounded values, no demographics (LTE-OUT1)
+- [ ] Test suite — pipeline correctness, preconditions validation, window lifecycle, withdrawal re-run, floor enforcement, rate limit, community governance flag gating (LTE-TEST1)
+- [ ] Register new LTE routes in `konote-qa-scenarios/pages/page-inventory.yaml` and add scenario for LTE happy path + small-population block (LTE-QA1)
+- [ ] LTE user documentation — ED guide + privacy officer guide, separate from EME docs (LTE-DOC1)
+- [ ] GK reviews completed LTE implementation before merge — verifies demographic suppression, fuzzing correctness, community governance gating (LTE-GKREVIEW1)
+
 ### Phase: Documentation & Website Updates
 
 _All documentation tasks completed — see Recently Done._

--- a/tasks/design-rationale/evaluation-microdata-export.md
+++ b/tasks/design-rationale/evaluation-microdata-export.md
@@ -1,8 +1,8 @@
 # De-Identified Microdata Export for Program Evaluation
 
-**Date:** 2026-04-07
+**Date:** 2026-04-09
 **Status:** Decided — GK
-**Panels:** 1 expert panel (program evaluator, privacy/data governance, nonprofit program manager, health informatics), 3 rounds
+**Panels:** Expert panel review covering program evaluation, de-identification methodology, Indigenous and community data governance, nonprofit operations, and risk/systems analysis (multi-round).
 
 ---
 
@@ -10,18 +10,25 @@
 
 External program evaluators need participant-level outcome data with demographic breakdowns to do rigorous evaluation — trajectory analysis, equity disaggregation, dose-response modelling, attrition analysis. KoNote currently offers aggregate-only template reports (which can't support individual-level analysis) and PII-containing individual exports (which include names and are too sensitive to hand to an external party). There is no middle option.
 
+### Scope: Regular Program Evaluation, Not Research
+
+This DRR governs the workflow for **regular program evaluation** — the everyday work of answering "is this program working, and for whom?" It does **not** attempt to serve **research-grade data access** (formal research studies, secondary data analysis, academic publication requiring complete microdata). Research-grade access is handled through an entirely separate workflow that is intentionally high-friction: a full agency export gated by ED authority, legal review, institutional data sharing agreements, and case-by-case governance. That workflow is **out of scope** for this DRR.
+
+The practical consequence is clear and should be applied consistently: both export tiers below (EME and LTE) are designed for program evaluators who need **sufficient** data to assess outcomes, subgroup equity, dose-response, and service effectiveness — not **complete** data. An evaluator who insists on complete data (raw metric values, narrow demographics, names, or full client records) is doing research, not program evaluation, and the agency should direct them to the research workflow rather than relax the evaluation-export safeguards. This separation is deliberate: it protects participants and communities, it protects the agency from scope creep, and it gives staff a principled answer to pressure from well-meaning evaluators who "just need a bit more."
+
 ## The Decision
 
 Build a **de-identified microdata export** — individual rows with pseudonymous IDs, generalised demographics, and outcome metric values, with all direct identifiers removed. Deliver as CSV via the existing SecureExportLink infrastructure.
 
-This is a new export tier sitting between template reports and individual exports:
+This DRR defines **two** de-identified tiers sitting between template reports and PII-containing individual exports:
 
-| Tier | What | Who | Contains PII |
-|---|---|---|---|
-| Template reports | Aggregate metrics by demographic group | PM, Executive | No |
-| **Evaluation export (new)** | **De-identified individual rows with generalised demographics** | **ED / designated user** | **No (de-identified)** |
-| Individual client export | Full client record including names | PM | Yes |
-| Full agency export | Encrypted dump of everything | CLI / KoNote team | Yes |
+| Tier | What | Who | Contains PII | Population floor |
+|---|---|---|---|---|
+| Template reports | Aggregate metrics by demographic group | PM, Executive | No | k < 5 suppressed |
+| **Evaluation Microdata Export (EME)** | **De-identified individual rows with generalised demographics and outcome metrics** | **ED / designated user** | **No (de-identified)** | **n ≥ 15, k ≥ 5** |
+| **Longitudinal Trajectory Export (LTE)** | **De-identified longitudinal rows with NO demographic fields — fuzzed metric trajectories and service intensity** | **Privacy officer (separate permission)** | **No (de-identified)** | **n ≥ 10 (n ≥ 15 for OCAP- or EGAP-governed programs)** |
+| Individual client export | Full client record including names | PM | Yes | n/a |
+| Full agency export (research-grade, out of scope for this DRR) | Encrypted dump of everything | CLI / KoNote team | Yes | n/a |
 
 ### What Evaluators Get
 
@@ -204,10 +211,181 @@ Standard report exports log a generic metadata blob. Evaluation exports log stru
 
 The audit log is immutable (append-only, enforced at Django and PostgreSQL levels). If there is ever a privacy complaint, the audit entry answers: who exported what, for whom, with what de-identification applied, and under what authority.
 
+## Longitudinal Trajectory Export (LTE) — Small-Population Tier
+
+The LTE is a second, structurally separate export tier designed for small programs (10 ≤ n < 15) that the EME population floor would otherwise block. **It is not a relaxation of the EME.** It is a different data product with different trade-offs, gated by stronger governance, and routed through its own permission, its own form, and its own audit category.
+
+### The Core Reframe
+
+The EME defends against re-identification at the data layer by generalising and k-anonymising demographic quasi-identifiers, and then enforcing a population floor to prevent the quasi-identifier surface from overwhelming small populations. That approach works above n ≥ 15 but blocks evaluation of smaller programs entirely — and small programs are precisely where rigorous evaluation matters most, because they cannot fall back on aggregate averages to demonstrate impact. In very small programs, **demographic disaggregation is simultaneously statistically weak and re-identification-expensive** — claims about "women vs men" outcomes at n = 10 are noise, while the same demographic combination can uniquely identify a community member. The analytically valuable content in small-n evaluation is not subgroup breakdowns; it is:
+
+- **Individual outcome trajectories** — intake → mid → exit paths for each participant, to see heterogeneity and response patterns
+- **Service-intensity correlation** — sessions and hours correlated with metric change, to see dose-response
+- **Attrition patterns** — who left, how far along, and where their trajectories were heading, to detect selection bias and drop-out signals
+
+None of this requires demographic quasi-identifiers. The LTE therefore **drops demographics entirely** and delivers longitudinal individual rows. k-anonymity is trivially satisfied because there are no demographic fields to group on; every row is indistinguishable from every other row on any quasi-identifier. The re-identification surface shifts to the trajectory shape itself, which is addressed by fuzzing metric and service-intensity values.
+
+### What LTE Exports
+
+One row per participant, with the following columns:
+
+- `study_id` — random UUID, generated fresh per export; never derived from record ID, sequence number, or any linkable pattern
+- `enrolment_quarter` — quarter and year only (e.g., `Q3-2025`), never exact enrolment date
+- `exit_quarter` — quarter and year only, null if still enrolled
+- `sessions_count_banded` — session count rounded to the nearest 5
+- `total_hours_banded` — total hours rounded to the nearest half-hour
+- One column per metric per measurement point (e.g., `metric_wellbeing_intake`, `metric_wellbeing_mid`, `metric_wellbeing_exit`), with each value **rounded to the natural unit of the scale**:
+  - 0–10 ordinal scales → rounded to the nearest integer
+  - 0–100 percentage scales → rounded to the nearest 5
+  - Continuous scales → rounded to one decimal place or the nearest unit, whichever is coarser
+
+### What LTE Does NOT Export
+
+- **No demographic fields of any kind.** Not age, not age band, not gender, not ethnicity, not geography, not urban/rural, not anything derived from demographics. This is a hard rule enforced at the schema layer, not a form option. The re-identification defence in LTE *is* the absence of these fields.
+- **No clinical note text**, same as EME
+- **No direct identifiers**, same as EME
+- **No exact dates**, same as EME
+- **No unrounded metric values**, even though EME permits them. Rounding is a re-identification safeguard specific to the LTE where trajectory shape could otherwise identify a socially-known participant.
+- **No real record IDs**, same as EME
+
+### Why Fuzz the Metric and Service-Intensity Values?
+
+In the EME, demographic generalisation is the primary defence against re-identification: an evaluator looking at an EME row sees "Woman, 25–29, Urban, Q3-2025" which matches many people. In the LTE, demographic fields are gone, so the remaining re-identification surface is **the trajectory shape itself** — a known participant's approximate metric values plus their session count plus the quarter they enrolled could identify them to an evaluator who also knows participants socially (not an abstract threat — community evaluators are often themselves embedded in the community being evaluated). Rounding metric values to the natural scale unit and banding session/hour counts reduces the uniqueness of the trajectory profile at minimal analytical cost. Dose-response and trajectory analyses tolerate this rounding well because they look at the *shape* of change, not its exact magnitude.
+
+### Population Floor
+
+| Program type | Minimum n for LTE | Notes |
+|---|---|---|
+| Default | n ≥ 10 | Enforced at the form layer. No administrative waiver. |
+| Programs with OCAP governance flag (First Nations, Inuit, Métis) | n ≥ 15 | Higher floor reflects the panel's finding that small Indigenous cohorts are inherently identifying at the community level. Requires community reviewer signoff in addition to the floor. |
+| Programs with EGAP governance flag (Black communities) | n ≥ 15 | Same rationale. Requires community reviewer signoff in addition to the floor. |
+| Programs with "other small-population community review" flag (e.g., newcomer, 2SLGBTQ+, disability community programs) | n ≥ 10 | Documented community reviewer signoff required, but the community framework is not OCAP or EGAP specifically. |
+| Below the applicable floor | **Blocked.** | Direct the user to aggregate reports, or (if the use case is genuinely research) to the out-of-scope research workflow. No override. |
+
+**The floor is system-enforced**, consistent with the existing "Advisory-only population thresholds" anti-pattern. Funders and stakeholders will pressure agencies to waive it; the system must refuse. The refusal is part of the design, not a bug to work around.
+
+### Access Control
+
+A **new permission**, distinct from the existing evaluation-export permission:
+
+- `report.evaluation_export_small_population`
+
+This permission is not bundled with `report.evaluation_export`, not granted to any default role, and not inferred from any other role. An agency admin must explicitly grant it. We strongly recommend one grantee per agency, typically the agency's privacy officer.
+
+**Designation is a hard precondition.** If no user in the agency has been granted `report.evaluation_export_small_population`, the LTE form is unavailable to everyone — there is no "ED override" or temporary permission. Agencies that lack the governance capacity to designate a privacy officer are not ready for LTE, and the feature should not be reachable until the role is assigned. This creates constructive pressure to establish privacy governance before using the feature rather than after. Bundling this permission with the existing evaluation-export permission is an explicit anti-pattern (see Anti-Patterns section) because it erodes the "separate path, separate door" principle that keeps the LTE from becoming a default.
+
+### Preconditions Enforced by the Form
+
+Before generating an LTE, the form **requires** all of the following. Missing or invalid values block submission; there are no optional fields in this list.
+
+1. **REB approval number** — a non-empty string of at least 5 characters, stored in the audit metadata. The string is not strictly format-validated because REB approval numbers vary by institution; the precondition is simply that a value is present and plausible. *(Future enhancement: verification against an external REB registry. Not required for v1.)*
+2. **REB name and approval date**
+3. **Data sharing agreement expiry date** — the DSA is necessary but not sufficient; it is captured because its existence is a precondition even though it does not unlock anything on its own.
+4. **Evaluator name, organisation, email**
+5. **Evaluator degree or certification** — structured field, required
+6. **Evaluator years of evaluation experience** — numeric, required
+7. **Evaluator prior programs evaluated** — free text, minimum 50 characters, required. Auditable narrative of prior work.
+8. **Destruction attestation window** — 30, 60, or 90 days from download. KoNote sends a reminder email to the agency at the end of the window; the agency records the evaluator's destruction acknowledgement in the audit log **manually** (v1 has no automated evaluator acknowledgement UI — the agency enters the date on behalf of the evaluator). If no acknowledgement is recorded by the deadline, a follow-up task is auto-created for the privacy officer.
+9. **Community governance flags**, where applicable:
+   - **OCAP flag** — requires community reviewer name, affiliation, and signoff date
+   - **EGAP flag** — requires community reviewer name, affiliation, and signoff date
+   - **Other-community flag** — requires community reviewer name, affiliation, community framework description, and signoff date
+10. **Purpose statement** — plain-language description of the evaluation question. This becomes part of the audit record and is printed in the CSV metadata header.
+11. **Acknowledgement checkbox** — the submitter must explicitly check: *"I have read the re-identification risk notice and confirm this export is for program evaluation, not research. Research-grade data access (complete microdata, unfuzzed values, demographic detail) is handled through a separate workflow and is not available through this form."*
+
+### Review and Cancel Window
+
+After the form is submitted and the pipeline has prepared the export file, the download link is **inactive for 5 business days**. Business days (not calendar days) is the operational unit because it accommodates weekends, part-time privacy officers, and holidays without creating arbitrary weekend penalties for Friday submissions. Business days are defined as Monday through Friday in the agency's configured time zone, excluding any holidays the agency has configured.
+
+The window serves three distinct purposes:
+
+1. **Second-thought pause** for the submitter and the agency — time to notice a mistake before data leaves agency control
+2. **Privacy officer review** — time for the designated privacy officer to read the export metadata, the evaluator credentials, the REB details, and the community governance signoffs, and either approve implicitly (let the window elapse), explicitly cancel, or explicitly flag concerns
+3. **Distributed admin oversight** — any agency admin may cancel the export during the window; oversight is not reserved to the submitter or the privacy officer
+
+**Countdown visibility.** The remaining window duration must be visible on the submitter's export history page and on the privacy officer's dashboard, as a clear countdown with the activation timestamp. The export must not be a black box: an invisible pause is not a pause.
+
+**Cancellation rules.** Any agency admin may cancel the export at any time during the window. Cancellation discards the prepared file and the pipeline work; it is not a reset. The audit log retains the original submission metadata, marked "cancelled", including who cancelled and when. Re-submission after cancellation starts a fresh review-and-cancel window — there is no "resume" or "modify-and-continue" path.
+
+**Withdrawal during the window.** If a participant withdraws their consent during the review-and-cancel window, the export is automatically invalidated and must be re-run. The prepared file is discarded. The pipeline is re-executed against the current consent state, and a new review-and-cancel window begins. This ensures withdrawn participants never appear in the final output even if the pipeline ran before their withdrawal was recorded.
+
+**Population changes during the window.** The export is a snapshot at submission time, not at download time. New enrolments during the window do not enter the file. Consent withdrawals do remove rows (see above). If withdrawals drop the population below the applicable floor, the export is cancelled automatically and the submitter is notified.
+
+**Link expiry after activation.** Once the review-and-cancel window elapses and the download link activates, the standard SecureExportLink 24-hour rule applies — if the link is not downloaded within 24 hours of activation, it expires permanently and the export must be re-requested (which re-runs the review-and-cancel window from scratch). This is deliberate.
+
+### Distributed Oversight via Admin Notification
+
+At LTE submission time, **all agency admins** (not just the submitter and the privacy officer) receive an email that an LTE has been initiated. The email contains:
+
+- What was requested (program, period, evaluator, purpose)
+- Review-and-cancel window activation timestamp
+- A **"Flag concerns"** link that any admin may click to pause the export during the window
+
+A flagged concern freezes the review-and-cancel countdown, notifies the privacy officer by email, and requires explicit privacy officer resolution before the window can resume. This distributes oversight beyond the privacy officer alone, creates social accountability for the event, and allows any admin to intervene without requiring them to hold the LTE permission themselves.
+
+### Post-Hoc Privacy Officer Review
+
+At submission time, KoNote auto-creates an admin task assigned to the agency's designated privacy officer: *"Review LTE export dated YYYY-MM-DD for Program X"*. The task must be resolved (marked reviewed, or flagged as a concern) **before the same agency can generate another LTE**. The rate limit is per-agency, not per-program — the review burden sits on the privacy officer and there is one per agency. A pending review from a prior LTE blocks submission of any new LTE agency-wide, regardless of which program it targets. This creates a natural rate limit based on the privacy officer's review throughput and ensures every small-population export is seen by a second pair of eyes.
+
+### Enhanced Audit Metadata
+
+LTE audit log entries have a **distinct category** (`longitudinal_trajectory_export`), not a flag or subtype on the EME category. This ensures LTE activity can be monitored, reported, and alerted on separately:
+
+```json
+{
+    "export_category": "longitudinal_trajectory_export",
+    "program_id": 7,
+    "program_name": "Peer Support Circle",
+    "period_start": "2025-09-01",
+    "period_end": "2026-03-31",
+    "population_count": 11,
+    "evaluator_name": "Dr. Ana Martinez",
+    "evaluator_email": "dr.martinez@llewelyn.ca",
+    "evaluator_organisation": "Llewelyn Consulting",
+    "evaluator_degree": "PhD Community Psychology, McMaster University",
+    "evaluator_years_experience": 15,
+    "evaluator_prior_programs": "Youth Employment Program (Llewelyn, 2021-2023); Community Mental Health Initiative (Hamilton, 2019-2022); First Nations Wellness Collaborative (external evaluator, 2020-2024).",
+    "reb_name": "Llewelyn Consulting Research Ethics Board",
+    "reb_approval_number": "LCR-2026-014",
+    "reb_approval_date": "2026-03-15",
+    "data_sharing_agreement_expiry": "2026-10-31",
+    "destruction_window_days": 90,
+    "destruction_confirmed_date": null,
+    "community_governance_flags": {
+        "ocap": false,
+        "egap": false,
+        "other_community": false
+    },
+    "community_reviewer": null,
+    "purpose_statement": "Peer Support Circle outcome evaluation — trajectory and dose-response analysis",
+    "review_and_cancel_window_ends": "2026-04-16T17:00:00Z",
+    "review_and_cancel_window_business_days": 5,
+    "post_hoc_review_task_id": 4231,
+    "admin_notifications_sent": ["jane@agency.ca", "lee@agency.ca", "kwame@agency.ca"],
+    "metric_rounding_applied": true,
+    "session_count_banded_to": 5,
+    "total_hours_banded_to": 0.5
+}
+```
+
+`destruction_confirmed_date` is initially null and is updated when the agency records the evaluator's destruction acknowledgement (manual entry in v1; no automated evaluator-facing UI). If it remains null past the window, a follow-up task is auto-created for the privacy officer.
+
+### What LTE Is NOT
+
+The panel was clear that several adjacent designs are **not** what LTE is, and implementers should resist requests to morph LTE into any of them:
+
+- **LTE is not a toggle on the EME form.** It is a separate route, a separate permission, a separate form, a separate audit category. Bundling erodes structural separation.
+- **LTE is not a "DSA unlock."** The DSA is captured for the audit trail, but it is not the permission gate. REB approval and (where applicable) community governance review are the gates.
+- **LTE is not research-grade access.** Researchers needing complete microdata have a separate, high-friction workflow outside the scope of this DRR. If an evaluator insists on complete data or unfuzzed values, they are not doing program evaluation.
+- **LTE is not a workaround for the n ≥ 15 EME floor.** The EME floor exists for good reasons and remains enforced. LTE serves a different analytical need (trajectories without demographics) in a population range where EME cannot.
+- **LTE is not available to evaluators who "the agency trusts."** Trust is not an operational concept in the pipeline. Structural safeguards and governance preconditions are.
+
 ## CSV Output Format
 
+### EME (Evaluation Microdata Export)
+
 ```csv
-# Evaluation Export — Youth Employment Program
+# Evaluation Microdata Export — Youth Employment Program
 # Period: 2025-09 to 2026-03
 # Generated: 2026-04-07 by Jane Admin
 # Evaluator: Dr. Ana Martinez (dr.martinez@llewelyn.ca), Llewelyn Consulting
@@ -223,6 +401,33 @@ EVL-001,25-29,Woman,Urban,Q3-2025,,12,18.5,3,6,2,4
 EVL-002,25-29,Woman,Urban,Q3-2025,Q1-2026,8,12.0,4,5,3,5
 ```
 
+### LTE (Longitudinal Trajectory Export)
+
+```csv
+# Longitudinal Trajectory Export — Peer Support Circle (pilot)
+# Period: 2025-09 to 2026-03
+# Submitted: 2026-04-09 by Sam Privacy-Officer
+# Review-and-cancel window: 5 business days (activates 2026-04-16, expires 24h after activation)
+# Evaluator: Dr. Ana Martinez (dr.martinez@llewelyn.ca), Llewelyn Consulting
+# Evaluator degree: PhD Community Psychology, McMaster University
+# Evaluator years experience: 15
+# REB: Llewelyn Consulting REB, approval LCR-2026-014, approved 2026-03-15
+# Agreement expiry: 2026-10-31
+# Destruction window: 90 days from download (manual attestation)
+# Purpose: Peer Support Circle outcome evaluation — trajectory and dose-response analysis
+# Population: 13 eligible, 11 consented, 11 exported, 0 suppressed
+# NO demographic fields. Metric values rounded to nearest scale unit.
+# Session count banded to nearest 5. Total hours banded to nearest half-hour.
+# This file is for PROGRAM EVALUATION, not research.
+# Attempting to re-identify participants violates the data sharing agreement and REB approval.
+#
+study_id,enrolment_quarter,exit_quarter,sessions_count_banded,total_hours_banded,metric_wellbeing_intake,metric_wellbeing_mid,metric_wellbeing_exit,metric_connectedness_intake,metric_connectedness_mid,metric_connectedness_exit
+LTE-001,Q3-2025,,15,22.5,3,4,6,2,3,5
+LTE-002,Q3-2025,Q1-2026,10,15.0,4,5,5,3,4,4
+```
+
+The LTE format intentionally omits every quasi-identifier that EME includes. What remains is enough for trajectory analysis, attrition patterns, and dose-response modelling — the analyses that small-n evaluation actually needs — while leaving no demographic surface for re-identification.
+
 ## Anti-Patterns — Do Not Build
 
 | Anti-pattern | Why |
@@ -232,10 +437,19 @@ EVL-002,25-29,Woman,Urban,Q3-2025,Q1-2026,8,12.0,4,5,3,5
 | **Automatic evaluator notification** | KoNote should not email the evaluator or manage the delivery channel. The ED controls how and when data is shared. |
 | **Reusing real record IDs as pseudonyms** | Linkable to other KoNote data. Pseudonymous IDs must be random with no derivable relationship to real IDs. |
 | **Hashing record IDs as pseudonyms** | Hashes are reversible when the input space is small (sequential integers). Use random UUIDs or random short codes. |
-| **Skipping k-anonymity for "trusted" evaluators** | Trust doesn't prevent laptop theft. De-identification protects against all downstream risks, not just the evaluator's intent. |
-| **Advisory-only population thresholds** | Funders will pressure agencies to override warnings. System-enforced blocks protect the program manager from having to argue. |
-| **Separate consent flag for evaluation** | Creates consent fatigue at intake, introduces selection bias. Broaden existing consent language instead. |
-| **Synthetic data as default** | Can distort subgroup patterns that equity analysis aims to detect. Defer until validated. |
+| **Skipping k-anonymity for "trusted" evaluators** | Trust doesn't prevent laptop theft. De-identification protects against all downstream risks, not just the evaluator's intent. Applies equally to EME and LTE. A signed DSA is a liability instrument, not a risk-reduction instrument, and does not justify weakening de-identification. |
+| **DSA as an unlock for relaxed thresholds** | The request "they signed a DSA, so we can give them more data" re-introduces the "trusted evaluator" anti-pattern in a new wrapper. DSAs shift liability downstream but do not reduce the upstream risk of device theft, laptop compromise, or unauthorised secondary use. The LTE tier is the approved alternative for small-population evaluation — it is gated by REB approval, community governance review, the review-and-cancel window, and post-hoc privacy officer review, **never by DSA alone**. |
+| **Serving research-grade data access through the evaluation export path** | Researchers needing complete microdata (unfuzzed values, full demographic detail, unrounded metrics) have a separate, intentionally high-friction workflow (full agency export gated by ED authority, legal review, institutional data sharing agreements). If an evaluator insists on this level of access, direct them to the research workflow — do not relax EME or LTE safeguards to meet the request. Both evaluation export tiers are for *sufficient* data, not *complete* data. |
+| **Advisory-only population thresholds** | Funders will pressure agencies to override warnings. System-enforced blocks protect the program manager from having to argue. This applies to both the EME floor (n ≥ 15) and the LTE floor (n ≥ 10, or n ≥ 15 for OCAP/EGAP-governed programs). No administrative waiver path exists for either. |
+| **LTE available to agencies without a designated privacy officer** | The LTE assumes a privacy officer role for post-hoc review, distributed oversight, and destruction-attestation follow-up. Agencies that have not designated a privacy officer with the LTE permission should not be able to reach the form at all — the feature depends on governance capacity that the agency must establish first. |
+| **Bundling LTE as a toggle on the EME form** | The LTE must be a structurally separate path with its own permission, its own form, its own route, and its own audit category. Bundling would allow the LTE to become the default through UI proximity and muscle memory, and would dilute the distinct governance preconditions. Separate path, separate door, separate key. |
+| **Demographic fields in LTE output** | The LTE's re-identification defence comes from *removing* demographic quasi-identifiers entirely, not from generalising them. Adding any demographic field to LTE output — even "just age band" or "just urban/rural" — re-opens the full re-identification surface and violates the tier's design principle. The EME is the path for demographic analysis; LTE is the path for trajectory analysis. Do not blur them. |
+| **Lowering the k-anonymity floor below 5** | k = 5 aligns with Statistics Canada and CIHI guidance and with KoNote's internal small-cell suppression threshold for CIDS aggregate reporting. Keeping the floor consistent across tiers removes ambiguity and prevents inter-tier pressure to "just lower it here too." |
+| **LTE without REB approval** | REB approval is the substantive pre-review check for small-population evaluation; it evidences that the risk-benefit trade-off has been considered by an independent body with ethics authority. A DSA alone captures a contractual relationship but not an ethical review. If the evaluator does not have REB approval, they either need to obtain it or to accept the EME tier (where applicable) or aggregate reports. |
+| **LTE bypass for Indigenous or Black community programs without community governance signoff** | OCAP and EGAP frameworks require community decision-making about community data. Agency ED authorisation is not a substitute for community review. A community reviewer signoff is a hard precondition for LTE on programs flagged under these frameworks. |
+| **Fast-path early approval to shorten the review-and-cancel window** | A "privacy officer clicks approve to activate immediately" path was considered and deferred. The rubber-stamp risk is real, the operational need has not been demonstrated, and the pause is part of what makes the LTE a deliberate event rather than a routine one. Revisit only if real operational experience shows the default window is unworkable for legitimate cases. |
+| **Separate consent flag for evaluation** | Creates consent fatigue at intake, introduces selection bias. Broaden existing consent language instead. The same consent language covers both EME and LTE. |
+| **Synthetic data as default** | Can distort subgroup patterns that equity analysis aims to detect. Defer until validated. The LTE tier covers most of the small-n use cases that synthetic data was being held in reserve for. |
 
 ## What This DRR Does NOT Restrict
 
@@ -244,12 +458,22 @@ EVL-002,25-29,Woman,Urban,Q3-2025,Q1-2026,8,12.0,4,5,3,5
 - **Individual client exports** — unchanged, still available for PIPEDA requests
 - **CIDS JSON-LD aggregate exports** — unchanged, governed by reporting architecture DRR
 
+## What This DRR Does NOT Cover (Out of Scope)
+
+- **Research-grade data access** — formal research studies, secondary data analysis, and academic publication that require *complete* microdata (unfuzzed values, narrow demographics, raw metric series, or direct identifiers) are handled through a separate, intentionally high-friction workflow: a full agency export gated by ED authority, legal review, institutional data sharing agreements, and case-by-case governance. An evaluator who cannot accept the EME or LTE data product is doing research, not program evaluation, and should be directed to the research workflow. The decision to grant research access is a governance decision, not a product decision, and sits outside the scope of this DRR.
+- **Ongoing sharing with researchers** — continuous or periodic access by a researcher is neither EME nor LTE. If that need exists, treat it as a research agreement and handle it through the research workflow, not by automating repeat exports.
+- **Cross-agency pooled microdata** — combining microdata from multiple KoNote tenants for a multi-site evaluation is governed by the data sovereignty and multi-tenancy DRRs. It is not something the EME or LTE pipelines do on their own.
+
 ## Future Considerations
 
-1. **Synthetic data option** — for programs with n < 15 where aggregate reports are insufficient. Requires validation research before implementation.
-2. **Longitudinal export format** — one row per participant-per-measurement-point instead of one row per participant. More useful for trajectory analysis but increases re-identification risk (more rows = more combinatorial surface). Design separately.
-3. **Cross-program evaluation export** — spanning multiple programs in one export. Raises consent complexity (different programs may have different consent rates). Defer until single-program exports are proven.
-4. **Data sharing agreement tracking model** — if many agencies need to track multiple concurrent evaluations, a lightweight `EvaluationAgreement` model could be useful. Not needed for Phase 1 — the audit log metadata is sufficient.
+1. **Long-format longitudinal export** — one row per participant-per-measurement-point instead of the wide LTE format (which puts each measurement point in its own column). Long format is more natural for some statistical tools but it increases the re-identification surface (multiple rows sharing a study_id create additional combinatorial leakage). Not implemented; the wide LTE format covers current analytical needs. Revisit only if multiple evaluators specifically request long format and can demonstrate that wide format cannot meet their tooling constraints.
+2. **Synthetic data option** — the LTE tier covers most of the n < 15 use cases that synthetic data was being held in reserve for. Synthetic data remains a possible option for *very* small programs (n < 10) but requires validation research before implementation, and no strong need has been identified given that the LTE floor at n = 10 is defensible for the target audience (regular program evaluation, not research).
+3. **REB registry verification** — the LTE form captures the REB approval number but does not verify it against an external registry at submission time. Future enhancement: integrate with a REB directory for the relevant jurisdictions (Canadian REBs, institutional REBs) to verify the approval number is real and currently active. Not blocking for v1.
+4. **Automated destruction attestation UI for evaluators** — v1 captures destruction attestation through manual agency entry in the audit log. A future enhancement could let the evaluator acknowledge destruction directly via a magic-link form, or parse email replies. Deferred until operational experience shows whether manual entry is workable.
+5. **Fast-path early approval** — the current review-and-cancel window is a fixed 5 business days. A future enhancement could let the privacy officer explicitly approve early to activate the download link sooner, for time-sensitive legitimate exports. Deferred because the rubber-stamp risk is real and the operational need has not been demonstrated. Revisit only if real operational experience shows the default window is unworkable for legitimate cases.
+6. **Cross-program evaluation export** — spanning multiple programs in one export. Raises consent complexity (different programs may have different consent rates) and multi-program equivalence-class mathematics for the EME. Defer until single-program exports are proven in both tiers.
+7. **Data sharing agreement tracking model** — if many agencies need to track multiple concurrent evaluations, a lightweight `EvaluationAgreement` model could be useful. Not needed for v1; the audit log metadata is sufficient.
+8. **Secure delivery channel to the evaluator** — the DRR treats file delivery (from the agency to the evaluator) as out of scope, assuming the agency has a secure channel of its own. Small agencies may not, which is a known operational gap. A future enhancement could offer a KoNote-mediated secure delivery link (encrypted, time-limited, evaluator-email-gated) if demand justifies the added complexity.
 
 ## Related Documents
 

--- a/tasks/phase-lte-prompt.md
+++ b/tasks/phase-lte-prompt.md
@@ -1,0 +1,526 @@
+# LTE — Longitudinal Trajectory Export (Small-Population Evaluation Tier)
+
+**Status:** Ready to build
+**DRR:** [tasks/design-rationale/evaluation-microdata-export.md](design-rationale/evaluation-microdata-export.md)
+**Approved by:** GK after two expert panel rounds (2026-04-09)
+**Depends on:** Existing EME implementation (PR #617, #622, #623, #624), `DeidentificationPipeline` base class
+**Scope owner (implementation):** new session can pick this up cold
+**Scope reviewer (before merge):** GK reviews completed LTE for demographic suppression correctness, metric fuzzing, and community governance gating
+
+## Stop and read this first
+
+This is **not** a quick task. LTE is a second, structurally separate export tier with its own permission, its own form, its own pipeline class, its own audit category, its own review lifecycle, and its own tests. Before writing any code, read the following in full — do not skim:
+
+1. **[tasks/design-rationale/evaluation-microdata-export.md](design-rationale/evaluation-microdata-export.md)** — the DRR in full. Pay special attention to:
+   - Section **"Longitudinal Trajectory Export (LTE) — Small-Population Tier"** — the complete specification
+   - Subsection **"The Core Reframe"** — the design principle (trade data richness for data safety; the analytical value comes from trajectories, not demographics)
+   - Subsection **"What LTE Does NOT Export"** — the hard rules. No demographic fields. Ever. Not even "just age band."
+   - Subsection **"Review and Cancel Window"** — the 5-business-day lifecycle, withdrawal rules, population snapshot, cancellation
+   - Subsection **"What LTE Is NOT"** — the guardrails against bundling, trust-based carve-outs, research-grade use
+   - **"Anti-Patterns — Do Not Build"** — at least four of these apply directly to this implementation. Know them cold before you touch the code.
+2. **[apps/reports/deidentify.py](../apps/reports/deidentify.py)** — the existing `DeidentificationPipeline` class. Your LTE pipeline should **compose or subclass** this, not fork it. Read the 10-step structure and the dataclass definitions (`PreviewResult`, `GenerateResult`).
+3. **[apps/reports/forms.py](../apps/reports/forms.py)** — find `EvaluationExportForm` (search for `class EvaluationExportForm`). Your LTE form is distinct but should follow the same patterns for program selection and validation.
+4. **[apps/reports/views.py](../apps/reports/views.py)** — find `evaluation_export_form` (search for `def evaluation_export_form`). The LTE views will mirror but not share this one.
+5. **[apps/reports/urls.py](../apps/reports/urls.py)** — understand where the existing `evaluation-export/` route is. Add LTE routes under a **distinct prefix** (suggestion: `longitudinal-trajectory-export/`), not as children of the existing route.
+6. **[tests/test_export_permissions.py](../tests/test_export_permissions.py)** — read `EvaluatorExportPermissionTest` to understand the existing permission test patterns. Your LTE tests should live in a new class in the same file or a new file.
+7. **[apps/reports/utils.py](../apps/reports/utils.py)** — find `can_create_evaluation_export`. You will add a sibling `can_create_lte_export` with stricter preconditions.
+
+## The problem LTE solves
+
+The existing Evaluation Microdata Export (EME) blocks programs with fewer than 15 participants entirely — `n < 15 → aggregate reports only`. This is correct for the EME's design (demographic microdata needs a large enough equivalence class population for k-anonymity to work) but it denies small programs the ability to evaluate outcomes they have already consented to. Small programs are precisely where rigorous evaluation matters most because aggregate averages cannot demonstrate impact at low n. They are also frequently the programs serving Indigenous, Black, newcomer, 2SLGBTQ+, disability, and other equity-deserving communities.
+
+LTE is the answer. It is not a relaxation of EME. It is a different data product with different trade-offs:
+
+- **Drops demographic fields entirely.** No age, no gender, no ethnicity, no geography. k-anonymity is trivially satisfied because there are no demographic columns to group on.
+- **Keeps longitudinal individual rows** — pseudonymous study_id, enrolment quarter, exit quarter, session count, total hours, metric values at each measurement point.
+- **Fuzzes trajectory values** to prevent re-identification by shape — metric values rounded to the scale unit, session count banded to 5, total hours banded to half-hour.
+- **Is gated by REB approval, community governance, a 5-business-day review window, distributed admin oversight, and post-hoc privacy officer review** — not by a signed DSA alone.
+
+The DRR is clear: "separate path, separate door, separate key." Everything about LTE must be structurally distinct from EME — different permission, different form, different URL prefix, different audit category, different UI labelling. Do not bundle it as a checkbox on the EME form. Do not reuse the EME permission.
+
+## What to build
+
+### 1. Data models + migration
+
+Create `apps/reports/models.py` additions (or a new module `apps/reports/lte_models.py` if you prefer):
+
+```python
+class LTEExportRequest(models.Model):
+    """A request to generate a Longitudinal Trajectory Export.
+
+    One row per request. The lifecycle is:
+      submitted -> review_and_cancel_window -> active -> downloaded -> expired
+      (or at any point: cancelled, flagged, auto_cancelled)
+
+    The record lives forever for audit purposes; the generated file
+    lives on the SecureExportLink for the 24-hour download window
+    after activation.
+    """
+    STATUS_CHOICES = [
+        ("submitted", "Submitted"),
+        ("flagged", "Flagged — privacy officer action required"),
+        ("cancelled", "Cancelled"),
+        ("auto_cancelled", "Auto-cancelled — population dropped below floor"),
+        ("invalidated_by_withdrawal", "Invalidated — participant withdrew consent"),
+        ("active", "Download link active"),
+        ("downloaded", "Downloaded"),
+        ("expired", "Expired without download"),
+    ]
+
+    submitted_by = models.ForeignKey(User, on_delete=models.PROTECT, related_name="lte_requests_submitted")
+    submitted_at = models.DateTimeField(auto_now_add=True)
+    program = models.ForeignKey("programs.Program", on_delete=models.PROTECT)
+    period_start = models.DateField()
+    period_end = models.DateField()
+
+    # Preconditions (all required)
+    reb_name = models.CharField(max_length=200)
+    reb_approval_number = models.CharField(max_length=100)
+    reb_approval_date = models.DateField()
+    data_sharing_agreement_expiry = models.DateField()
+    evaluator_name = models.CharField(max_length=200)
+    evaluator_email = models.EmailField()
+    evaluator_organisation = models.CharField(max_length=200)
+    evaluator_degree = models.CharField(max_length=300)
+    evaluator_years_experience = models.PositiveSmallIntegerField()
+    evaluator_prior_programs = models.TextField()  # min 50 chars at form layer
+    destruction_window_days = models.PositiveSmallIntegerField(
+        choices=[(30, "30 days"), (60, "60 days"), (90, "90 days")]
+    )
+    purpose_statement = models.TextField()
+    # Community governance signoff (nullable — only required if program flag is set)
+    community_reviewer_name = models.CharField(max_length=200, blank=True)
+    community_reviewer_affiliation = models.CharField(max_length=300, blank=True)
+    community_framework_description = models.TextField(blank=True)  # for "other" flag
+    community_signoff_date = models.DateField(null=True, blank=True)
+    acknowledgement_confirmed = models.BooleanField()  # must be True to submit
+
+    # Lifecycle state
+    status = models.CharField(max_length=30, choices=STATUS_CHOICES, default="submitted")
+    window_activates_at = models.DateTimeField()  # 5 business days after submission
+    population_snapshot = models.PositiveIntegerField()  # at submission time
+    secure_export_link = models.OneToOneField(
+        "SecureExportLink", on_delete=models.SET_NULL, null=True, blank=True,
+        related_name="lte_request",
+    )
+    cancelled_by = models.ForeignKey(User, on_delete=models.PROTECT, null=True, blank=True, related_name="lte_requests_cancelled")
+    cancelled_at = models.DateTimeField(null=True, blank=True)
+    cancellation_reason = models.CharField(max_length=500, blank=True)
+
+    # Destruction attestation (updated after download, manual agency entry in v1)
+    destruction_confirmed_at = models.DateTimeField(null=True, blank=True)
+    destruction_confirmed_by = models.ForeignKey(User, on_delete=models.PROTECT, null=True, blank=True, related_name="lte_destruction_confirmations")
+
+
+class LTELifecycleEvent(models.Model):
+    """Append-only log of state transitions on an LTEExportRequest.
+
+    Lives alongside the request for quick reference; the canonical
+    audit record also goes to the audit DB (separate from this).
+    """
+    request = models.ForeignKey(LTEExportRequest, on_delete=models.CASCADE, related_name="lifecycle_events")
+    timestamp = models.DateTimeField(auto_now_add=True)
+    actor = models.ForeignKey(User, on_delete=models.PROTECT, null=True, blank=True)
+    event_type = models.CharField(max_length=50)  # "submitted", "flagged", "cancelled", "activated", "downloaded", "withdrawal_invalidation", "floor_auto_cancel"
+    notes = models.TextField(blank=True)
+```
+
+Add **community governance fields to Program**:
+
+```python
+# apps/programs/models.py — additions to Program model
+COMMUNITY_GOVERNANCE_NONE = ""
+COMMUNITY_GOVERNANCE_OCAP = "ocap"
+COMMUNITY_GOVERNANCE_EGAP = "egap"
+COMMUNITY_GOVERNANCE_OTHER = "other"
+COMMUNITY_GOVERNANCE_CHOICES = [
+    (COMMUNITY_GOVERNANCE_NONE, "No specific framework"),
+    (COMMUNITY_GOVERNANCE_OCAP, "OCAP (First Nations, Inuit, Métis)"),
+    (COMMUNITY_GOVERNANCE_EGAP, "EGAP (Black communities)"),
+    (COMMUNITY_GOVERNANCE_OTHER, "Other small-population community review"),
+]
+
+community_governance_framework = models.CharField(
+    max_length=10, choices=COMMUNITY_GOVERNANCE_CHOICES, default=COMMUNITY_GOVERNANCE_NONE,
+    help_text="If set, LTE exports on this program require community reviewer signoff.",
+)
+```
+
+**Migrations:** run `makemigrations reports programs` and commit the migration files in the same commit as the model changes. Use a descriptive migration name: `add_lte_export_request` and `add_community_governance_framework_to_program`.
+
+### 2. Permission + "no privacy officer designated = no LTE" enforcement
+
+Add the permission to `apps/auth_app/permissions.py`:
+
+```python
+REPORT_EVALUATION_EXPORT_SMALL_POPULATION = "report.evaluation_export_small_population"
+```
+
+Register it in the permission map. **Do not grant it to any default role.** Do not infer it from any other role or flag. Explicit grant only.
+
+Follow the existing EVAL-GOV1 pattern for the grant workflow if EVAL-GOV1 is merged by the time you build this. If EVAL-GOV1 is not yet merged, use the same per-user cache field pattern (`lte_export_granted` BooleanField on User, backed by an `LTEExportGrant` model if you want full audit parity). **Coordinate with whoever is building EVAL-GOV1 to avoid conflicting migration numbers on `apps/auth_app/`.**
+
+Add a helper in `apps/reports/utils.py`:
+
+```python
+def can_create_lte_export(user) -> bool:
+    """LTE has stricter preconditions than EME.
+
+    Returns True if and only if:
+      1. The user has report.evaluation_export_small_population permission
+      2. The agency has at least one user with this permission (role is designated)
+
+    Admin bypass does NOT apply — LTE is not available to admins by default.
+    """
+    if not user.is_authenticated:
+        return False
+    if not user.has_permission("report.evaluation_export_small_population"):
+        return False
+    return True
+
+
+def lte_available_in_agency() -> bool:
+    """Returns True iff the current tenant has at least one designated privacy officer."""
+    from apps.auth_app.models import User
+    return User.objects.filter(lte_export_granted=True).exists()
+```
+
+The form view must check `lte_available_in_agency()` before rendering. If no privacy officer is designated, the form is not reachable — return a helpful 403 or 404 with a message directing the admin to designate a privacy officer first.
+
+### 3. Pipeline — `LTESmallPopulationPipeline` class
+
+In `apps/reports/deidentify.py` (or a new file `apps/reports/lte_pipeline.py`), create a new class that composes or subclasses `DeidentificationPipeline`. Do not fork the code — reuse the base pipeline's extract, decrypt, consent filter, and output steps.
+
+Key differences from `DeidentificationPipeline`:
+
+1. **Skip the generalisation step entirely** — LTE has no QI columns to generalise.
+2. **Strip ALL demographic fields at Step 4** — not just direct identifiers. Age, gender, ethnicity, geography, postal code, FSA, urban/rural, and anything derived from demographics must be dropped. This is a hard schema guarantee.
+3. **Skip the k-anonymity check** — k is trivially `n` because there are no QI columns. Log the effective k as "trivially k=n (no QI columns)" in the audit metadata.
+4. **Fuzz trajectory values before writing**:
+   - Metric values: round to the natural unit of the scale (0-10 ordinal → nearest integer; 0-100 percentage → nearest 5; continuous → one decimal place or nearest unit)
+   - Session count: round to nearest 5
+   - Total hours: round to nearest 0.5
+5. **Enforce the population floor**: default `n >= 10`, `n >= 15` for programs with `community_governance_framework in ("ocap", "egap")`. If below floor, block with a clear error — no override.
+6. **Generate pseudonymous study_id** as a random UUID (not derived from record ID, not hashed from anything linkable).
+
+Write a new `LTEPreviewResult` dataclass if the existing `PreviewResult` doesn't fit (it probably won't — LTE has no QI columns, no suppression rate, no equivalence class math).
+
+### 4. Form — `LTEExportRequestForm`
+
+In `apps/reports/forms.py`, add a new form class:
+
+```python
+class LTEExportRequestForm(ProgramSelectionMixin, forms.Form):
+    """Longitudinal Trajectory Export request form.
+
+    Strict validation — every field is required. Form rejects
+    any submission where preconditions are missing or invalid.
+    """
+    # Period
+    period_start = forms.DateField(...)
+    period_end = forms.DateField(...)
+
+    # REB
+    reb_name = forms.CharField(max_length=200)
+    reb_approval_number = forms.CharField(min_length=5, max_length=100)
+    reb_approval_date = forms.DateField()
+
+    # DSA
+    data_sharing_agreement_expiry = forms.DateField()
+
+    # Evaluator
+    evaluator_name = forms.CharField(max_length=200)
+    evaluator_email = forms.EmailField()
+    evaluator_organisation = forms.CharField(max_length=200)
+    evaluator_degree = forms.CharField(max_length=300, label=_("Evaluator degree or certification"))
+    evaluator_years_experience = forms.IntegerField(min_value=0, max_value=60)
+    evaluator_prior_programs = forms.CharField(
+        widget=forms.Textarea(attrs={"rows": 4}),
+        min_length=50,
+        help_text=_("Describe at least two prior program evaluations this evaluator has conducted. Minimum 50 characters."),
+    )
+
+    # Destruction
+    destruction_window_days = forms.ChoiceField(choices=[(30, "30 days"), (60, "60 days"), (90, "90 days")])
+
+    # Community governance (conditionally required)
+    community_reviewer_name = forms.CharField(max_length=200, required=False)
+    community_reviewer_affiliation = forms.CharField(max_length=300, required=False)
+    community_framework_description = forms.CharField(widget=forms.Textarea, required=False)
+    community_signoff_date = forms.DateField(required=False)
+
+    # Purpose
+    purpose_statement = forms.CharField(widget=forms.Textarea(attrs={"rows": 3}), min_length=30)
+
+    # Acknowledgement
+    acknowledgement_confirmed = forms.BooleanField(
+        label=_("I have read the re-identification risk notice and confirm this export is for program evaluation, not research. Research-grade data access is handled through a separate workflow and is not available through this form."),
+    )
+
+    def clean(self):
+        cleaned = super().clean()
+        program = cleaned.get("program")
+        if program and program.community_governance_framework in ("ocap", "egap", "other"):
+            required_fields = ["community_reviewer_name", "community_reviewer_affiliation", "community_signoff_date"]
+            if program.community_governance_framework == "other":
+                required_fields.append("community_framework_description")
+            for f in required_fields:
+                if not cleaned.get(f):
+                    self.add_error(f, _("Required for programs with community governance framework."))
+        return cleaned
+```
+
+### 5. Views + URLs
+
+Add a new URL prefix in `apps/reports/urls.py`:
+
+```python
+# Longitudinal Trajectory Export (DRR: evaluation-microdata-export.md, LTE section)
+path("longitudinal-trajectory-export/", views.lte_list, name="lte_list"),
+path("longitudinal-trajectory-export/new/", views.lte_submit, name="lte_submit"),
+path("longitudinal-trajectory-export/<int:request_id>/", views.lte_detail, name="lte_detail"),
+path("longitudinal-trajectory-export/<int:request_id>/cancel/", views.lte_cancel, name="lte_cancel"),
+path("longitudinal-trajectory-export/<int:request_id>/flag/", views.lte_flag_concerns, name="lte_flag_concerns"),
+path("longitudinal-trajectory-export/<int:request_id>/download/", views.lte_download, name="lte_download"),
+```
+
+Add the corresponding view functions in `apps/reports/views.py`:
+
+- `lte_list` — shows all LTE requests in the agency with status, countdown, actions (cancel, flag, download)
+- `lte_submit` — GET renders form; POST validates, runs pipeline in preview mode, then creates `LTEExportRequest`, sends admin notifications, starts the review-and-cancel window
+- `lte_detail` — shows the request metadata, lifecycle events, and actions available based on status
+- `lte_cancel` — POST only, accepts cancellation reason, marks status `cancelled`, logs lifecycle event
+- `lte_flag_concerns` — POST only (from the "Flag concerns" email link), marks status `flagged`, notifies privacy officer, freezes countdown
+- `lte_download` — only accessible while status is `active`, proxies through the SecureExportLink
+
+All views must check `can_create_lte_export` OR `has_permission("report.evaluation_export_small_population")` as appropriate. All views must check `lte_available_in_agency()` at the top.
+
+### 6. Review-and-cancel window lifecycle
+
+Write a helper module `apps/reports/lte_lifecycle.py` (or put these as methods on the model — your call):
+
+```python
+def calculate_window_end(submitted_at: datetime, business_days: int = 5) -> datetime:
+    """Return the datetime at which the review-and-cancel window ends.
+
+    Counts 5 business days (Mon-Fri) in the agency's configured timezone,
+    excluding any configured holidays. See settings.LTE_EXCLUDED_HOLIDAYS
+    for the holiday list (may be empty in v1).
+    """
+    ...
+
+
+def check_population_snapshot_for_lte(request: LTEExportRequest) -> None:
+    """Re-run the consent query and compare to the snapshot.
+
+    If a participant has withdrawn consent since submission,
+    invalidate the request and re-run the pipeline.
+
+    If the effective population drops below the floor,
+    auto-cancel the request.
+
+    Call this from:
+      - a daily background task
+      - the pre-download hook
+      - the post-withdrawal signal on ClientFile consent change
+    """
+    ...
+
+
+def activate_window_if_elapsed(request: LTEExportRequest) -> None:
+    """If the window has elapsed and status is 'submitted', activate it.
+
+    Creates the SecureExportLink and transitions status -> 'active'.
+    """
+    ...
+```
+
+The window lifecycle requires a scheduled job or signal-driven checks. Options:
+
+- **Preferred**: Django management command `check_lte_window_lifecycle` run every 15 minutes by cron (or once daily if that's enough)
+- **Alternative**: check lifecycle at view time — every time `lte_list` or `lte_detail` is accessed, re-evaluate window state for all pending requests. Simpler but slower.
+
+Document your choice in a comment at the top of the lifecycle module.
+
+### 7. Distributed oversight — admin notification + flag-concerns flow
+
+At submission time, send an email to **all agency admins** with:
+
+- Program name, evaluator, purpose
+- Review-and-cancel window countdown (expressed as "5 business days, activates at <datetime>")
+- A **"Flag concerns"** link containing a signed token that lands on `lte_flag_concerns` and marks the request flagged without requiring admin login (the token is scoped to the specific request and expires when the window closes)
+- A **"View in KoNote"** link for admins who want to cancel or see details
+
+Follow the existing email template patterns in `templates/emails/` or wherever the EME notifications live. Respect bilingual requirements: EN/FR translations for all email strings.
+
+Flagging freezes the window countdown. The privacy officer resolves the flag either by dismissing it (window resumes) or cancelling the request. Dismissal restarts the remaining countdown from the time of dismissal — do not fast-forward.
+
+### 8. Post-hoc review task + agency-wide rate limit
+
+At submission time, create an admin task: `"Review LTE export for <program> submitted <date>"`, assigned to the agency's designated privacy officer (the first user with `lte_export_granted=True`).
+
+The task must be marked resolved (or flagged as a concern) **before the same agency can generate another LTE**. The rate limit is agency-wide, not per-program. Enforce at submission time:
+
+```python
+def can_submit_new_lte(agency) -> tuple[bool, str | None]:
+    pending_reviews = LTEExportRequest.objects.filter(
+        status__in=["submitted", "active", "downloaded"],
+        post_hoc_review_task__status="pending",
+    ).exists()
+    if pending_reviews:
+        return False, "A prior LTE export is pending privacy officer review. Resolve it before submitting a new request."
+    return True, None
+```
+
+Use whatever admin-task model KoNote has for this. If there isn't one, add a simple `LTEReviewTask` model alongside `LTEExportRequest`.
+
+### 9. Audit log integration — distinct category
+
+Write a single audit log entry at each lifecycle transition to the audit DB:
+
+```python
+AuditLog.objects.using("audit").create(
+    event_type="longitudinal_trajectory_export.submitted",  # or .activated, .cancelled, .downloaded, .flagged, etc.
+    actor_id=user.pk,
+    metadata={
+        "export_category": "longitudinal_trajectory_export",
+        "lte_request_id": request.pk,
+        # ... all the fields from the DRR's "Enhanced Audit Metadata" section
+    },
+)
+```
+
+The `export_category` field must be `longitudinal_trajectory_export`, **not** a flag or subtype of `evaluation_microdata`. Alerts and reports should be able to filter on this category independently.
+
+Do NOT reuse the `SecureExportLink.agency_notes` field for LTE metadata — that field serves EME and will get confusing. Store the full lifecycle metadata on the `LTEExportRequest` row itself.
+
+### 10. Templates + navigation + translations
+
+- `templates/reports/lte_list.html` — table showing all LTE requests with status, countdown, actions
+- `templates/reports/lte_submit.html` — the submission form with conditional community governance section (shown only when the selected program has a governance flag)
+- `templates/reports/lte_detail.html` — request detail view with lifecycle events and status-dependent actions
+- `templates/emails/lte_submitted.html` + `.txt` — admin notification at submission time (EN and FR)
+- `templates/emails/lte_flagged.html` + `.txt` — privacy officer notification when an admin flags concerns
+- `templates/emails/lte_destruction_reminder.html` + `.txt` — sent at end of destruction window if no acknowledgement recorded
+
+Navigation: add an **"Evaluation Export (Small Population)"** entry to the admin reports menu, distinct from the existing Evaluation Export entry. Visibility conditional on `can_create_lte_export(user)` AND `lte_available_in_agency()`. Use Pico CSS patterns consistent with the rest of the admin UI.
+
+After any template with `{% trans %}` strings is added or modified, run `python manage.py translate_strings` and fill in any empty French translations before committing.
+
+### 11. Tests — new test file or class
+
+Create `tests/test_lte.py` (or add to `tests/test_exports.py` — your call based on what's there) with coverage for:
+
+- **Permission gating**: only users with `report.evaluation_export_small_population` can reach LTE views; admin bypass does NOT grant LTE access
+- **"No privacy officer = no LTE"**: if no user in the agency has the permission, the form is unreachable
+- **Form validation**: each precondition rejects invalid/missing input with a clear error (REB number too short, evaluator prior programs under 50 chars, acknowledgement unchecked, etc.)
+- **Community governance gating**: program with OCAP flag requires community reviewer signoff; submission without it fails
+- **Population floor**: n < 10 blocks; n ≥ 10 allows (unless OCAP/EGAP and n < 15); n < 15 on OCAP program blocks
+- **Pipeline correctness**: output rows contain NO demographic fields; metric values are rounded; session counts are banded; study_ids are random UUIDs
+- **Review-and-cancel window**: business days calculation (Friday submission activates 5 business days later, not 5 calendar days); cancellation during window discards; re-submission starts fresh window
+- **Withdrawal invalidation**: mid-window withdrawal invalidates and re-runs the pipeline
+- **Population snapshot**: new enrolments during the window do NOT enter the file; withdrawals DO remove rows
+- **Auto-cancel on floor drop**: if withdrawals drop population below floor, status → `auto_cancelled`
+- **Distributed oversight**: admin notification email sent; flag-concerns link works; flagged status freezes the window
+- **Post-hoc review rate limit**: pending prior LTE blocks new LTE submission agency-wide
+- **Audit category**: every lifecycle transition writes an audit entry with `export_category=longitudinal_trajectory_export`
+- **CSV output**: metadata header includes the "for program evaluation, not research" warning; no demographic columns present
+
+Test approach: **prefer integration tests over unit tests** for the pipeline and form — use the existing `seed_eval_export_demo` patterns to build a realistic test fixture, then run the LTE pipeline end-to-end and assert on outputs.
+
+### 12. QA scenarios, documentation, final checks
+
+1. Add new pages to `konote-qa-scenarios/pages/page-inventory.yaml`:
+   - `/reports/longitudinal-trajectory-export/`
+   - `/reports/longitudinal-trajectory-export/new/`
+   - `/reports/longitudinal-trajectory-export/<id>/`
+   - `/reports/longitudinal-trajectory-export/<id>/cancel/`
+   - `/reports/longitudinal-trajectory-export/<id>/flag/`
+2. Write at least one QA scenario in `konote-qa-scenarios/scenarios/admin/` for the LTE happy path: submit → window countdown visible → admin notification received → privacy officer review task created → window elapses → download link active → file contains no demographics
+3. Write a second scenario for the small-population block: submit with n < 10 → blocked with clear error → directed to aggregate reports
+4. Write a third scenario for OCAP-flagged program with missing community signoff → form rejects submission
+5. Update `docs/admin/reporting.md` with an LTE section (separate from EME section) explaining when to use LTE, the preconditions, and the review window
+6. Update `docs/evaluation-export-guide.md` (the ED-facing guide) to mention LTE as an option for small-population evaluation
+7. Create `docs/lte-privacy-officer-guide.md` — a short guide for the designated privacy officer on their responsibilities (review requests, resolve flags, confirm destruction)
+
+## Out of scope for LTE v1 (leave for later tasks)
+
+- **Long-format longitudinal export** — the DRR uses wide format (one row per participant, multiple metric columns for each time point). Long format (one row per measurement point) is a deferred consideration.
+- **Synthetic data option** — deferred pending validation research
+- **REB registry verification** — v1 captures the REB approval number as a string, no external verification
+- **Automated evaluator-facing destruction attestation UI** — v1 uses manual agency entry
+- **Fast-path early approval** — explicitly deferred as an anti-pattern. Do not add a "privacy officer approves early" button.
+- **Secure delivery channel from agency to evaluator** — v1 assumes the agency has its own secure channel
+- **Cross-program LTE** — v1 is single-program only
+
+## Anti-patterns — do not build these
+
+Read **[tasks/design-rationale/evaluation-microdata-export.md](design-rationale/evaluation-microdata-export.md)** "Anti-Patterns" section in full before starting. The following apply directly to LTE and must not be built under any circumstances:
+
+| Do NOT build | Why |
+|---|---|
+| **Any demographic field in LTE output**, including "just age band" or "just urban/rural" | The LTE's re-identification defence IS the absence of these fields. Adding any of them re-opens the full re-identification surface. |
+| **Bundling LTE as a toggle or checkbox on the EME form** | Separate path, separate door, separate key. The LTE must have its own permission, its own form, its own URL prefix, its own audit category. |
+| **"DSA as an unlock" framing** | A signed DSA does not justify LTE access. REB + community governance + compensating controls are the gates. The DSA is captured for the audit record but does not bypass anything. |
+| **Fast-path early approval to shorten the window** | Rubber-stamp risk. Do not add a "privacy officer approves early" button or any mechanism that lets someone activate the download link before the 5-business-day window elapses. |
+| **Lowering the k floor below 5** | k = 5 is fixed across all KoNote tiers. LTE satisfies it trivially because it has no QI columns — do not add a lower "k = 3" mode for any reason. |
+| **LTE without REB approval** | REB is mandatory. Do not add a "REB not required" checkbox or override. |
+| **LTE bypass for OCAP/EGAP programs without community signoff** | Agency ED authorisation is not a substitute for community review. |
+| **Making LTE available to agencies without a designated privacy officer** | The form must be unreachable until the permission is explicitly granted to at least one user. |
+| **Reusing the existing `report.evaluation_export` permission** | Bundling erodes the structural separation. Create a new permission. |
+| **Storing the linkage table (study_id ↔ real record_id) indefinitely** | The linkage blob should be encrypted, stored on the LTEExportRequest, and destroyed when the export is cancelled or expires. It exists only to support participant withdrawal requests ("remove my data"). |
+
+## Acceptance criteria
+
+Before marking LTE done:
+
+1. [ ] `LTEExportRequest`, `LTELifecycleEvent` models exist with migrations committed
+2. [ ] Program model has `community_governance_framework` field with migration
+3. [ ] New permission `report.evaluation_export_small_population` registered and NOT granted by default
+4. [ ] `can_create_lte_export` and `lte_available_in_agency` helpers in place
+5. [ ] `LTEExportRequestForm` validates all preconditions strictly; community governance fields are conditionally required
+6. [ ] `LTESmallPopulationPipeline` runs end-to-end on a test fixture and produces CSV with NO demographic columns
+7. [ ] Metric values, session counts, and total hours are correctly fuzzed per the DRR rules
+8. [ ] Population floor enforced: n < 10 blocks; n < 15 blocks for OCAP/EGAP programs
+9. [ ] Review-and-cancel window correctly calculates 5 business days; countdown visible on submitter and privacy officer dashboards
+10. [ ] Submission sends admin notification email with working "Flag concerns" link
+11. [ ] Flagging freezes the window; resolving unflags it; cancellation discards the file
+12. [ ] Withdrawal during the window invalidates and re-runs the pipeline
+13. [ ] Population snapshot: new enrolments do not enter the file, withdrawals remove rows
+14. [ ] Auto-cancel works when withdrawals drop population below floor
+15. [ ] Post-hoc privacy officer review task is auto-created; a pending task blocks new LTE submission agency-wide
+16. [ ] Audit log entries use `export_category=longitudinal_trajectory_export`, distinct from EME
+17. [ ] LTE is reachable via Admin → Reports → Evaluation Export (Small Population), only when permission is granted and privacy officer is designated
+18. [ ] All user-facing strings are translated (EN + FR)
+19. [ ] All tests pass: pipeline, form, views, lifecycle, rate limit, audit, templates
+20. [ ] `konote-qa-scenarios/pages/page-inventory.yaml` updated with 6 new LTE pages
+21. [ ] At least 3 new QA scenarios (happy path, floor block, OCAP without signoff)
+22. [ ] Documentation updated: admin guide, ED guide, privacy officer guide
+23. [ ] TODO.md LTE tasks marked complete and moved to Recently Done
+24. [ ] **GK reviews completed LTE implementation before merge to develop** — verifies demographic suppression, metric fuzzing, community governance gating, and overall alignment with the DRR. Add a comment to the PR tagging GK for review.
+
+## Development notes
+
+- **Branch naming**: `feat/lte-small-population-export`
+- **Commit discipline**: commit after each of the 12 numbered steps above. The PR will be large — reviewers need the logical chunks to track the build.
+- **Pipeline reuse**: do not copy-paste the 10-step EME pipeline. Subclass or compose. If you find yourself duplicating more than 20 lines from `DeidentificationPipeline`, stop and refactor into shared helpers.
+- **Run locally**: Django commands run on the VPS, not locally. Use `/deploy-to-vps` or `ssh konote-vps` to run migrations and tests. See the global `CLAUDE.md` notes on VPS workflow.
+- **Run these before merging**: `/simplify` (checks for reuse and over-engineering), `/review-session` (final audit against the DRR), and GK review.
+- **Consultation gate**: LTE is explicitly a GK consultation gate (evaluation methodology, data modelling). **Do not merge to develop without GK sign-off.**
+- **Two worktrees risk**: if EVAL-GOV1 is still in flight, coordinate migration numbers on `apps/auth_app/` and `apps/reports/`. Check `git log --oneline develop` for recent migration files before running `makemigrations`.
+
+## What success looks like
+
+A privacy officer at a small agency opens **Admin → Reports → Evaluation Export (Small Population)**. They see an empty list and a "New request" button. They click it. The form shows: program selector (listing their 11-participant peer support program with an OCAP flag indicator), period selector, REB section, evaluator credentials (structured, not free text), destruction window, purpose statement, and a community governance section that appears because the program is OCAP-flagged, asking for the community reviewer name, affiliation, and signoff date. They fill everything in, check the acknowledgement, click submit.
+
+The form validates. They see a preview page: "11 eligible, 11 consented, 11 will be exported. No demographic fields. Metric values rounded to nearest integer. Session counts banded to nearest 5. Total hours banded to nearest half-hour. Review and cancel window: 5 business days, activates 2026-04-16 at 17:00."
+
+They confirm. The submission is recorded. Every admin in the agency receives an email with a "Flag concerns" link and a "View in KoNote" link. The privacy officer's dashboard now shows a review task. The submitter's export history shows a new row with a visible countdown.
+
+Four business days later, one admin clicks "Flag concerns" because they noticed the REB approval is from the evaluator's own institution and want to double-check it. The window countdown freezes. The privacy officer gets a flag notification. They check with the evaluator, confirm the REB is legitimate, and dismiss the flag. The countdown resumes from where it froze.
+
+One more business day. The window elapses. The status transitions to `active`. The submitter's dashboard now shows a download button. They download the file once — a CSV with a warning header (`This file is for PROGRAM EVALUATION, not research`), no demographic columns, 11 pseudonymous rows with longitudinal metric trajectories. The link expires 24 hours later. The agency delivers the file to the evaluator through their own secure channel.
+
+Ninety days after download, the destruction reminder email arrives. The agency contacts the evaluator, records the destruction acknowledgement manually in the detail view, and the LTE lifecycle completes.
+
+That's the LTE working as designed: rigorous evaluation of a small program, with safeguards matched to the risk profile, and no demographic detail anywhere in the file.


### PR DESCRIPTION
## Summary

- **DRR amendment**: Add the **Longitudinal Trajectory Export (LTE)** tier to `tasks/design-rationale/evaluation-microdata-export.md`. LTE is a second, structurally separate export tier for small-population evaluation (10 ≤ n < 15, or n ≥ 15 for OCAP/EGAP-governed programs). It drops demographics entirely and substitutes longitudinal individual trajectories with fuzzed metric and service-intensity values. Gated by REB approval, community governance review, a 5-business-day review-and-cancel window, distributed admin oversight, and post-hoc privacy officer review — never by DSA alone.
- **Scope clarification**: explicitly scopes the DRR to regular program evaluation, not research. Research-grade data access (complete microdata) is handled through a separate high-friction workflow and is out of scope.
- **Anti-patterns strengthened**: added DSA-as-unlock, research-through-evaluation-path, LTE-without-privacy-officer, fast-path-early-approval, and several others.
- **TODO.md**: new "Phase: Longitudinal Trajectory Export (LTE)" with 12 sub-tasks and a GK review gate before merge.
- **DRR index**: register `evaluation-microdata-export.md` (previously unlisted) under Reports, Data export, and a new Program evaluation topic row.
- **Implementation prompt**: `tasks/phase-lte-prompt.md` — detailed prompt for a new session to implement LTE cold. Covers models, pipeline, form, views, lifecycle, oversight, audit, templates, and tests.

## Provenance

- **GK-approved** after two expert panel rounds (convene-experts):
  - Round 1: validated the need for a second tier and rejected the "loosen k for DSA-signed evaluators" framing as an anti-pattern
  - Round 2: reviewed the draft and refined cooling-off → review-and-cancel window (7 calendar days → 5 business days), renamed the concept, added distributed oversight via "flag concerns" link, added withdrawal-during-window invalidation, replaced free-text evaluator credentials with structured fields, added the "no privacy officer designated = no LTE" hard precondition, and deferred fast-path approval as an anti-pattern.

## Scope

This PR is **documentation only**. No code in `apps/` changes. The DRR is the source of truth for what LTE is; `tasks/phase-lte-prompt.md` is the instruction set for the next session to build it.

## Test plan

- [ ] Review the amended DRR — does it read as a single coherent document (no change-log framing)?
- [ ] Confirm the tier table lists both EME and LTE with population floors
- [ ] Confirm the anti-patterns section includes the new entries
- [ ] Confirm TODO.md has a new "Phase: Longitudinal Trajectory Export (LTE)" section with sub-tasks
- [ ] Confirm the DRR index lists `evaluation-microdata-export.md` under Implementation Decisions (23 files)
- [ ] Skim `tasks/phase-lte-prompt.md` — is the implementation path clear to a new session?

🤖 Generated with [Claude Code](https://claude.com/claude-code)