### PR TITLE
🛡️ Sentinel: [HIGH] Fix Login CSRF vulnerability in demo mode

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,7 @@
 **Vulnerability:** XSS risk due to modifying the DOM using `.innerHTML` with potentially dynamic or unescaped translated values in `static/js/app.js`.
 **Learning:** `innerHTML` exposes a risk of executing unescaped input or malformed HTML translations. Instead of clearing nodes with `.innerHTML = ""` or creating nested HTML structures via strings, safer programmatic node manipulation should be utilized.
 **Prevention:** Use `.textContent` for assigning simple text to elements. Use programmatic DOM creation methods like `document.createElement` and `node.appendChild` instead of injecting raw HTML strings into `.innerHTML`. To clear an element, loop through and use `removeChild` on its children (e.g. `while (el.firstChild) el.removeChild(el.firstChild);`).
+## 2026-03-07 - [Login CSRF in Demo Views]
+**Vulnerability:** The `demo_login` and `demo_portal_login` views were annotated with `@csrf_exempt`, creating a Login CSRF vulnerability despite forms in templates already having `{% csrf_token %}`.
+**Learning:** Using `@csrf_exempt` on authentication boundaries opens the door for an attacker to log a victim into the attacker's account, allowing them to monitor the victim's subsequent actions.
+**Prevention:** Avoid using `@csrf_exempt` on authentication-related endpoints (login, password reset, invite accept) unless explicitly required for external callback integration where it's not possible to send the CSRF token.

--- a/apps/auth_app/views.py
+++ b/apps/auth_app/views.py
@@ -7,7 +7,6 @@ from django.contrib.auth.decorators import login_required
 from django.core.cache import cache
 from django.http import HttpResponse, HttpResponseNotAllowed
 from django.shortcuts import redirect, render
-from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 from django.utils import timezone
 from django.utils import translation
@@ -340,7 +339,6 @@ def azure_callback(request):
     return _set_language_cookie(response, lang_code)
 
 
-@csrf_exempt
 @require_POST
 @ratelimit(key="ip", rate="10/m", method=["POST"], block=True)
 def demo_login(request, role):
@@ -383,7 +381,6 @@ def demo_login(request, role):
     return _set_language_cookie(response, lang_code)
 
 
-@csrf_exempt
 @require_POST
 @ratelimit(key="ip", rate="10/m", method=["POST"], block=True)
 def demo_portal_login(request, record_id):


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Login CSRF
🎯 Impact: Attackers could log a user into an attacker-controlled account (or demo account) via forged requests, tracking their activity.
🔧 Fix: Removed the unnecessary `@csrf_exempt` decorator from the demo login views. The frontend already provides the necessary CSRF tokens.
✅ Verification: Ran relevant test suites, verifying that CSRF tests pass and the demo login flows continue working as expected.

---
*PR created automatically by Jules for task [8793763087895758042](https://jules.google.com/task/8793763087895758042) started by @pboachie*