### PR TITLE
LTE: Longitudinal Trajectory Export for small-population evaluation

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -118,18 +118,19 @@ Step-by-step commands for each task are in [tasks/recurring-tasks.md](tasks/recu
 
 DRR approved by GK after two expert panel rounds — `tasks/design-rationale/evaluation-microdata-export.md`. LTE is a second, structurally separate export tier for small-population evaluation (10 ≤ n < 15, or n ≥ 15 for OCAP/EGAP-governed programs). It drops demographics entirely and substitutes fuzzed longitudinal trajectories. New permission, separate form, reused pipeline base, distinct audit category, review-and-cancel window, distributed admin oversight, post-hoc privacy officer review. GK reviews on completion before merge.
 
-- [ ] LTE permission + "no designated privacy officer = no LTE" enforcement — new `report.evaluation_export_small_population` permission, settings check, form unavailable if unassigned (LTE-PERM1)
-- [ ] LTE form with structured preconditions — REB number/name/date, DSA expiry, structured evaluator credentials (degree/years/prior programs), destruction window, community governance flags (OCAP/EGAP/other), purpose statement, acknowledgement checkbox (LTE-FORM1)
-- [ ] LTE pipeline — reuse EME pipeline base, strip all demographic fields, round metric values to scale unit, band session count to 5 and hours to 0.5, generate pseudonymous study_id, trivial k check (LTE-PIPE1)
-- [ ] Review-and-cancel window — 5 business days, countdown visible on submitter history and privacy officer dashboard, withdrawal-during-window invalidation, population snapshot at submission, auto-cancel if population drops below floor (LTE-WINDOW1)
-- [ ] Distributed oversight — admin notification email at submission time with "flag concerns" link; any admin may cancel during the window; cancellation discards (LTE-OVERSIGHT1)
-- [ ] Post-hoc privacy officer review task + agency-wide rate limit — auto-created at submission, blocks next LTE agency-wide until resolved (LTE-REVIEW1)
-- [ ] Distinct audit category + enhanced metadata — `longitudinal_trajectory_export`, structured credential fields, community governance flags, window timestamps, destruction attestation (LTE-AUDIT1)
-- [ ] LTE CSV output — metadata header with "for program evaluation, not research" warning, rounded values, no demographics (LTE-OUT1)
-- [ ] Test suite — pipeline correctness, preconditions validation, window lifecycle, withdrawal re-run, floor enforcement, rate limit, community governance flag gating (LTE-TEST1)
-- [ ] Register new LTE routes in `konote-qa-scenarios/pages/page-inventory.yaml` and add scenario for LTE happy path + small-population block (LTE-QA1)
-- [ ] LTE user documentation — ED guide + privacy officer guide, separate from EME docs (LTE-DOC1)
+- [x] LTE permission + "no designated privacy officer = no LTE" enforcement — `report.evaluation_export_small_population`, LTEExportGrant model + signal, `lte_available_in_agency()` gate in views (LTE-PERM1)
+- [x] LTE form with structured preconditions — REB number/name/date, DSA expiry, structured evaluator credentials, destruction window, community governance flags, purpose statement, acknowledgement checkbox (LTE-FORM1)
+- [x] LTE pipeline — `LTESmallPopulationPipeline` subclasses `DeidentificationPipeline`; strips all demographics, fuzzes metrics / sessions / hours, UUID study_id, trivial k check, snapshot restriction for withdrawal handling (LTE-PIPE1)
+- [x] Review-and-cancel window — 5 business days via `add_business_days()`, countdown on list/detail, flag-freeze with resume from hold point, `refresh_pending_requests()` called at view time + daily `check_lte_window_lifecycle` management command (LTE-WINDOW1)
+- [x] Distributed oversight — admin notification email with signed "Flag concerns" token, `lte_flag_concerns` view works without the LTE permission; any admin can cancel during the window (LTE-OVERSIGHT1)
+- [x] Post-hoc privacy officer review + agency-wide rate limit — `post_hoc_review_pending` flag blocks new submissions agency-wide; resolved via `lte_resolve_review` view (LTE-REVIEW1)
+- [x] Distinct audit category — every LTE lifecycle write tags `export_category=longitudinal_trajectory_export`; never bundled with evaluation_microdata (LTE-AUDIT1)
+- [x] LTE CSV output — metadata header with PROGRAM EVALUATION warning, rounded values, no demographics, LTE-XXXXXXXX study ids (LTE-OUT1)
+- [x] Test suite — tests/test_lte.py covers permissions, form validation, business-day arithmetic, fuzzing, study id generator, lifecycle transitions, rate limit, CSV shape, audit category, view access (LTE-TEST1)
+- [ ] Register new LTE routes in `konote-qa-scenarios/pages/page-inventory.yaml` and add scenarios (happy path, floor block, OCAP without signoff) — follow-up session in the konote-qa-scenarios repo (LTE-QA1)
+- [x] LTE user documentation — `docs/lte-privacy-officer-guide.md` + LTE section in `docs/admin/reporting.md` (LTE-DOC1)
 - [ ] GK reviews completed LTE implementation before merge — verifies demographic suppression, fuzzing correctness, community governance gating (LTE-GKREVIEW1)
+- [ ] Translate new LTE strings into French — run `translate_strings` on VPS, fill in msgstrs, commit updated .po/.mo (LTE-I18N1)
 
 ### Phase: Documentation & Website Updates
 

--- a/apps/auth_app/migrations/0015_lte_export_grant.py
+++ b/apps/auth_app/migrations/0015_lte_export_grant.py
@@ -1,0 +1,106 @@
+"""LTE — Add LTEExportGrant model + User.lte_export_granted cache flag.
+
+Mirrors the EvaluationExportGrant pattern but is a strictly separate
+permission. The DRR treats LTE as a structurally separate path that
+must not be bundled with EME access (see
+tasks/design-rationale/evaluation-microdata-export.md, "Anti-Patterns
+— Do Not Build").
+"""
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("auth_app", "0014_eval_grant_reason_max_length"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="user",
+            name="lte_export_granted",
+            field=models.BooleanField(
+                default=False,
+                help_text=(
+                    "Cached flag — set by LTEExportGrant signal. "
+                    "Do not edit directly; use the LTE Privacy Officer admin UI."
+                ),
+            ),
+        ),
+        migrations.CreateModel(
+            name="LTEExportGrant",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("granted_at", models.DateTimeField(auto_now_add=True)),
+                (
+                    "reason",
+                    models.TextField(
+                        max_length=2000,
+                        help_text=(
+                            "Why this grant was issued — typically references "
+                            "the board or ED decision to designate this user as "
+                            "the agency's LTE privacy officer. Max 2000 chars "
+                            "so reviewers can scan the audit log without "
+                            "wading through page-length narratives."
+                        ),
+                    ),
+                ),
+                ("active", models.BooleanField(default=True)),
+                ("revoked_at", models.DateTimeField(blank=True, null=True)),
+                (
+                    "granted_by",
+                    models.ForeignKey(
+                        blank=True,
+                        help_text=(
+                            "Admin who issued the grant. Null only for "
+                            "backfilled legacy rows."
+                        ),
+                        null=True,
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="lte_export_grants_issued",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    "revoked_by",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="lte_export_grants_revoked",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    "user",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="lte_export_grants",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+            ],
+            options={
+                "db_table": "lte_export_grants",
+                "ordering": ["-granted_at"],
+            },
+        ),
+        migrations.AddConstraint(
+            model_name="lteexportgrant",
+            constraint=models.UniqueConstraint(
+                condition=models.Q(("active", True)),
+                fields=("user",),
+                name="one_active_lte_export_grant_per_user",
+            ),
+        ),
+    ]

--- a/apps/auth_app/models.py
+++ b/apps/auth_app/models.py
@@ -68,6 +68,21 @@ class User(AbstractBaseUser, PermissionsMixin):
             "Do not edit directly; use the Evaluator Export Access admin UI."
         ),
     )
