### PR TITLE
🎨 Palette: Add auto-selection to copyable inputs

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -9,3 +9,6 @@
 ## 2025-03-10 - Add Contextual ARIA Labels to Action Buttons in Lists
 **Learning:** Action buttons like "Approve" and "Dismiss" in dynamically generated lists (like survey assignments) lack context for screen readers when they don't explicitly reference the target item. A user tabbing through the page would hear "Approve, button", "Dismiss, button", etc., multiple times without knowing *what* is being approved.
 **Action:** Always add descriptive `aria-label` attributes to generic action buttons inside iterative loops, using `{% blocktrans %}` to include the item's name dynamically (e.g., `aria-label="{% blocktrans with name=a.survey.name %}Approve {{ name }}{% endblocktrans %}"`).
+## 2025-03-10 - Add `data-select-on-click` to Copyable Text Inputs
+**Learning:** For read-only inputs containing shareable URLs (e.g. calendar feed, direct registration link), requiring users to manually highlight the text before copying can be frustrating and error-prone. The codebase already supports an accessible `data-select-on-click="true"` pattern used in invite links.
+**Action:** Consistently apply the `data-select-on-click="true"` attribute to all read-only `input` elements designated for copying, ensuring users can instantly select the full value with a single click.

--- a/templates/events/calendar_feed_settings.html
+++ b/templates/events/calendar_feed_settings.html
@@ -15,7 +15,7 @@
     <h2>{% trans "Your calendar link" %}</h2>
     <p>{% trans "Copy this link and paste it into your calendar app using the steps below." %}</p>
     <div role="group">
-        <input type="text" id="feed-url" value="{{ feed_url }}" readonly aria-label="{% trans 'Calendar link' %}">
+        <input type="text" id="feed-url" value="{{ feed_url }}" readonly aria-label="{% trans 'Calendar link' %}" data-select-on-click="true">
         <button type="button" class="outline copy-btn" data-clipboard-target="feed-url" aria-label="{% trans 'Copy calendar link' %}">{% trans "Copy" %}</button>
     </div>
 
@@ -23,7 +23,7 @@
     <h3 style="margin-top: 1.5rem;">{% trans "Outlook link" %}</h3>
     <p>{% trans "Outlook sometimes needs a different format. If the link above doesn't work in Outlook, try this one instead." %}</p>
     <div role="group">
-        <input type="text" id="outlook-url" value="{{ outlook_subscribe_url }}" readonly aria-label="{% trans 'Outlook calendar link' %}">
+        <input type="text" id="outlook-url" value="{{ outlook_subscribe_url }}" readonly aria-label="{% trans 'Outlook calendar link' %}" data-select-on-click="true">
         <button type="button" class="outline copy-btn" data-clipboard-target="outlook-url" aria-label="{% trans 'Copy Outlook link' %}">{% trans "Copy" %}</button>
     </div>
     {% endif %}

--- a/templates/registration/admin/link_embed.html
+++ b/templates/registration/admin/link_embed.html
@@ -55,6 +55,7 @@
                    id="direct-url"
                    value="{{ direct_url }}"
                    readonly
+                   data-select-on-click="true"
                    style="padding-right: 5rem;">
             <button type="button"
                     class="copy-btn"

--- a/templates/reports/export_link_created.html
+++ b/templates/reports/export_link_created.html
@@ -101,6 +101,7 @@
                 value="{{ download_url }}"
                 readonly
                 aria-label="{% trans 'Shareable download URL' %}"
+                data-select-on-click="true"
                 style="font-family: monospace; font-size: 0.85rem;"
             >
             <button

--- a/templates/surveys/admin/survey_links.html
+++ b/templates/surveys/admin/survey_links.html
@@ -60,6 +60,7 @@
                                readonly
                                value="{{ request.scheme }}://{{ request.get_host }}/s/{{ link.token }}/"
                                aria-label="{% trans 'Survey link URL' %}"
+                               data-select-on-click="true"
                                style="margin-bottom:0">
                         <button type="button" class="outline secondary copy-btn"
                                 data-clipboard-text="{{ request.scheme }}://{{ request.get_host }}/s/{{ link.token }}/"


### PR DESCRIPTION
💡 What: Added the `data-select-on-click="true"` attribute to several read-only inputs displaying shareable URLs across the app (calendar feed links, registration direct links, export download links, and survey links).

🎯 Why: To improve usability. When a user wants to select a link, requiring them to click and manually drag to highlight text is tedious and prone to errors. This change utilizes an existing frontend JS pattern (from `static/js/app.js`) to select all text inside the input automatically upon clicking it, streamlining the copy-paste workflow.

♿ Accessibility: Ensures that keyboard users and mouse users can select text more easily, reducing the required precision for dragging.

---
*PR created automatically by Jules for task [11363964920908643558](https://jules.google.com/task/11363964920908643558) started by @pboachie*