### PR TITLE
🎨 Palette: Add ARIA role 'status' to empty states

### DIFF
--- a/templates/auth_app/eval_export_grant_list.html
+++ b/templates/auth_app/eval_export_grant_list.html
@@ -66,7 +66,7 @@
 </table>
 </figure>
 {% else %}
-<div class="empty-state">
+<div class="empty-state" role="status">
     <p>{% trans "No active grants. Evaluation exports are disabled until a user is granted access." %}</p>
 </div>
 {% endif %}

--- a/templates/auth_app/user_list.html
+++ b/templates/auth_app/user_list.html
@@ -66,7 +66,7 @@
 </table>
 </figure>
 {% else %}
-<div class="empty-state">
+<div class="empty-state" role="status">
     <p>{% trans "No users found." %}</p>
 </div>
 {% endif %}

--- a/templates/auth_app/user_roles.html
+++ b/templates/auth_app/user_roles.html
@@ -42,7 +42,7 @@
 </table>
 </figure>
 {% else %}
-<div class="empty-state">
+<div class="empty-state" role="status">
     <p>{% trans "No program roles assigned. This user cannot access any program data." %}</p>
 </div>
 {% endif %}

--- a/templates/circles/circle_list.html
+++ b/templates/circles/circle_list.html
@@ -51,7 +51,7 @@
 </table>
 </figure>
 {% else %}
-<div class="empty-state">
+<div class="empty-state" role="status">
     {% if search_query %}
         <p>{% blocktrans with circles=term.circle_plural|default:"circles" %}No {{ circles }} match your search.{% endblocktrans %}</p>
     {% else %}

--- a/templates/clients/_client_list_table.html
+++ b/templates/clients/_client_list_table.html
@@ -14,7 +14,7 @@
 {% include "clients/_client_pagination.html" %}
 
 {% else %}
-<div class="empty-state">
+<div class="empty-state" role="status">
     {% if search_query %}
     <p>{% blocktrans with clients=term.client_plural|default:"participants" query=search_query %}No {{ clients }} found matching "{{ query }}". Try a different name or check the spelling.{% endblocktrans %}</p>
     <a href="{% url 'clients:client_list' %}" role="button">{% trans "Clear search" %}</a>

--- a/templates/clients/_search_results.html
+++ b/templates/clients/_search_results.html
@@ -34,7 +34,7 @@
     </tbody>
 </table>
 {% elif query %}
-<div class="empty-state">
+<div class="empty-state" role="status">
     <p>{% blocktrans with clients=term.client_plural|default:"participants" %}No {{ clients }} match "{{ query }}".{% endblocktrans %}</p>
     {% if can_create %}
     <p><a href="{% url 'clients:client_create' %}" role="button" class="outline small">+ {% blocktrans with client=term.client|default:"Participant" %}New {{ client }}{% endblocktrans %}</a></p>

--- a/templates/clients/custom_fields_admin.html
+++ b/templates/clients/custom_fields_admin.html
@@ -53,12 +53,12 @@
         </tbody>
     </table>
     {% else %}
-    <p class="empty-state">{% trans "No fields in this group yet." %}</p>
+    <p class="empty-state" role="status">{% trans "No fields in this group yet." %}</p>
     {% endif %}
 </article>
 {% endfor %}
 {% else %}
-<div class="empty-state">
+<div class="empty-state" role="status">
     <p>{% trans "No custom field groups defined yet." %}</p>
 </div>
 {% endif %}

--- a/templates/communications/my_messages.html
+++ b/templates/communications/my_messages.html
@@ -13,11 +13,11 @@
         {% include "communications/_my_message_card.html" %}
     {% endfor %}
 {% elif has_any_messages %}
-    <div class="empty-state">
+    <div class="empty-state" role="status">
         <p>{% trans "You're all caught up — no unread messages." %}</p>
     </div>
 {% else %}
-    <div class="empty-state">
+    <div class="empty-state" role="status">
         <p>{% trans "No messages yet." %}</p>
         <p class="secondary">{% blocktrans with worker_term=term.worker_plural|default:"workers" %}Messages from colleagues will appear here when someone leaves a note about a participant you're working with.{% endblocktrans %}</p>
     </div>

--- a/templates/events/_timeline_entries.html
+++ b/templates/events/_timeline_entries.html
@@ -84,7 +84,7 @@
 </button>
 {% endif %}
 {% else %}
