### PR TITLE
🎨 Palette: Add aria-pressed state to metric toggle buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -12,3 +12,7 @@
 ## 2025-03-10 - Add `data-select-on-click` to Copyable Text Inputs
 **Learning:** For read-only inputs containing shareable URLs (e.g. calendar feed, direct registration link), requiring users to manually highlight the text before copying can be frustrating and error-prone. The codebase already supports an accessible `data-select-on-click="true"` pattern used in invite links.
 **Action:** Consistently apply the `data-select-on-click="true"` attribute to all read-only `input` elements designated for copying, ensuring users can instantly select the full value with a single click.
+
+## 2024-04-16 - Add ARIA pressed state for metric toggle buttons
+**Learning:** HTMX toggle buttons (like the plan metric toggle) need explicit `aria-pressed="true|false"` to communicate their active state correctly to screen readers. Relying solely on changing the `aria-label` or visible text does not provide native toggle semantics.
+**Action:** When creating or fixing toggle-style buttons, always use `aria-pressed="{{ boolean_value|yesno:'true,false' }}"` to represent the binary state.

--- a/templates/plans/_metric_toggle.html
+++ b/templates/plans/_metric_toggle.html
@@ -3,6 +3,7 @@
         hx-target="#metric-toggle-{{ metric.pk }}"
         hx-swap="innerHTML"
         class="outline small {% if metric.is_enabled %}contrast{% else %}secondary{% endif %}"
+        aria-pressed="{{ metric.is_enabled|yesno:'true,false' }}"
         aria-label="{% if metric.is_enabled %}{% blocktrans with name=metric.name %}Disable {{ name }}{% endblocktrans %}{% else %}{% blocktrans with name=metric.name %}Enable {{ name }}{% endblocktrans %}{% endif %}">
     {% if metric.is_enabled %}{% trans "Enabled" %}{% else %}{% trans "Disabled" %}{% endif %}
 </button>


### PR DESCRIPTION
🎨 **Palette: UX Improvement**

💡 **What:** Added the `aria-pressed` attribute to the metric toggle buttons on plan targets.
🎯 **Why:** To improve accessibility for screen reader users by providing native toggle button semantics, making the active/inactive state explicit instead of relying solely on changing the `aria-label` or visible text.
📸 **Before/After:** The visual appearance remains identical, but the underlying HTML structure now accurately reflects a toggle component.
♿ **Accessibility:** Added native ARIA state (`aria-pressed="true|false"`) via Django's `yesno` filter to properly convey component state.

---
*PR created automatically by Jules for task [2612584476211305706](https://jules.google.com/task/2612584476211305706) started by @pboachie*