### PR TITLE
docs(EVAL-DOCS): Evaluation export guide + cross-references

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -104,8 +104,7 @@ Step-by-step commands for each task are in [tasks/recurring-tasks.md](tasks/recu
 
 **Code & UI:** ✅ All done — see Recently Done.
 
-**Documentation:**
-- [ ] Evaluation export documentation bundle — ED-facing one-pager (`docs/evaluation-export-guide.md`) as the primary deliverable, plus short cross-reference sections in `docs/admin/reporting.md`, `docs/help.md`, and `tasks/agency-permissions-interview.md` Section 7 pointing to the one-pager. (EVAL-DOCS)
+**Documentation:** ✅ Done — see Recently Done.
 
 ### Phase: Longitudinal Trajectory Export (LTE) — see tasks/phase-lte-prompt.md
 
@@ -138,6 +137,7 @@ Not yet clear we should build these, or the design isn't settled. May be too com
 
 ## Recently Done
 
+- [x] Evaluation export documentation bundle — ED-facing one-pager (`docs/evaluation-export-guide.md`) + cross-references in admin reporting guide, help page, and agency permissions interview (Section 7.4) — 2026-04-10 (EVAL-DOCS)
 - [x] Pipeline test suite for `deidentify.py` — 75 safety-critical tests covering consent filtering, PII stripping, study IDs, age bands, geography, k-anonymity, population thresholds, suppression ceiling, CSV format, full integration — 2026-04-10 (EVAL-GOV7)
 - [x] Wire up `is_evaluation_exportable` custom field groups — form dynamically queries `CustomFieldGroup.is_evaluation_exportable` and adds QI column checkboxes; 2 tests — 2026-04-10 (EVAL-GOV6)
 - [x] Export history view with agreement-expiry banner — lists past evaluation exports with evaluator info, status (active/expired/revoked), expired agreement warning banner; nav entry; 8 tests — 2026-04-10 (EVAL-GOV-HISTORY)

--- a/docs/admin/reporting.md
+++ b/docs/admin/reporting.md
@@ -132,6 +132,21 @@ This gives more accurate reporting — paused goals aren't counted as failures o
 
 ---
 
+## Evaluation Microdata Export
+
+The Evaluation Microdata Export (EME) lets designated staff generate a de-identified CSV file for an external evaluator. The system automatically removes identifying information and enforces k-anonymity (k ≥ 5) so that no participant can be singled out from their demographic profile.
+
+**Key points for administrators:**
+
+- Permission is granted per-user through **Admin → Evaluator Export Access**. There is no admin bypass — even administrators need an explicit grant.
+- Programs must have at least 15 participants with outcome data in the selected period. Smaller programs should use [LTE](../lte-privacy-officer-guide.md) instead.
+- Each export records the evaluator's name, organisation, and data-sharing agreement expiry date in the audit log.
+- The **Export History** page (Reports → Export History) lists all past evaluation exports and shows a warning banner when an agreement has expired.
+
+For the full step-by-step guide (intended for EDs and program managers), see [Evaluation Export Guide](../evaluation-export-guide.md).
+
+---
+
 ## Longitudinal Trajectory Export (small-population evaluation)
 
 LTE is a second, structurally separate export tier for programs with

--- a/docs/evaluation-export-guide.md
+++ b/docs/evaluation-export-guide.md
@@ -1,0 +1,103 @@
+# Evaluation Export Guide
+
+This guide is for **executive directors and program managers** — the people who approve, generate, and deliver de-identified evaluation data to external evaluators.
+
+The Evaluation Microdata Export (EME) produces a de-identified CSV file that an external evaluator can use for outcome analysis. All identifying information is removed automatically, and the system blocks the export if privacy thresholds cannot be met.
+
+The full technical rationale is in [`tasks/design-rationale/evaluation-microdata-export.md`](../tasks/design-rationale/evaluation-microdata-export.md).
+
+---
+
+## Before you begin
+
+Make sure these are in place:
+
+1. **A signed data-sharing agreement (DSA)** between your agency and the evaluator, specifying what data will be shared, how long the evaluator may keep it, and when they must delete it.
+2. **An evaluator with confirmed credentials** — name, organisation, email, and purpose of the evaluation.
+3. **A KoNote admin has granted you the Evaluator Export permission** — this is done through **Admin → Evaluator Export Access**. Without the grant, you will see a 403 error. No one, including administrators, can bypass this step.
+4. **The program has at least 15 participants** with outcome data in the selected period. Programs below this threshold are blocked because demographic privacy cannot be guaranteed. For smaller programs, see [LTE (small-population evaluation)](lte-privacy-officer-guide.md).
+
+---
+
+## How to generate an export
+
+1. Go to **Reports → Evaluator Export (Confidential)**.
+2. Choose the **program**, **start date**, and **end date**.
+3. Fill in the **evaluator details**: name, organisation, email, purpose, and agreement expiry date.
+4. Select which **demographic columns** (quasi-identifiers) to include. Fewer columns means stronger privacy — only include what the evaluator actually needs.
+5. Click **Preview**.
+
+### Understanding the preview
+
+The preview shows you:
+
+- **Participant count** — how many people are included after consent filtering.
+- **Suppression report** — how many records were removed or generalised to protect privacy. If more than 15% of records had to be suppressed, the export is blocked entirely.
+- **K-anonymity score** — the minimum number of people who share the same combination of demographic values. KoNote requires k ≥ 5 (meaning every person's demographic profile matches at least 4 others).
+
+If the preview passes all checks, click **Confirm and generate**. If it fails, the system will explain why and suggest reducing the number of demographic columns.
+
+### Download and delivery
+
+After confirming, KoNote creates a secure download link that is **available for 24 hours**. Large exports (100+ participants or exports that include clinical notes) have a **10-minute delay** before the download link becomes active — this gives administrators a chance to review the export before it can be downloaded.
+
+**How to deliver the file to the evaluator:**
+
+- Use **encrypted email** or a **secure file transfer service** (e.g., your agency's secure SharePoint, Google Drive with restricted access, or an encrypted ZIP).
+- **Do not** send the CSV as a plain email attachment. The data is de-identified, but it still contains sensitive program information.
+- Note the **agreement expiry date** you entered — KoNote will display a warning banner on the Export History page when this date passes.
+
+---
+
+## After the evaluation
+
+When the evaluator's work is complete:
+
+1. **Confirm the evaluator has deleted the data** in accordance with your data-sharing agreement.
+2. **Check Export History** (Reports → Export History) — look for any exports with an expired agreement. Follow up with evaluators whose agreements have lapsed.
+3. If an evaluator should no longer receive data, ask your admin to **revoke their export access** through Admin → Evaluator Export Access.
+
+---
+
+## What the evaluator receives
+
+The CSV file contains one row per participant with:
+
+| Column type | Example | Notes |
+|---|---|---|
+| **Study ID** | `a3f9c1b2` | Randomly generated per export — cannot be linked back to a real person |
+| **Demographic columns** | Age band, gender, geography | Generalised (e.g., "25–29" not exact age, "Urban" not postal code) |
+| **Metric scores** | `Confidence: 4.0` | Raw scale values for selected metrics |
+| **Enrolment quarter** | `2025-Q3` | When the participant started the program (quarter, not exact date) |
+
+**What is NOT in the file:** names, dates of birth, addresses, phone numbers, email addresses, case notes, worker names, or anything that could identify a specific person.
+
+**Suppression notation:** If a cell has been suppressed for privacy, it appears as an empty value. The suppression report (included separately) tells the evaluator how many records were affected and why.
+
+---
+
+## What to tell the evaluator
+
+Share these points when you deliver the file:
+
+1. **Study IDs are random** — they change with every export and cannot be linked across exports or back to real people.
+2. **Demographic values are generalised** — age is in 5-year bands, geography is Urban/Rural, not specific locations.
+3. **Some records may be suppressed** — if including a record would make someone identifiable, it is removed. The suppression report explains how many and why.
+4. **Data must be deleted** by the date in your agreement. KoNote tracks this date and will flag it if it passes.
+5. **Do not attempt to re-identify participants.** This violates PHIPA and your data-sharing agreement.
+
+---
+
+## Quick reference
+
+| Item | Detail |
+|---|---|
+| Where to find it | Reports → Evaluator Export (Confidential) |
+| Permission required | `report.evaluation_export` (granted by admin) |
+| Minimum program size | 15 participants with outcome data |
+| Privacy standard | k-anonymity ≥ 5, suppression ceiling 15% |
+| Download window | 24 hours |
+| Smaller programs | Use [LTE](lte-privacy-officer-guide.md) (requires separate permission + REB) |
+| Export history | Reports → Export History |
+| Agreement expiry tracking | Entered at export time; banner warns when expired |
+| Related admin guide | [Reporting admin guide](admin/reporting.md) |

--- a/docs/help.md
+++ b/docs/help.md
@@ -17,6 +17,7 @@ Welcome to KoNote! This guide helps you find what you need quickly.
 | View or edit a client's plan | [Outcome Plans](#outcome-plans) |
 | See progress charts | [Analysis and Reports](#analysis-and-reports) |
 | See program patterns | [Outcome Insights](#outcome-insights) |
+| Generate data for an evaluator | [Evaluation Export](#evaluation-export-confidential) |
 | Invite a participant to the portal | [Portal Staff Management](#portal-staff-management) |
 | Review registration submissions | [Registration Forms](#registration-forms) |
 | Change my password | [Account Settings](#account-settings) |
@@ -479,6 +480,20 @@ Reports now automatically include episode-level statistics — such as total ser
 - **PDF Reports** — Generate printable progress reports
 
 Find export options under **Reports** in the main navigation.
+
+### Evaluation Export (Confidential)
+
+If you have been granted the Evaluator Export permission, you can generate a de-identified data file for an external evaluator:
+
+1. Go to **Reports → Evaluator Export (Confidential)**
+2. Choose the program, time period, and evaluator details
+3. Select which demographic columns to include
+4. Preview — the system checks that privacy thresholds are met
+5. Confirm — a secure 24-hour download link is created
+
+The Export History page (Reports → Export History) lists all past exports and warns you when a data-sharing agreement has expired.
+
+For the full guide, see [Evaluation Export Guide](evaluation-export-guide.md).
 
 ---
 

--- a/tasks/agency-permissions-interview.md
+++ b/tasks/agency-permissions-interview.md
@@ -495,6 +495,18 @@ KoNote has features that can be turned on or off for each agency. Walk through t
 | Who receives export notifications? | Default (admins) / Specific people | |
 | Email addresses (if specific) | | |
 
+**7.4** "Does your agency work with external evaluators who need participant-level outcome data? If so, we can enable the Evaluation Export feature — it produces a de-identified data file that removes all identifying information and enforces statistical privacy thresholds before the file can be downloaded."
+
+*If yes: explain that a designated staff member (typically the ED or program manager) will need the Evaluator Export permission. The permission is granted per-person through Admin → Evaluator Export Access — there's no blanket admin access. Point them to the [Evaluation Export Guide](../docs/evaluation-export-guide.md) for the full walkthrough.*
+
+*If the agency has programs with fewer than 15 participants, mention the [LTE tier](../docs/lte-privacy-officer-guide.md) as a separate, higher-friction option.*
+
+| Evaluation Export Decision | Choice | Notes |
+|---|---|---|
+| Enable Evaluation Export? | Yes / No | |
+| Who should receive the permission? | | (name and role) |
+| Any programs with fewer than 15 participants? | Yes / No | If yes, discuss LTE |
+
 *What this means: You've chosen which KoNote features to turn on and who gets notified when data is exported. Your system will only include the tools your agency actually needs.*
 
 ---


### PR DESCRIPTION
## What this PR does

**EVAL-DOCS** — the documentation deliverable for the Evaluation Export Governance phase.

### New file: docs/evaluation-export-guide.md
ED-facing one-pager covering:
- Prerequisites (DSA, evaluator credentials, permission grant, minimum program size)
- Step-by-step export generation with preview interpretation
- Secure delivery guidance
- Post-evaluation cleanup (confirm deletion, check expired agreements)
- What the evaluator receives (CSV format, suppression, study IDs)
- What to tell the evaluator (5 key points)
- Quick reference table

### Cross-references added
- **docs/admin/reporting.md** — new EME section above the existing LTE section
- **docs/help.md** — Evaluation Export subsection under Exporting Data + Quick Navigation entry
- **tasks/agency-permissions-interview.md** — new question 7.4 about evaluation export during agency onboarding