-<div class="empty-state">
+<div class="empty-state" role="status">
     {% if active_filter == "events" %}
         <p>{% trans "No events recorded yet." %}</p>
     {% else %}

--- a/templates/events/alert_recommendation_queue.html
+++ b/templates/events/alert_recommendation_queue.html
@@ -34,7 +34,7 @@
 </article>
 {% endfor %}
 {% else %}
-<div class="empty-state">
+<div class="empty-state" role="status">
     <p>{% trans "No pending recommendations." %}</p>
 </div>
 {% endif %}

--- a/templates/events/event_type_list.html
+++ b/templates/events/event_type_list.html
@@ -46,7 +46,7 @@
 </table>
 </figure>
 {% else %}
-<div class="empty-state">
+<div class="empty-state" role="status">
     <p>{% trans "No event types yet. Create one to get started." %}</p>
 </div>
 {% endif %}

--- a/templates/events/sre_category_list.html
+++ b/templates/events/sre_category_list.html
@@ -65,7 +65,7 @@
 </table>
 </figure>
 {% else %}
-<div class="empty-state">
+<div class="empty-state" role="status">
     <p>{% trans "No SRE categories yet. Run the seed command or create one to get started." %}</p>
 </div>
 {% endif %}

--- a/templates/events/sre_report.html
+++ b/templates/events/sre_report.html
@@ -145,7 +145,7 @@
 </table>
 </figure>
 {% else %}
-<div class="empty-state">
+<div class="empty-state" role="status">
     <p>{% trans "No SREs found in the selected date range." %}</p>
 </div>
 {% endif %}

--- a/templates/groups/attendance_hub.html
+++ b/templates/groups/attendance_hub.html
@@ -42,7 +42,7 @@
 </table>
 </figure>
 {% else %}
-<div class="empty-state">
+<div class="empty-state" role="status">
     <p>{% blocktrans with groups=term.group_plural|default:"Groups" %}No active {{ groups }} are available for attendance yet.{% endblocktrans %}</p>
     <a href="{% url 'groups:group_list' %}" role="button" class="outline">{{ term.group_plural|default:"Groups" }}</a>
 </div>

--- a/templates/groups/attendance_report.html
+++ b/templates/groups/attendance_report.html
@@ -99,7 +99,7 @@
 </div>
 </figure>
 {% else %}
-<div class="empty-state">
+<div class="empty-state" role="status">
     <p>{% trans "No attendance data for this date range." %}</p>
 </div>
 {% endif %}

--- a/templates/groups/group_list.html
+++ b/templates/groups/group_list.html
@@ -45,7 +45,7 @@
 </table>
 </figure>
 {% else %}
-<div class="empty-state">
+<div class="empty-state" role="status">
     <p>{% blocktrans with group=term.group|default:"group" %}No {{ group }} records yet.{% endblocktrans %}</p>
     <a href="{% url 'groups:group_create' %}" role="button">{% trans "Create the first one" %}</a>
 </div>

--- a/templates/notes/_tab_notes.html
+++ b/templates/notes/_tab_notes.html
@@ -112,12 +112,12 @@
 {% endif %}
 
 {% elif search_query %}
-<div class="empty-state">
+<div class="empty-state" role="status">
     <p>{% blocktrans with query=search_query %}No notes match "{{ query }}".{% endblocktrans %}</p>
     <a href="{% url 'notes:note_list' client_id=client.pk %}" role="button" class="outline">{% trans "Clear search" %}</a>
 </div>
 {% else %}
-<div class="empty-state">
+<div class="empty-state" role="status">
     <p>{% blocktrans with notes=term.progress_note|default:"notes" %}No {{ notes }} recorded yet.{% endblocktrans %}</p>
     {% if active_service_model != "group" %}
     <p><small>{% trans "Choose the faster Log Contact flow for brief updates, or Detailed Note for a full session note." %}</small></p>

--- a/templates/notes/admin/template_list.html
+++ b/templates/notes/admin/template_list.html
@@ -41,6 +41,6 @@
     </tbody>
 </table>
 {% else %}
-<p class="empty-state">{% trans "No templates created yet." %}</p>
+<p class="empty-state" role="status">{% trans "No templates created yet." %}</p>
 {% endif %}
 {% endblock %}

