### PR TITLE
🎨 Palette: Improve screen reader accessibility of erasure empty states

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -9,3 +9,6 @@
 ## 2025-03-10 - Add Contextual ARIA Labels to Action Buttons in Lists
 **Learning:** Action buttons like "Approve" and "Dismiss" in dynamically generated lists (like survey assignments) lack context for screen readers when they don't explicitly reference the target item. A user tabbing through the page would hear "Approve, button", "Dismiss, button", etc., multiple times without knowing *what* is being approved.
 **Action:** Always add descriptive `aria-label` attributes to generic action buttons inside iterative loops, using `{% blocktrans %}` to include the item's name dynamically (e.g., `aria-label="{% blocktrans with name=a.survey.name %}Approve {{ name }}{% endblocktrans %}"`).
+## 2024-04-12 - Ensure empty states are announced to screen readers
+**Learning:** Empty states in UI components (like `<div class="empty-state">`) convey important status information visually but are often missed by screen readers when updated dynamically.
+**Action:** When creating or updating empty states, always append `role="status"` to ensure screen readers announce these state changes.

--- a/templates/clients/erasure/erasure_history.html
+++ b/templates/clients/erasure/erasure_history.html
@@ -68,7 +68,7 @@
 {% endif %}
 
 {% else %}
-<div class="empty-state empty-state--erasure">
+<div class="empty-state empty-state--erasure" role="status">
     <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" style="opacity: 0.45; margin-bottom: 0.5rem;"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="m9 12 2 2 4-4"/></svg>
     <p>{% trans "No erasure requests have been made." %}</p>
 </div>

--- a/templates/clients/erasure/erasure_pending_list.html
+++ b/templates/clients/erasure/erasure_pending_list.html
@@ -61,7 +61,7 @@
     </table>
 </figure>
 {% else %}
-<div class="empty-state empty-state--erasure">
+<div class="empty-state empty-state--erasure" role="status">
     <svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" width="48" height="48" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" style="opacity: 0.45; margin-bottom: 0.5rem;"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/><path d="m9 12 2 2 4-4"/></svg>
     <p>{% trans "No pending erasure requests." %}</p>
 </div>


### PR DESCRIPTION
**💡 What**: Added `role="status"` to the `<div class="empty-state empty-state--erasure">` elements in the erasure history and pending list views.
**🎯 Why**: Without this role, screen readers may fail to announce these "no data" states when they are dynamically updated or loaded. Adding this semantic ARIA role ensures visually impaired users receive the correct status feedback.
**♿ Accessibility**: Defines the empty states as status messages so they are read aloud by screen reading technologies.

---
*PR created automatically by Jules for task [13628766593347853934](https://jules.google.com/task/13628766593347853934) started by @pboachie*