### PR TITLE
🛡️ Sentinel: [HIGH] Fix Login CSRF vulnerability on demo endpoints

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,8 @@
 **Vulnerability:** XSS risk due to modifying the DOM using `.innerHTML` with potentially dynamic or unescaped translated values in `static/js/app.js`.
 **Learning:** `innerHTML` exposes a risk of executing unescaped input or malformed HTML translations. Instead of clearing nodes with `.innerHTML = ""` or creating nested HTML structures via strings, safer programmatic node manipulation should be utilized.
 **Prevention:** Use `.textContent` for assigning simple text to elements. Use programmatic DOM creation methods like `document.createElement` and `node.appendChild` instead of injecting raw HTML strings into `.innerHTML`. To clear an element, loop through and use `removeChild` on its children (e.g. `while (el.firstChild) el.removeChild(el.firstChild);`).
+
+## 2024-10-25 - [Login CSRF Vulnerability on Demo Endpoints]
+**Vulnerability:** The `demo_login` and `demo_portal_login` endpoints in `apps/auth_app/views.py` used the `@csrf_exempt` decorator despite accepting form submissions.
+**Learning:** Using `@csrf_exempt` on authentication boundaries introduces a Login CSRF vulnerability, where an attacker can force a victim to log in as the attacker, potentially tricking the victim into revealing sensitive information within the attacker's account context. Even demo endpoints must be protected if they create authenticated sessions.
+**Prevention:** Avoid using `@csrf_exempt` on authentication boundaries (e.g., login, invite accept, password reset) unless absolutely required by an external system callback. Always ensure forms include `{% csrf_token %}` and rely on Django's built-in CSRF protection.

--- a/apps/auth_app/views.py
+++ b/apps/auth_app/views.py
@@ -7,7 +7,6 @@ from django.contrib.auth.decorators import login_required
 from django.core.cache import cache
 from django.http import HttpResponse, HttpResponseNotAllowed
 from django.shortcuts import redirect, render
-from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 from django.utils import timezone
 from django.utils import translation
@@ -340,7 +339,6 @@ def azure_callback(request):
     return _set_language_cookie(response, lang_code)
 
 
-@csrf_exempt
 @require_POST
 @ratelimit(key="ip", rate="10/m", method=["POST"], block=True)
 def demo_login(request, role):
@@ -383,7 +381,6 @@ def demo_login(request, role):
     return _set_language_cookie(response, lang_code)
 
 
-@csrf_exempt
 @require_POST
 @ratelimit(key="ip", rate="10/m", method=["POST"], block=True)
 def demo_portal_login(request, record_id):


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: The `demo_login` and `demo_portal_login` endpoints in `apps/auth_app/views.py` used the `@csrf_exempt` decorator despite accepting form submissions.
🎯 **Impact**: This introduces a Login CSRF vulnerability, where an attacker could force a victim to log in under the attacker's account, potentially tricking them into revealing sensitive information within the attacker's context. 
🔧 **Fix**: Removed the `@csrf_exempt` decorator from the `demo_login` and `demo_portal_login` views. The `login.html` template already includes the `{% csrf_token %}`, so Django's built-in CSRF protection will now properly validate these POST requests. Also removed the unused `csrf_exempt` import. Logged the learning in `.jules/sentinel.md`.
✅ **Verification**: Tests in `tests/test_auth_views.py`, `tests/test_rbac.py`, and `tests/test_security.py` pass without regressions.

---
*PR created automatically by Jules for task [2546201637276796893](https://jules.google.com/task/2546201637276796893) started by @pboachie*