### PR TITLE
🛡️ Sentinel: [HIGH] Fix Login CSRF on demo endpoints

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,8 @@
 **Vulnerability:** XSS risk due to modifying the DOM using `.innerHTML` with potentially dynamic or unescaped translated values in `static/js/app.js`.
 **Learning:** `innerHTML` exposes a risk of executing unescaped input or malformed HTML translations. Instead of clearing nodes with `.innerHTML = ""` or creating nested HTML structures via strings, safer programmatic node manipulation should be utilized.
 **Prevention:** Use `.textContent` for assigning simple text to elements. Use programmatic DOM creation methods like `document.createElement` and `node.appendChild` instead of injecting raw HTML strings into `.innerHTML`. To clear an element, loop through and use `removeChild` on its children (e.g. `while (el.firstChild) el.removeChild(el.firstChild);`).
+
+## 2024-10-24 - [Login CSRF on Demo Endpoints]
+**Vulnerability:** The `demo_login` and `demo_portal_login` endpoints in `apps/auth_app/views.py` were decorated with `@csrf_exempt`, bypassing Django's built-in Cross-Site Request Forgery protections.
+**Learning:** Even though these are demo endpoints and only active when `DEMO_MODE` is true, omitting CSRF protection makes the application vulnerable to Login CSRF, where an attacker could forge a request to log a victim into a demo account. The login forms in the template already correctly included `{% csrf_token %}`, so the exemption was both unnecessary and insecure. Authentication boundaries must never be exempt from CSRF checks unless explicitly required by an external system callback.
+**Prevention:** Avoid using `@csrf_exempt` on any endpoint that handles user authentication (login, password reset, demo login, invite accept). Always verify that the corresponding HTML forms contain the `{% csrf_token %}` tag.

--- a/apps/auth_app/views.py
+++ b/apps/auth_app/views.py
@@ -340,7 +340,6 @@ def azure_callback(request):
     return _set_language_cookie(response, lang_code)
 
 
-@csrf_exempt
 @require_POST
 @ratelimit(key="ip", rate="10/m", method=["POST"], block=True)
 def demo_login(request, role):
@@ -383,7 +382,6 @@ def demo_login(request, role):
     return _set_language_cookie(response, lang_code)
 
 
-@csrf_exempt
 @require_POST
 @ratelimit(key="ip", rate="10/m", method=["POST"], block=True)
 def demo_portal_login(request, record_id):


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix Login CSRF vulnerability on demo endpoints
    
    🚨 Severity: HIGH
    💡 Vulnerability: The `demo_login` and `demo_portal_login` endpoints in `apps/auth_app/views.py` had `@csrf_exempt` decorators, bypassing Django's built-in CSRF protection.
    🎯 Impact: An attacker could perform a Login CSRF attack, tricking an authenticated user into submitting a forged login request that logs them into an attacker-controlled demo session.
    🔧 Fix: Removed the unnecessary `@csrf_exempt` decorators from these endpoints. The corresponding frontend forms already safely included `{% csrf_token %}`.
    ✅ Verification: All tests in `test_auth_views.py` pass, confirming standard login and demo login flows function properly with CSRF protection enforced.

---
*PR created automatically by Jules for task [2885494458290808544](https://jules.google.com/task/2885494458290808544) started by @pboachie*