### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix missing encryption for existing survey responses

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,7 @@
 **Vulnerability:** XSS risk due to modifying the DOM using `.innerHTML` with potentially dynamic or unescaped translated values in `static/js/app.js`.
 **Learning:** `innerHTML` exposes a risk of executing unescaped input or malformed HTML translations. Instead of clearing nodes with `.innerHTML = ""` or creating nested HTML structures via strings, safer programmatic node manipulation should be utilized.
 **Prevention:** Use `.textContent` for assigning simple text to elements. Use programmatic DOM creation methods like `document.createElement` and `node.appendChild` instead of injecting raw HTML strings into `.innerHTML`. To clear an element, loop through and use `removeChild` on its children (e.g. `while (el.firstChild) el.removeChild(el.firstChild);`).
+## 2026-04-18 - [Incorrect Encryption Key Check in Migration]
+**Vulnerability:** The migration file `apps/surveys/migrations/0010_encrypt_respondent_name.py` checked for the environment variable `FERNET_KEY` instead of the actual key `FIELD_ENCRYPTION_KEY` used by the application.
+**Learning:** This caused the migration to silently skip encrypting sensitive data in production because the expected environment variable was missing, leaving the data in plaintext.
+**Prevention:** Always verify that environment variable names used in setup or migration scripts match the ones defined in the configuration (e.g. `settings/base.py`).

--- a/apps/surveys/migrations/0010_encrypt_respondent_name.py
+++ b/apps/surveys/migrations/0010_encrypt_respondent_name.py
@@ -6,7 +6,7 @@ from konote.encryption import DecryptionError, decrypt_field, encrypt_field
 
 
 def encrypt_existing_respondent_names(apps, schema_editor):
-    if not os.environ.get("FERNET_KEY"):
+    if not os.environ.get("FIELD_ENCRYPTION_KEY"):
         # No encryption key available (CI/test). Skip — no real data to encrypt.
         return
     SurveyResponse = apps.get_model("surveys", "SurveyResponse")
@@ -18,7 +18,7 @@ def encrypt_existing_respondent_names(apps, schema_editor):
 
 
 def decrypt_existing_respondent_names(apps, schema_editor):
-    if not os.environ.get("FERNET_KEY"):
+    if not os.environ.get("FIELD_ENCRYPTION_KEY"):
         return
     SurveyResponse = apps.get_model("surveys", "SurveyResponse")
     for response in SurveyResponse.objects.exclude(_respondent_name_encrypted=b"").iterator():


### PR DESCRIPTION
Fix incorrect encryption key check in survey migration

The migration 0010_encrypt_respondent_name.py was checking for `FERNET_KEY`
instead of `FIELD_ENCRYPTION_KEY`, causing it to silently skip encrypting
existing respondent names when run in production. This PR updates the
variable check to use the correct key name, matching the rest of the
application.

---
*PR created automatically by Jules for task [12291745977964359893](https://jules.google.com/task/12291745977964359893) started by @pboachie*