+    # Longitudinal Trajectory Export (LTE) — see
+    # tasks/design-rationale/evaluation-microdata-export.md. This is a
+    # strictly separate permission from evaluation_export_granted: the
+    # LTE governance model expects one privacy-officer grantee per agency,
+    # and the two permissions must not be bundled. Maintained by the
+    # post_save signal on LTEExportGrant. Do NOT write to this field
+    # directly — go through the grant model so the audit trail and
+    # reason requirement are enforced.
+    lte_export_granted = models.BooleanField(
+        default=False,
+        help_text=(
+            "Cached flag — set by LTEExportGrant signal. "
+            "Do not edit directly; use the LTE Privacy Officer admin UI."
+        ),
+    )
     is_demo = models.BooleanField(
         default=False,
         help_text="Demo users see demo data only. Set at creation, never changed.",
@@ -375,6 +390,84 @@ class EvaluationExportGrant(models.Model):
         (e.g., as a queryset annotation). When None, the grant is
         considered stale relative to its creation date — a grant that
         was never used and is older than STALE_DAYS is stale.
+        """
+        from datetime import timedelta
+        from django.utils import timezone
+
+        reference = last_export_at or self.granted_at
+        return reference < timezone.now() - timedelta(days=self.STALE_DAYS)
+
+
+class LTEExportGrant(models.Model):
+    """Per-user grant record for `report.evaluation_export_small_population`.
+
+    This is the LTE-specific counterpart to EvaluationExportGrant. LTE
+    access is governed separately because the DRR treats LTE as a
+    different data product with different governance preconditions
+    (REB approval, community review, distributed oversight), and the
+    designation of a privacy officer is a hard precondition — if no
+    user in the agency holds this grant, the LTE form is unreachable.
+
+    One row per grant event, same partial-unique-by-user pattern as
+    EvaluationExportGrant. See tasks/design-rationale/evaluation-microdata-export.md.
+    """
+
+    # Mirror EvaluationExportGrant (kept in sync deliberately — see
+    # EVAL-GOV1 simplify review for the rationale).
+    REASON_MAX_LENGTH = 2000
+    STALE_DAYS = 180
+
+    user = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.CASCADE,
+        related_name="lte_export_grants",
+    )
+    granted_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.PROTECT,
+        related_name="lte_export_grants_issued",
+        null=True, blank=True,
+        help_text="Admin who issued the grant. Null only for backfilled legacy rows.",
+    )
+    granted_at = models.DateTimeField(auto_now_add=True)
+    reason = models.TextField(
+        max_length=REASON_MAX_LENGTH,
+        help_text=(
+            "Why this grant was issued — typically references the board "
+            "or ED decision to designate this user as the agency's LTE "
+            "privacy officer. Max 2000 chars so reviewers can scan the "
+            "audit log without wading through page-length narratives."
+        ),
+    )
+    active = models.BooleanField(default=True)
+    revoked_at = models.DateTimeField(null=True, blank=True)
+    revoked_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.PROTECT,
+        null=True, blank=True,
+        related_name="lte_export_grants_revoked",
+    )
+
+    class Meta:
+        app_label = "auth_app"
+        db_table = "lte_export_grants"
+        ordering = ["-granted_at"]
+        constraints = [
+            models.UniqueConstraint(
+                fields=["user"],
+                condition=models.Q(active=True),
+                name="one_active_lte_export_grant_per_user",
+            ),
+        ]
+
+    def __str__(self):
+        status = "active" if self.active else "revoked"
+        return f"LTEExportGrant({self.user_id}, {status})"
+
+    def is_stale(self, last_export_at=None):
+        """Same staleness model as EvaluationExportGrant — grants that
+        haven't been used for STALE_DAYS show a visual indicator in the
+        privacy officer admin UI. No auto-revocation.
         """
         from datetime import timedelta
         from django.utils import timezone

--- a/apps/auth_app/permissions.py
+++ b/apps/auth_app/permissions.py
@@ -71,6 +71,7 @@ PERMISSIONS = {
         "report.program_report": DENY,  # Managers generate, not front desk
         "report.funder_report": DENY,  # Managers/executives generate funder reports
         "report.evaluation_export": DENY,  # Explicit per-user grant only — not tied to any role (admins must be granted too)
+        "report.evaluation_export_small_population": DENY,  # LTE — strictly separate per-user grant; never bundled with evaluation_export. DRR: evaluation-microdata-export.md
         "report.data_extract": DENY,
 
         "insights.view": DENY,  # Outcome insights — staff+ only
@@ -177,6 +178,7 @@ PERMISSIONS = {
         "report.program_report": DENY,
         "report.funder_report": DENY,  # Managers/executives generate funder reports
         "report.evaluation_export": DENY,  # Explicit per-user grant only — not tied to any role (admins must be granted too)
+        "report.evaluation_export_small_population": DENY,  # LTE — strictly separate per-user grant; never bundled with evaluation_export. DRR: evaluation-microdata-export.md
         "report.data_extract": DENY,
 
         "insights.view": PROGRAM,  # Program-level outcome insights. Enforced by @requires_permission
@@ -402,6 +404,7 @@ PERMISSIONS = {
         "report.funder_report": ALLOW,  # Executives can generate aggregate funder reports.
                                         # Enforced by @requires_permission
         "report.evaluation_export": DENY,  # Explicit per-user grant only — not tied to any role (admins must be granted too)
+        "report.evaluation_export_small_population": DENY,  # LTE — strictly separate per-user grant; never bundled with evaluation_export. DRR: evaluation-microdata-export.md
         "report.data_extract": DENY,
 
         "insights.view": ALLOW,  # Aggregate outcome insights only (quotes suppressed).
@@ -575,6 +578,7 @@ def permission_to_plain_english(perm_key, perm_level):
         "report.program_report": "Generate program outcome reports",
         "report.funder_report": "Generate funder demographic reports",
         "report.evaluation_export": "Generate de-identified evaluation exports for external evaluators",
+        "report.evaluation_export_small_population": "Generate Longitudinal Trajectory Exports for small-population programs (LTE — privacy officer only)",
         "report.data_extract": "Export client data extracts",
 
         "event.view": "View client events and timeline",

--- a/apps/auth_app/signals.py
+++ b/apps/auth_app/signals.py
@@ -2,7 +2,7 @@
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 
-from .models import EvaluationExportGrant, User
+from .models import EvaluationExportGrant, LTEExportGrant, User
 
 
 @receiver(post_save, sender=EvaluationExportGrant)
@@ -25,4 +25,21 @@ def sync_user_eval_export_flag(sender, instance, **kwargs):
     if instance.user.evaluation_export_granted != has_active:
         User.objects.filter(pk=instance.user_id).update(
             evaluation_export_granted=has_active,
+        )
+
+
+@receiver(post_save, sender=LTEExportGrant)
+def sync_user_lte_export_flag(sender, instance, **kwargs):
+    """Keep User.lte_export_granted in sync with active LTE grants.
+
+    Same pattern as sync_user_eval_export_flag. LTE has its own grant
+    model because the governance model treats it as a structurally
+    separate permission (see tasks/design-rationale/evaluation-microdata-export.md).
+    """
+    has_active = LTEExportGrant.objects.filter(
+        user=instance.user, active=True,
+    ).exists()
+    if instance.user.lte_export_granted != has_active:
+        User.objects.filter(pk=instance.user_id).update(
+            lte_export_granted=has_active,
         )

--- a/apps/auth_app/templatetags/permissions_tags.py
+++ b/apps/auth_app/templatetags/permissions_tags.py
@@ -62,4 +62,10 @@ def has_permission(context, permission_key):
     if permission_key == "report.evaluation_export":
         return getattr(user, "evaluation_export_granted", False)
 
+    # LTE — strictly separate from evaluation_export. Mirrors
+    # apps.reports.utils.can_create_lte_export — keep in sync. Admin
+    # bypass does not apply; the grant is per-user.
+    if permission_key == "report.evaluation_export_small_population":
+        return getattr(user, "lte_export_granted", False)
+
     return False

--- a/apps/programs/migrations/0013_program_community_governance_framework.py
+++ b/apps/programs/migrations/0013_program_community_governance_framework.py
@@ -1,0 +1,38 @@
+"""LTE — Add community_governance_framework field to Program.
+
+When set, Longitudinal Trajectory Export submissions on this program
+require community reviewer signoff and, for OCAP/EGAP, a higher
+population floor (n>=15). See
+tasks/design-rationale/evaluation-microdata-export.md, LTE section.
+"""
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("programs", "0012_program_default_goal_review_days"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="program",
+            name="community_governance_framework",
+            field=models.CharField(
+                blank=True,
+                choices=[
+                    ("", "No specific framework"),
+                    ("ocap", "OCAP (First Nations, Inuit, Métis)"),
+                    ("egap", "EGAP (Black communities)"),
+                    ("other", "Other small-population community review"),
+                ],
+                default="",
+                help_text=(
+                    "If set, Longitudinal Trajectory Export submissions on this "
+                    "program require community reviewer signoff. OCAP and EGAP "
+                    "raise the LTE population floor to n>=15."
+                ),
+                max_length=10,
+            ),
+        ),
+    ]

--- a/apps/programs/models.py
+++ b/apps/programs/models.py
@@ -74,6 +74,33 @@ class Program(models.Model):
         help_text=_("Default target date offset (days) for goals created in this program."),
     )
 
+    # ── Community governance (LTE — DRR: evaluation-microdata-export.md) ──
+    # When set, Longitudinal Trajectory Export submissions on this program
+    # require community reviewer signoff in addition to the usual preconditions.
+    # OCAP (First Nations / Inuit / Métis) and EGAP (Black communities) raise
+    # the LTE population floor from n≥10 to n≥15.
+    COMMUNITY_GOVERNANCE_NONE = ""
+    COMMUNITY_GOVERNANCE_OCAP = "ocap"
+    COMMUNITY_GOVERNANCE_EGAP = "egap"
+    COMMUNITY_GOVERNANCE_OTHER = "other"
+    COMMUNITY_GOVERNANCE_CHOICES = [
+        (COMMUNITY_GOVERNANCE_NONE, _("No specific framework")),
+        (COMMUNITY_GOVERNANCE_OCAP, _("OCAP (First Nations, Inuit, Métis)")),
+        (COMMUNITY_GOVERNANCE_EGAP, _("EGAP (Black communities)")),
+        (COMMUNITY_GOVERNANCE_OTHER, _("Other small-population community review")),
+    ]
+    community_governance_framework = models.CharField(
+        max_length=10,
+        choices=COMMUNITY_GOVERNANCE_CHOICES,
+        default=COMMUNITY_GOVERNANCE_NONE,
+        blank=True,
+        help_text=_(
+            "If set, Longitudinal Trajectory Export submissions on this program "
+            "require community reviewer signoff. OCAP and EGAP raise the LTE "
+            "population floor to n≥15."
+        ),
+    )
+
     class Meta:
         app_label = "programs"
         db_table = "programs"

--- a/apps/reports/forms.py
+++ b/apps/reports/forms.py
@@ -1333,3 +1333,266 @@ class EvaluationExportForm(ProgramSelectionMixin, forms.Form):
             "purpose": self.cleaned_data.get("evaluation_purpose", ""),
             "agreement_expiry": self.cleaned_data.get("agreement_expiry"),
         }
+
+
+class LTEExportRequestForm(ProgramSelectionMixin, forms.Form):
+    """Longitudinal Trajectory Export request form.
+
+    Strict validation — every precondition is required. The form
+    rejects any submission where REB, evaluator credentials, or
+    (where applicable) community governance signoff are missing or
+    invalid. See tasks/design-rationale/evaluation-microdata-export.md,
+    "Preconditions Enforced by the Form" for the full list and
+    rationale.
+
+    Access is restricted to users with the
+    report.evaluation_export_small_population permission AND the
+    agency must have at least one designated privacy officer
+    (checked in the view, not the form).
+    """
+
+    ACKNOWLEDGEMENT_TEXT = _(
+        "I have read the re-identification risk notice and confirm "
+        "this export is for program evaluation, not research. "
+        "Research-grade data access (complete microdata, unfuzzed "
+        "values, demographic detail) is handled through a separate "
+        "workflow and is not available through this form."
+    )
+
+    program = forms.ChoiceField(
+        required=True,
+        label=_("Program"),
+    )
+
+    # Period
+    period_start = forms.DateField(
+        required=True,
+        label=_("Period start"),
+        widget=forms.DateInput(attrs={"type": "date"}),
+    )
+    period_end = forms.DateField(
+        required=True,
+        label=_("Period end"),
+        widget=forms.DateInput(attrs={"type": "date"}),
+    )
+
+    # REB
+    reb_name = forms.CharField(
+        max_length=200,
+        label=_("REB name"),
+        help_text=_("Name of the Research Ethics Board that approved this evaluation."),
+    )
+    reb_approval_number = forms.CharField(
+        min_length=5,
+        max_length=100,
+        label=_("REB approval number"),
+    )
+    reb_approval_date = forms.DateField(
+        label=_("REB approval date"),
+        widget=forms.DateInput(attrs={"type": "date"}),
+    )
+
+    # DSA — captured for audit, not an unlock
+    data_sharing_agreement_expiry = forms.DateField(
+        label=_("Data sharing agreement expiry"),
+        widget=forms.DateInput(attrs={"type": "date"}),
+        help_text=_(
+            "When does the data sharing agreement with this evaluator expire? "
+            "A signed DSA is required but does not on its own unlock LTE access."
+        ),
+    )
+
+    # Evaluator credentials — structured, not free text
+    evaluator_name = forms.CharField(max_length=200, label=_("Evaluator name"))
+    evaluator_email = forms.EmailField(label=_("Evaluator email"))
+    evaluator_organisation = forms.CharField(
+        max_length=200, label=_("Evaluator organisation"),
+    )
+    evaluator_degree = forms.CharField(
+        max_length=300,
+        label=_("Evaluator degree or certification"),
+    )
+    evaluator_years_experience = forms.IntegerField(
+        min_value=0, max_value=60,
+        label=_("Evaluator years of experience"),
+    )
+    evaluator_prior_programs = forms.CharField(
+        widget=forms.Textarea(attrs={"rows": 4}),
+        min_length=50,
+        label=_("Prior programs evaluated"),
+        help_text=_(
+            "Describe at least two prior program evaluations this evaluator "
+            "has conducted. Minimum 50 characters. This becomes part of the "
+            "immutable audit record."
+        ),
+    )
+
+    # Destruction window
+    destruction_window_days = forms.TypedChoiceField(
+        coerce=int,
+        choices=[(30, _("30 days")), (60, _("60 days")), (90, _("90 days"))],
+        label=_("Destruction attestation window"),
+        help_text=_(
+            "How long after download the evaluator has to destroy the file. "
+            "KoNote sends a reminder at the end of the window."
+        ),
+    )
+
+    # Purpose statement
+    purpose_statement = forms.CharField(
+        widget=forms.Textarea(attrs={"rows": 3}),
+        min_length=30,
+        label=_("Purpose statement"),
+        help_text=_(
+            "Plain-language description of the evaluation question. "
+            "Printed in the CSV metadata header and in the audit record."
+        ),
+    )
+
+    # Community governance (conditionally required — see clean())
+    community_reviewer_name = forms.CharField(
+        max_length=200, required=False,
+        label=_("Community reviewer name"),
+    )
+    community_reviewer_affiliation = forms.CharField(
+        max_length=300, required=False,
+        label=_("Community reviewer affiliation"),
+    )
+    community_framework_description = forms.CharField(
+        widget=forms.Textarea(attrs={"rows": 2}),
+        required=False,
+        label=_("Community review framework description"),
+        help_text=_("Required when the program's community governance flag is 'Other'."),
+    )
+    community_signoff_date = forms.DateField(
+        required=False,
+        label=_("Community signoff date"),
+        widget=forms.DateInput(attrs={"type": "date"}),
+    )
+
+    # Acknowledgement — must be True to submit
+    acknowledgement_confirmed = forms.BooleanField(
+        required=True,
+        label=ACKNOWLEDGEMENT_TEXT,
+        error_messages={
+            "required": _(
+                "You must confirm the re-identification risk acknowledgement "
+                "to submit an LTE request."
+            ),
+        },
+    )
+
+    def __init__(self, *args, **kwargs):
+        user = kwargs.pop("user", None)
+        super().__init__(*args, **kwargs)
+        self._user = user
+        if user:
+            from .utils import get_manageable_programs
+            programs = get_manageable_programs(user)
+        else:
+            programs = Program.objects.filter(status="active")
+        program_choices = [("", _("\u2014 Select a program \u2014"))]
+        for p in programs.order_by("name"):
+            program_choices.append((str(p.pk), str(p)))
+        self.fields["program"].choices = program_choices
+
+    def clean_program(self):
+        """LTE requires a single program — no All Programs option."""
+        value = self.cleaned_data.get("program", "")
+        if not value or value == self.ALL_PROGRAMS_VALUE:
+            raise forms.ValidationError(_("Please select a program."))
+        try:
+            program = Program.objects.get(pk=int(value), status="active")
+        except (Program.DoesNotExist, ValueError, TypeError):
+            raise forms.ValidationError(_("Invalid program selection."))
+        if self._user:
+            from .utils import get_manageable_programs
+            if not get_manageable_programs(self._user).filter(pk=program.pk).exists():
+                raise forms.ValidationError(_("You do not have access to this program."))
+        return program
+
+    def clean(self):
+        cleaned = super().clean()
+        period_start = cleaned.get("period_start")
+        period_end = cleaned.get("period_end")
+        if period_start and period_end and period_start > period_end:
+            self.add_error(
+                "period_end",
+                _("Period end must be on or after period start."),
+            )
+
+        # REB date sanity
+        reb_date = cleaned.get("reb_approval_date")
+        from datetime import date as _date
+        if reb_date and reb_date > _date.today():
+            self.add_error(
+                "reb_approval_date",
+                _("REB approval date cannot be in the future."),
+            )
+
+        # DSA expiry must be in the future — no point running an LTE
+        # against a DSA that has already expired.
+        dsa_expiry = cleaned.get("data_sharing_agreement_expiry")
+        if dsa_expiry and dsa_expiry < _date.today():
+            self.add_error(
+                "data_sharing_agreement_expiry",
+                _("Data sharing agreement has already expired."),
+            )
+
+        # Community governance conditional validation — the program's
+        # community_governance_framework flag controls which fields
+        # become required.
+        program = cleaned.get("program")
+        if program and getattr(program, "community_governance_framework", ""):
+            framework = program.community_governance_framework
+            required = [
+                "community_reviewer_name",
+                "community_reviewer_affiliation",
+                "community_signoff_date",
+            ]
+            if framework == "other":
+                required.append("community_framework_description")
+            for field_name in required:
+                if not cleaned.get(field_name):
+                    self.add_error(
+                        field_name,
+                        _(
+                            "Required for programs with a "
+                            "community governance framework."
+                        ),
+                    )
+
+            # Signoff date must not be in the future
+            signoff = cleaned.get("community_signoff_date")
+            if signoff and signoff > _date.today():
+                self.add_error(
+                    "community_signoff_date",
+                    _("Community signoff date cannot be in the future."),
+                )
+
+        return cleaned
+
+    def get_evaluator_info(self):
+        """Return evaluator + preconditions dict for the LTE pipeline."""
+        return {
+            "name": self.cleaned_data.get("evaluator_name", ""),
+            "email": self.cleaned_data.get("evaluator_email", ""),
+            "organisation": self.cleaned_data.get("evaluator_organisation", ""),
+            "degree": self.cleaned_data.get("evaluator_degree", ""),
+            "years_experience": self.cleaned_data.get("evaluator_years_experience", 0),
+            "prior_programs": self.cleaned_data.get("evaluator_prior_programs", ""),
+            "purpose": self.cleaned_data.get("purpose_statement", ""),
+            "reb_name": self.cleaned_data.get("reb_name", ""),
+            "reb_approval_number": self.cleaned_data.get("reb_approval_number", ""),
+            "reb_approval_date": self.cleaned_data.get("reb_approval_date"),
+            "agreement_expiry": self.cleaned_data.get("data_sharing_agreement_expiry"),
+            "destruction_window_days": self.cleaned_data.get("destruction_window_days"),
+            "community_reviewer_name": self.cleaned_data.get("community_reviewer_name", ""),
+            "community_reviewer_affiliation": self.cleaned_data.get(
+                "community_reviewer_affiliation", "",
+            ),
+            "community_framework_description": self.cleaned_data.get(
+                "community_framework_description", "",
+            ),
+            "community_signoff_date": self.cleaned_data.get("community_signoff_date"),
+        }

--- a/apps/reports/lte_lifecycle.py
+++ b/apps/reports/lte_lifecycle.py
@@ -1,0 +1,639 @@
+"""Lifecycle helpers for Longitudinal Trajectory Export (LTE) requests.
+
+The LTE review-and-cancel window is a 5-business-day pause between
+submission and download-link activation. During the window any agency
+admin can cancel the request, flag concerns, or let it elapse. When it
+elapses without intervention, the request transitions to "active" and
+a SecureExportLink is generated from the prepared file.
+
+See tasks/design-rationale/evaluation-microdata-export.md, "Review and
+Cancel Window" for the full design.
+
+Lifecycle evaluation strategy: **view-time + management command**. Each
+time an LTE list/detail view renders, `refresh_pending_requests()` is
+called to transition any request whose window has elapsed. A daily
+management command (`check_lte_window_lifecycle`) handles the cases
+where no admin hits the list view for >5 business days (e.g., a quiet
+weekend or holiday run).
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import date, datetime, time, timedelta
+from typing import Iterable
+
+from django.conf import settings
+from django.db import transaction
+from django.utils import timezone
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Business day arithmetic
+# ---------------------------------------------------------------------------
+
+LTE_WINDOW_BUSINESS_DAYS_DEFAULT = 5
+LTE_DESTRUCTION_WINDOW_DEFAULT = 90
+
+
+def _get_excluded_holidays() -> set[date]:
+    """Return the configured holiday set (empty by default in v1)."""
+    holidays = getattr(settings, "LTE_EXCLUDED_HOLIDAYS", [])
+    out: set[date] = set()
+    for h in holidays:
+        if isinstance(h, date):
+            out.add(h)
+        elif isinstance(h, str):
+            try:
+                out.add(date.fromisoformat(h))
+            except ValueError:
+                logger.warning("LTE: invalid LTE_EXCLUDED_HOLIDAYS entry: %r", h)
+    return out
+
+
+def add_business_days(
+    start: datetime,
+    business_days: int = LTE_WINDOW_BUSINESS_DAYS_DEFAULT,
+) -> datetime:
+    """Return the datetime `business_days` business days after `start`.
+
+    A business day is Monday–Friday in the agency's configured timezone,
+    excluding any configured holidays (settings.LTE_EXCLUDED_HOLIDAYS).
+    The returned datetime preserves the time-of-day of `start` and
+    lands on a business day.
+
+    Examples (empty holiday list):
+      - Monday 09:00 + 5 business days → Monday 09:00 (next week)
+      - Friday 09:00 + 5 business days → Friday 09:00 (next week)
+      - Saturday 09:00 + 5 business days → Friday 09:00 (next week)
+    """
+    if business_days <= 0:
+        return start
+
+    holidays = _get_excluded_holidays()
+    current = start
+    # If start falls on a weekend/holiday, advance to the next business
+    # day first, so "5 business days from Saturday" means "Friday".
+    while current.weekday() >= 5 or current.date() in holidays:
+        current = current + timedelta(days=1)
+
+    added = 0
+    while added < business_days:
+        current = current + timedelta(days=1)
+        if current.weekday() < 5 and current.date() not in holidays:
+            added += 1
+    return current
+
+
+def calculate_window_end(
+    submitted_at: datetime,
+    business_days: int = LTE_WINDOW_BUSINESS_DAYS_DEFAULT,
+) -> datetime:
+    """Return the datetime at which the review-and-cancel window ends
+    (i.e. the download link activates) if no flags or cancellations
+    intervene. Wraps add_business_days with a descriptive name.
+    """
+    return add_business_days(submitted_at, business_days)
+
+
+# ---------------------------------------------------------------------------
+# State transitions
+# ---------------------------------------------------------------------------
+
+def activate_window_if_elapsed(request, *, actor=None) -> bool:
+    """If the window has elapsed and status is 'submitted', activate it.
+
+    Returns True if the request was activated, False otherwise.
+    Generates the SecureExportLink by re-running the LTE pipeline
+    against the submission-time snapshot (minus any withdrawals).
+    """
+    from apps.reports.models import LTELifecycleEvent, LTEExportRequest
+
+    if request.status != LTEExportRequest.STATUS_SUBMITTED:
+        return False
+
+    now = timezone.now()
+    if now < request.effective_window_activates_at:
+        return False
+
+    # Re-run the pipeline against the current consent state, restricted
+    # to the submission-time client_ids. This is where withdrawal-
+    # during-window drops rows from the file — the pipeline's consent
+    # filter will skip withdrawn participants.
+    from apps.reports.lte_pipeline import LTESmallPopulationPipeline
+
+    evaluator_info = _evaluator_info_from_request(request)
+
+    pipeline = LTESmallPopulationPipeline(
+        program=request.program,
+        period_start=request.period_start,
+        period_end=request.period_end,
+        evaluator_info=evaluator_info,
+        user=request.submitted_by,
+        restrict_to_client_ids=list(request.population_client_ids or []),
+    )
+
+    try:
+        result = pipeline.run_generate()
+    except ValueError as exc:
+        # Population dropped below floor during the window → auto-cancel
+        logger.warning(
+            "LTE #%s: auto-cancelling at activation — %s",
+            request.pk, exc,
+        )
+        auto_cancel_for_floor_drop(request)
+        return False
+
+    # Persist the CSV via the standard secure link helper. We need a
+    # mock request-like object to reuse _save_export_and_create_link —
+    # but the management command path has no HttpRequest, so instead
+    # we create the SecureExportLink directly here.
+    from apps.reports.models import SecureExportLink
+
+    link = _create_lte_secure_link(
+        request=request,
+        csv_content=result.csv_content,
+        filename=result.filename,
+        population_count=result.preview.exportable_count,
+    )
+
+    with transaction.atomic():
+        LTEExportRequest.objects.filter(pk=request.pk).update(
+            status=LTEExportRequest.STATUS_ACTIVE,
+            secure_export_link=link,
+            linkage_blob_encrypted=result.linkage_blob,
+        )
+        LTELifecycleEvent.objects.create(
+            request=request,
+            actor=actor,
+            event_type="window_activated",
+            notes=(
+                f"Window elapsed — download link active. "
+                f"Exported {result.preview.exportable_count} rows."
+            ),
+        )
+    request.refresh_from_db()
+
+    _write_audit_entry(
+        request,
+        action="export",
+        event_type="window_activated",
+        metadata={
+            "lte_request_id": request.pk,
+            "population_count": result.preview.exportable_count,
+            "secure_export_link_id": str(link.pk),
+        },
+    )
+
+    logger.info(
+        "LTE #%s activated — %d rows exported",
+        request.pk, result.preview.exportable_count,
+    )
+    return True
+
+
+def auto_cancel_for_floor_drop(request) -> None:
+    """Transition a request to auto_cancelled because the population
+    dropped below the LTE floor during the review-and-cancel window.
+    """
+    from apps.reports.models import LTELifecycleEvent, LTEExportRequest
+
+    with transaction.atomic():
+        LTEExportRequest.objects.filter(pk=request.pk).update(
+            status=LTEExportRequest.STATUS_AUTO_CANCELLED,
+            cancelled_at=timezone.now(),
+            cancellation_reason="Population dropped below LTE floor",
+            linkage_blob_encrypted=b"",
+        )
+        LTELifecycleEvent.objects.create(
+            request=request,
+            event_type="auto_cancelled",
+            notes="Population dropped below the LTE floor during the review window.",
+        )
+    request.refresh_from_db()
+    _write_audit_entry(
+        request,
+        action="cancel",
+        event_type="auto_cancelled",
+        metadata={"lte_request_id": request.pk, "reason": "floor_drop"},
+    )
+
+
+def invalidate_for_withdrawal(request) -> None:
+    """Mark a request invalidated because a participant withdrew consent.
+
+    The DRR requires that the pipeline be re-run after withdrawal so the
+    withdrawn participant never appears in the final file. The simplest
+    implementation is to mark the in-progress request invalidated and
+    force the user to re-submit; that matches the DRR's "starts a fresh
+    review-and-cancel window" rule.
+    """
+    from apps.reports.models import LTELifecycleEvent, LTEExportRequest
+
+    if request.is_terminal:
+        return
+
+    with transaction.atomic():
+        LTEExportRequest.objects.filter(pk=request.pk).update(
+            status=LTEExportRequest.STATUS_INVALIDATED_BY_WITHDRAWAL,
+            cancelled_at=timezone.now(),
+            cancellation_reason=(
+                "Participant withdrew consent — request invalidated."
+            ),
+            linkage_blob_encrypted=b"",
+        )
+        LTELifecycleEvent.objects.create(
+            request=request,
+            event_type="withdrawal_invalidation",
+            notes=(
+                "A participant withdrew consent during the review-and-cancel "
+                "window. The prepared file is discarded and the submitter "
+                "must re-submit."
+            ),
+        )
+    request.refresh_from_db()
+    _write_audit_entry(
+        request,
+        action="cancel",
+        event_type="invalidated_by_withdrawal",
+        metadata={"lte_request_id": request.pk},
+    )
+
+
+def check_population_snapshot_for_lte(request) -> None:
+    """Re-run the consent check for an in-window request and detect
+    withdrawals or floor drops.
+
+    Intended to be called:
+      - From the daily management command
+      - From a withdrawal signal (if one is wired up later)
+      - From view-time refresh of the LTE list
+    """
+    from apps.clients.models import ServiceEpisode
+    from apps.reports.models import LTEExportRequest
+
+    if not request.is_window_running and request.status != LTEExportRequest.STATUS_ACTIVE:
+        return
+
+    snapshot_ids = set(request.population_client_ids or [])
+    if not snapshot_ids:
+        return
+
+    # Which of the snapshotted clients still have aggregate reporting
+    # consent on an active/finished episode? (The pipeline uses the
+    # same filter.)
+    still_consenting = set(
+        ServiceEpisode.objects.filter(
+            client_file_id__in=snapshot_ids,
+            program=request.program,
+            status__in=["active", "on_hold", "finished"],
+            consent_to_aggregate_reporting=True,
+        ).values_list("client_file_id", flat=True)
+    )
+    withdrawn = snapshot_ids - still_consenting
+    if not withdrawn:
+        return
+
+    # Apply the applicable floor
+    from apps.reports.lte_pipeline import (
+        LTE_FLOOR_DEFAULT,
+        LTE_FLOOR_OCAP_EGAP,
+    )
+
+    framework = (request.program.community_governance_framework or "").lower()
+    floor = LTE_FLOOR_OCAP_EGAP if framework in ("ocap", "egap") else LTE_FLOOR_DEFAULT
+
+    remaining = len(still_consenting)
+    if remaining < floor:
+        auto_cancel_for_floor_drop(request)
+    else:
+        invalidate_for_withdrawal(request)
+
+
+def refresh_pending_requests(
+    *, requests: Iterable | None = None,
+) -> int:
+    """Evaluate pending requests and trigger any state transitions.
+
+    Called from the LTE list view and the management command. Returns
+    the number of requests whose state changed.
+    """
+    from apps.reports.models import LTEExportRequest
+
+    if requests is None:
+        requests = LTEExportRequest.objects.filter(
+            status__in=[
+                LTEExportRequest.STATUS_SUBMITTED,
+                LTEExportRequest.STATUS_ACTIVE,
+            ],
+        )
+    else:
+        requests = list(requests)  # allow re-iteration
+
+    changed = 0
+    for req in requests:
+        # Check for withdrawals / floor drops first — withdrawal
+        # invalidation short-circuits activation.
+        check_population_snapshot_for_lte(req)
+        req.refresh_from_db()
+        if req.status == LTEExportRequest.STATUS_SUBMITTED:
+            if activate_window_if_elapsed(req):
+                changed += 1
+        elif req.status == LTEExportRequest.STATUS_ACTIVE:
+            # Once active, expire the request if the 24-hour download
+            # window has elapsed without a download.
+            if req.secure_export_link and not req.secure_export_link.is_valid():
+                _expire_request(req)
+                changed += 1
+    return changed
+
+
+# ---------------------------------------------------------------------------
+# Flag handling — freeze the countdown, resume on dismissal
+# ---------------------------------------------------------------------------
+
+def start_flag_hold(request, *, actor=None, reason: str = "") -> None:
+    """Freeze the review-and-cancel countdown by recording a flag.
+
+    The remaining window duration is preserved — on resume, we add the
+    elapsed hold time to flag_hold_seconds so the computed
+    effective_window_activates_at shifts forward by that amount.
+    """
+    from apps.reports.models import LTEExportRequest, LTELifecycleEvent
+
+    if request.status not in (
+        LTEExportRequest.STATUS_SUBMITTED,
+        LTEExportRequest.STATUS_FLAGGED,
+    ):
+        return
+    if request.status == LTEExportRequest.STATUS_FLAGGED:
+        return  # already frozen
+
+    now = timezone.now()
+    with transaction.atomic():
+        LTEExportRequest.objects.filter(pk=request.pk).update(
+            status=LTEExportRequest.STATUS_FLAGGED,
+            flag_hold_started_at=now,
+        )
+        LTELifecycleEvent.objects.create(
+            request=request,
+            actor=actor,
+            event_type="flagged",
+            notes=reason or "Flagged for privacy officer review.",
+        )
+    request.refresh_from_db()
+    _write_audit_entry(
+        request,
+        action="update",
+        event_type="flagged",
+        metadata={"lte_request_id": request.pk, "reason": reason},
+    )
+
+
+def resolve_flag(request, *, actor=None, dismissed: bool, notes: str = "") -> None:
+    """Resolve a flag — either dismiss it (resume countdown) or cancel
+    the request. On dismissal, the elapsed hold time is added to
+    flag_hold_seconds so the window resumes from where it was frozen
+    (no fast-forwarding).
+    """
+    from apps.reports.models import LTEExportRequest, LTELifecycleEvent
+
+    if request.status != LTEExportRequest.STATUS_FLAGGED:
+        return
+
+    now = timezone.now()
+    hold_duration = 0
+    if request.flag_hold_started_at:
+        hold_duration = max(
+            0,
+            int((now - request.flag_hold_started_at).total_seconds()),
+        )
+
+    if dismissed:
+        with transaction.atomic():
+            LTEExportRequest.objects.filter(pk=request.pk).update(
+                status=LTEExportRequest.STATUS_SUBMITTED,
+                flag_hold_started_at=None,
+                flag_hold_seconds=request.flag_hold_seconds + hold_duration,
+            )
+            LTELifecycleEvent.objects.create(
+                request=request,
+                actor=actor,
+                event_type="flag_resolved",
+                notes=notes or "Flag dismissed — countdown resumed.",
+            )
+        _write_audit_entry(
+            request,
+            action="update",
+            event_type="flag_resolved_dismissed",
+            metadata={
+                "lte_request_id": request.pk,
+                "hold_seconds_added": hold_duration,
+                "notes": notes,
+            },
+        )
+    else:
+        # Resolution = cancellation
+        cancel_request(request, actor=actor, reason=notes or "Flag resolved as cancellation.")
+
+
+def cancel_request(request, *, actor, reason: str) -> None:
+    """Cancel an LTE request. Allowed during the window or after
+    activation (before download).
+    """
+    from apps.reports.models import LTEExportRequest, LTELifecycleEvent
+
+    if request.is_terminal:
+        return
+
+    with transaction.atomic():
+        LTEExportRequest.objects.filter(pk=request.pk).update(
+            status=LTEExportRequest.STATUS_CANCELLED,
+            cancelled_at=timezone.now(),
+            cancelled_by=actor,
+            cancellation_reason=reason[:500],
+            linkage_blob_encrypted=b"",
+        )
+        LTELifecycleEvent.objects.create(
+            request=request,
+            actor=actor,
+            event_type="cancelled",
+            notes=reason,
+        )
+    request.refresh_from_db()
+    _write_audit_entry(
+        request,
+        action="cancel",
+        event_type="cancelled",
+        metadata={
+            "lte_request_id": request.pk,
+            "cancelled_by_id": actor.pk if actor else None,
+            "reason": reason,
+        },
+    )
+
+
+def mark_downloaded(request, *, actor) -> None:
+    """Transition an active request to downloaded."""
+    from apps.reports.models import LTEExportRequest, LTELifecycleEvent
+
+    if request.status != LTEExportRequest.STATUS_ACTIVE:
+        return
+
+    with transaction.atomic():
+        LTEExportRequest.objects.filter(pk=request.pk).update(
+            status=LTEExportRequest.STATUS_DOWNLOADED,
+        )
+        LTELifecycleEvent.objects.create(
+            request=request,
+            actor=actor,
+            event_type="downloaded",
+            notes="File downloaded.",
+        )
+    _write_audit_entry(
+        request,
+        action="export",
+        event_type="downloaded",
+        metadata={
+            "lte_request_id": request.pk,
+            "downloaded_by_id": actor.pk if actor else None,
+        },
+    )
+
+
+def _expire_request(request) -> None:
+    """Transition an expired-without-download request."""
+    from apps.reports.models import LTEExportRequest, LTELifecycleEvent
+
+    with transaction.atomic():
+        LTEExportRequest.objects.filter(pk=request.pk).update(
+            status=LTEExportRequest.STATUS_EXPIRED,
+            linkage_blob_encrypted=b"",
+        )
+        LTELifecycleEvent.objects.create(
+            request=request,
+            event_type="expired",
+            notes="Download window lapsed without a download.",
+        )
+    _write_audit_entry(
+        request,
+        action="update",
+        event_type="expired",
+        metadata={"lte_request_id": request.pk},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _evaluator_info_from_request(request) -> dict:
+    """Reconstruct an evaluator_info dict from a persisted LTEExportRequest.
+
+    Used when re-running the pipeline at window-activation time.
+    """
+    return {
+        "name": request.evaluator_name,
+        "email": request.evaluator_email,
+        "organisation": request.evaluator_organisation,
+        "degree": request.evaluator_degree,
+        "years_experience": request.evaluator_years_experience,
+        "prior_programs": request.evaluator_prior_programs,
+        "purpose": request.purpose_statement,
+        "reb_name": request.reb_name,
+        "reb_approval_number": request.reb_approval_number,
+        "reb_approval_date": request.reb_approval_date,
+        "agreement_expiry": request.data_sharing_agreement_expiry,
+        "destruction_window_days": request.destruction_window_days,
+        "community_reviewer_name": request.community_reviewer_name,
+        "community_reviewer_affiliation": request.community_reviewer_affiliation,
+        "community_framework_description": request.community_framework_description,
+        "community_signoff_date": request.community_signoff_date,
+    }
+
+
+def _create_lte_secure_link(
+    request, csv_content: str, filename: str, population_count: int,
+):
+    """Create a SecureExportLink carrying the LTE file.
+
+    Unlike the EME path (which goes through _save_export_and_create_link
+    and requires an HttpRequest), we may be called from a management
+    command, so we write the file + create the link manually.
+    """
+    import json
+    import os
+    import uuid
+    from datetime import timedelta
+
+    from apps.reports.models import SecureExportLink
+
+    export_dir = settings.SECURE_EXPORT_DIR
+    os.makedirs(export_dir, exist_ok=True)
+
+    link_id = uuid.uuid4()
+    safe_filename = f"{link_id}_{filename}"
+    file_path = os.path.join(export_dir, safe_filename)
+    with open(file_path, "w", encoding="utf-8-sig") as f:
+        f.write(csv_content)
+
+    expiry_hours = getattr(settings, "SECURE_EXPORT_LINK_EXPIRY_HOURS", 24)
+
+    return SecureExportLink.objects.create(
+        id=link_id,
+        created_by=request.submitted_by,
+        expires_at=timezone.now() + timedelta(hours=expiry_hours),
+        export_type="longitudinal_trajectory_export",
+        filters_json=json.dumps({
+            "lte_request_id": request.pk,
+            "program_id": request.program_id,
+            "period_start": str(request.period_start),
+            "period_end": str(request.period_end),
+        }),
+        client_count=population_count,
+        includes_notes=False,
+        contains_pii=False,  # LTE has no direct identifiers
+        recipient=(
+            f"{request.evaluator_name} ({request.evaluator_email}), "
+            f"{request.evaluator_organisation}"
+        ),
+        filename=filename,
+        file_path=file_path,
+        is_elevated=False,  # review-and-cancel window already provides the delay
+    )
+
+
+def _write_audit_entry(
+    request, *, action: str, event_type: str, metadata: dict,
+) -> None:
+    """Append an LTE lifecycle entry to the audit DB.
+
+    The export_category is always longitudinal_trajectory_export so
+    LTE lifecycle events are filterable independently of EME events.
+    """
+    from apps.audit.models import AuditLog
+
+    full_metadata = {
+        "export_category": "longitudinal_trajectory_export",
+        "lte_event_type": event_type,
+        **metadata,
+    }
+    try:
+        AuditLog.objects.using("audit").create(
+            event_timestamp=timezone.now(),
+            user_id=None,
+            user_display="",
+            ip_address=None,
+            action=action,
+            resource_type="export",
+            resource_id=request.pk,
+            program_id=request.program_id,
+            metadata=full_metadata,
+        )
+    except Exception:
+        logger.exception(
+            "LTE: failed to write audit entry for request %s event %s",
+            request.pk, event_type,
+        )

--- a/apps/reports/lte_pipeline.py
+++ b/apps/reports/lte_pipeline.py
@@ -1,0 +1,766 @@
+"""Pipeline for Longitudinal Trajectory Export (LTE) — small-population tier.
+
+LTE is a structurally separate export tier from the Evaluation Microdata
+Export. See tasks/design-rationale/evaluation-microdata-export.md, "LTE"
+section for the full specification.
+
+Key differences from the base DeidentificationPipeline:
+
+1. No QI columns. Demographic fields are stripped at the schema layer,
+   not merely generalised. This is a HARD rule — LTE's re-identification
+   defence IS the absence of these fields.
+2. No k-anonymity check. k is trivially n because there are no QI columns
+   to form equivalence classes on.
+3. Lower population floor, enforced per-program:
+     - default: n >= 10
+     - OCAP/EGAP governed programs: n >= 15
+4. Metric values, session counts, and total hours are FUZZED — rounded
+   to the natural scale unit / banded to 5 / banded to 0.5 respectively
+   — to reduce the uniqueness of each trajectory shape.
+5. study_id is a random UUID (not the EVL-XXXXXX hex pattern). Random
+   UUID with no derivable relationship to the real record id.
+6. CSV output uses an LTE-specific metadata header with the "for
+   program evaluation, not research" warning.
+
+This pipeline composes with the base DeidentificationPipeline — it
+reuses extract/decrypt/consent-filter/bulk-metric logic rather than
+forking. If you find yourself duplicating more than a few lines from
+the base, refactor into a shared helper instead of copying.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import logging
+import uuid
+from collections import defaultdict
+from dataclasses import dataclass, field
+from datetime import date
+from typing import Any
+
+from django.utils import timezone
+from django.db.models import Count, Q, Sum
+
+from apps.clients.models import ServiceEpisode
+from apps.notes.models import MetricValue, ProgressNote
+from apps.plans.models import MetricDefinition
+from apps.reports.csv_utils import sanitise_csv_value
+from apps.reports.deidentify import DeidentificationPipeline
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Floors and fuzzing constants (DRR: LTE section)
+# ---------------------------------------------------------------------------
+
+LTE_FLOOR_DEFAULT = 10
+LTE_FLOOR_OCAP_EGAP = 15
+LTE_K_FLOOR = 5  # trivially satisfied — kept here for audit clarity
+
+SESSION_COUNT_BAND = 5           # round session count to nearest 5
+TOTAL_HOURS_BAND = 0.5           # round total hours to nearest 0.5
+
+# Metric rounding strategy — inferred from the metric scale. The DRR
+# prescribes:
+#   0-10 ordinal scales      → nearest integer
+#   0-100 percentage scales  → nearest 5
+#   continuous scales        → one decimal place or nearest unit,
+#                              whichever is coarser
+# We detect the scale from the MetricDefinition min/max if present,
+# otherwise fall back to one decimal place.
+
+
+# ---------------------------------------------------------------------------
+# Result dataclasses
+# ---------------------------------------------------------------------------
+
+@dataclass
+class LTEPreviewResult:
+    """Summary of what the LTE pipeline would produce.
+
+    LTE has no QI columns, no suppression rate, and no equivalence-class
+    math, so this is shaped differently from the base PreviewResult.
+    """
+
+    eligible_count: int
+    consented_count: int
+    exportable_count: int
+    blocked: bool
+    block_reason: str | None
+    floor_applied: int
+    program_governance_framework: str
+    # Metric columns that will appear in the output, in order
+    metric_columns: list[str] = field(default_factory=list)
+    # Snapshot of the client_ids that WILL enter the export — used as
+    # the population snapshot when the request is persisted
+    snapshot_client_ids: list[int] = field(default_factory=list)
+
+
+@dataclass
+class LTEGenerateResult:
+    """Output of a successful LTE pipeline generate run."""
+
+    csv_content: str
+    filename: str
+    linkage_blob: bytes        # encrypted JSON {study_id: real_client_id}
+    preview: LTEPreviewResult
+    audit_metadata: dict[str, Any]
+
+
+# ---------------------------------------------------------------------------
+# Pipeline
+# ---------------------------------------------------------------------------
+
+class LTESmallPopulationPipeline(DeidentificationPipeline):
+    """LTE pipeline — reuses extract/decrypt/consent from the base, then
+    diverges to drop demographics entirely, fuzz trajectory values, and
+    enforce the small-population floor.
+
+    Usage (two-phase):
+
+        pipeline = LTESmallPopulationPipeline(
+            program=program,
+            period_start=date(2025, 9, 1),
+            period_end=date(2026, 3, 31),
+            evaluator_info={...},
+            user=request.user,
+        )
+        preview = pipeline.run_preview()
+        if not preview.blocked:
+            result = pipeline.run_generate()
+
+    For the "re-run at window activation" path, pass
+    `restrict_to_client_ids` — the extract step will then limit its
+    query to that set and the snapshot check is skipped because the
+    caller has already enforced it.
+    """
+
+    def __init__(
+        self,
+        program,
+        period_start: date,
+        period_end: date,
+        evaluator_info: dict[str, Any],
+        user,
+        request=None,
+        restrict_to_client_ids: list[int] | None = None,
+    ):
+        # LTE has no QI columns — pass an empty list to the base so
+        # nothing tries to include demographic fields.
+        super().__init__(
+            program=program,
+            period_start=period_start,
+            period_end=period_end,
+            qi_columns=[],
+            evaluator_info=evaluator_info,
+            user=user,
+            request=request,
+        )
+        self._restrict_to_client_ids = (
+            set(restrict_to_client_ids) if restrict_to_client_ids else None
+        )
+        # Longitudinal metric values (computed fresh — the base pipeline
+        # only produces intake/latest, LTE wants intake/mid/exit).
+        self._longitudinal_metrics: dict[int, dict[str, dict[str, Any]]] = {}
+
+    # ------------------------------------------------------------------
+    # Public interface — preview + generate
+    # ------------------------------------------------------------------
+
+    def run_preview(self) -> LTEPreviewResult:  # type: ignore[override]
+        """Run through extract → consent → floor check without producing
+        files. Returns an LTEPreviewResult with snapshot client_ids.
+        """
+        self._reset_state()
+
+        self._extract_raw_data()               # Step 1 (base)
+        self._apply_snapshot_restriction()     # LTE-specific
+        self._decrypt_and_stage()              # Step 2 (base)
+        self._apply_consent_filter()           # Step 3 (base)
+        self._compute_longitudinal_metrics()   # LTE-specific
+        self._strip_direct_identifiers()       # Step 4 — LTE override
+
+        blocked, reason, floor = self._check_lte_population_floor()
+
+        metric_columns = self._build_lte_metric_columns()
+        snapshot_ids = [
+            int(r["_real_client_id"]) for r in self._deidentified_records
+        ]
+
+        return LTEPreviewResult(
+            eligible_count=len(self._raw_records),
+            consented_count=len(self._consented_records),
+            exportable_count=len(self._deidentified_records),
+            blocked=blocked,
+            block_reason=reason,
+            floor_applied=floor,
+            program_governance_framework=(
+                self.program.community_governance_framework or ""
+            ),
+            metric_columns=metric_columns,
+            snapshot_client_ids=snapshot_ids,
+        )
+
+    def run_generate(self) -> LTEGenerateResult:  # type: ignore[override]
+        """Run preview then produce the CSV + linkage blob.
+
+        Raises ValueError if blocked.
+        """
+        import json
+
+        preview = self.run_preview()
+        if preview.blocked:
+            raise ValueError(f"LTE export blocked: {preview.block_reason}")
+
+        csv_content = self._generate_lte_csv(preview)
+        filename = (
+            f"lte_{self.program.pk}_"
+            f"{timezone.now().strftime('%Y%m%d_%H%M%S')}.csv"
+        )
+
+        # Encrypt the linkage table — exists only to support participant
+        # withdrawal requests. Destroyed when request is cancelled or expires.
+        from konote.encryption import encrypt_field
+
+        linkage_blob = encrypt_field(json.dumps(self._linkage_table))
+
+        audit_metadata = self._build_lte_audit_metadata(preview)
+        self._log_audit(
+            "export",
+            "LTE export generated",
+            metadata=audit_metadata,
+        )
+
+        return LTEGenerateResult(
+            csv_content=csv_content,
+            filename=filename,
+            linkage_blob=linkage_blob,
+            preview=preview,
+            audit_metadata=audit_metadata,
+        )
+
+    # ------------------------------------------------------------------
+    # LTE-specific extract filter
+    # ------------------------------------------------------------------
+
+    def _apply_snapshot_restriction(self) -> None:
+        """If we're re-running for a snapshot, drop raw records not in it.
+
+        Used at window-activation time to respect the submission-time
+        population snapshot — new enrolments since submission must not
+        enter the export. Withdrawals are handled by the later consent
+        filter step (withdrawn participants fail consent).
+        """
+        if self._restrict_to_client_ids is None:
+            return
+
+        before = len(self._raw_records)
+        self._raw_records = [
+            r for r in self._raw_records
+            if r["_client_id"] in self._restrict_to_client_ids
+        ]
+        dropped = before - len(self._raw_records)
+        if dropped:
+            logger.info(
+                "LTE snapshot restriction: dropped %d new enrolments "
+                "(not in submission-time snapshot)",
+                dropped,
+            )
+
+    # ------------------------------------------------------------------
+    # LTE-specific: longitudinal metric extraction (intake / mid / exit)
+    # ------------------------------------------------------------------
+
+    def _compute_longitudinal_metrics(self) -> None:
+        """Produce {client_id: {metric_slug: {intake, mid, exit}}}.
+
+        Base pipeline only tracks intake/latest; LTE wants the middle
+        measurement too so trajectory analysis is possible. When fewer
+        than 3 measurements exist, `mid` is omitted for that client.
+        """
+        client_ids = [r["_client_id"] for r in self._consented_records]
+        if not client_ids or not self._metric_defs:
+            return
+
+        all_values = (
+            MetricValue.objects.filter(
+                metric_def__in=self._metric_defs,
+                progress_note_target__progress_note__client_file_id__in=client_ids,
+                progress_note_target__progress_note__created_at__date__range=(
+                    self.period_start, self.period_end,
+                ),
+            )
+            .select_related(
+                "metric_def",
+                "progress_note_target__progress_note",
+            )
+            .order_by("progress_note_target__progress_note__created_at")
+        )
+
+        # Group by (client_id, metric_def_id)
+        grouped: dict[tuple[int, int], list] = defaultdict(list)
+        metric_name_map: dict[int, str] = {}
+        for mv in all_values:
+            cid = mv.progress_note_target.progress_note.client_file_id
+            mid = mv.metric_def_id
+            grouped[(cid, mid)].append(mv)
+            if mid not in metric_name_map:
+                metric_name_map[mid] = self._sanitise_metric_name(
+                    mv.metric_def.name,
+                )
+
+        result: dict[int, dict[str, dict[str, Any]]] = defaultdict(dict)
+        for (cid, mid), values in grouped.items():
+            if not values:
+                continue
+            safe_name = metric_name_map[mid]
+            metric_def = values[0].metric_def
+            trio: dict[str, Any] = {
+                "intake": self._fuzz_metric_value(values[0].value, metric_def),
+                "exit": self._fuzz_metric_value(values[-1].value, metric_def),
+            }
+            if len(values) >= 3:
+                mid_idx = len(values) // 2
+                trio["mid"] = self._fuzz_metric_value(
+                    values[mid_idx].value, metric_def,
+                )
+            result[cid][safe_name] = trio
+
+        self._longitudinal_metrics = dict(result)
+
+    # ------------------------------------------------------------------
+    # LTE-specific: strip ALL demographics, generate UUID study_ids
+    # ------------------------------------------------------------------
+
+    def _strip_direct_identifiers(self):  # type: ignore[override]
+        """Override the base step.
+
+        LTE drops demographic fields entirely (not generalised). The
+        output record contains only:
+          - study_id (random UUID — no linkable pattern)
+          - enrolment_quarter / exit_quarter (quarter granularity only)
+          - fuzzed sessions_count and total_hours
+          - fuzzed longitudinal metric values
+
+        birth_date, postal_code, gender, ethnicity, custom fields — none
+        of these enter the output. This is a hard schema guarantee; it
+        is not configurable.
+        """
+        self._log_audit("view", "LTE: stripping all demographic fields")
+
+        used_study_ids: set[str] = set()
+
+        for record in self._consented_records:
+            study_id = self._generate_lte_study_id(used_study_ids)
+            used_study_ids.add(study_id)
+
+            # Linkage table entry — kept for withdrawal support only
+            self._linkage_table[study_id] = record["_client_id"]
+
+            deidentified = {
+                "study_id": study_id,
+                # Carry forward for the snapshot diff (not exported)
+                "_real_client_id": record["_client_id"],
+                # Service intensity — will be fuzzed in _record_to_lte_row
+                "sessions_count_raw": record.get("sessions_count", 0) or 0,
+                "total_hours_raw": record.get("total_hours", 0.0) or 0.0,
+                # Enrolment / exit quarters (quarter granularity only)
+                "enrolment_quarter": self._date_to_quarter(
+                    record.get("enrolment_date"),
+                ),
+                "exit_quarter": self._date_to_quarter(
+                    record.get("exit_date"),
+                ),
+                # Longitudinal metric values
+                "metrics": self._longitudinal_metrics.get(
+                    record["_client_id"], {},
+                ),
+                # Suppression tracking (trivially False — no k-anon step)
+                "_suppressed": False,
+            }
+            self._deidentified_records.append(deidentified)
+
+        # Trivially k = n — no QI columns means every row is in the
+        # same equivalence class on the empty QI tuple.
+        self._effective_k = len(self._deidentified_records)
+
+        logger.info(
+            "LTE: generated %d pseudonymous study_ids (k trivially n=%d)",
+            len(self._deidentified_records),
+            self._effective_k,
+        )
+
+    @staticmethod
+    def _generate_lte_study_id(existing: set[str]) -> str:
+        """Random UUID prefixed with LTE- for visual distinction.
+
+        UUID4 rather than sequential/hashed — see DRR anti-pattern:
+        "Reusing real record IDs as pseudonyms" and "Hashing record IDs
+        as pseudonyms".
+        """
+        for _ in range(1000):
+            candidate = f"LTE-{uuid.uuid4().hex[:8].upper()}"
+            if candidate not in existing:
+                return candidate
+        return f"LTE-{uuid.uuid4().hex[:12].upper()}"
+
+    # ------------------------------------------------------------------
+    # Disabled base steps — LTE has no QI columns, so these are no-ops
+    # ------------------------------------------------------------------
+
+    def _generalise_quasi_identifiers(self):  # type: ignore[override]
+        """No-op — LTE has no QI columns. Logged for audit clarity."""
+        self._log_audit(
+            "view",
+            "LTE: no QI columns to generalise (by design)",
+        )
+
+    def _compute_k_anonymity(self):  # type: ignore[override]
+        """No-op — k is trivially n because there are no QI columns.
+
+        The effective_k field is already set in _strip_direct_identifiers.
+        """
+        self._log_audit(
+            "view",
+            "LTE: k-anonymity trivially satisfied (no QI columns)",
+        )
+
+    def _resolve_k_violations(self):  # type: ignore[override]
+        """No-op — no equivalence classes exist to violate k."""
+        return
+
+    def _check_population_threshold(self):  # type: ignore[override]
+        """Override — LTE uses its own floor model, not the EME tiers."""
+        return "lte"
+
+    # ------------------------------------------------------------------
+    # LTE population floor
+    # ------------------------------------------------------------------
+
+    def _check_lte_population_floor(self) -> tuple[bool, str | None, int]:
+        """Apply the LTE floor (10 default, 15 for OCAP/EGAP).
+
+        Returns (blocked, block_reason, floor_applied).
+        """
+        framework = (self.program.community_governance_framework or "").lower()
+        if framework in ("ocap", "egap"):
+            floor = LTE_FLOOR_OCAP_EGAP
+        else:
+            floor = LTE_FLOOR_DEFAULT
+
+        n = len(self._deidentified_records)
+        if n < floor:
+            self._blocked = True
+            self._block_reason = (
+                f"population_below_lte_floor (n={n}, floor={floor}, "
+                f"framework={framework or 'default'})"
+            )
+            logger.warning(
+                "LTE: population %d < floor %d (framework=%s) — blocked",
+                n, floor, framework or "default",
+            )
+            return True, self._block_reason, floor
+
+        return False, None, floor
+
+    # ------------------------------------------------------------------
+    # Fuzzing helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _band_session_count(value: int | float | None) -> int | None:
+        """Round session count to the nearest SESSION_COUNT_BAND (5)."""
+        if value is None:
+            return None
+        return int(round(value / SESSION_COUNT_BAND) * SESSION_COUNT_BAND)
+
+    @staticmethod
+    def _band_total_hours(value: int | float | None) -> float | None:
+        """Round total hours to the nearest TOTAL_HOURS_BAND (0.5)."""
+        if value is None:
+            return None
+        return round(value / TOTAL_HOURS_BAND) * TOTAL_HOURS_BAND
+
+    @staticmethod
+    def _fuzz_metric_value(value: Any, metric_def: MetricDefinition) -> Any:
+        """Round a metric value to the natural unit of its scale.
+
+        Rules (DRR):
+          0-10 ordinal scales      → nearest integer
+          0-100 percentage scales  → nearest 5
+          continuous / unknown     → one decimal place
+        """
+        if value is None:
+            return None
+        try:
+            numeric = float(value)
+        except (TypeError, ValueError):
+            return value  # non-numeric passes through (text answers etc.)
+
+        scale_min = getattr(metric_def, "min_value", None)
+        scale_max = getattr(metric_def, "max_value", None)
+
+        # 0-10 ordinal → nearest integer
+        if scale_min == 0 and scale_max == 10:
+            return int(round(numeric))
+        # 0-100 percentage → nearest 5
+        if scale_min == 0 and scale_max == 100:
+            return int(round(numeric / 5) * 5)
+        # Continuous / unknown → one decimal place
+        return round(numeric, 1)
+
+    # ------------------------------------------------------------------
+    # LTE-specific CSV output
+    # ------------------------------------------------------------------
+
+    def _build_lte_metric_columns(self) -> list[str]:
+        """Produce the ordered list of metric columns that will appear
+        in the output, e.g. [metric_wellbeing_intake, metric_wellbeing_mid,
+        metric_wellbeing_exit, metric_connectedness_intake, ...]."""
+        if not self._metric_defs:
+            return []
+
+        has_mid_any = any(
+            "mid" in per_metric
+            for per_client in self._longitudinal_metrics.values()
+            for per_metric in per_client.values()
+        )
+
+        columns: list[str] = []
+        for md in self._metric_defs:
+            slug = self._sanitise_metric_name(md.name)
+            columns.append(f"metric_{slug}_intake")
+            if has_mid_any:
+                columns.append(f"metric_{slug}_mid")
+            columns.append(f"metric_{slug}_exit")
+        return columns
+
+    def _generate_lte_csv(self, preview: LTEPreviewResult) -> str:
+        """Produce the LTE CSV content as a string.
+
+        Unlike the base pipeline, LTE writes to a string buffer rather
+        than disk here — the caller (view) is responsible for saving
+        the content via _save_export_and_create_link.
+        """
+        base_columns = [
+            "study_id",
+            "enrolment_quarter",
+            "exit_quarter",
+            "sessions_count_banded",
+            "total_hours_banded",
+        ]
+        metric_columns = preview.metric_columns
+        columns = base_columns + metric_columns
+
+        buf = io.StringIO()
+
+        # Metadata header (comment lines). Every line starts with "#"
+        # so analytical tools can skip them with a standard option.
+        buf.write("# Longitudinal Trajectory Export — "
+                  f"{sanitise_csv_value(self.program.name)}\n")
+        buf.write(f"# Period: {self.period_start} to {self.period_end}\n")
+        buf.write(
+            f"# Submitted: {timezone.now().isoformat()} by "
+            f"{sanitise_csv_value(self.user.get_display_name() or self.user.username)}\n"
+        )
+        buf.write(
+            f"# Evaluator: {sanitise_csv_value(self.evaluator_info.get('name', ''))} "
+            f"({sanitise_csv_value(self.evaluator_info.get('email', ''))}), "
+            f"{sanitise_csv_value(self.evaluator_info.get('organisation', ''))}\n"
+        )
+        buf.write(
+            f"# Evaluator degree: "
+            f"{sanitise_csv_value(self.evaluator_info.get('degree', ''))}\n"
+        )
+        buf.write(
+            f"# Evaluator years experience: "
+            f"{self.evaluator_info.get('years_experience', '')}\n"
+        )
+        buf.write(
+            f"# REB: {sanitise_csv_value(self.evaluator_info.get('reb_name', ''))}, "
+            f"approval {sanitise_csv_value(self.evaluator_info.get('reb_approval_number', ''))}, "
+            f"approved {self.evaluator_info.get('reb_approval_date', '')}\n"
+        )
+        buf.write(
+            f"# Agreement expiry: {self.evaluator_info.get('agreement_expiry', '')}\n"
+        )
+        buf.write(
+            f"# Destruction window: "
+            f"{self.evaluator_info.get('destruction_window_days', '')} "
+            "days from download (manual attestation)\n"
+        )
+        buf.write(
+            f"# Purpose: "
+            f"{sanitise_csv_value(self.evaluator_info.get('purpose', ''))}\n"
+        )
+        buf.write(
+            f"# Population: {preview.eligible_count} eligible, "
+            f"{preview.consented_count} consented, "
+            f"{preview.exportable_count} exported, 0 suppressed\n"
+        )
+        buf.write(
+            "# NO demographic fields. Metric values rounded to nearest scale unit.\n"
+        )
+        buf.write(
+            f"# Session count banded to nearest {SESSION_COUNT_BAND}. "
+            f"Total hours banded to nearest {TOTAL_HOURS_BAND}.\n"
+        )
+        buf.write(
+            "# This file is for PROGRAM EVALUATION, not research.\n"
+        )
+        buf.write(
+            "# Attempting to re-identify participants violates the data "
+            "sharing agreement and REB approval.\n"
+        )
+        buf.write("#\n")
+
+        writer = csv.writer(buf)
+        writer.writerow([sanitise_csv_value(c) for c in columns])
+
+        for record in self._deidentified_records:
+            row = self._record_to_lte_row(record, columns)
+            writer.writerow([sanitise_csv_value(v) for v in row])
+
+        return buf.getvalue()
+
+    def _record_to_lte_row(
+        self,
+        record: dict[str, Any],
+        columns: list[str],
+    ) -> list[Any]:
+        """Build one CSV row for an LTE record, applying the fuzzing
+        rules at write time so rounding is visible in the output.
+        """
+        metrics = record.get("metrics", {})
+        row: list[Any] = []
+        for col in columns:
+            if col == "study_id":
+                row.append(record.get("study_id", ""))
+            elif col == "enrolment_quarter":
+                row.append(record.get("enrolment_quarter", "") or "")
+            elif col == "exit_quarter":
+                row.append(record.get("exit_quarter", "") or "")
+            elif col == "sessions_count_banded":
+                row.append(
+                    self._band_session_count(record.get("sessions_count_raw"))
+                    or 0,
+                )
+            elif col == "total_hours_banded":
+                row.append(
+                    self._band_total_hours(record.get("total_hours_raw"))
+                    or 0.0,
+                )
+            elif col.startswith("metric_") and col.endswith("_intake"):
+                slug = col[len("metric_"):-len("_intake")]
+                row.append(metrics.get(slug, {}).get("intake", ""))
+            elif col.startswith("metric_") and col.endswith("_mid"):
+                slug = col[len("metric_"):-len("_mid")]
+                row.append(metrics.get(slug, {}).get("mid", ""))
+            elif col.startswith("metric_") and col.endswith("_exit"):
+                slug = col[len("metric_"):-len("_exit")]
+                row.append(metrics.get(slug, {}).get("exit", ""))
+            else:
+                row.append("")
+        return row
+
+    # ------------------------------------------------------------------
+    # Audit metadata
+    # ------------------------------------------------------------------
+
+    def _build_lte_audit_metadata(
+        self, preview: LTEPreviewResult,
+    ) -> dict[str, Any]:
+        """Build the full audit metadata blob for an LTE export.
+
+        The `export_category` field is `longitudinal_trajectory_export`
+        — NOT a flag or subtype of evaluation_microdata. Alerts and
+        reports filter on this category independently. See DRR
+        "Enhanced Audit Metadata" section.
+        """
+        framework = self.program.community_governance_framework or ""
+        return {
+            "export_category": "longitudinal_trajectory_export",
+            "program_id": self.program.pk,
+            "program_name": self.program.name,
+            "period_start": str(self.period_start),
+            "period_end": str(self.period_end),
+            "population_count": preview.exportable_count,
+            "population_eligible": preview.eligible_count,
+            "population_consented": preview.consented_count,
+            "floor_applied": preview.floor_applied,
+            "community_governance_framework": framework,
+            "evaluator_name": self.evaluator_info.get("name", ""),
+            "evaluator_email": self.evaluator_info.get("email", ""),
+            "evaluator_organisation": self.evaluator_info.get("organisation", ""),
+            "evaluator_degree": self.evaluator_info.get("degree", ""),
+            "evaluator_years_experience": self.evaluator_info.get(
+                "years_experience", "",
+            ),
+            "evaluator_prior_programs": self.evaluator_info.get(
+                "prior_programs", "",
+            ),
+            "reb_name": self.evaluator_info.get("reb_name", ""),
+            "reb_approval_number": self.evaluator_info.get(
+                "reb_approval_number", "",
+            ),
+            "reb_approval_date": str(
+                self.evaluator_info.get("reb_approval_date", ""),
+            ),
+            "data_sharing_agreement_expiry": str(
+                self.evaluator_info.get("agreement_expiry", ""),
+            ),
+            "destruction_window_days": self.evaluator_info.get(
+                "destruction_window_days", "",
+            ),
+            "community_reviewer_name": self.evaluator_info.get(
+                "community_reviewer_name", "",
+            ),
+            "community_reviewer_affiliation": self.evaluator_info.get(
+                "community_reviewer_affiliation", "",
+            ),
+            "community_signoff_date": str(
+                self.evaluator_info.get("community_signoff_date", ""),
+            ),
+            "community_framework_description": self.evaluator_info.get(
+                "community_framework_description", "",
+            ),
+            "purpose_statement": self.evaluator_info.get("purpose", ""),
+            "metric_rounding_applied": True,
+            "session_count_banded_to": SESSION_COUNT_BAND,
+            "total_hours_banded_to": TOTAL_HOURS_BAND,
+            "k_floor": LTE_K_FLOOR,
+            "effective_k_note": "trivially k=n (no QI columns)",
+        }
+
+    # ------------------------------------------------------------------
+    # Audit log — override category to longitudinal_trajectory_export
+    # ------------------------------------------------------------------
+
+    def _log_audit(self, action: str, description: str, metadata=None):  # type: ignore[override]
+        """Same append-only audit write as the base, but with the LTE
+        export_category injected automatically so audit filters work.
+        """
+        from apps.audit.models import AuditLog
+        from konote.utils import get_client_ip
+
+        try:
+            AuditLog.objects.using("audit").create(
+                event_timestamp=timezone.now(),
+                user_id=self.user.pk,
+                user_display=str(self.user),
+                ip_address=(
+                    get_client_ip(self.request) if self.request else None
+                ),
+                action=action,
+                resource_type="export",
+                program_id=self.program.pk,
+                metadata={
+                    "pipeline_step": description,
+                    "export_category": "longitudinal_trajectory_export",
+                    **(metadata or {}),
+                },
+            )
+        except Exception:
+            logger.exception("Failed to write LTE audit entry: %s", description)

--- a/apps/reports/management/commands/check_lte_window_lifecycle.py
+++ b/apps/reports/management/commands/check_lte_window_lifecycle.py
@@ -1,0 +1,56 @@
+"""Daily management command — refresh LTE request lifecycle state.
+
+Evaluates every in-window or active LTE request, applying any
+transitions that are due:
+
+- submitted → active  (if 5 business days elapsed with no flags)
+- submitted → auto_cancelled  (if population dropped below floor)
+- submitted → invalidated_by_withdrawal  (if a participant withdrew)
+- active    → expired  (if the 24-hour download window lapsed)
+
+Run from cron or a scheduled task once per day (weekdays only is fine;
+the view-time refresh picks up anything missed between runs).
+
+Usage:
+    python manage.py check_lte_window_lifecycle
+    python manage.py check_lte_window_lifecycle --dry-run
+"""
+
+from django.core.management.base import BaseCommand
+
+from apps.reports.lte_lifecycle import refresh_pending_requests
+from apps.reports.models import LTEExportRequest
+
+
+class Command(BaseCommand):
+    help = "Refresh LTE request lifecycle state (activate, expire, cancel as due)."
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--dry-run",
+            action="store_true",
+            help="Count changes without applying them.",
+        )
+
+    def handle(self, *args, **options):
+        pending = LTEExportRequest.objects.filter(
+            status__in=[
+                LTEExportRequest.STATUS_SUBMITTED,
+                LTEExportRequest.STATUS_ACTIVE,
+            ],
+        )
+        count = pending.count()
+        self.stdout.write(f"LTE: {count} pending requests to evaluate")
+
+        if options["dry_run"]:
+            for req in pending:
+                self.stdout.write(
+                    f"  [dry-run] #{req.pk} status={req.status} "
+                    f"activates={req.effective_window_activates_at}"
+                )
+            return
+
+        changed = refresh_pending_requests(requests=pending)
+        self.stdout.write(self.style.SUCCESS(
+            f"LTE: {changed} request(s) transitioned state"
+        ))

--- a/apps/reports/migrations/0021_add_lte_export_request.py
+++ b/apps/reports/migrations/0021_add_lte_export_request.py
@@ -1,0 +1,288 @@
+"""LTE — Add LTEExportRequest and LTELifecycleEvent models.
+
+The Longitudinal Trajectory Export is a structurally separate export
+tier from the Evaluation Microdata Export. See
+tasks/design-rationale/evaluation-microdata-export.md for the full
+specification.
+"""
+import django.db.models.deletion
+from django.conf import settings
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("auth_app", "0015_lte_export_grant"),
+        ("programs", "0013_program_community_governance_framework"),
+        ("reports", "0020_reporttemplate_taxonomy_system"),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name="secureexportlink",
+            name="export_type",
+            field=models.CharField(
+                choices=[
+                    ("client_data", "Participant Data"),
+                    ("metrics", "Metric Report"),
+                    ("standard_report", "Standard Report"),
+                    ("individual_client", "Individual Client Export"),
+                    ("session_report", "Session Report"),
+                    ("evaluation_microdata", "Evaluation Microdata"),
+                    (
+                        "longitudinal_trajectory_export",
+                        "Longitudinal Trajectory Export (Small Population)",
+                    ),
+                ],
+                max_length=50,
+            ),
+        ),
+        migrations.CreateModel(
+            name="LTEExportRequest",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("submitted_at", models.DateTimeField(auto_now_add=True)),
+                ("period_start", models.DateField()),
+                ("period_end", models.DateField()),
+                ("reb_name", models.CharField(max_length=200)),
+                ("reb_approval_number", models.CharField(max_length=100)),
+                ("reb_approval_date", models.DateField()),
+                ("data_sharing_agreement_expiry", models.DateField()),
+                ("evaluator_name", models.CharField(max_length=200)),
+                ("evaluator_email", models.EmailField(max_length=254)),
+                ("evaluator_organisation", models.CharField(max_length=200)),
+                ("evaluator_degree", models.CharField(max_length=300)),
+                ("evaluator_years_experience", models.PositiveSmallIntegerField()),
+                (
+                    "evaluator_prior_programs",
+                    models.TextField(
+                        help_text=(
+                            "Auditable narrative of prior evaluation work. "
+                            "Minimum 50 characters."
+                        ),
+                    ),
+                ),
+                (
+                    "destruction_window_days",
+                    models.PositiveSmallIntegerField(
+                        choices=[
+                            (30, "30 days"),
+                            (60, "60 days"),
+                            (90, "90 days"),
+                        ],
+                    ),
+                ),
+                ("purpose_statement", models.TextField()),
+                (
+                    "community_reviewer_name",
+                    models.CharField(blank=True, default="", max_length=200),
+                ),
+                (
+                    "community_reviewer_affiliation",
+                    models.CharField(blank=True, default="", max_length=300),
+                ),
+                (
+                    "community_framework_description",
+                    models.TextField(
+                        blank=True,
+                        default="",
+                        help_text=(
+                            "Description of community review framework — "
+                            "required for 'other' flag."
+                        ),
+                    ),
+                ),
+                ("community_signoff_date", models.DateField(blank=True, null=True)),
+                ("acknowledgement_confirmed", models.BooleanField(default=False)),
+                (
+                    "status",
+                    models.CharField(
+                        choices=[
+                            ("submitted", "Submitted — review and cancel window"),
+                            ("flagged", "Flagged — privacy officer action required"),
+                            ("cancelled", "Cancelled"),
+                            (
+                                "auto_cancelled",
+                                "Auto-cancelled — population dropped below floor",
+                            ),
+                            (
+                                "invalidated_by_withdrawal",
+                                "Invalidated — participant withdrew consent",
+                            ),
+                            ("active", "Download link active"),
+                            ("downloaded", "Downloaded"),
+                            ("expired", "Expired without download"),
+                        ],
+                        default="submitted",
+                        max_length=30,
+                    ),
+                ),
+                ("window_activates_at", models.DateTimeField()),
+                ("flag_hold_seconds", models.PositiveIntegerField(default=0)),
+                ("flag_hold_started_at", models.DateTimeField(blank=True, null=True)),
+                ("population_snapshot", models.PositiveIntegerField()),
+                (
+                    "population_client_ids",
+                    models.JSONField(blank=True, default=list),
+                ),
+                ("cancelled_at", models.DateTimeField(blank=True, null=True)),
+                (
+                    "cancellation_reason",
+                    models.CharField(blank=True, default="", max_length=500),
+                ),
+                ("destruction_confirmed_at", models.DateTimeField(blank=True, null=True)),
+                ("post_hoc_review_resolved_at", models.DateTimeField(blank=True, null=True)),
+                ("post_hoc_review_notes", models.TextField(blank=True, default="")),
+                ("linkage_blob_encrypted", models.BinaryField(blank=True, default=b"")),
+                (
+                    "cancelled_by",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="lte_requests_cancelled",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    "destruction_confirmed_by",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="lte_destruction_confirmations",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    "post_hoc_review_resolved_by",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="lte_reviews_resolved",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    "program",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="lte_requests",
+                        to="programs.program",
+                    ),
+                ),
+                (
+                    "secure_export_link",
+                    models.OneToOneField(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="lte_request",
+                        to="reports.secureexportlink",
+                    ),
+                ),
+                (
+                    "submitted_by",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="lte_requests_submitted",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+            ],
+            options={
+                "db_table": "lte_export_requests",
+                "ordering": ["-submitted_at"],
+            },
+        ),
+        migrations.AddIndex(
+            model_name="lteexportrequest",
+            index=models.Index(
+                fields=["status", "window_activates_at"],
+                name="lte_req_status_window_idx",
+            ),
+        ),
+        migrations.AddIndex(
+            model_name="lteexportrequest",
+            index=models.Index(
+                fields=["program", "-submitted_at"],
+                name="lte_req_program_submitted_idx",
+            ),
+        ),
+        migrations.CreateModel(
+            name="LTELifecycleEvent",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("timestamp", models.DateTimeField(auto_now_add=True)),
+                (
+                    "event_type",
+                    models.CharField(
+                        choices=[
+                            ("submitted", "Submitted"),
+                            ("flagged", "Flagged"),
+                            ("flag_resolved", "Flag resolved"),
+                            ("cancelled", "Cancelled"),
+                            (
+                                "auto_cancelled",
+                                "Auto-cancelled (population floor)",
+                            ),
+                            (
+                                "withdrawal_invalidation",
+                                "Invalidated by withdrawal",
+                            ),
+                            ("window_activated", "Download link activated"),
+                            ("downloaded", "Downloaded"),
+                            ("expired", "Expired without download"),
+                            (
+                                "post_hoc_review_resolved",
+                                "Post-hoc review resolved",
+                            ),
+                            ("destruction_confirmed", "Destruction confirmed"),
+                        ],
+                        max_length=50,
+                    ),
+                ),
+                ("notes", models.TextField(blank=True, default="")),
+                (
+                    "actor",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.PROTECT,
+                        related_name="lte_lifecycle_events",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    "request",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="lifecycle_events",
+                        to="reports.lteexportrequest",
+                    ),
+                ),
+            ],
+            options={
+                "db_table": "lte_lifecycle_events",
+                "ordering": ["timestamp"],
+            },
+        ),
+    ]

--- a/apps/reports/models.py
+++ b/apps/reports/models.py
@@ -477,6 +477,10 @@ class SecureExportLink(models.Model):
         ("individual_client", _("Individual Client Export")),
         ("session_report", _("Session Report")),
         ("evaluation_microdata", _("Evaluation Microdata")),
+        (
+            "longitudinal_trajectory_export",
+            _("Longitudinal Trajectory Export (Small Population)"),
+        ),
     ]
 
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
@@ -796,6 +800,275 @@ class ReportSchedule(models.Model):
 
     def __str__(self):
         return f"{self.name} (due {self.due_date})"
+
+
+# ---------------------------------------------------------------------------
+# Longitudinal Trajectory Export (LTE) — DRR: evaluation-microdata-export.md
+# ---------------------------------------------------------------------------
+#
+# LTE is a second, structurally separate export tier from the Evaluation
+# Microdata Export (EME). It serves programs with 10 ≤ n < 15 (where EME
+# is blocked) by dropping demographic fields entirely and substituting
+# fuzzed longitudinal trajectories. Separate permission, separate form,
+# separate URL prefix, separate audit category. See the DRR's "Separate
+# path, separate door, separate key" principle.
+
+
+class LTEExportRequest(models.Model):
+    """A request to generate a Longitudinal Trajectory Export.
+
+    One row per request. The lifecycle is:
+
+        submitted → (window) → active → downloaded → expired
+
+    At any point during the window or after activation, the status can
+    transition to cancelled, flagged, auto_cancelled, or
+    invalidated_by_withdrawal. The record lives forever for audit
+    purposes; the generated file lives on the SecureExportLink for the
+    24-hour download window after activation.
+    """
+
+    STATUS_SUBMITTED = "submitted"
+    STATUS_FLAGGED = "flagged"
+    STATUS_CANCELLED = "cancelled"
+    STATUS_AUTO_CANCELLED = "auto_cancelled"
+    STATUS_INVALIDATED_BY_WITHDRAWAL = "invalidated_by_withdrawal"
+    STATUS_ACTIVE = "active"
+    STATUS_DOWNLOADED = "downloaded"
+    STATUS_EXPIRED = "expired"
+
+    STATUS_CHOICES = [
+        (STATUS_SUBMITTED, _("Submitted — review and cancel window")),
+        (STATUS_FLAGGED, _("Flagged — privacy officer action required")),
+        (STATUS_CANCELLED, _("Cancelled")),
+        (STATUS_AUTO_CANCELLED, _("Auto-cancelled — population dropped below floor")),
+        (STATUS_INVALIDATED_BY_WITHDRAWAL, _("Invalidated — participant withdrew consent")),
+        (STATUS_ACTIVE, _("Download link active")),
+        (STATUS_DOWNLOADED, _("Downloaded")),
+        (STATUS_EXPIRED, _("Expired without download")),
+    ]
+
+    DESTRUCTION_WINDOW_CHOICES = [
+        (30, _("30 days")),
+        (60, _("60 days")),
+        (90, _("90 days")),
+    ]
+
+    # Submitter and scope
+    submitted_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.PROTECT,
+        related_name="lte_requests_submitted",
+    )
+    submitted_at = models.DateTimeField(auto_now_add=True)
+    program = models.ForeignKey(
+        "programs.Program",
+        on_delete=models.PROTECT,
+        related_name="lte_requests",
+    )
+    period_start = models.DateField()
+    period_end = models.DateField()
+
+    # REB preconditions
+    reb_name = models.CharField(max_length=200)
+    reb_approval_number = models.CharField(max_length=100)
+    reb_approval_date = models.DateField()
+
+    # DSA — captured for audit, does not unlock anything on its own
+    data_sharing_agreement_expiry = models.DateField()
+
+    # Evaluator credentials — structured, not free text
+    evaluator_name = models.CharField(max_length=200)
+    evaluator_email = models.EmailField()
+    evaluator_organisation = models.CharField(max_length=200)
+    evaluator_degree = models.CharField(max_length=300)
+    evaluator_years_experience = models.PositiveSmallIntegerField()
+    evaluator_prior_programs = models.TextField(
+        help_text=_("Auditable narrative of prior evaluation work. Minimum 50 characters."),
+    )
+
+    # Destruction attestation window
+    destruction_window_days = models.PositiveSmallIntegerField(
+        choices=DESTRUCTION_WINDOW_CHOICES,
+    )
+
+    # Purpose statement
+    purpose_statement = models.TextField()
+
+    # Community governance signoff — required when the program is flagged
+    community_reviewer_name = models.CharField(max_length=200, blank=True, default="")
+    community_reviewer_affiliation = models.CharField(max_length=300, blank=True, default="")
+    community_framework_description = models.TextField(
+        blank=True, default="",
+        help_text=_("Description of community review framework — required for 'other' flag."),
+    )
+    community_signoff_date = models.DateField(null=True, blank=True)
+
+    # Acknowledgement — must be True to submit
+    acknowledgement_confirmed = models.BooleanField(default=False)
+
+    # Lifecycle state
+    status = models.CharField(
+        max_length=30, choices=STATUS_CHOICES, default=STATUS_SUBMITTED,
+    )
+    # When the review-and-cancel window activates (5 business days after
+    # submission by default). If the current time is before this value and
+    # status is "submitted", the window is still running.
+    window_activates_at = models.DateTimeField()
+    # Total duration (in seconds) of flag holds applied to this request.
+    # When a flag is resolved, the remaining countdown resumes from the
+    # point of dismissal — we do NOT fast-forward. Tracked as a cumulative
+    # offset to window_activates_at.
+    flag_hold_seconds = models.PositiveIntegerField(default=0)
+    flag_hold_started_at = models.DateTimeField(null=True, blank=True)
+
+    # Population snapshot at submission time — the export is a snapshot,
+    # not a live query. Compared against current consent state to detect
+    # withdrawals that should invalidate or auto-cancel the request.
+    population_snapshot = models.PositiveIntegerField()
+    # Snapshot of the exportable client ids at submission, so we can
+    # detect withdrawals precisely without re-running the whole pipeline.
+    population_client_ids = models.JSONField(default=list, blank=True)
+
+    # Download link — populated when the window elapses and the request
+    # transitions to "active". The SecureExportLink carries the actual
+    # file and enforces the 24-hour download window.
+    secure_export_link = models.OneToOneField(
+        SecureExportLink,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="lte_request",
+    )
+
+    # Cancellation metadata
+    cancelled_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.PROTECT,
+        null=True, blank=True,
+        related_name="lte_requests_cancelled",
+    )
+    cancelled_at = models.DateTimeField(null=True, blank=True)
+    cancellation_reason = models.CharField(max_length=500, blank=True, default="")
+
+    # Destruction attestation — manual agency entry in v1
+    destruction_confirmed_at = models.DateTimeField(null=True, blank=True)
+    destruction_confirmed_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.PROTECT,
+        null=True, blank=True,
+        related_name="lte_destruction_confirmations",
+    )
+
+    # Post-hoc privacy officer review task
+    post_hoc_review_resolved_at = models.DateTimeField(null=True, blank=True)
+    post_hoc_review_resolved_by = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.PROTECT,
+        null=True, blank=True,
+        related_name="lte_reviews_resolved",
+    )
+    post_hoc_review_notes = models.TextField(blank=True, default="")
+
+    # Encrypted linkage blob (study_id → real client_id). Exists solely to
+    # support participant withdrawal requests ("remove my data"). Destroyed
+    # when the request is cancelled or expires.
+    linkage_blob_encrypted = models.BinaryField(default=b"", blank=True)
+
+    class Meta:
+        db_table = "lte_export_requests"
+        ordering = ["-submitted_at"]
+        indexes = [
+            models.Index(fields=["status", "window_activates_at"]),
+            models.Index(fields=["program", "-submitted_at"]),
+        ]
+
+    def __str__(self):
+        return f"LTE #{self.pk} — {self.program} ({self.status})"
+
+    @property
+    def is_terminal(self):
+        """True if the request is in a final state and cannot transition further."""
+        return self.status in {
+            self.STATUS_CANCELLED,
+            self.STATUS_AUTO_CANCELLED,
+            self.STATUS_INVALIDATED_BY_WITHDRAWAL,
+            self.STATUS_DOWNLOADED,
+            self.STATUS_EXPIRED,
+        }
+
+    @property
+    def is_window_running(self):
+        """True if we're still inside the review-and-cancel window."""
+        return self.status in {self.STATUS_SUBMITTED, self.STATUS_FLAGGED}
+
+    @property
+    def effective_window_activates_at(self):
+        """Window activation, including any flag holds accumulated so far."""
+        if self.flag_hold_seconds:
+            return self.window_activates_at + timedelta(seconds=self.flag_hold_seconds)
+        return self.window_activates_at
+
+    @property
+    def post_hoc_review_pending(self):
+        """True if the post-hoc privacy officer review is still pending.
+
+        A cancelled or auto-cancelled request does not block future
+        submissions — only requests that actually produced (or could still
+        produce) a file need review.
+        """
+        if self.status in {
+            self.STATUS_CANCELLED,
+            self.STATUS_AUTO_CANCELLED,
+            self.STATUS_INVALIDATED_BY_WITHDRAWAL,
+        }:
+            return False
+        return self.post_hoc_review_resolved_at is None
+
+
+class LTELifecycleEvent(models.Model):
+    """Append-only log of state transitions on an LTEExportRequest.
+
+    Lives alongside the request for quick reference in the detail view.
+    The canonical immutable audit record also goes to the audit DB via
+    AuditLog entries — this is a denormalised copy for display.
+    """
+
+    EVENT_TYPES = [
+        ("submitted", _("Submitted")),
+        ("flagged", _("Flagged")),
+        ("flag_resolved", _("Flag resolved")),
+        ("cancelled", _("Cancelled")),
+        ("auto_cancelled", _("Auto-cancelled (population floor)")),
+        ("withdrawal_invalidation", _("Invalidated by withdrawal")),
+        ("window_activated", _("Download link activated")),
+        ("downloaded", _("Downloaded")),
+        ("expired", _("Expired without download")),
+        ("post_hoc_review_resolved", _("Post-hoc review resolved")),
+        ("destruction_confirmed", _("Destruction confirmed")),
+    ]
+
+    request = models.ForeignKey(
+        LTEExportRequest,
+        on_delete=models.CASCADE,
+        related_name="lifecycle_events",
+    )
+    timestamp = models.DateTimeField(auto_now_add=True)
+    actor = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.PROTECT,
+        null=True, blank=True,
+        related_name="lte_lifecycle_events",
+    )
+    event_type = models.CharField(max_length=50, choices=EVENT_TYPES)
+    notes = models.TextField(blank=True, default="")
+
+    class Meta:
+        db_table = "lte_lifecycle_events"
+        ordering = ["timestamp"]
+
+    def __str__(self):
+        return f"LTE #{self.request_id}: {self.event_type} @ {self.timestamp}"
 
     def advance_due_date(self):
         """Move due_date to the next period after generation."""

--- a/apps/reports/urls.py
+++ b/apps/reports/urls.py
@@ -47,6 +47,44 @@ urlpatterns = [
     path("sessions/", views.session_report_form, name="session_report"),
     # Evaluation microdata export (DRR: evaluation-microdata-export.md)
     path("evaluation-export/", views.evaluation_export_form, name="evaluation_export"),
+    # Longitudinal Trajectory Export — small-population tier, structurally
+    # separate from the EME route (separate URL prefix is part of the
+    # DRR's "separate path, separate door, separate key" principle).
+    path(
+        "longitudinal-trajectory-export/",
+        views.lte_list,
+        name="lte_list",
+    ),
+    path(
+        "longitudinal-trajectory-export/new/",
+        views.lte_submit,
+        name="lte_submit",
+    ),
+    path(
+        "longitudinal-trajectory-export/<int:request_id>/",
+        views.lte_detail,
+        name="lte_detail",
+    ),
+    path(
+        "longitudinal-trajectory-export/<int:request_id>/cancel/",
+        views.lte_cancel,
+        name="lte_cancel",
+    ),
+    path(
+        "longitudinal-trajectory-export/<int:request_id>/flag/",
+        views.lte_flag_concerns,
+        name="lte_flag_concerns",
+    ),
+    path(
+        "longitudinal-trajectory-export/<int:request_id>/download/",
+        views.lte_download,
+        name="lte_download",
+    ),
+    path(
+        "longitudinal-trajectory-export/<int:request_id>/resolve-review/",
+        views.lte_resolve_review,
+        name="lte_resolve_review",
+    ),
     # Report Schedules
     path("schedules/", oversight_views.report_schedule_list, name="schedule_list"),
     path("schedules/create/", oversight_views.report_schedule_create, name="schedule_create"),

--- a/apps/reports/utils.py
+++ b/apps/reports/utils.py
@@ -69,6 +69,46 @@ def can_create_evaluation_export(user):
     return getattr(user, "evaluation_export_granted", False)
 
 
+def can_create_lte_export(user):
+    """Return True if this user holds the per-user LTE grant.
+
+    LTE has stricter preconditions than EME and a strictly separate
+    permission. Per-user only — not bundled with evaluation_export,
+    not auto-granted to admins. See
+    tasks/design-rationale/evaluation-microdata-export.md, "Access
+    Control" and "Anti-Patterns" sections. The nav-level check in
+    apps/auth_app/templatetags/permissions_tags.py mirrors this rule;
+    keep them in sync.
+
+    Note: this helper returns True when the individual user holds the
+    grant, but the view must ALSO check `lte_available_in_agency()` to
+    enforce the "no designated privacy officer = no LTE" rule.
+    """
+    if not user or not user.is_authenticated:
+        return False
+    return getattr(user, "lte_export_granted", False)
+
+
+def lte_available_in_agency():
+    """Return True iff at least one user in the current agency (tenant)
+    holds an active LTE grant.
+
+    This enforces the hard precondition from the DRR: "Designation is a
+    hard precondition. If no user in the agency has been granted
+    report.evaluation_export_small_population, the LTE form is
+    unavailable to everyone." There is no ED override.
+
+    Called from LTE views before rendering the form or list; a False
+    return should yield a 403/404 with a message directing the admin
+    to designate a privacy officer first.
+    """
+    from apps.auth_app.models import User
+
+    return User.objects.filter(
+        lte_export_granted=True, is_active=True,
+    ).exists()
+
+
 def can_create_export(user, export_type, program=None):
     """
     Check if a user can create an export of the given type.

--- a/apps/reports/views.py
+++ b/apps/reports/views.py
@@ -2461,3 +2461,533 @@ def evaluation_export_form(request):
         % {"count": result.preview.exportable_count},
     )
     return redirect("reports:download_export", link_id=link.pk)
+
+
+# ---------------------------------------------------------------------------
+# Longitudinal Trajectory Export (LTE) — DRR: evaluation-microdata-export.md
+# ---------------------------------------------------------------------------
+#
+# LTE is structurally separate from EME: its own permission, its own
+# form, its own URL prefix, its own audit category, and its own
+# review-and-cancel lifecycle. See the DRR's "Separate path, separate
+# door, separate key" principle before modifying any of this.
+
+
+def _lte_access_check(request):
+    """Return None if the user may use LTE, or an HttpResponse blocking
+    access with a clear reason. Enforces both per-user grant AND
+    "no designated privacy officer = no LTE".
+    """
+    from .utils import can_create_lte_export, lte_available_in_agency
+
+    if not can_create_lte_export(request.user):
+        return HttpResponseForbidden(
+            _(
+                "Access denied. You do not have permission to create "
+                "Longitudinal Trajectory Exports. This permission is "
+                "granted to the designated privacy officer only."
+            )
+        )
+    if not lte_available_in_agency():
+        return HttpResponseForbidden(
+            _(
+                "Longitudinal Trajectory Export is unavailable — no privacy "
+                "officer has been designated for this agency. Ask an admin "
+                "to grant the permission to a designated privacy officer "
+                "first."
+            )
+        )
+    return None
+
+
+def _lte_rate_limit_check():
+    """Return (ok, message). Enforces the DRR's agency-wide rate limit:
+    while a prior LTE has an unresolved post-hoc review, no new LTE may
+    be submitted anywhere in the agency.
+    """
+    from .models import LTEExportRequest
+
+    pending = LTEExportRequest.objects.filter(
+        status__in=[
+            LTEExportRequest.STATUS_SUBMITTED,
+            LTEExportRequest.STATUS_FLAGGED,
+            LTEExportRequest.STATUS_ACTIVE,
+            LTEExportRequest.STATUS_DOWNLOADED,
+        ],
+        post_hoc_review_resolved_at__isnull=True,
+    ).first()
+    if pending:
+        return False, _(
+            "A prior LTE export (#%(pk)s, %(program)s, submitted "
+            "%(submitted)s) is pending privacy officer review. Resolve "
+            "it before submitting a new request."
+        ) % {
+            "pk": pending.pk,
+            "program": pending.program.name,
+            "submitted": pending.submitted_at.date(),
+        }
+    return True, None
+
+
+def _notify_admins_lte_submitted(lte_request, request):
+    """Send the at-submission notification to all agency admins.
+
+    Includes a "Flag concerns" link carrying a signed token so any
+    admin — not just the privacy officer — can freeze the countdown
+    without requiring them to hold the LTE permission themselves.
+    """
+    from django.core.signing import TimestampSigner
+
+    signer = TimestampSigner()
+    flag_token = signer.sign(str(lte_request.pk))
+
+    flag_url = request.build_absolute_uri(
+        reverse(
+            "reports:lte_flag_concerns",
+            kwargs={"request_id": lte_request.pk},
+        )
+        + f"?token={flag_token}"
+    )
+    detail_url = request.build_absolute_uri(
+        reverse("reports:lte_detail", kwargs={"request_id": lte_request.pk})
+    )
+
+    admin_emails = list(getattr(settings, "EXPORT_NOTIFICATION_EMAILS", []))
+    if not admin_emails:
+        admins = User.objects.filter(is_admin=True, is_active=True)
+        admin_emails = [u.email for u in admins if u.email]
+    if not admin_emails:
+        logger.warning(
+            "LTE #%s: no admin email addresses configured — "
+            "submission notification not sent",
+            lte_request.pk,
+        )
+        return
+
+    context = {
+        "lte_request": lte_request,
+        "submitter": lte_request.submitted_by,
+        "program": lte_request.program,
+        "activates_at": lte_request.effective_window_activates_at,
+        "flag_url": flag_url,
+        "detail_url": detail_url,
+        "business_days": 5,
+    }
+
+    subject = (
+        f"LTE submitted — {lte_request.program.name} "
+        f"(review-and-cancel window running)"
+    )
+    text_body = render_to_string("reports/email/lte_submitted.txt", context)
+    html_body = render_to_string("reports/email/lte_submitted.html", context)
+
+    try:
+        send_mail(
+            subject=subject,
+            message=text_body,
+            html_message=html_body,
+            from_email=None,
+            recipient_list=admin_emails,
+        )
+    except Exception:
+        logger.warning(
+            "LTE #%s: failed to send admin notification",
+            lte_request.pk,
+            exc_info=True,
+        )
+
+
+@login_required
+def lte_list(request):
+    """Show all LTE requests in the agency with status + actions."""
+    from .lte_lifecycle import refresh_pending_requests
+    from .models import LTEExportRequest
+
+    blocked = _lte_access_check(request)
+    if blocked is not None:
+        return blocked
+
+    # Refresh pending requests so the list reflects any elapsed windows
+    # since the last view. Errors here must not break the list view.
+    try:
+        refresh_pending_requests()
+    except Exception:
+        logger.exception("LTE: refresh_pending_requests failed at list-view time")
+
+    requests_qs = LTEExportRequest.objects.select_related(
+        "program", "submitted_by",
+    ).order_by("-submitted_at")
+
+    ok, rate_limit_message = _lte_rate_limit_check()
+
+    return render(request, "reports/lte_list.html", {
+        "lte_requests": requests_qs,
+        "rate_limited": not ok,
+        "rate_limit_message": rate_limit_message,
+        "nav_active": "reports",
+    })
+
+
+@login_required
+def lte_submit(request):
+    """GET renders the form; POST runs preview then creates the request."""
+    from .forms import LTEExportRequestForm
+    from .lte_lifecycle import calculate_window_end, _write_audit_entry
+    from .lte_pipeline import LTESmallPopulationPipeline
+    from .models import LTEExportRequest, LTELifecycleEvent
+
+    blocked = _lte_access_check(request)
+    if blocked is not None:
+        return blocked
+
+    ok, rate_limit_message = _lte_rate_limit_check()
+    if not ok:
+        from django.contrib import messages as django_messages
+        django_messages.error(request, rate_limit_message)
+        return redirect("reports:lte_list")
+
+    if request.method == "GET":
+        form = LTEExportRequestForm(user=request.user)
+        return render(request, "reports/lte_submit.html", {
+            "form": form,
+            "nav_active": "reports",
+        })
+
+    action = request.POST.get("action", "preview")
+    form = LTEExportRequestForm(request.POST, user=request.user)
+
+    if not form.is_valid():
+        return render(request, "reports/lte_submit.html", {
+            "form": form,
+            "nav_active": "reports",
+        })
+
+    program = form.cleaned_data["program"]
+    period_start = form.cleaned_data["period_start"]
+    period_end = form.cleaned_data["period_end"]
+    evaluator_info = form.get_evaluator_info()
+
+    pipeline = LTESmallPopulationPipeline(
+        program=program,
+        period_start=period_start,
+        period_end=period_end,
+        evaluator_info=evaluator_info,
+        user=request.user,
+        request=request,
+    )
+
+    preview = pipeline.run_preview()
+
+    if action == "preview":
+        return render(request, "reports/lte_submit_preview.html", {
+            "form": form,
+            "preview": preview,
+            "program": program,
+            "period_start": period_start,
+            "period_end": period_end,
+            "evaluator_info": evaluator_info,
+            "nav_active": "reports",
+        })
+
+    # action == "submit" — create the LTEExportRequest row and start
+    # the review-and-cancel window
+    if preview.blocked:
+        from django.contrib import messages as django_messages
+        django_messages.error(
+            request,
+            _("LTE export blocked: %(reason)s") % {"reason": preview.block_reason},
+        )
+        return render(request, "reports/lte_submit.html", {
+            "form": form,
+            "nav_active": "reports",
+        })
+
+    from django.db import transaction as db_transaction
+
+    with db_transaction.atomic():
+        now = timezone.now()
+        lte_request = LTEExportRequest.objects.create(
+            submitted_by=request.user,
+            program=program,
+            period_start=period_start,
+            period_end=period_end,
+            reb_name=form.cleaned_data["reb_name"],
+            reb_approval_number=form.cleaned_data["reb_approval_number"],
+            reb_approval_date=form.cleaned_data["reb_approval_date"],
+            data_sharing_agreement_expiry=(
+                form.cleaned_data["data_sharing_agreement_expiry"]
+            ),
+            evaluator_name=evaluator_info["name"],
+            evaluator_email=evaluator_info["email"],
+            evaluator_organisation=evaluator_info["organisation"],
+            evaluator_degree=evaluator_info["degree"],
+            evaluator_years_experience=evaluator_info["years_experience"],
+            evaluator_prior_programs=evaluator_info["prior_programs"],
+            destruction_window_days=evaluator_info["destruction_window_days"],
+            purpose_statement=evaluator_info["purpose"],
+            community_reviewer_name=evaluator_info["community_reviewer_name"],
+            community_reviewer_affiliation=(
+                evaluator_info["community_reviewer_affiliation"]
+            ),
+            community_framework_description=(
+                evaluator_info["community_framework_description"]
+            ),
+            community_signoff_date=evaluator_info["community_signoff_date"],
+            acknowledgement_confirmed=True,
+            status=LTEExportRequest.STATUS_SUBMITTED,
+            window_activates_at=calculate_window_end(now),
+            population_snapshot=preview.exportable_count,
+            population_client_ids=preview.snapshot_client_ids,
+        )
+        LTELifecycleEvent.objects.create(
+            request=lte_request,
+            actor=request.user,
+            event_type="submitted",
+            notes=(
+                f"Submitted by {request.user.get_display_name()}. "
+                f"Population snapshot: {preview.exportable_count}."
+            ),
+        )
+
+    # Audit log
+    audit_meta = pipeline._build_lte_audit_metadata(preview)
+    audit_meta.update({
+        "lte_request_id": lte_request.pk,
+        "window_activates_at": lte_request.window_activates_at.isoformat(),
+        "review_and_cancel_window_business_days": 5,
+    })
+    _write_audit_entry(
+        lte_request,
+        action="create",
+        event_type="submitted",
+        metadata=audit_meta,
+    )
+
+    # Admin notification — do not let email failures block submission
+    try:
+        _notify_admins_lte_submitted(lte_request, request)
+    except Exception:
+        logger.exception(
+            "LTE #%s: admin notification raised after submission",
+            lte_request.pk,
+        )
+
+    from django.contrib import messages as django_messages
+    django_messages.success(
+        request,
+        _(
+            "LTE request submitted. Review-and-cancel window activates "
+            "%(activates)s."
+        ) % {"activates": lte_request.window_activates_at.strftime("%Y-%m-%d %H:%M")},
+    )
+    return redirect("reports:lte_detail", request_id=lte_request.pk)
+
+
+@login_required
+def lte_detail(request, request_id):
+    """Show request metadata, lifecycle events, and available actions."""
+    from .lte_lifecycle import refresh_pending_requests
+    from .models import LTEExportRequest
+
+    blocked = _lte_access_check(request)
+    if blocked is not None:
+        return blocked
+
+    lte_request = get_object_or_404(LTEExportRequest, pk=request_id)
+
+    # Refresh this single request's lifecycle so the detail view
+    # reflects any elapsed window or withdrawal since the last visit.
+    try:
+        refresh_pending_requests(requests=[lte_request])
+        lte_request.refresh_from_db()
+    except Exception:
+        logger.exception("LTE #%s: detail-view refresh failed", lte_request.pk)
+
+    events = lte_request.lifecycle_events.select_related("actor").order_by("timestamp")
+
+    return render(request, "reports/lte_detail.html", {
+        "lte_request": lte_request,
+        "events": events,
+        "can_cancel": lte_request.is_window_running or lte_request.status == LTEExportRequest.STATUS_ACTIVE,
+        "nav_active": "reports",
+    })
+
+
+@login_required
+def lte_cancel(request, request_id):
+    """POST only — cancel an in-window or active LTE request."""
+    from .lte_lifecycle import cancel_request
+    from .models import LTEExportRequest
+
+    if request.method != "POST":
+        return redirect("reports:lte_detail", request_id=request_id)
+
+    blocked = _lte_access_check(request)
+    if blocked is not None:
+        return blocked
+
+    lte_request = get_object_or_404(LTEExportRequest, pk=request_id)
+
+    if lte_request.is_terminal:
+        from django.contrib import messages as django_messages
+        django_messages.warning(
+            request,
+            _("This LTE request is already in a terminal state and cannot be cancelled."),
+        )
+        return redirect("reports:lte_detail", request_id=request_id)
+
+    reason = (request.POST.get("reason") or "").strip()[:500]
+    if not reason:
+        from django.contrib import messages as django_messages
+        django_messages.error(request, _("A cancellation reason is required."))
+        return redirect("reports:lte_detail", request_id=request_id)
+
+    cancel_request(lte_request, actor=request.user, reason=reason)
+
+    from django.contrib import messages as django_messages
+    django_messages.success(request, _("LTE request cancelled."))
+    return redirect("reports:lte_detail", request_id=request_id)
+
+
+def lte_flag_concerns(request, request_id):
+    """Accept a signed-token GET or POST from the admin notification email.
+
+    This view intentionally does NOT require the LTE permission — the
+    flag-concerns mechanism is designed to let any agency admin freeze
+    the countdown even if they are not the designated privacy officer.
+    The signed token from the notification email scopes the flag to
+    the specific request.
+    """
+    from django.core.signing import BadSignature, SignatureExpired, TimestampSigner
+    from .lte_lifecycle import start_flag_hold
+    from .models import LTEExportRequest
+
+    lte_request = get_object_or_404(LTEExportRequest, pk=request_id)
+
+    signer = TimestampSigner()
+    token = request.GET.get("token") or request.POST.get("token") or ""
+    signed_pk: str | None = None
+    try:
+        # Tokens expire once the window has closed — the window cannot
+        # be longer than 5 business days + any flag holds, so cap the
+        # token lifetime at 30 days as a safety margin.
+        signed_pk = signer.unsign(token, max_age=60 * 60 * 24 * 30)
+    except (BadSignature, SignatureExpired):
+        return HttpResponseForbidden(
+            _("Invalid or expired flag link. Ask an admin to re-flag from KoNote.")
+        )
+
+    if signed_pk != str(lte_request.pk):
+        return HttpResponseForbidden(_("Flag link does not match this request."))
+
+    if lte_request.status != LTEExportRequest.STATUS_SUBMITTED:
+        return render(request, "reports/lte_flag_result.html", {
+            "lte_request": lte_request,
+            "already_handled": True,
+        })
+
+    if request.method == "POST":
+        actor = request.user if request.user.is_authenticated else None
+        reason = (request.POST.get("reason") or "Flagged from admin notification email.").strip()[:500]
+        start_flag_hold(lte_request, actor=actor, reason=reason)
+        return render(request, "reports/lte_flag_result.html", {
+            "lte_request": lte_request,
+            "flagged": True,
+        })
+
+    return render(request, "reports/lte_flag_confirm.html", {
+        "lte_request": lte_request,
+        "token": token,
+    })
+
+
+@login_required
+def lte_download(request, request_id):
+    """Proxy to the SecureExportLink while the status is 'active'.
+
+    Only the submitter or a user with the LTE permission may download.
+    Downloading transitions status to 'downloaded' and marks the
+    post-hoc review task still pending.
+    """
+    from .lte_lifecycle import mark_downloaded
+    from .models import LTEExportRequest
+
+    blocked = _lte_access_check(request)
+    if blocked is not None:
+        return blocked
+
+    lte_request = get_object_or_404(LTEExportRequest, pk=request_id)
+
+    if lte_request.status != LTEExportRequest.STATUS_ACTIVE:
+        from django.contrib import messages as django_messages
+        django_messages.error(
+            request,
+            _("LTE file is not available for download (status: %(status)s)."),
+            {"status": lte_request.get_status_display()},
+        )
+        return redirect("reports:lte_detail", request_id=request_id)
+
+    if not lte_request.secure_export_link:
+        return HttpResponseForbidden(_("No file is associated with this LTE request."))
+
+    mark_downloaded(lte_request, actor=request.user)
+    return redirect(
+        "reports:download_export", link_id=lte_request.secure_export_link.pk,
+    )
+
+
+@login_required
+def lte_resolve_review(request, request_id):
+    """Mark the post-hoc privacy officer review as resolved.
+
+    Allowed only for users who hold the LTE permission. Resolving
+    the review unblocks future LTE submissions agency-wide.
+    """
+    from .lte_lifecycle import _write_audit_entry
+    from .models import LTEExportRequest, LTELifecycleEvent
+
+    if request.method != "POST":
+        return redirect("reports:lte_detail", request_id=request_id)
+
+    blocked = _lte_access_check(request)
+    if blocked is not None:
+        return blocked
+
+    lte_request = get_object_or_404(LTEExportRequest, pk=request_id)
+
+    if lte_request.post_hoc_review_resolved_at is not None:
+        return redirect("reports:lte_detail", request_id=request_id)
+
+    notes = (request.POST.get("notes") or "").strip()[:2000]
+    lte_request.post_hoc_review_resolved_at = timezone.now()
+    lte_request.post_hoc_review_resolved_by = request.user
+    lte_request.post_hoc_review_notes = notes
+    lte_request.save(update_fields=[
+        "post_hoc_review_resolved_at",
+        "post_hoc_review_resolved_by",
+        "post_hoc_review_notes",
+    ])
+
+    LTELifecycleEvent.objects.create(
+        request=lte_request,
+        actor=request.user,
+        event_type="post_hoc_review_resolved",
+        notes=notes or "Post-hoc privacy officer review resolved.",
+    )
+    _write_audit_entry(
+        lte_request,
+        action="update",
+        event_type="post_hoc_review_resolved",
+        metadata={
+            "lte_request_id": lte_request.pk,
+            "resolved_by_id": request.user.pk,
+            "notes": notes,
+        },
+    )
+
+    from django.contrib import messages as django_messages
+    django_messages.success(
+        request,
+        _("Post-hoc review resolved. Agency may now submit new LTE requests."),
+    )
+    return redirect("reports:lte_detail", request_id=request_id)

--- a/docs/admin/reporting.md
+++ b/docs/admin/reporting.md
@@ -132,4 +132,72 @@ This gives more accurate reporting — paused goals aren't counted as failures o
 
 ---
 
+## Longitudinal Trajectory Export (small-population evaluation)
+
+LTE is a second, structurally separate export tier for programs with
+10–14 participants (or 15+ for OCAP/EGAP-governed programs). The
+standard Evaluator Export blocks programs below n = 15 because
+demographic k-anonymity cannot be guaranteed. LTE is the answer for
+smaller programs: it drops demographics entirely, substitutes fuzzed
+longitudinal metric trajectories, and gates access behind REB
+approval, community governance review, distributed admin oversight,
+and a 5-business-day review-and-cancel window.
+
+### When to use LTE
+
+- Small program with fewer than 15 participants
+- External evaluator (not internal staff) needs participant-level
+  data for outcome or dose-response analysis
+- REB approval is in place
+- The evaluation has a data sharing agreement
+- You have a designated privacy officer with the LTE permission
+
+If demographic breakdowns are required, LTE is **not** the right
+tool — use aggregate reports or, for larger programs, the standard
+Evaluator Export. Research-grade data access (unfuzzed values,
+complete microdata) is out of scope for both EME and LTE and has its
+own high-friction workflow.
+
+### Setup
+
+1. A KoNote admin grants `report.evaluation_export_small_population`
+   to the designated privacy officer through **Admin → Evaluator
+   Export Access**. The grant is strictly separate from the standard
+   Evaluator Export permission.
+2. For programs that need community governance, set the
+   **Community governance framework** field on the program
+   (OCAP / EGAP / other). This triggers the conditional community
+   reviewer signoff requirement in the LTE form and raises the
+   population floor to 15 for OCAP and EGAP.
+3. Distribute the [LTE Privacy Officer Guide](../lte-privacy-officer-guide.md)
+   to the designated officer.
+
+### How LTE differs from the standard Evaluator Export
+
+| | Standard Evaluator Export | LTE |
+|---|---|---|
+| Population floor | n ≥ 15 (hard) | n ≥ 10 (15 for OCAP/EGAP) |
+| Demographic columns | Age / gender / ethnicity / geography, generalised and k-anonymised | **None** — dropped at the schema layer |
+| Metric values | Unrounded | Rounded to nearest scale unit |
+| Session count | Exact | Banded to nearest 5 |
+| Total hours | Exact | Banded to nearest half-hour |
+| Delivery | Immediate download link | 5-business-day review-and-cancel window, then 24h download |
+| Permission | `report.evaluation_export` | `report.evaluation_export_small_population` (separate) |
+| Preconditions | DSA + evaluator contact details | REB approval, structured evaluator credentials, community signoff (where applicable), destruction attestation window |
+| Audit category | `evaluation_microdata` | `longitudinal_trajectory_export` |
+
+### Rate limit
+
+After an LTE request is submitted, KoNote automatically creates a
+post-hoc privacy officer review task. **Until the officer resolves
+that task, no new LTE requests can be submitted anywhere in the
+agency.** The rate limit is agency-wide, not per-program — this is
+deliberate, as the review burden sits with a single designee.
+
+See [`tasks/design-rationale/evaluation-microdata-export.md`](../../tasks/design-rationale/evaluation-microdata-export.md)
+for the full design rationale, including what LTE explicitly does
+not do and why.
+
+---
+
 [Back to Admin Guide](index.md)

--- a/docs/lte-privacy-officer-guide.md
+++ b/docs/lte-privacy-officer-guide.md
@@ -1,0 +1,137 @@
+# LTE Privacy Officer Guide
+
+This short guide describes what the designated privacy officer for
+Longitudinal Trajectory Export (LTE) is responsible for. LTE is
+KoNote's small-population evaluation export tier — for programs with
+fewer than 15 participants, where the standard Evaluator Export is
+blocked.
+
+LTE is **for program evaluation, not research**. It drops demographic
+fields entirely and substitutes fuzzed longitudinal metric
+trajectories. The full rationale is in
+[`tasks/design-rationale/evaluation-microdata-export.md`](../tasks/design-rationale/evaluation-microdata-export.md).
+
+## Who should hold this role
+
+A KoNote admin grants the LTE permission to one user per agency —
+typically the privacy officer, board data steward, or equivalent
+role. The grant is a strictly separate permission from the standard
+Evaluator Export — holding one does not confer the other.
+
+If your agency does not have a designated privacy officer, **LTE is
+unreachable** until one is appointed. This is enforced in code: the
+form will 403 with a message directing the admin to designate a
+privacy officer first.
+
+## Your responsibilities
+
+### 1. Decide whether a requested export meets the preconditions
+
+When a staff member submits an LTE request, you'll receive two
+touchpoints:
+
+- **Email notification at submission time** (goes to all agency
+  admins), with a signed "Flag concerns" link you can click to freeze
+  the review-and-cancel countdown.
+- **Post-hoc review task** on your dashboard — auto-created at
+  submission time. This task must be resolved before the agency can
+  submit another LTE request (rate limit is agency-wide).
+
+Use the 5-business-day review-and-cancel window to verify:
+
+- **REB approval exists** and matches a recognised research ethics
+  board. The LTE form captures the approval number as a string;
+  verification is a human step.
+- **Evaluator credentials are plausible** — degree, years of
+  experience, prior programs evaluated. The prior programs field
+  must be at least 50 characters and is preserved in the audit log.
+- **Data sharing agreement is signed and in force.** The DSA is
+  captured for audit; it does not on its own unlock anything.
+- **Community governance signoff** (if applicable). Programs flagged
+  OCAP, EGAP, or "other small-population community review" require
+  a community reviewer's name, affiliation, and signoff date on top
+  of the usual preconditions. Agency ED authorisation is not a
+  substitute for community review — this is a hard rule from the
+  DRR.
+- **Purpose statement** is evaluation, not research. If the request
+  looks like it needs complete microdata, demographic detail, or
+  unrounded values, it's research and should go through the research
+  workflow (outside KoNote's scope).
+
+### 2. Flag or cancel if anything is wrong
+
+During the review-and-cancel window, any agency admin (including you)
+may:
+
+- **Flag concerns** — freezes the countdown until you (or another
+  privacy officer) resolve the flag. Dismissing the flag resumes the
+  countdown from where it froze, not from zero. Cancelling the
+  request discards the prepared file and the pipeline work.
+- **Cancel outright** — discards the file, ends the lifecycle, and
+  requires re-submission if the evaluation is still needed. The
+  request stays in the audit log marked "cancelled", including who
+  cancelled and when.
+
+If the export has been activated (window elapsed, download link is
+live) and you notice a problem before download, you can still cancel.
+
+### 3. Confirm destruction attestation after download
+
+After the evaluator downloads the file, the destruction window
+(30, 60, or 90 days) begins. At the end of the window KoNote sends
+a reminder email. The agency contacts the evaluator, confirms the
+file has been destroyed, and records the attestation manually on the
+LTE request detail page. This is a v1 limitation — there is no
+automated evaluator acknowledgement UI.
+
+If no attestation is recorded by the deadline, a follow-up task is
+auto-created for you.
+
+### 4. Resolve the post-hoc review task
+
+Once you've reviewed the request (either during the window or after
+download), mark the post-hoc review task as resolved from the LTE
+detail page. Until you resolve it, the agency cannot submit another
+LTE request. This creates a natural per-agency rate limit based on
+your review throughput.
+
+## Things you cannot do
+
+- **You cannot approve an LTE early.** There is no "fast-path early
+  approval" button. The 5-business-day pause is part of the design,
+  not a delay to be worked around.
+- **You cannot waive the population floor.** The LTE floor is 10
+  participants (or 15 for OCAP/EGAP programs), and the system will
+  refuse to generate below that. Funder pressure to waive it is
+  expected; the refusal is part of the safeguard.
+- **You cannot grant LTE access to another user.** Grant management
+  is an admin function — ask a KoNote admin to add a second designee
+  if your agency needs one.
+- **You cannot add demographic fields to the output.** The absence of
+  demographics is LTE's primary re-identification defence. Adding
+  "just age band" or "just urban/rural" is an anti-pattern —
+  implementers are explicitly prohibited from building it.
+
+## Escalation
+
+If an evaluator insists on complete microdata, unfuzzed metric values,
+or demographic detail:
+
+- They are **doing research**, not program evaluation.
+- Direct them to the research-grade data access workflow (REB
+  approval + legal review + institutional data sharing agreement +
+  case-by-case governance). That workflow is out of scope for KoNote
+  itself and sits with your agency's legal or research office.
+
+If you see repeated LTE requests from the same evaluator with
+different purpose statements, or any pattern that looks like attempts
+to circumvent the safeguards, contact GK (evaluation methodology lead)
+via the consultation gate.
+
+## Audit log
+
+Every LTE lifecycle event (submitted, flagged, cancelled, activated,
+downloaded, expired, post-hoc review resolved, destruction confirmed)
+writes to the immutable audit log with the category
+`longitudinal_trajectory_export`. The audit log is separate from the
+EME category — you can filter on LTE events independently.

--- a/templates/base.html
+++ b/templates/base.html
@@ -159,6 +159,10 @@
                         {% if can_see_eval_export %}
                         <li role="none"><a role="menuitem" href="{% url 'reports:evaluation_export' %}">{% trans "Evaluator Export (Confidential)" %}</a></li>
                         {% endif %}
+                        {% has_permission "report.evaluation_export_small_population" as can_see_lte %}
+                        {% if can_see_lte %}
+                        <li role="none"><a role="menuitem" href="{% url 'reports:lte_list' %}">{% trans "Evaluation Export (Small Population)" %}</a></li>
+                        {% endif %}
                         {% if can_see_compliance %}
                         <li role="none"><a role="menuitem" href="{% url 'audit:compliance_summary' %}">{% trans "Privacy & Access Audit" %}</a></li>
                         {% endif %}

--- a/templates/reports/email/lte_submitted.html
+++ b/templates/reports/email/lte_submitted.html
@@ -1,0 +1,23 @@
+{% load i18n %}<!DOCTYPE html>
+<html>
+<head><meta charset="UTF-8"><title>{% trans "LTE submitted" %}</title></head>
+<body style="font-family: sans-serif; color: #111;">
+<h2>{% blocktrans with program=program.name %}Longitudinal Trajectory Export submitted — {{ program }}{% endblocktrans %}</h2>
+
+<p><strong>{% trans "Submitted by" %}:</strong> {{ submitter.display_name }}<br>
+<strong>{% trans "Review-and-cancel window activates" %}:</strong> {{ activates_at|date:"Y-m-d H:i" }}
+({% blocktrans count days=business_days %}{{ days }} business day{% plural %}{{ days }} business days{% endblocktrans %} {% trans "from submission" %})</p>
+
+<p>{% trans "An LTE request has been submitted. The download link will not activate until the review-and-cancel window elapses. During the window any agency admin may:" %}</p>
+
+<ul>
+    <li><a href="{{ flag_url }}">{% trans "Flag concerns" %}</a> {% trans "(freezes the countdown — the privacy officer must resolve the flag before the countdown resumes)" %}</li>
+    <li><a href="{{ detail_url }}">{% trans "View details and cancel the request" %}</a></li>
+</ul>
+
+<p style="background: #fffbeb; border-left: 4px solid #d97706; padding: 0.75rem;">
+<strong>{% trans "LTE is for program evaluation, not research." %}</strong><br>
+{% trans "If you believe this request does not meet the preconditions (REB approval, community review, evaluator credentials, DSA), flag it." %}
+</p>
+</body>
+</html>

--- a/templates/reports/email/lte_submitted.txt
+++ b/templates/reports/email/lte_submitted.txt
@@ -1,0 +1,18 @@
+{% load i18n %}{% blocktrans with program=program.name %}Longitudinal Trajectory Export submitted — {{ program }}{% endblocktrans %}
+
+{% blocktrans with name=submitter.display_name %}Submitted by: {{ name }}{% endblocktrans %}
+{% blocktrans with activates=activates_at|date:"Y-m-d H:i" %}Review-and-cancel window activates: {{ activates }} ({{ business_days }} business days from submission){% endblocktrans %}
+
+{% trans "What this is" %}:
+{% trans "An LTE request has been submitted. The download link will not activate until the review-and-cancel window elapses. During the window you may:" %}
+
+  * {% trans "Flag concerns (freezes the countdown; link below)" %}
+  * {% trans "View details and cancel the request (link below)" %}
+
+{% trans "Flag concerns" %}:
+{{ flag_url }}
+
+{% trans "View details" %}:
+{{ detail_url }}
+
+{% trans "LTE is for program evaluation, not research. If you believe this request does not meet the LTE preconditions, flag it." %}

--- a/templates/reports/lte_detail.html
+++ b/templates/reports/lte_detail.html
@@ -1,0 +1,127 @@
+{% extends "base.html" %}
+{% load i18n %}
+
+{% block title %}LTE #{{ lte_request.pk }} — {{ site.product_name|default:"KoNote" }}{% endblock %}
+
+{% block content %}
+<hgroup>
+    <h1>LTE #{{ lte_request.pk }}</h1>
+    <p>{{ lte_request.program.name }} &mdash; {{ lte_request.period_start }} to {{ lte_request.period_end }}</p>
+</hgroup>
+
+<article>
+    <header><strong>{% trans "Status" %}: {{ lte_request.get_status_display }}</strong></header>
+    {% if lte_request.is_window_running %}
+    <p>
+        {% blocktrans with when=lte_request.effective_window_activates_at|date:"Y-m-d H:i" %}Review-and-cancel window — download link activates at {{ when }} (if not cancelled or flagged).{% endblocktrans %}
+    </p>
+    {% elif lte_request.status == "active" %}
+    <p>{% trans "Download link is active for 24 hours from activation." %}</p>
+    {% elif lte_request.status == "downloaded" %}
+    <p>{% trans "File has been downloaded. Destruction attestation due at the end of the configured window." %}</p>
+    {% elif lte_request.status == "cancelled" %}
+    <p>{% trans "Cancelled." %} {% if lte_request.cancellation_reason %}<em>{{ lte_request.cancellation_reason }}</em>{% endif %}</p>
+    {% elif lte_request.status == "auto_cancelled" %}
+    <p>{% trans "Auto-cancelled — population dropped below the LTE floor." %}</p>
+    {% elif lte_request.status == "invalidated_by_withdrawal" %}
+    <p>{% trans "Invalidated — a participant withdrew consent during the window. Re-submit if still needed." %}</p>
+    {% elif lte_request.status == "flagged" %}
+    <p>{% trans "Flagged — privacy officer action required. Countdown is frozen." %}</p>
+    {% elif lte_request.status == "expired" %}
+    <p>{% trans "Expired without download." %}</p>
+    {% endif %}
+</article>
+
+<article>
+    <header><strong>{% trans "Evaluator credentials" %}</strong></header>
+    <dl>
+        <dt>{% trans "Name" %}</dt><dd>{{ lte_request.evaluator_name }}</dd>
+        <dt>{% trans "Email" %}</dt><dd>{{ lte_request.evaluator_email }}</dd>
+        <dt>{% trans "Organisation" %}</dt><dd>{{ lte_request.evaluator_organisation }}</dd>
+        <dt>{% trans "Degree / certification" %}</dt><dd>{{ lte_request.evaluator_degree }}</dd>
+        <dt>{% trans "Years experience" %}</dt><dd>{{ lte_request.evaluator_years_experience }}</dd>
+        <dt>{% trans "Prior programs" %}</dt><dd>{{ lte_request.evaluator_prior_programs|linebreaksbr }}</dd>
+    </dl>
+</article>
+
+<article>
+    <header><strong>{% trans "REB and DSA" %}</strong></header>
+    <dl>
+        <dt>{% trans "REB" %}</dt><dd>{{ lte_request.reb_name }}</dd>
+        <dt>{% trans "Approval number" %}</dt><dd>{{ lte_request.reb_approval_number }}</dd>
+        <dt>{% trans "Approval date" %}</dt><dd>{{ lte_request.reb_approval_date }}</dd>
+        <dt>{% trans "DSA expiry" %}</dt><dd>{{ lte_request.data_sharing_agreement_expiry }}</dd>
+        <dt>{% trans "Destruction window" %}</dt><dd>{{ lte_request.destruction_window_days }} {% trans "days" %}</dd>
+        <dt>{% trans "Purpose" %}</dt><dd>{{ lte_request.purpose_statement|linebreaksbr }}</dd>
+    </dl>
+</article>
+
+{% if lte_request.community_reviewer_name %}
+<article>
+    <header><strong>{% trans "Community governance signoff" %}</strong></header>
+    <dl>
+        <dt>{% trans "Reviewer" %}</dt><dd>{{ lte_request.community_reviewer_name }} ({{ lte_request.community_reviewer_affiliation }})</dd>
+        <dt>{% trans "Signoff date" %}</dt><dd>{{ lte_request.community_signoff_date }}</dd>
+        {% if lte_request.community_framework_description %}
+        <dt>{% trans "Framework" %}</dt><dd>{{ lte_request.community_framework_description|linebreaksbr }}</dd>
+        {% endif %}
+    </dl>
+</article>
+{% endif %}
+
+<article>
+    <header><strong>{% trans "Lifecycle" %}</strong></header>
+    <ul>
+        {% for event in events %}
+        <li>
+            <small>{{ event.timestamp|date:"Y-m-d H:i" }}</small>
+            &mdash;
+            <strong>{{ event.get_event_type_display }}</strong>
+            {% if event.actor %}<small>({{ event.actor.display_name }})</small>{% endif %}
+            {% if event.notes %}<br><small>{{ event.notes }}</small>{% endif %}
+        </li>
+        {% empty %}
+        <li><em>{% trans "No lifecycle events recorded yet." %}</em></li>
+        {% endfor %}
+    </ul>
+</article>
+
+<div style="display: flex; flex-wrap: wrap; gap: 0.5rem; margin-top: 1rem;">
+    {% if lte_request.status == "active" %}
+    <form method="post" action="{% url 'reports:lte_download' request_id=lte_request.pk %}" style="margin: 0;">
+        {% csrf_token %}
+        <button type="submit">{% trans "Download file" %}</button>
+    </form>
+    {% endif %}
+
+    {% if can_cancel %}
+    <form method="post" action="{% url 'reports:lte_cancel' request_id=lte_request.pk %}" style="margin: 0;">
+        {% csrf_token %}
+        <details>
+            <summary role="button" class="secondary outline">{% trans "Cancel request" %}</summary>
+            <label>
+                {% trans "Reason (required)" %}
+                <input type="text" name="reason" required maxlength="500">
+            </label>
+            <button type="submit" class="contrast">{% trans "Confirm cancel" %}</button>
+        </details>
+    </form>
+    {% endif %}
+
+    {% if lte_request.post_hoc_review_pending %}
+    <form method="post" action="{% url 'reports:lte_resolve_review' request_id=lte_request.pk %}" style="margin: 0;">
+        {% csrf_token %}
+        <details>
+            <summary role="button" class="secondary">{% trans "Resolve post-hoc review" %}</summary>
+            <label>
+                {% trans "Review notes" %}
+                <textarea name="notes" rows="3"></textarea>
+            </label>
+            <button type="submit">{% trans "Mark resolved" %}</button>
+        </details>
+    </form>
+    {% endif %}
+
+    <a href="{% url 'reports:lte_list' %}" role="button" class="secondary outline">{% trans "Back to list" %}</a>
+</div>
+{% endblock %}

--- a/templates/reports/lte_flag_confirm.html
+++ b/templates/reports/lte_flag_confirm.html
@@ -1,0 +1,25 @@
+{% extends "base.html" %}
+{% load i18n %}
+
+{% block title %}{% trans "Flag LTE request" %} — {{ site.product_name|default:"KoNote" }}{% endblock %}
+
+{% block content %}
+<hgroup>
+    <h1>{% trans "Flag concerns on LTE request" %} #{{ lte_request.pk }}</h1>
+    <p>{{ lte_request.program.name }} &mdash; {% trans "submitted" %} {{ lte_request.submitted_at|date:"Y-m-d" }}</p>
+</hgroup>
+
+<article aria-label="{% trans 'About flagging' %}">
+    <p>{% trans "Flagging freezes the review-and-cancel countdown. The privacy officer will be notified and must resolve the flag before the countdown resumes. Dismissal restarts the remaining time — it does not fast-forward." %}</p>
+</article>
+
+<form method="post" action="{% url 'reports:lte_flag_concerns' request_id=lte_request.pk %}">
+    {% csrf_token %}
+    <input type="hidden" name="token" value="{{ token }}">
+    <label>
+        {% trans "Reason for flagging" %}
+        <textarea name="reason" rows="3" required></textarea>
+    </label>
+    <button type="submit">{% trans "Flag this request" %}</button>
+</form>
+{% endblock %}

--- a/templates/reports/lte_flag_result.html
+++ b/templates/reports/lte_flag_result.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %}
+{% load i18n %}
+
+{% block title %}{% trans "LTE flag recorded" %} — {{ site.product_name|default:"KoNote" }}{% endblock %}
+
+{% block content %}
+<hgroup>
+    <h1>{% trans "LTE flag recorded" %}</h1>
+</hgroup>
+
+<article>
+    {% if flagged %}
+    <p>{% trans "The LTE request has been flagged. The review-and-cancel countdown is now frozen." %}</p>
+    <p>{% trans "The privacy officer has been notified and will resolve the flag." %}</p>
+    {% elif already_handled %}
+    <p>{% trans "This LTE request is no longer in the review-and-cancel window — it has already been resolved, cancelled, or activated." %}</p>
+    {% endif %}
+    <p><a href="{% url 'reports:lte_detail' request_id=lte_request.pk %}">{% trans "View request details" %} &rarr;</a></p>
+</article>
+{% endblock %}

--- a/templates/reports/lte_list.html
+++ b/templates/reports/lte_list.html
@@ -1,0 +1,75 @@
+{% extends "base.html" %}
+{% load i18n %}
+
+{% block title %}{% trans "Evaluation Export (Small Population)" %} — {{ site.product_name|default:"KoNote" }}{% endblock %}
+
+{% block content %}
+<hgroup>
+    <h1>{% trans "Evaluation Export (Small Population)" %}</h1>
+    <p>{% trans "Longitudinal Trajectory Export — small-population evaluation tier. Drops demographics, fuzzes metric trajectories, and gates submission behind REB approval, community governance review, and a 5-business-day review-and-cancel window." %}</p>
+</hgroup>
+
+<article aria-label="{% trans 'About LTE' %}" style="margin-bottom: 1.5rem;">
+    <strong>{% trans "When to use this tier" %}</strong>
+    <p>{% trans "Use LTE for programs with fewer than 15 participants where the standard Evaluator Export is blocked. LTE is for PROGRAM EVALUATION, not research — it does not include demographic detail or unrounded metric values." %}</p>
+    <p style="margin-bottom: 0;">
+        <a href="{% url 'reports:evaluation_export' %}">{% trans "For larger programs, use the standard Evaluator Export" %} →</a>
+    </p>
+</article>
+
+{% if rate_limited %}
+<article role="alert" style="background: var(--kn-warning-bg, #fffbeb); border-left: 4px solid var(--kn-warning-fg, #d97706); padding: 1rem; margin-bottom: 1.5rem;">
+    <strong>{% trans "New LTE submissions paused" %}</strong>
+    <p style="margin-bottom: 0;">{{ rate_limit_message }}</p>
+</article>
+{% endif %}
+
+<div style="margin-bottom: 1rem;">
+    {% if not rate_limited %}
+    <a href="{% url 'reports:lte_submit' %}" role="button">{% trans "New request" %}</a>
+    {% else %}
+    <button type="button" disabled aria-disabled="true">{% trans "New request" %}</button>
+    {% endif %}
+</div>
+
+{% if lte_requests %}
+<figure>
+<table role="grid">
+    <thead>
+        <tr>
+            <th scope="col">{% trans "ID" %}</th>
+            <th scope="col">{% trans "Program" %}</th>
+            <th scope="col">{% trans "Submitted" %}</th>
+            <th scope="col">{% trans "By" %}</th>
+            <th scope="col">{% trans "Status" %}</th>
+            <th scope="col">{% trans "Window activates" %}</th>
+            <th scope="col">{% trans "Actions" %}</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for req in lte_requests %}
+        <tr>
+            <td>#{{ req.pk }}</td>
+            <td>{{ req.program.name }}</td>
+            <td><small>{{ req.submitted_at|date:"Y-m-d H:i" }}</small></td>
+            <td><small>{{ req.submitted_by.display_name }}</small></td>
+            <td>{{ req.get_status_display }}</td>
+            <td>
+                {% if req.is_window_running %}
+                <small>{{ req.effective_window_activates_at|date:"Y-m-d H:i" }}</small>
+                {% else %}
+                <small>&mdash;</small>
+                {% endif %}
+            </td>
+            <td>
+                <a href="{% url 'reports:lte_detail' request_id=req.pk %}">{% trans "View" %}</a>
+            </td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+</figure>
+{% else %}
+<p><em>{% trans "No LTE requests in this agency yet." %}</em></p>
+{% endif %}
+{% endblock %}

--- a/templates/reports/lte_submit.html
+++ b/templates/reports/lte_submit.html
@@ -1,0 +1,83 @@
+{% extends "base.html" %}
+{% load i18n %}
+
+{% block title %}{% trans "New LTE request" %} — {{ site.product_name|default:"KoNote" }}{% endblock %}
+
+{% block content %}
+<hgroup>
+    <h1>{% trans "New Longitudinal Trajectory Export request" %}</h1>
+    <p>{% trans "Fill in every field. Each precondition is captured in the immutable audit log and reviewed during the 5-business-day review-and-cancel window." %}</p>
+</hgroup>
+
+<article aria-label="{% trans 'Risk notice' %}" role="alert" style="background: var(--kn-warning-bg, #fffbeb); border-left: 4px solid var(--kn-warning-fg, #d97706); padding: 1rem; margin-bottom: 1.5rem;">
+    <strong>{% trans "This is a privacy-sensitive export." %}</strong>
+    <p style="margin-bottom: 0;">
+        {% trans "LTE drops demographics to protect identity at small n, and fuzzes metric trajectories to reduce the uniqueness of each participant's shape of change. It is for program evaluation — not research. If your evaluator needs unrounded values or demographic detail, use the research-grade workflow instead." %}
+    </p>
+</article>
+
+<form method="post" action="{% url 'reports:lte_submit' %}">
+    {% csrf_token %}
+    <input type="hidden" name="action" value="preview">
+
+    {% if form.non_field_errors %}
+    <article role="alert" style="background: var(--kn-error-bg, #fef2f2); border-left: 4px solid var(--kn-error-fg, #dc2626); padding: 1rem; margin-bottom: 1.5rem;">
+        {% for error in form.non_field_errors %}<p>{{ error }}</p>{% endfor %}
+    </article>
+    {% endif %}
+
+    <fieldset>
+        <legend>{% trans "Program and Period" %}</legend>
+        {% include "includes/_form_field.html" with field=form.program %}
+        {% include "includes/_form_field.html" with field=form.period_start %}
+        {% include "includes/_form_field.html" with field=form.period_end %}
+    </fieldset>
+
+    <fieldset>
+        <legend>{% trans "REB approval" %}</legend>
+        {% include "includes/_form_field.html" with field=form.reb_name %}
+        {% include "includes/_form_field.html" with field=form.reb_approval_number %}
+        {% include "includes/_form_field.html" with field=form.reb_approval_date %}
+    </fieldset>
+
+    <fieldset>
+        <legend>{% trans "Data sharing agreement" %}</legend>
+        {% include "includes/_form_field.html" with field=form.data_sharing_agreement_expiry %}
+    </fieldset>
+
+    <fieldset>
+        <legend>{% trans "Evaluator credentials" %}</legend>
+        {% include "includes/_form_field.html" with field=form.evaluator_name %}
+        {% include "includes/_form_field.html" with field=form.evaluator_email %}
+        {% include "includes/_form_field.html" with field=form.evaluator_organisation %}
+        {% include "includes/_form_field.html" with field=form.evaluator_degree %}
+        {% include "includes/_form_field.html" with field=form.evaluator_years_experience %}
+        {% include "includes/_form_field.html" with field=form.evaluator_prior_programs %}
+    </fieldset>
+
+    <fieldset>
+        <legend>{% trans "Destruction and purpose" %}</legend>
+        {% include "includes/_form_field.html" with field=form.destruction_window_days %}
+        {% include "includes/_form_field.html" with field=form.purpose_statement %}
+    </fieldset>
+
+    <fieldset>
+        <legend>{% trans "Community governance signoff" %}</legend>
+        <small style="display: block; margin-bottom: 1rem;">
+            {% trans "Required when the selected program carries an OCAP, EGAP, or other-community governance flag. Leave blank otherwise — the form will enforce the right rule based on the program's configuration." %}
+        </small>
+        {% include "includes/_form_field.html" with field=form.community_reviewer_name %}
+        {% include "includes/_form_field.html" with field=form.community_reviewer_affiliation %}
+        {% include "includes/_form_field.html" with field=form.community_signoff_date %}
+        {% include "includes/_form_field.html" with field=form.community_framework_description %}
+    </fieldset>
+
+    <fieldset>
+        <legend>{% trans "Acknowledgement" %}</legend>
+        {% include "includes/_form_field.html" with field=form.acknowledgement_confirmed %}
+    </fieldset>
+
+    <button type="submit">{% trans "Preview" %}</button>
+    <a href="{% url 'reports:lte_list' %}" role="button" class="secondary">{% trans "Cancel" %}</a>
+</form>
+{% endblock %}

--- a/templates/reports/lte_submit_preview.html
+++ b/templates/reports/lte_submit_preview.html
@@ -1,0 +1,91 @@
+{% extends "base.html" %}
+{% load i18n %}
+
+{% block title %}{% trans "LTE Preview" %} — {{ site.product_name|default:"KoNote" }}{% endblock %}
+
+{% block content %}
+<hgroup>
+    <h1>{% trans "LTE Preview" %}</h1>
+    <p>{% trans "Review the pipeline result before submitting the request. Submission starts the review-and-cancel window — the file is not generated until the window elapses." %}</p>
+</hgroup>
+
+{% if preview.blocked %}
+<article role="alert" style="background: var(--kn-error-bg, #fef2f2); border-left: 4px solid var(--kn-error-fg, #dc2626); padding: 1rem; margin-bottom: 1.5rem;">
+    <strong>{% trans "Export Blocked" %}</strong>
+    <p>{{ preview.block_reason }}</p>
+    <p style="margin-bottom: 0;">
+        {% trans "Programs below the LTE floor cannot generate a Longitudinal Trajectory Export. Use aggregate reports instead, or direct research-grade requests through the separate research workflow." %}
+    </p>
+    <a href="{% url 'reports:lte_submit' %}" role="button" class="secondary">{% trans "Back to Form" %}</a>
+</article>
+{% else %}
+
+<article>
+    <header><strong>{% trans "Pipeline Summary" %}</strong></header>
+    <table role="grid">
+        <tbody>
+            <tr>
+                <td>{% trans "Program" %}</td>
+                <td><strong>{{ program.name }}</strong></td>
+            </tr>
+            <tr>
+                <td>{% trans "Period" %}</td>
+                <td>{{ period_start }} &mdash; {{ period_end }}</td>
+            </tr>
+            <tr>
+                <td>{% trans "Eligible participants" %}</td>
+                <td><strong>{{ preview.eligible_count }}</strong></td>
+            </tr>
+            <tr>
+                <td>{% trans "With consent" %}</td>
+                <td><strong>{{ preview.consented_count }}</strong></td>
+            </tr>
+            <tr>
+                <td>{% trans "Will be exported" %}</td>
+                <td><strong>{{ preview.exportable_count }}</strong></td>
+            </tr>
+            <tr>
+                <td>{% trans "Population floor applied" %}</td>
+                <td>{{ preview.floor_applied }}</td>
+            </tr>
+            <tr>
+                <td>{% trans "Community governance framework" %}</td>
+                <td>{{ preview.program_governance_framework|default:"—" }}</td>
+            </tr>
+        </tbody>
+    </table>
+</article>
+
+<article aria-label="{% trans 'Fuzzing and privacy' %}">
+    <header><strong>{% trans "Fuzzing applied to the output" %}</strong></header>
+    <ul>
+        <li>{% trans "No demographic fields in the file (age, gender, ethnicity, geography all dropped)." %}</li>
+        <li>{% trans "Metric values rounded to nearest scale unit." %}</li>
+        <li>{% trans "Session counts banded to nearest 5, total hours banded to nearest half-hour." %}</li>
+        <li>{% trans "study_id is a random UUID with no relationship to real record IDs." %}</li>
+    </ul>
+</article>
+
+<article aria-label="{% trans 'Review window' %}">
+    <header><strong>{% trans "What happens next" %}</strong></header>
+    <ol>
+        <li>{% trans "The request is recorded and all agency admins are emailed." %}</li>
+        <li>{% trans "Any admin can cancel or flag concerns during the 5-business-day review-and-cancel window." %}</li>
+        <li>{% trans "A post-hoc review task is assigned to the privacy officer — until it is resolved, the agency cannot submit another LTE request." %}</li>
+        <li>{% trans "When the window elapses without intervention, the download link activates for 24 hours." %}</li>
+        <li>{% trans "If a participant withdraws consent during the window, the request is invalidated and must be re-submitted." %}</li>
+    </ol>
+</article>
+
+<form method="post" action="{% url 'reports:lte_submit' %}">
+    {% csrf_token %}
+    <input type="hidden" name="action" value="submit">
+    {# Re-submit all form fields so Django re-validates on final submit #}
+    {% for field in form %}
+    <input type="hidden" name="{{ field.name }}" value="{{ field.value|default_if_none:'' }}">
+    {% endfor %}
+    <button type="submit">{% trans "Confirm and start review window" %}</button>
+    <a href="{% url 'reports:lte_submit' %}" role="button" class="secondary">{% trans "Back to form" %}</a>
+</form>
+{% endif %}
+{% endblock %}

--- a/tests/test_lte.py
+++ b/tests/test_lte.py
@@ -1,0 +1,915 @@
+"""Tests for Longitudinal Trajectory Export (LTE).
+
+Covers the high-value, deterministic aspects of the LTE implementation:
+
+- Permission gating (per-user grant + "no privacy officer = no LTE")
+- Form validation (every precondition is required)
+- Community governance conditional validation
+- Business-day window arithmetic
+- Fuzzing helpers (metric rounding, session count bands, total hours bands)
+- study_id generator format + uniqueness
+- Pipeline floor enforcement (default and OCAP/EGAP)
+- Lifecycle state transitions (submit, cancel, flag freeze, expire)
+- Agency-wide rate limit (pending post-hoc review blocks new submission)
+- Audit category is longitudinal_trajectory_export (never bundled with EME)
+- CSV output has no demographic columns and has the research warning
+
+See tasks/design-rationale/evaluation-microdata-export.md for the
+specification that drives these tests.
+"""
+import os
+import shutil
+import tempfile
+import uuid
+from datetime import date, datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+from cryptography.fernet import Fernet
+from django.test import Client, TestCase, override_settings
+from django.utils import timezone
+
+import konote.encryption as enc_module
+from apps.auth_app.models import LTEExportGrant, User
+from apps.programs.models import Program, UserProgramRole
+
+
+TEST_KEY = Fernet.generate_key().decode()
+
+
+# ═════════════════════════════════════════════════════════════════════
+# 1. Permission helpers
+# ═════════════════════════════════════════════════════════════════════
+
+
+@override_settings(FIELD_ENCRYPTION_KEY=TEST_KEY)
+class LTEPermissionHelperTest(TestCase):
+    """can_create_lte_export + lte_available_in_agency."""
+
+    def setUp(self):
+        enc_module._fernet = None
+
+    def test_anonymous_user_denied(self):
+        from apps.reports.utils import can_create_lte_export
+        anon = MagicMock()
+        anon.is_authenticated = False
+        self.assertFalse(can_create_lte_export(anon))
+
+    def test_admin_without_grant_denied(self):
+        """Admin bypass MUST NOT apply to LTE."""
+        from apps.reports.utils import can_create_lte_export
+        admin = User.objects.create_user(
+            username="lte_admin_no_grant", password="x",
+            is_admin=True, display_name="LTE Admin No Grant",
+        )
+        self.assertFalse(can_create_lte_export(admin))
+
+    def test_granted_user_allowed(self):
+        from apps.reports.utils import can_create_lte_export
+        user = User.objects.create_user(
+            username="lte_grantee", password="x",
+            is_admin=False, display_name="Privacy Officer",
+            lte_export_granted=True,
+        )
+        self.assertTrue(can_create_lte_export(user))
+
+    def test_grant_not_shared_with_evaluation_export(self):
+        """LTE permission must not be inferred from evaluation_export_granted."""
+        from apps.reports.utils import can_create_evaluation_export, can_create_lte_export
+        user = User.objects.create_user(
+            username="eme_only", password="x",
+            display_name="EME Only",
+            evaluation_export_granted=True,
+            lte_export_granted=False,
+        )
+        self.assertTrue(can_create_evaluation_export(user))
+        self.assertFalse(can_create_lte_export(user))
+
+    def test_lte_available_in_agency_requires_designated_officer(self):
+        from apps.reports.utils import lte_available_in_agency
+        self.assertFalse(lte_available_in_agency())
+        User.objects.create_user(
+            username="officer", password="x",
+            display_name="Officer",
+            lte_export_granted=True,
+        )
+        self.assertTrue(lte_available_in_agency())
+
+
+@override_settings(FIELD_ENCRYPTION_KEY=TEST_KEY)
+class LTEExportGrantSignalTest(TestCase):
+    """The post_save signal keeps User.lte_export_granted in sync."""
+
+    def setUp(self):
+        enc_module._fernet = None
+        self.admin = User.objects.create_user(
+            username="lte_grant_admin", password="x",
+            is_admin=True, display_name="Admin",
+        )
+        self.target = User.objects.create_user(
+            username="lte_grant_target", password="x",
+            display_name="Target",
+        )
+
+    def test_signal_sets_flag_on_create(self):
+        self.assertFalse(self.target.lte_export_granted)
+        LTEExportGrant.objects.create(
+            user=self.target,
+            granted_by=self.admin,
+            reason="Board designated privacy officer 2026-04-09.",
+        )
+        self.target.refresh_from_db()
+        self.assertTrue(self.target.lte_export_granted)
+
+    def test_signal_clears_flag_on_revoke(self):
+        grant = LTEExportGrant.objects.create(
+            user=self.target,
+            granted_by=self.admin,
+            reason="Initial grant.",
+        )
+        self.target.refresh_from_db()
+        self.assertTrue(self.target.lte_export_granted)
+
+        grant.active = False
+        grant.revoked_at = timezone.now()
+        grant.save()
+        self.target.refresh_from_db()
+        self.assertFalse(self.target.lte_export_granted)
+
+    def test_unique_active_grant_constraint(self):
+        from django.db import IntegrityError, transaction
+        LTEExportGrant.objects.create(
+            user=self.target, granted_by=self.admin,
+            reason="First grant.",
+        )
+        with self.assertRaises(IntegrityError):
+            with transaction.atomic():
+                LTEExportGrant.objects.create(
+                    user=self.target, granted_by=self.admin,
+                    reason="Duplicate active grant — should fail.",
+                )
+
+
+# ═════════════════════════════════════════════════════════════════════
+# 2. Permission matrix — report.evaluation_export_small_population is DENY for all roles
+# ═════════════════════════════════════════════════════════════════════
+
+
+class LTEPermissionMatrixTest(TestCase):
+    """The matrix must list DENY for every role — no accidental ALLOW."""
+
+    def test_denied_across_all_roles(self):
+        from apps.auth_app.constants import (
+            ROLE_EXECUTIVE,
+            ROLE_PROGRAM_MANAGER,
+            ROLE_RECEPTIONIST,
+            ROLE_STAFF,
+        )
+        from apps.auth_app.permissions import DENY, can_access
+
+        for role in (
+            ROLE_RECEPTIONIST,
+            ROLE_STAFF,
+            ROLE_PROGRAM_MANAGER,
+            ROLE_EXECUTIVE,
+        ):
+            self.assertEqual(
+                can_access(role, "report.evaluation_export_small_population"),
+                DENY,
+                f"LTE permission must default to DENY for role {role}",
+            )
+
+
+# ═════════════════════════════════════════════════════════════════════
+# 3. Form validation — strict preconditions
+# ═════════════════════════════════════════════════════════════════════
+
+
+@override_settings(FIELD_ENCRYPTION_KEY=TEST_KEY)
+class LTEFormValidationTest(TestCase):
+    """Every precondition from the DRR must be required at the form layer."""
+
+    def setUp(self):
+        enc_module._fernet = None
+        self.user = User.objects.create_user(
+            username="lte_form_user", password="x",
+            is_admin=True, display_name="Form User",
+        )
+        self.program = Program.objects.create(name="Peer Support Circle")
+
+    def _valid_payload(self, **overrides):
+        payload = {
+            "program": str(self.program.pk),
+            "period_start": "2025-09-01",
+            "period_end": "2026-03-31",
+            "reb_name": "Llewelyn Consulting REB",
+            "reb_approval_number": "LCR-2026-014",
+            "reb_approval_date": "2026-03-15",
+            "data_sharing_agreement_expiry": (
+                (date.today() + timedelta(days=180)).isoformat()
+            ),
+            "evaluator_name": "Dr. Ana Martinez",
+            "evaluator_email": "dr.martinez@llewelyn.ca",
+            "evaluator_organisation": "Llewelyn Consulting",
+            "evaluator_degree": "PhD Community Psychology, McMaster",
+            "evaluator_years_experience": "15",
+            "evaluator_prior_programs": (
+                "Youth Employment Program (Llewelyn, 2021-2023); "
+                "Community Mental Health Initiative (Hamilton, 2019-2022)."
+            ),
+            "destruction_window_days": "90",
+            "purpose_statement": (
+                "Peer Support Circle outcome evaluation — "
+                "trajectory and dose-response analysis."
+            ),
+            "acknowledgement_confirmed": "on",
+        }
+        payload.update(overrides)
+        return payload
+
+    def test_valid_payload_passes(self):
+        from apps.reports.forms import LTEExportRequestForm
+        form = LTEExportRequestForm(self._valid_payload(), user=self.user)
+        self.assertTrue(form.is_valid(), form.errors)
+
+    def test_missing_acknowledgement_rejected(self):
+        from apps.reports.forms import LTEExportRequestForm
+        form = LTEExportRequestForm(
+            self._valid_payload(acknowledgement_confirmed=""),
+            user=self.user,
+        )
+        self.assertFalse(form.is_valid())
+        self.assertIn("acknowledgement_confirmed", form.errors)
+
+    def test_short_reb_number_rejected(self):
+        from apps.reports.forms import LTEExportRequestForm
+        form = LTEExportRequestForm(
+            self._valid_payload(reb_approval_number="AB"),
+            user=self.user,
+        )
+        self.assertFalse(form.is_valid())
+        self.assertIn("reb_approval_number", form.errors)
+
+    def test_short_prior_programs_rejected(self):
+        from apps.reports.forms import LTEExportRequestForm
+        form = LTEExportRequestForm(
+            self._valid_payload(evaluator_prior_programs="Just one thing."),
+            user=self.user,
+        )
+        self.assertFalse(form.is_valid())
+        self.assertIn("evaluator_prior_programs", form.errors)
+
+    def test_expired_dsa_rejected(self):
+        from apps.reports.forms import LTEExportRequestForm
+        form = LTEExportRequestForm(
+            self._valid_payload(
+                data_sharing_agreement_expiry=(
+                    (date.today() - timedelta(days=1)).isoformat()
+                ),
+            ),
+            user=self.user,
+        )
+        self.assertFalse(form.is_valid())
+        self.assertIn("data_sharing_agreement_expiry", form.errors)
+
+    def test_future_reb_date_rejected(self):
+        from apps.reports.forms import LTEExportRequestForm
+        form = LTEExportRequestForm(
+            self._valid_payload(
+                reb_approval_date=(date.today() + timedelta(days=30)).isoformat(),
+            ),
+            user=self.user,
+        )
+        self.assertFalse(form.is_valid())
+        self.assertIn("reb_approval_date", form.errors)
+
+    def test_reversed_period_rejected(self):
+        from apps.reports.forms import LTEExportRequestForm
+        form = LTEExportRequestForm(
+            self._valid_payload(
+                period_start="2026-03-31",
+                period_end="2025-09-01",
+            ),
+            user=self.user,
+        )
+        self.assertFalse(form.is_valid())
+        self.assertIn("period_end", form.errors)
+
+    def test_ocap_program_requires_community_signoff(self):
+        from apps.reports.forms import LTEExportRequestForm
+        self.program.community_governance_framework = "ocap"
+        self.program.save()
+        form = LTEExportRequestForm(self._valid_payload(), user=self.user)
+        self.assertFalse(form.is_valid())
+        self.assertIn("community_reviewer_name", form.errors)
+        self.assertIn("community_reviewer_affiliation", form.errors)
+        self.assertIn("community_signoff_date", form.errors)
+
+    def test_ocap_program_with_community_signoff_passes(self):
+        from apps.reports.forms import LTEExportRequestForm
+        self.program.community_governance_framework = "ocap"
+        self.program.save()
+        form = LTEExportRequestForm(
+            self._valid_payload(
+                community_reviewer_name="Elder Grey Wolf",
+                community_reviewer_affiliation="Community Council",
+                community_signoff_date=(
+                    (date.today() - timedelta(days=5)).isoformat()
+                ),
+            ),
+            user=self.user,
+        )
+        self.assertTrue(form.is_valid(), form.errors)
+
+    def test_other_framework_requires_description(self):
+        from apps.reports.forms import LTEExportRequestForm
+        self.program.community_governance_framework = "other"
+        self.program.save()
+        form = LTEExportRequestForm(
+            self._valid_payload(
+                community_reviewer_name="Newcomer Council Liaison",
+                community_reviewer_affiliation="Regional Newcomer Council",
+                community_signoff_date=(
+                    (date.today() - timedelta(days=5)).isoformat()
+                ),
+                community_framework_description="",  # missing
+            ),
+            user=self.user,
+        )
+        self.assertFalse(form.is_valid())
+        self.assertIn("community_framework_description", form.errors)
+
+
+# ═════════════════════════════════════════════════════════════════════
+# 4. Business day arithmetic
+# ═════════════════════════════════════════════════════════════════════
+
+
+class LTEBusinessDayTest(TestCase):
+    """add_business_days / calculate_window_end."""
+
+    def test_weekday_start_advances_to_next_weekday(self):
+        from apps.reports.lte_lifecycle import add_business_days
+        monday = datetime(2026, 4, 6, 9, 0)  # Monday
+        result = add_business_days(monday, business_days=5)
+        # Mon → +5 business days → next Monday 09:00
+        self.assertEqual(result, datetime(2026, 4, 13, 9, 0))
+        self.assertEqual(result.weekday(), 0)  # Monday
+
+    def test_friday_submission_skips_weekend(self):
+        from apps.reports.lte_lifecycle import add_business_days
+        friday = datetime(2026, 4, 10, 9, 0)  # Friday
+        result = add_business_days(friday, business_days=5)
+        # Fri + 5 business days → next Fri (skips Sat/Sun)
+        self.assertEqual(result, datetime(2026, 4, 17, 9, 0))
+        self.assertEqual(result.weekday(), 4)  # Friday
+
+    def test_saturday_submission_rolls_to_monday_first(self):
+        from apps.reports.lte_lifecycle import add_business_days
+        saturday = datetime(2026, 4, 11, 9, 0)  # Saturday
+        result = add_business_days(saturday, business_days=5)
+        # Sat is not a business day; advance to Mon then +5
+        # Saturday → Monday → +5 business days → following Monday
+        self.assertEqual(result.weekday(), 4)  # Friday
+        self.assertEqual(result, datetime(2026, 4, 17, 9, 0))
+
+    def test_holidays_are_skipped(self):
+        from apps.reports.lte_lifecycle import add_business_days
+        monday = datetime(2026, 4, 6, 9, 0)  # Monday
+        holiday = date(2026, 4, 10)  # Friday — declared holiday
+        with override_settings(LTE_EXCLUDED_HOLIDAYS=[holiday]):
+            result = add_business_days(monday, business_days=5)
+        # Mon + 4 working days (Tue/Wed/Thu/Fri skipped) lands on Tue next week
+        # Actually: Tue, Wed, Thu — Fri skipped — next Mon, next Tue → result is Tuesday
+        self.assertEqual(result.weekday(), 1)  # Tuesday
+        self.assertEqual(result, datetime(2026, 4, 14, 9, 0))
+
+    def test_zero_business_days_returns_start(self):
+        from apps.reports.lte_lifecycle import add_business_days
+        t = datetime(2026, 4, 6, 9, 0)
+        self.assertEqual(add_business_days(t, business_days=0), t)
+
+
+# ═════════════════════════════════════════════════════════════════════
+# 5. Fuzzing helpers
+# ═════════════════════════════════════════════════════════════════════
+
+
+class LTEFuzzingTest(TestCase):
+    """Metric rounding and service-intensity banding."""
+
+    def test_band_session_count(self):
+        from apps.reports.lte_pipeline import LTESmallPopulationPipeline as P
+        self.assertEqual(P._band_session_count(0), 0)
+        self.assertEqual(P._band_session_count(1), 0)
+        self.assertEqual(P._band_session_count(3), 5)
+        self.assertEqual(P._band_session_count(7), 5)
+        self.assertEqual(P._band_session_count(8), 10)
+        self.assertEqual(P._band_session_count(12), 10)
+        self.assertEqual(P._band_session_count(13), 15)
+
+    def test_band_total_hours(self):
+        from apps.reports.lte_pipeline import LTESmallPopulationPipeline as P
+        self.assertEqual(P._band_total_hours(0.0), 0.0)
+        self.assertEqual(P._band_total_hours(0.24), 0.0)
+        self.assertEqual(P._band_total_hours(0.25), 0.0)
+        self.assertEqual(P._band_total_hours(0.3), 0.5)
+        self.assertEqual(P._band_total_hours(12.2), 12.0)
+        self.assertEqual(P._band_total_hours(12.3), 12.5)
+
+    def test_fuzz_metric_ordinal_0_10(self):
+        from apps.reports.lte_pipeline import LTESmallPopulationPipeline as P
+        metric = MagicMock(min_value=0, max_value=10)
+        self.assertEqual(P._fuzz_metric_value(3.4, metric), 3)
+        self.assertEqual(P._fuzz_metric_value(3.5, metric), 4)
+        self.assertEqual(P._fuzz_metric_value(7.9, metric), 8)
+
+    def test_fuzz_metric_percentage_0_100(self):
+        from apps.reports.lte_pipeline import LTESmallPopulationPipeline as P
+        metric = MagicMock(min_value=0, max_value=100)
+        self.assertEqual(P._fuzz_metric_value(42.0, metric), 40)
+        self.assertEqual(P._fuzz_metric_value(67.0, metric), 65)
+        self.assertEqual(P._fuzz_metric_value(68.0, metric), 70)
+
+    def test_fuzz_metric_continuous_falls_back_to_one_decimal(self):
+        from apps.reports.lte_pipeline import LTESmallPopulationPipeline as P
+        metric = MagicMock(min_value=None, max_value=None)
+        self.assertEqual(P._fuzz_metric_value(3.14159, metric), 3.1)
+        self.assertEqual(P._fuzz_metric_value(7.86, metric), 7.9)
+
+    def test_fuzz_metric_none_passes_through(self):
+        from apps.reports.lte_pipeline import LTESmallPopulationPipeline as P
+        metric = MagicMock(min_value=0, max_value=10)
+        self.assertIsNone(P._fuzz_metric_value(None, metric))
+
+
+# ═════════════════════════════════════════════════════════════════════
+# 6. Study-id generator
+# ═════════════════════════════════════════════════════════════════════
+
+
+class LTEStudyIDTest(TestCase):
+    """UUID-based study ids — no linkable pattern."""
+
+    def test_format_is_lte_prefix_hex(self):
+        import re
+        from apps.reports.lte_pipeline import LTESmallPopulationPipeline as P
+        study_id = P._generate_lte_study_id(set())
+        self.assertTrue(study_id.startswith("LTE-"))
+        self.assertTrue(re.match(r"^LTE-[0-9A-F]{8,}$", study_id))
+
+    def test_uniqueness_across_many(self):
+        from apps.reports.lte_pipeline import LTESmallPopulationPipeline as P
+        seen: set[str] = set()
+        for _ in range(1000):
+            sid = P._generate_lte_study_id(seen)
+            self.assertNotIn(sid, seen)
+            seen.add(sid)
+        self.assertEqual(len(seen), 1000)
+
+
+# ═════════════════════════════════════════════════════════════════════
+# 7. Model + lifecycle transitions
+# ═════════════════════════════════════════════════════════════════════
+
+
+@override_settings(FIELD_ENCRYPTION_KEY=TEST_KEY)
+class LTEModelTest(TestCase):
+    """LTEExportRequest state helpers and lifecycle fundamentals."""
+
+    def setUp(self):
+        enc_module._fernet = None
+        self.user = User.objects.create_user(
+            username="lte_model_user", password="x",
+            display_name="Model User",
+        )
+        self.program = Program.objects.create(name="Test Program")
+
+    def _make_request(self, **overrides):
+        from apps.reports.models import LTEExportRequest
+        defaults = dict(
+            submitted_by=self.user,
+            program=self.program,
+            period_start=date(2025, 9, 1),
+            period_end=date(2026, 3, 31),
+            reb_name="REB A",
+            reb_approval_number="R-001",
+            reb_approval_date=date(2026, 1, 1),
+            data_sharing_agreement_expiry=date(2027, 1, 1),
+            evaluator_name="E",
+            evaluator_email="e@example.com",
+            evaluator_organisation="Org",
+            evaluator_degree="PhD",
+            evaluator_years_experience=10,
+            evaluator_prior_programs="x" * 60,
+            destruction_window_days=90,
+            purpose_statement="p" * 40,
+            acknowledgement_confirmed=True,
+            window_activates_at=timezone.now() + timedelta(days=7),
+            population_snapshot=12,
+            population_client_ids=[1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+        )
+        defaults.update(overrides)
+        return LTEExportRequest.objects.create(**defaults)
+
+    def test_is_window_running_for_submitted(self):
+        from apps.reports.models import LTEExportRequest
+        req = self._make_request(status=LTEExportRequest.STATUS_SUBMITTED)
+        self.assertTrue(req.is_window_running)
+        self.assertFalse(req.is_terminal)
+
+    def test_terminal_states(self):
+        from apps.reports.models import LTEExportRequest
+        for status in (
+            LTEExportRequest.STATUS_CANCELLED,
+            LTEExportRequest.STATUS_AUTO_CANCELLED,
+            LTEExportRequest.STATUS_INVALIDATED_BY_WITHDRAWAL,
+            LTEExportRequest.STATUS_DOWNLOADED,
+            LTEExportRequest.STATUS_EXPIRED,
+        ):
+            req = self._make_request(status=status)
+            self.assertTrue(req.is_terminal, f"{status} should be terminal")
+            self.assertFalse(req.is_window_running)
+
+    def test_post_hoc_review_pending_skipped_for_cancelled(self):
+        from apps.reports.models import LTEExportRequest
+        cancelled = self._make_request(status=LTEExportRequest.STATUS_CANCELLED)
+        self.assertFalse(cancelled.post_hoc_review_pending)
+
+    def test_post_hoc_review_pending_for_active(self):
+        from apps.reports.models import LTEExportRequest
+        active = self._make_request(status=LTEExportRequest.STATUS_ACTIVE)
+        self.assertTrue(active.post_hoc_review_pending)
+
+    def test_effective_window_activates_at_with_flag_hold(self):
+        req = self._make_request(flag_hold_seconds=3600)  # 1h flag hold
+        delta = req.effective_window_activates_at - req.window_activates_at
+        self.assertEqual(delta, timedelta(seconds=3600))
+
+    def test_start_flag_hold_freezes_status(self):
+        from apps.reports.lte_lifecycle import start_flag_hold
+        from apps.reports.models import LTEExportRequest
+        req = self._make_request(status=LTEExportRequest.STATUS_SUBMITTED)
+        start_flag_hold(req, actor=self.user, reason="Test concern")
+        req.refresh_from_db()
+        self.assertEqual(req.status, LTEExportRequest.STATUS_FLAGGED)
+        self.assertIsNotNone(req.flag_hold_started_at)
+
+    def test_resolve_flag_dismiss_resumes_with_hold(self):
+        from apps.reports.lte_lifecycle import resolve_flag, start_flag_hold
+        from apps.reports.models import LTEExportRequest
+        req = self._make_request(status=LTEExportRequest.STATUS_SUBMITTED)
+        start_flag_hold(req, actor=self.user)
+        req.refresh_from_db()
+        # Backdate the flag_hold_started_at so the resolution records
+        # a non-zero hold duration.
+        req.flag_hold_started_at = timezone.now() - timedelta(seconds=1800)
+        req.save()
+        resolve_flag(req, actor=self.user, dismissed=True, notes="All good.")
+        req.refresh_from_db()
+        self.assertEqual(req.status, LTEExportRequest.STATUS_SUBMITTED)
+        self.assertGreaterEqual(req.flag_hold_seconds, 1700)
+        self.assertIsNone(req.flag_hold_started_at)
+
+    def test_resolve_flag_cancel_transitions_to_cancelled(self):
+        from apps.reports.lte_lifecycle import resolve_flag, start_flag_hold
+        from apps.reports.models import LTEExportRequest
+        req = self._make_request(status=LTEExportRequest.STATUS_SUBMITTED)
+        start_flag_hold(req, actor=self.user)
+        resolve_flag(req, actor=self.user, dismissed=False, notes="Unsafe.")
+        req.refresh_from_db()
+        self.assertEqual(req.status, LTEExportRequest.STATUS_CANCELLED)
+
+    def test_cancel_request_discards_linkage_blob(self):
+        from apps.reports.lte_lifecycle import cancel_request
+        from apps.reports.models import LTEExportRequest
+        req = self._make_request(
+            status=LTEExportRequest.STATUS_SUBMITTED,
+            linkage_blob_encrypted=b"some-encrypted-blob",
+        )
+        cancel_request(req, actor=self.user, reason="No longer needed")
+        req.refresh_from_db()
+        self.assertEqual(req.status, LTEExportRequest.STATUS_CANCELLED)
+        self.assertEqual(bytes(req.linkage_blob_encrypted), b"")
+        self.assertEqual(req.cancelled_by, self.user)
+
+
+# ═════════════════════════════════════════════════════════════════════
+# 8. Rate limit — pending post-hoc review blocks new submissions
+# ═════════════════════════════════════════════════════════════════════
+
+
+@override_settings(FIELD_ENCRYPTION_KEY=TEST_KEY)
+class LTERateLimitTest(TestCase):
+    """The agency-wide rate limit must block new submissions while a
+    prior LTE has a pending post-hoc review.
+    """
+
+    def setUp(self):
+        enc_module._fernet = None
+        self.user = User.objects.create_user(
+            username="lte_rl_user", password="x",
+            display_name="RL User",
+        )
+        self.program = Program.objects.create(name="RL Program")
+
+    def _make(self, **overrides):
+        from apps.reports.models import LTEExportRequest
+        base = dict(
+            submitted_by=self.user, program=self.program,
+            period_start=date(2025, 9, 1),
+            period_end=date(2026, 3, 31),
+            reb_name="R", reb_approval_number="12345",
+            reb_approval_date=date(2026, 1, 1),
+            data_sharing_agreement_expiry=date(2027, 1, 1),
+            evaluator_name="E", evaluator_email="e@example.com",
+            evaluator_organisation="Org", evaluator_degree="PhD",
+            evaluator_years_experience=5, evaluator_prior_programs="x" * 60,
+            destruction_window_days=90,
+            purpose_statement="p" * 40,
+            acknowledgement_confirmed=True,
+            window_activates_at=timezone.now() + timedelta(days=7),
+            population_snapshot=11,
+            population_client_ids=list(range(1, 12)),
+        )
+        base.update(overrides)
+        return LTEExportRequest.objects.create(**base)
+
+    def test_no_rate_limit_when_no_pending_requests(self):
+        from apps.reports.views import _lte_rate_limit_check
+        ok, msg = _lte_rate_limit_check()
+        self.assertTrue(ok)
+        self.assertIsNone(msg)
+
+    def test_pending_submitted_request_blocks(self):
+        from apps.reports.models import LTEExportRequest
+        from apps.reports.views import _lte_rate_limit_check
+        self._make(status=LTEExportRequest.STATUS_SUBMITTED)
+        ok, msg = _lte_rate_limit_check()
+        self.assertFalse(ok)
+        self.assertIn("pending", str(msg).lower())
+
+    def test_cancelled_request_does_not_block(self):
+        """A cancelled prior request does NOT block future submissions."""
+        from apps.reports.models import LTEExportRequest
+        from apps.reports.views import _lte_rate_limit_check
+        self._make(
+            status=LTEExportRequest.STATUS_CANCELLED,
+            cancelled_at=timezone.now(),
+        )
+        ok, _msg = _lte_rate_limit_check()
+        self.assertTrue(ok)
+
+    def test_resolved_post_hoc_review_unblocks(self):
+        from apps.reports.models import LTEExportRequest
+        from apps.reports.views import _lte_rate_limit_check
+        self._make(
+            status=LTEExportRequest.STATUS_DOWNLOADED,
+            post_hoc_review_resolved_at=timezone.now(),
+            post_hoc_review_resolved_by=self.user,
+        )
+        ok, _msg = _lte_rate_limit_check()
+        self.assertTrue(ok)
+
+
+# ═════════════════════════════════════════════════════════════════════
+# 9. CSV output shape — NO demographics, warning header present
+# ═════════════════════════════════════════════════════════════════════
+
+
+@override_settings(FIELD_ENCRYPTION_KEY=TEST_KEY)
+class LTECSVOutputTest(TestCase):
+    """Direct test of the LTE CSV writer. Uses a hand-built record set
+    so the test is independent of the DB schema for client data.
+    """
+
+    def setUp(self):
+        enc_module._fernet = None
+        self.user = User.objects.create_user(
+            username="lte_csv_user", password="x", display_name="CSV",
+        )
+        self.program = Program.objects.create(name="CSV Program")
+
+    def _build_pipeline(self, records, metric_columns):
+        from apps.reports.lte_pipeline import (
+            LTEPreviewResult,
+            LTESmallPopulationPipeline,
+        )
+        pipeline = LTESmallPopulationPipeline(
+            program=self.program,
+            period_start=date(2025, 9, 1),
+            period_end=date(2026, 3, 31),
+            evaluator_info={
+                "name": "Evaluator",
+                "email": "e@example.com",
+                "organisation": "Org",
+                "degree": "PhD",
+                "years_experience": 10,
+                "purpose": "Evaluation purpose",
+                "reb_name": "REB A",
+                "reb_approval_number": "R-001",
+                "reb_approval_date": "2026-01-01",
+                "agreement_expiry": "2027-01-01",
+                "destruction_window_days": 90,
+            },
+            user=self.user,
+        )
+        pipeline._deidentified_records = records
+        pipeline._raw_records = [{} for _ in records]
+        pipeline._consented_records = [{} for _ in records]
+        preview = LTEPreviewResult(
+            eligible_count=len(records),
+            consented_count=len(records),
+            exportable_count=len(records),
+            blocked=False,
+            block_reason=None,
+            floor_applied=10,
+            program_governance_framework="",
+            metric_columns=metric_columns,
+            snapshot_client_ids=[],
+        )
+        return pipeline, preview
+
+    def test_header_contains_research_warning(self):
+        records = [
+            {
+                "study_id": "LTE-AAAAAAAA",
+                "_real_client_id": 1,
+                "enrolment_quarter": "Q3-2025",
+                "exit_quarter": "Q1-2026",
+                "sessions_count_raw": 12,
+                "total_hours_raw": 18.3,
+                "metrics": {},
+                "_suppressed": False,
+            },
+        ]
+        pipeline, preview = self._build_pipeline(records, [])
+        csv_content = pipeline._generate_lte_csv(preview)
+        self.assertIn("PROGRAM EVALUATION, not research", csv_content)
+        self.assertIn("NO demographic fields", csv_content)
+
+    def test_no_demographic_columns(self):
+        records = [
+            {
+                "study_id": "LTE-BBBBBBBB",
+                "_real_client_id": 2,
+                "enrolment_quarter": "Q3-2025",
+                "exit_quarter": "",
+                "sessions_count_raw": 7,
+                "total_hours_raw": 11.8,
+                "metrics": {},
+                "_suppressed": False,
+            },
+        ]
+        pipeline, preview = self._build_pipeline(records, [])
+        csv_content = pipeline._generate_lte_csv(preview)
+        first_data_line = next(
+            line for line in csv_content.splitlines()
+            if line and not line.startswith("#")
+        )
+        forbidden = (
+            "age", "gender", "ethnicity", "geography",
+            "postal", "urban", "rural",
+        )
+        for f in forbidden:
+            self.assertNotIn(f, first_data_line.lower(),
+                             f"Demographic field {f!r} must not appear in LTE header")
+
+    def test_session_counts_and_hours_banded_in_output(self):
+        records = [
+            {
+                "study_id": "LTE-CCCCCCCC",
+                "_real_client_id": 3,
+                "enrolment_quarter": "Q3-2025",
+                "exit_quarter": "",
+                "sessions_count_raw": 13,   # → 15
+                "total_hours_raw": 18.3,    # → 18.5
+                "metrics": {},
+                "_suppressed": False,
+            },
+        ]
+        pipeline, preview = self._build_pipeline(records, [])
+        csv_content = pipeline._generate_lte_csv(preview)
+        data_lines = [
+            line for line in csv_content.splitlines()
+            if line and not line.startswith("#")
+        ]
+        # Header line + 1 row
+        self.assertEqual(len(data_lines), 2)
+        data_row = data_lines[1]
+        # 13 sessions rounded to nearest 5 = 15
+        self.assertIn("15", data_row)
+        # 18.3 hours rounded to nearest 0.5 = 18.5
+        self.assertIn("18.5", data_row)
+
+
+# ═════════════════════════════════════════════════════════════════════
+# 10. Audit metadata uses the distinct export_category
+# ═════════════════════════════════════════════════════════════════════
+
+
+@override_settings(FIELD_ENCRYPTION_KEY=TEST_KEY)
+class LTEAuditCategoryTest(TestCase):
+    """LTE events must use export_category=longitudinal_trajectory_export,
+    never evaluation_microdata. DRR "Enhanced Audit Metadata" section.
+    """
+
+    def setUp(self):
+        enc_module._fernet = None
+        self.user = User.objects.create_user(
+            username="lte_audit_user", password="x", display_name="Audit",
+        )
+        self.program = Program.objects.create(name="Audit Program")
+
+    def test_build_audit_metadata_has_correct_category(self):
+        from apps.reports.lte_pipeline import (
+            LTEPreviewResult,
+            LTESmallPopulationPipeline,
+        )
+
+        pipeline = LTESmallPopulationPipeline(
+            program=self.program,
+            period_start=date(2025, 9, 1),
+            period_end=date(2026, 3, 31),
+            evaluator_info={
+                "name": "E", "email": "e@example.com",
+                "organisation": "Org", "degree": "PhD",
+                "years_experience": 5, "purpose": "p",
+                "reb_name": "REB", "reb_approval_number": "12345",
+                "reb_approval_date": date(2026, 1, 1),
+                "agreement_expiry": date(2027, 1, 1),
+                "destruction_window_days": 90,
+            },
+            user=self.user,
+        )
+        preview = LTEPreviewResult(
+            eligible_count=11, consented_count=11, exportable_count=11,
+            blocked=False, block_reason=None,
+            floor_applied=10, program_governance_framework="",
+            metric_columns=[], snapshot_client_ids=list(range(1, 12)),
+        )
+        metadata = pipeline._build_lte_audit_metadata(preview)
+        self.assertEqual(
+            metadata["export_category"], "longitudinal_trajectory_export",
+        )
+        # Must NOT be the EME category
+        self.assertNotEqual(metadata["export_category"], "evaluation_microdata")
+        self.assertTrue(metadata["metric_rounding_applied"])
+        self.assertEqual(metadata["session_count_banded_to"], 5)
+        self.assertEqual(metadata["total_hours_banded_to"], 0.5)
+
+
+# ═════════════════════════════════════════════════════════════════════
+# 11. View-level access control — 403 when grant or officer missing
+# ═════════════════════════════════════════════════════════════════════
+
+
+@override_settings(FIELD_ENCRYPTION_KEY=TEST_KEY)
+class LTEViewAccessTest(TestCase):
+    """lte_list and lte_submit must enforce both per-user grant and
+    'no designated privacy officer = no LTE'.
+    """
+
+    list_url = "/reports/longitudinal-trajectory-export/"
+    submit_url = "/reports/longitudinal-trajectory-export/new/"
+
+    def setUp(self):
+        enc_module._fernet = None
+
+    def test_anonymous_redirected(self):
+        resp = Client().get(self.list_url)
+        self.assertEqual(resp.status_code, 302)
+
+    def test_admin_without_grant_denied(self):
+        admin = User.objects.create_user(
+            username="lte_admin_view", password="x",
+            is_admin=True, display_name="Admin",
+        )
+        c = Client()
+        c.force_login(admin)
+        resp = c.get(self.list_url)
+        self.assertEqual(resp.status_code, 403)
+
+    def test_granted_user_with_no_other_officer_still_ok(self):
+        """A single privacy officer is sufficient — check the agency check
+        finds themselves too (the lte_available_in_agency query is
+        User-wide, so a user holding the grant counts themselves).
+        """
+        officer = User.objects.create_user(
+            username="lte_officer", password="x",
+            display_name="Officer", lte_export_granted=True,
+        )
+        c = Client()
+        c.force_login(officer)
+        resp = c.get(self.list_url)
+        self.assertEqual(resp.status_code, 200)
+
+    def test_granted_user_reaches_submit_form(self):
+        officer = User.objects.create_user(
+            username="lte_officer_submit", password="x",
+            display_name="Officer",
+            lte_export_granted=True,
+        )
+        c = Client()
+        c.force_login(officer)
+        resp = c.get(self.submit_url)
+        self.assertEqual(resp.status_code, 200)


### PR DESCRIPTION
## Summary

Implements the **Longitudinal Trajectory Export (LTE)** tier described in [`tasks/phase-lte-prompt.md`](tasks/phase-lte-prompt.md) and [`tasks/design-rationale/evaluation-microdata-export.md`](tasks/design-rationale/evaluation-microdata-export.md) — a structurally separate export for programs with 10–14 participants (or ≥15 for OCAP/EGAP-governed programs), where the standard Evaluator Export is blocked.

**GK review requested before merge.** LTE is a GK consultation gate per `CLAUDE.md` — evaluation methodology, data modelling, and community governance gating.

## What this changes

Following the DRR's **"separate path, separate door, separate key"** principle, LTE is implemented as a parallel feature to the existing EME — not as a toggle or variation.

### Step 1 — Data models + migrations
- `Program.community_governance_framework` — OCAP / EGAP / other flag
- `LTEExportRequest` — REB, DSA, evaluator credentials, destruction window, purpose, status lifecycle, window activation, flag hold accumulator, population snapshot, linkage blob
- `LTELifecycleEvent` — append-only state-transition log
- `LTEExportGrant` + `User.lte_export_granted` — strictly separate from `EvaluationExportGrant`
- Rebased over PR #632 so the auth_app migration is `0015_lte_export_grant` (not 0014)

### Step 2 — Permission
- `report.evaluation_export_small_population` registered as DENY across all roles (explicit per-user grant only)
- `can_create_lte_export()` + `lte_available_in_agency()` helpers (the DRR's hard "no designated privacy officer = no LTE" precondition)
- Template tag updated to read `User.lte_export_granted`

### Step 3 — Pipeline
- `apps/reports/lte_pipeline.py` — `LTESmallPopulationPipeline` subclasses `DeidentificationPipeline`
- **All demographic fields dropped at the schema layer** (hard rule — not configurable)
- Random UUID `study_id` (LTE-XXXXXXXX), no derivable link to real record id
- Longitudinal metric extraction (intake / mid / exit), metric values rounded by scale (0-10 ordinal → integer, 0-100 percentage → nearest 5, continuous → 1 decimal), sessions banded to 5, hours banded to 0.5
- LTE population floor (10 default, 15 for OCAP/EGAP) — no administrative waiver
- Snapshot restriction for withdrawal handling
- Audit writes tagged `export_category=longitudinal_trajectory_export`

### Step 4 — Form
- `LTEExportRequestForm` — every precondition is required
- Community governance conditionally required based on `program.community_governance_framework`
- Rejects expired DSA, future REB date, reversed period, short REB number, short prior-programs narrative, missing acknowledgement

### Steps 5-9 — Views, URLs, lifecycle, email, audit
- `apps/reports/lte_lifecycle.py` — business-day arithmetic (Mon-Fri + configurable `LTE_EXCLUDED_HOLIDAYS`), state transitions, `refresh_pending_requests()`, `check_population_snapshot_for_lte()`
- URL prefix `/reports/longitudinal-trajectory-export/` — distinct from EME
- Views: `lte_list`, `lte_submit`, `lte_detail`, `lte_cancel`, `lte_flag_concerns`, `lte_download`, `lte_resolve_review`
- Signed token flag-concerns endpoint — works without the LTE permission so any agency admin can freeze the countdown from the email link
- Agency-wide rate limit: pending post-hoc review blocks new submissions anywhere in the agency
- Flag holds use `flag_hold_seconds` accumulator so dismissal resumes the remaining countdown from the point of dismissal — no fast-forward
- Management command `check_lte_window_lifecycle` for daily cron runs

### Step 10 — Templates + nav
- `lte_list.html`, `lte_submit.html`, `lte_submit_preview.html`, `lte_detail.html`, `lte_flag_confirm.html`, `lte_flag_result.html`
- Email templates `email/lte_submitted.html` + `.txt`
- Admin nav entry "Evaluation Export (Small Population)" gated by the new permission

### Step 11 — Tests
- `tests/test_lte.py`: 11 test classes covering permission helpers, grant signal + unique constraint, permission matrix DENY guard, form validation (every precondition), business-day arithmetic, fuzzing helpers, study id generator, model state helpers + lifecycle transitions, rate limit, CSV output shape (no demographics, research warning present), audit category, view access control

### Step 12 — Docs
- New `docs/lte-privacy-officer-guide.md` — responsibilities, "things you cannot do", escalation
- Updated `docs/admin/reporting.md` with an LTE section and comparison table
- `TODO.md` — LTE-PERM1 / FORM1 / PIPE1 / WINDOW1 / OVERSIGHT1 / REVIEW1 / AUDIT1 / OUT1 / TEST1 / DOC1 marked done

## Follow-ups (tracked in TODO.md)

- **LTE-QA1** — QA scenarios and page inventory live in the sister repo `konote-qa-scenarios`; update there in a separate session
- **LTE-I18N1** — French translations need `translate_strings` on the VPS; the startup check is non-blocking so English will serve until filled
- **LTE-GKREVIEW1** — this PR

## Anti-pattern compliance (from the DRR)

| Anti-pattern | Status |
|---|---|
| Demographic fields in LTE output | **Removed at schema layer.** `_strip_direct_identifiers` override never carries them into the output record. |
| Bundling LTE as a toggle on the EME form | **Separate path.** Own permission, form, URL prefix, audit category, views. |
| DSA as an unlock | **Captured for audit only.** Form requires DSA expiry but does not use it as the gate. |
| Fast-path early approval | **Not built.** Only the 5-business-day countdown activates the link. |
| Lowering k floor below 5 | **Not touched.** LTE satisfies k=5 trivially because there are no QI columns. |
| LTE without REB approval | **Blocked at form layer.** |
| LTE bypass for OCAP/EGAP without community signoff | **Blocked at form layer.** |
| LTE without designated privacy officer | **Blocked at view layer.** `lte_available_in_agency()` returns False → 403. |
| Reusing `report.evaluation_export` permission | **Separate permission key.** |
| Indefinite linkage table | **Destroyed on cancel/expire/invalidation.** Linkage blob is nulled in every terminal transition. |

## Test plan

- [ ] GK reviews demographic suppression correctness in `apps/reports/lte_pipeline.py:_strip_direct_identifiers`
- [ ] GK reviews metric fuzzing thresholds in `_fuzz_metric_value` / `_band_session_count` / `_band_total_hours`
- [ ] GK reviews community governance gating in `LTEExportRequestForm.clean()` and `_check_lte_population_floor`
- [ ] Deploy to dev VPS, run `migrate` for the three new migrations
- [ ] Dev VPS: grant the new permission to a test user, confirm nav entry appears
- [ ] Dev VPS: submit an LTE request against a small program, confirm admin notification email arrives with working Flag Concerns link
- [ ] Dev VPS: confirm `check_lte_window_lifecycle` management command runs cleanly
- [ ] Dev VPS: run `pytest tests/test_lte.py` in the dev container once dev deps are installed
- [ ] Dev VPS: run `translate_strings` to extract French msgids, fill in translations, recompile
- [ ] Follow-up: update `konote-qa-scenarios` with new LTE pages + scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)