### PR TITLE
🛡️ Sentinel: [HIGH] Fix Login CSRF on Demo Endpoints

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,8 @@
 **Vulnerability:** XSS risk due to modifying the DOM using `.innerHTML` with potentially dynamic or unescaped translated values in `static/js/app.js`.
 **Learning:** `innerHTML` exposes a risk of executing unescaped input or malformed HTML translations. Instead of clearing nodes with `.innerHTML = ""` or creating nested HTML structures via strings, safer programmatic node manipulation should be utilized.
 **Prevention:** Use `.textContent` for assigning simple text to elements. Use programmatic DOM creation methods like `document.createElement` and `node.appendChild` instead of injecting raw HTML strings into `.innerHTML`. To clear an element, loop through and use `removeChild` on its children (e.g. `while (el.firstChild) el.removeChild(el.firstChild);`).
+
+## 2024-03-05 - [CSRF Protection on Authentication Endpoints]
+**Vulnerability:** The `@csrf_exempt` decorator was being used to bypass CSRF protection on the `demo_login` and `demo_portal_login` endpoints in `apps/auth_app/views.py`, resulting in a Login CSRF vulnerability. This could allow an attacker to force a victim's browser to log into an attacker-controlled account without their knowledge.
+**Learning:** These endpoints were previously exempt, perhaps because they are "demo" endpoints. But because they establish user sessions/tokens, they still represent an authentication boundary and must be protected. All endpoints associated with the login form `templates/auth/login.html` are protected by a `{% csrf_token %}` and no longer require this exemption.
+**Prevention:** Avoid bypassing `@csrf_exempt` on authentication boundaries (login endpoints, password reset endpoints, invite endpoints) unless required by a third-party callback. Doing so introduces significant security vulnerabilities.

--- a/apps/auth_app/views.py
+++ b/apps/auth_app/views.py
@@ -7,7 +7,6 @@ from django.contrib.auth.decorators import login_required
 from django.core.cache import cache
 from django.http import HttpResponse, HttpResponseNotAllowed
 from django.shortcuts import redirect, render
-from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 from django.utils import timezone
 from django.utils import translation
@@ -340,7 +339,6 @@ def azure_callback(request):
     return _set_language_cookie(response, lang_code)
 
 
-@csrf_exempt
 @require_POST
 @ratelimit(key="ip", rate="10/m", method=["POST"], block=True)
 def demo_login(request, role):
@@ -383,7 +381,6 @@ def demo_login(request, role):
     return _set_language_cookie(response, lang_code)
 
 
-@csrf_exempt
 @require_POST
 @ratelimit(key="ip", rate="10/m", method=["POST"], block=True)
 def demo_portal_login(request, record_id):


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `@csrf_exempt` decorator was being used to bypass CSRF protection on the `demo_login` and `demo_portal_login` endpoints in `apps/auth_app/views.py`. These endpoints establish user sessions/tokens, meaning they are an authentication boundary. 
🎯 Impact: This created a Login CSRF vulnerability, which could allow an attacker to force a victim's browser to log into an attacker-controlled account without their knowledge. This can be used as a vector for further attacks or data harvesting in some scenarios.
🔧 Fix: Removed the `@csrf_exempt` decorators from these endpoints, as well as the unused import. The forms that submit to these endpoints already had the correct `{% csrf_token %}` included.
✅ Verification: Ran `tests/test_auth_views.py`, `tests/test_roles_invites.py`, and `tests/test_security.py` to verify no functionality was broken.

---
*PR created automatically by Jules for task [18030532774208741397](https://jules.google.com/task/18030532774208741397) started by @pboachie*