### PR TITLE
🛡️ Sentinel: [HIGH] Fix Login CSRF on demo login endpoints

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,8 @@
 **Vulnerability:** XSS risk due to modifying the DOM using `.innerHTML` with potentially dynamic or unescaped translated values in `static/js/app.js`.
 **Learning:** `innerHTML` exposes a risk of executing unescaped input or malformed HTML translations. Instead of clearing nodes with `.innerHTML = ""` or creating nested HTML structures via strings, safer programmatic node manipulation should be utilized.
 **Prevention:** Use `.textContent` for assigning simple text to elements. Use programmatic DOM creation methods like `document.createElement` and `node.appendChild` instead of injecting raw HTML strings into `.innerHTML`. To clear an element, loop through and use `removeChild` on its children (e.g. `while (el.firstChild) el.removeChild(el.firstChild);`).
+
+## 2024-04-17 - [Login CSRF Risk on Demo Endpoints]
+**Vulnerability:** The `demo_login` and `demo_portal_login` views were annotated with `@csrf_exempt` in `apps/auth_app/views.py`. This allowed an attacker to potentially trick a user's browser into logging them in as a demo user (Login CSRF).
+**Learning:** Even though they are demo endpoints, authentication boundaries must be protected from Login CSRF. Since the UI in `templates/auth/login.html` renders these demo forms using `{% csrf_token %}`, exempting these endpoints from CSRF protection is unnecessary and introduces a vulnerability.
+**Prevention:** Avoid using `@csrf_exempt` on authentication boundaries (e.g., login, invite accept, password reset) unless absolutely required by an external system callback, as it introduces Login CSRF vulnerabilities.

--- a/apps/auth_app/views.py
+++ b/apps/auth_app/views.py
@@ -7,7 +7,7 @@ from django.contrib.auth.decorators import login_required
 from django.core.cache import cache
 from django.http import HttpResponse, HttpResponseNotAllowed
 from django.shortcuts import redirect, render
-from django.views.decorators.csrf import csrf_exempt
+
 from django.views.decorators.http import require_POST
 from django.utils import timezone
 from django.utils import translation
@@ -340,7 +340,6 @@ def azure_callback(request):
     return _set_language_cookie(response, lang_code)
 
 
-@csrf_exempt
 @require_POST
 @ratelimit(key="ip", rate="10/m", method=["POST"], block=True)
 def demo_login(request, role):
@@ -383,7 +382,6 @@ def demo_login(request, role):
     return _set_language_cookie(response, lang_code)
 
 
-@csrf_exempt
 @require_POST
 @ratelimit(key="ip", rate="10/m", method=["POST"], block=True)
 def demo_portal_login(request, record_id):


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The demo login endpoints (`demo_login` and `demo_portal_login`) were explicitly bypassing CSRF protection using `@csrf_exempt`.
🎯 **Impact:** An attacker could exploit this by embedding a malicious form on a third-party site and auto-submitting it, forcing a user to unwittingly log into a demo account (Login CSRF). This violates the authentication boundary principle.
🔧 **Fix:** Removed the `@csrf_exempt` decorators from the demo login views in `apps/auth_app/views.py`, allowing the default CSRF middleware to enforce token validation. The frontend HTML forms already correctly implemented the CSRF token.
✅ **Verification:** Verified that tests pass via `python -m pytest tests/test_security.py tests/test_auth_views.py tests/test_demo_data_separation.py`.

---
*PR created automatically by Jules for task [13332948134133536386](https://jules.google.com/task/13332948134133536386) started by @pboachie*