--- a/templates/notes/note_form.html
+++ b/templates/notes/note_form.html
@@ -226,7 +226,7 @@
     </div>
     {% endfor %}
     {% else %}
-    <p class="empty-state">{% blocktrans with targets=term.target_plural|default:"targets" %}No active {{ targets }} found.{% endblocktrans %} <a href="{% url 'plans:plan_view' client_id=client.pk %}">{% trans "Create a plan" %}</a> {% trans "first." %}</p>
+    <p class="empty-state" role="status">{% blocktrans with targets=term.target_plural|default:"targets" %}No active {{ targets }} found.{% endblocktrans %} <a href="{% url 'plans:plan_view' client_id=client.pk %}">{% trans "Create a plan" %}</a> {% trans "first." %}</p>
     {% endif %}
 
     <details id="session-overall-details" class="session-overall-details"{% if not target_forms %} open{% endif %}>

--- a/templates/notes/qualitative_summary.html
+++ b/templates/notes/qualitative_summary.html
@@ -52,7 +52,7 @@
 </article>
 {% endfor %}
 {% else %}
-<p class="empty-state">{% blocktrans with targets=term.target_plural|default:"targets" %}No active {{ targets }} found.{% endblocktrans %}</p>
+<p class="empty-state" role="status">{% blocktrans with targets=term.target_plural|default:"targets" %}No active {{ targets }} found.{% endblocktrans %}</p>
 {% endif %}
 
 <a href="{% url 'notes:note_list' client_id=client.pk %}" role="button" class="outline secondary">{% trans "Back to notes" %}</a>

--- a/templates/programs/_role_list.html
+++ b/templates/programs/_role_list.html
@@ -52,7 +52,7 @@
 </table>
 </figure>
 {% else %}
-<div class="empty-state">
+<div class="empty-state" role="status">
     <p>{% trans "No staff assigned yet." %}</p>
 </div>
 {% endif %}

--- a/templates/programs/list.html
+++ b/templates/programs/list.html
@@ -69,7 +69,7 @@
 </table>
 </figure>
 {% else %}
-<div class="empty-state">
+<div class="empty-state" role="status">
     <p>{% blocktrans with programs=term.program_plural|default:"programs" %}No {{ programs }} yet.{% endblocktrans %}</p>
 </div>
 {% endif %}

--- a/templates/registration/admin/link_list.html
+++ b/templates/registration/admin/link_list.html
@@ -83,7 +83,7 @@
 </table>
 </figure>
 {% else %}
-<div class="empty-state">
+<div class="empty-state" role="status">
     <p>{% trans "No registration links yet." %}</p>
     <p><a href="{% url 'registration:registration_link_create' %}">{% trans "Create your first registration link" %}</a></p>
 </div>

--- a/templates/registration/admin/submission_list.html
+++ b/templates/registration/admin/submission_list.html
@@ -97,7 +97,7 @@
 </table>
 </figure>
 {% else %}
-<div class="empty-state">
+<div class="empty-state" role="status">
     {% if status_filter %}
     <p>{% blocktrans with status=status_filter %}No {{ status }} submissions.{% endblocktrans %}</p>
     {% else %}

--- a/templates/reports/_insights_client.html
+++ b/templates/reports/_insights_client.html
@@ -5,7 +5,7 @@
 <h2>{% trans "Qualitative Insights" %}</h2>
 
 {% if structured.note_count == 0 %}
