### PR TITLE
🛡️ Sentinel: [HIGH] Fix Login CSRF on demo endpoints

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,8 @@
 **Vulnerability:** XSS risk due to modifying the DOM using `.innerHTML` with potentially dynamic or unescaped translated values in `static/js/app.js`.
 **Learning:** `innerHTML` exposes a risk of executing unescaped input or malformed HTML translations. Instead of clearing nodes with `.innerHTML = ""` or creating nested HTML structures via strings, safer programmatic node manipulation should be utilized.
 **Prevention:** Use `.textContent` for assigning simple text to elements. Use programmatic DOM creation methods like `document.createElement` and `node.appendChild` instead of injecting raw HTML strings into `.innerHTML`. To clear an element, loop through and use `removeChild` on its children (e.g. `while (el.firstChild) el.removeChild(el.firstChild);`).
+
+## 2024-03-07 - [Login CSRF on Demo Endpoints]
+**Vulnerability:** The `demo_login` and `demo_portal_login` endpoints in `apps/auth_app/views.py` were decorated with `@csrf_exempt`, meaning they did not validate CSRF tokens.
+**Learning:** Bypassing CSRF on authentication boundaries, even for demo endpoints, introduces a Login CSRF vulnerability. An attacker could force a victim to log in as a demo user (which might have elevated privileges in a demo environment or be used to track the victim's activity). The assumption that demo endpoints don't need CSRF protection is incorrect.
+**Prevention:** Avoid using `@csrf_exempt` on authentication boundaries (e.g., login, invite accept, password reset) unless absolutely required by an external system callback. Forms in `templates/auth/login.html` already include `{% csrf_token %}` and do not need the view to be exempted.

--- a/apps/auth_app/views.py
+++ b/apps/auth_app/views.py
@@ -340,7 +340,7 @@ def azure_callback(request):
     return _set_language_cookie(response, lang_code)
 
 
-@csrf_exempt
+
 @require_POST
 @ratelimit(key="ip", rate="10/m", method=["POST"], block=True)
 def demo_login(request, role):
@@ -383,7 +383,7 @@ def demo_login(request, role):
     return _set_language_cookie(response, lang_code)
 
 
-@csrf_exempt
+
 @require_POST
 @ratelimit(key="ip", rate="10/m", method=["POST"], block=True)
 def demo_portal_login(request, record_id):


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The `demo_login` and `demo_portal_login` endpoints in `apps/auth_app/views.py` were decorated with `@csrf_exempt`, bypassing CSRF validation.
🎯 **Impact:** This introduces a Login CSRF vulnerability. An attacker could potentially force a victim to log in as a demo user (which could be tracked or used maliciously in certain environments).
🔧 **Fix:** Removed the `@csrf_exempt` decorators. The HTML templates already included the CSRF tokens.
✅ **Verification:** Ran `python -m pytest tests/test_auth_views.py` and all 53 authentication tests passed.

---
*PR created automatically by Jules for task [14522287890316168004](https://jules.google.com/task/14522287890316168004) started by @pboachie*