### PR TITLE
🎨 Palette: Add role="status" to empty states for accessibility

### DIFF
--- a/apps/portal/templates/portal/goals.html
+++ b/apps/portal/templates/portal/goals.html
@@ -42,7 +42,7 @@
 {% endfor %}
 
 {% else %}
-<article class="portal-empty-state">
+<article class="portal-empty-state" role="status">
     <p>{% blocktrans with worker_term=term.worker %}No goals have been added yet. Your {{ worker_term }} will add goals as you work on them together.{% endblocktrans %}</p>
 </article>
 {% endif %}

--- a/apps/portal/templates/portal/journal.html
+++ b/apps/portal/templates/portal/journal.html
@@ -34,7 +34,7 @@
 </div>
 
 {% else %}
-<article class="portal-empty-state">
+<article class="portal-empty-state" role="status">
     <p>{% trans "Your journal is empty. Whenever you feel like writing something down, this is the place." %}</p>
 </article>
 {% endif %}

--- a/apps/portal/templates/portal/milestones.html
+++ b/apps/portal/templates/portal/milestones.html
@@ -40,7 +40,7 @@
 </div>
 
 {% else %}
-<article class="portal-empty-state">
+<article class="portal-empty-state" role="status">
     <p>{% trans "No milestones yet — but you're on your way! Milestones will show up here as you reach your goals." %}</p>
 </article>
 {% endif %}

--- a/apps/portal/templates/portal/my_words.html
+++ b/apps/portal/templates/portal/my_words.html
@@ -45,7 +45,7 @@
 </div>
 
 {% else %}
-<article class="portal-empty-state">
+<article class="portal-empty-state" role="status">
     <p>{% trans "Nothing here yet. When you share your thoughts during sessions, they'll appear here so you can look back on them." %}</p>
 </article>
 {% endif %}

--- a/apps/portal/templates/portal/progress.html
+++ b/apps/portal/templates/portal/progress.html
@@ -12,7 +12,7 @@
     {# Charts are rendered by JavaScript from the data below #}
 </div>
 {% else %}
-<article class="portal-empty-state">
+<article class="portal-empty-state" role="status">
     <p>{% blocktrans with worker_term=term.worker %}No progress data to show yet. As you work with your {{ worker_term }}, your progress will appear here.{% endblocktrans %}</p>
 </article>
 {% endif %}

--- a/templates/clients/erasure/erasure_history.html
+++ b/templates/clients/erasure/erasure_history.html
@@ -68,7 +68,7 @@
 {% endif %}
 
 {% else %}
-<div class="empty-state empty-state--erasure">
+<div class="empty-state empty-state--erasure" role="status">
     <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" style="opacity: 0.45; margin-bottom: 0.5rem;"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="m9 12 2 2 4-4"/></svg>
     <p>{% trans "No erasure requests have been made." %}</p>
 </div>

--- a/templates/clients/erasure/erasure_pending_list.html
+++ b/templates/clients/erasure/erasure_pending_list.html
@@ -61,7 +61,7 @@
     </table>
 </figure>
 {% else %}
-<div class="empty-state empty-state--erasure">
+<div class="empty-state empty-state--erasure" role="status">
     <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" style="opacity: 0.45; margin-bottom: 0.5rem;"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="m9 12 2 2 4-4"/></svg>
     <p>{% trans "No pending erasure requests." %}</p>
 </div>


### PR DESCRIPTION
**💡 What:** Added `role="status"` to missing `.empty-state` and `.portal-empty-state` variants.
**🎯 Why:** Without `role="status"`, screen readers do not dynamically announce when lists or sections are cleared or have no content, which can leave visually impaired users unaware of the UI's current state.
**📸 Before/After:** Visual appearance is unchanged (validated via screenshot/Playwright).
**♿ Accessibility:** Turns empty state messages into polite live regions.

---
*PR created automatically by Jules for task [1723369946042889577](https://jules.google.com/task/1723369946042889577) started by @pboachie*