-<p class="empty-state">{% trans "No notes recorded yet for this participant." %}</p>
+<p class="empty-state" role="status">{% trans "No notes recorded yet for this participant." %}</p>
 {% else %}
 
 {# Per-goal current status #}

--- a/templates/reports/_tab_analysis.html
+++ b/templates/reports/_tab_analysis.html
@@ -123,7 +123,7 @@
 {{ chart_data|json_script:"chart-data" }}
 {# Chart init moved to app.js — inline scripts break when loaded via HTMX due to CSP nonce mismatch #}
 {% else %}
-    <p class="empty-state">{% trans "No metric data recorded yet. Record metrics through progress notes to see charts here." %}</p>
+    <p class="empty-state" role="status">{% trans "No metric data recorded yet. Record metrics through progress notes to see charts here." %}</p>
 {% endif %}
 
 {# ── Qualitative Insights section ── #}

--- a/templates/surveys/admin/rule_list.html
+++ b/templates/surveys/admin/rule_list.html
@@ -76,7 +76,7 @@
     </tbody>
 </table>
 {% else %}
-<p class="empty-state">{% trans "No trigger rules yet. Create one to automatically assign this survey." %}</p>
+<p class="empty-state" role="status">{% trans "No trigger rules yet. Create one to automatically assign this survey." %}</p>
 {% endif %}
 
 <p><a href="{% url 'survey_manage:survey_detail' survey_id=survey.pk %}">&#8592; {% trans "Back to survey" %}</a></p>

--- a/templates/surveys/admin/survey_detail.html
+++ b/templates/surveys/admin/survey_detail.html
@@ -77,7 +77,7 @@
     </ol>
 </article>
 {% empty %}
-<p class="empty-state">{% trans "No sections yet." %} <a href="{% url 'survey_manage:survey_edit' survey_id=survey.pk %}">{% trans "Add sections" %}</a></p>
+<p class="empty-state" role="status">{% trans "No sections yet." %} <a href="{% url 'survey_manage:survey_edit' survey_id=survey.pk %}">{% trans "Add sections" %}</a></p>
 {% endfor %}
 
 {# Trigger rules #}
@@ -98,7 +98,7 @@
 {% endfor %}
 </ul>
 {% else %}
-<p class="empty-state">{% trans "No trigger rules configured." %}</p>
+<p class="empty-state" role="status">{% trans "No trigger rules configured." %}</p>
 {% endif %}
 <p><a href="{% url 'survey_manage:survey_rules' survey_id=survey.pk %}" role="button" class="outline">{% trans "Manage Rules" %}</a></p>
 

--- a/templates/surveys/admin/survey_links.html
+++ b/templates/surveys/admin/survey_links.html
@@ -85,7 +85,7 @@
     </tbody>
 </table>
 {% else %}
-<p class="empty-state">{% trans "No shareable links yet. Create one below." %}</p>
+<p class="empty-state" role="status">{% trans "No shareable links yet. Create one below." %}</p>
 {% endif %}
 
 {# Create new link form #}

--- a/templates/surveys/admin/survey_list.html
+++ b/templates/surveys/admin/survey_list.html
@@ -54,6 +54,6 @@
     </tbody>
 </table>
 {% else %}
-<p class="empty-state">{% trans "No surveys yet. Create one to get started." %}</p>
+<p class="empty-state" role="status">{% trans "No surveys yet. Create one to get started." %}</p>
 {% endif %}
 {% endblock %}

--- a/templates/surveys/admin/survey_questions.html
+++ b/templates/surveys/admin/survey_questions.html
@@ -71,7 +71,7 @@
     {% endfor %}
     </ol>
     {% else %}
-    <p class="empty-state">{% trans "No questions in this section yet." %}</p>
+    <p class="empty-state" role="status">{% trans "No questions in this section yet." %}</p>
     {% endif %}
 
     {# Add a question to this section #}
@@ -118,6 +118,6 @@ Strongly disagree' %}"></textarea>
     </details>
 </article>
 {% empty %}
-<p class="empty-state">{% trans "This survey has no sections." %} <a href="{% url 'survey_manage:survey_edit' survey_id=survey.pk %}">{% trans "Add sections first" %}</a>.</p>
+<p class="empty-state" role="status">{% trans "This survey has no sections." %} <a href="{% url 'survey_manage:survey_edit' survey_id=survey.pk %}">{% trans "Add sections first" %}</a>.</p>
 {% endfor %}
 {% endblock %}

--- a/templates/surveys/client_surveys.html
+++ b/templates/surveys/client_surveys.html
@@ -109,6 +109,6 @@
 {% endif %}
 
 {% if not assignments and not responses %}
-<p class="empty-state">{% trans "No surveys assigned or completed yet." %}</p>
+<p class="empty-state" role="status">{% trans "No surveys assigned or completed yet." %}</p>
 {% endif %}
 {% endblock %}


### PR DESCRIPTION
Added `role="status"` to `.empty-state` containers across templates to ensure screen readers dynamically announce empty data states.

---
*PR created automatically by Jules for task [14694446823621840458](https://jules.google.com/task/14694446823621840458) started by @pboachie*