### PR TITLE
🛡️ Sentinel: [HIGH] Fix CSRF vulnerability on login endpoints

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,8 @@
 **Vulnerability:** XSS risk due to modifying the DOM using `.innerHTML` with potentially dynamic or unescaped translated values in `static/js/app.js`.
 **Learning:** `innerHTML` exposes a risk of executing unescaped input or malformed HTML translations. Instead of clearing nodes with `.innerHTML = ""` or creating nested HTML structures via strings, safer programmatic node manipulation should be utilized.
 **Prevention:** Use `.textContent` for assigning simple text to elements. Use programmatic DOM creation methods like `document.createElement` and `node.appendChild` instead of injecting raw HTML strings into `.innerHTML`. To clear an element, loop through and use `removeChild` on its children (e.g. `while (el.firstChild) el.removeChild(el.firstChild);`).
+
+## 2024-10-25 - [Removed CSRF Exemption on Login Endpoints]
+**Vulnerability:** Explicit `@csrf_exempt` decorators on demo login endpoints (`demo_login`, `demo_portal_login`) allowed them to bypass Django's cross-site request forgery protection, creating a risk of Login CSRF attacks.
+**Learning:** Even demo or local environment forms need CSRF protections. In this case, `{% csrf_token %}` was already present in the templates, so removing `@csrf_exempt` correctly secured these endpoints without breaking functionality.
+**Prevention:** Avoid `@csrf_exempt` on authentication endpoints. Always ensure forms in `templates/auth/login.html` (and similar auth templates) include `{% csrf_token %}`.

--- a/apps/auth_app/views.py
+++ b/apps/auth_app/views.py
@@ -7,7 +7,6 @@ from django.contrib.auth.decorators import login_required
 from django.core.cache import cache
 from django.http import HttpResponse, HttpResponseNotAllowed
 from django.shortcuts import redirect, render
-from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 from django.utils import timezone
 from django.utils import translation
@@ -340,7 +339,6 @@ def azure_callback(request):
     return _set_language_cookie(response, lang_code)
 
 
-@csrf_exempt
 @require_POST
 @ratelimit(key="ip", rate="10/m", method=["POST"], block=True)
 def demo_login(request, role):
@@ -383,7 +381,6 @@ def demo_login(request, role):
     return _set_language_cookie(response, lang_code)
 
 
-@csrf_exempt
 @require_POST
 @ratelimit(key="ip", rate="10/m", method=["POST"], block=True)
 def demo_portal_login(request, record_id):


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Explicit `@csrf_exempt` decorators on POST-based login endpoints (`demo_login`, `demo_portal_login`) bypassed Django's cross-site request forgery protection.
🎯 Impact: This created a risk of Login CSRF attacks where an attacker could forge a login request and force the victim into the attacker's account or a demo account.
🔧 Fix: Removed the `@csrf_exempt` decorators (and unused import) from `apps/auth_app/views.py`. Verified that the template (`templates/auth/login.html`) already includes `{% csrf_token %}` in the relevant forms. Also added the finding to `.jules/sentinel.md`.
✅ Verification: Ran `python -m pytest tests/test_auth_views.py` and `python -m pytest tests/ux_walkthrough/` to confirm that tests pass and the login pages still function correctly with CSRF protection enabled.

---
*PR created automatically by Jules for task [9510468493113171102](https://jules.google.com/task/9510468493113171102) started by @pboachie*