### PR TITLE
🛡️ Sentinel: [HIGH] Fix CSRF missing protection on demo login endpoints

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,8 @@
 **Vulnerability:** XSS risk due to modifying the DOM using `.innerHTML` with potentially dynamic or unescaped translated values in `static/js/app.js`.
 **Learning:** `innerHTML` exposes a risk of executing unescaped input or malformed HTML translations. Instead of clearing nodes with `.innerHTML = ""` or creating nested HTML structures via strings, safer programmatic node manipulation should be utilized.
 **Prevention:** Use `.textContent` for assigning simple text to elements. Use programmatic DOM creation methods like `document.createElement` and `node.appendChild` instead of injecting raw HTML strings into `.innerHTML`. To clear an element, loop through and use `removeChild` on its children (e.g. `while (el.firstChild) el.removeChild(el.firstChild);`).
+
+## 2024-05-28 - Removed @csrf_exempt from Demo Login Endpoints
+**Vulnerability:** The `demo_login` and `demo_portal_login` views in `apps/auth_app/views.py` were decorated with `@csrf_exempt`, leaving them vulnerable to Login CSRF, where an attacker could log a victim into an attacker-controlled account to steal data they enter.
+**Learning:** These endpoints had `DEMO_MODE` checks, but the frontend form (`templates/auth/login.html`) actually included `{% csrf_token %}`. The `@csrf_exempt` decorator was redundant and introduced unnecessary risk. Avoid `@csrf_exempt` on authentication boundaries unless external systems force it.
+**Prevention:** Ensure all login and authentication endpoints enforce CSRF validation. Never bypass CSRF simply because it is a "demo" or "test" endpoint, especially if it handles session creation.

--- a/apps/auth_app/views.py
+++ b/apps/auth_app/views.py
@@ -7,7 +7,7 @@ from django.contrib.auth.decorators import login_required
 from django.core.cache import cache
 from django.http import HttpResponse, HttpResponseNotAllowed
 from django.shortcuts import redirect, render
-from django.views.decorators.csrf import csrf_exempt
+
 from django.views.decorators.http import require_POST
 from django.utils import timezone
 from django.utils import translation
@@ -340,7 +340,7 @@ def azure_callback(request):
     return _set_language_cookie(response, lang_code)
 
 
-@csrf_exempt
+
 @require_POST
 @ratelimit(key="ip", rate="10/m", method=["POST"], block=True)
 def demo_login(request, role):
@@ -383,7 +383,7 @@ def demo_login(request, role):
     return _set_language_cookie(response, lang_code)
 
 
-@csrf_exempt
+
 @require_POST
 @ratelimit(key="ip", rate="10/m", method=["POST"], block=True)
 def demo_portal_login(request, record_id):


### PR DESCRIPTION
Removed the `@csrf_exempt` decorator from the `demo_login` and `demo_portal_login` views in `apps/auth_app/views.py`. These endpoints process POST requests to create user sessions and were previously bypassing CSRF checks. The frontend `login.html` template already supplies the `{% csrf_token %}`, so this removal corrects a Login CSRF vulnerability without breaking demo functionality. Also appended this learning to the `.jules/sentinel.md` journal.

---
*PR created automatically by Jules for task [17129119793561496855](https://jules.google.com/task/17129119793561496855) started by @pboachie*