### PR TITLE
🎨 Palette: Contextual ARIA Labels for SRE Category List Actions

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -12,3 +12,6 @@
 ## 2025-03-10 - Add `data-select-on-click` to Copyable Text Inputs
 **Learning:** For read-only inputs containing shareable URLs (e.g. calendar feed, direct registration link), requiring users to manually highlight the text before copying can be frustrating and error-prone. The codebase already supports an accessible `data-select-on-click="true"` pattern used in invite links.
 **Action:** Consistently apply the `data-select-on-click="true"` attribute to all read-only `input` elements designated for copying, ensuring users can instantly select the full value with a single click.
+## 2025-03-10 - Add Contextual ARIA Labels to SRE Category Actions
+**Learning:** Action buttons like "Archive", "Activate", and "Edit" in dynamically generated lists lack context for screen readers when they don't explicitly reference the target item. A user tabbing through the page would hear the action out of context without knowing *which* category is being affected.
+**Action:** Always add descriptive `aria-label` attributes to generic action buttons inside iterative loops, using `{% blocktrans %}` to include the item's name dynamically (e.g., `aria-label="{% blocktrans with name=cat.name %}Archive {{ name }}{% endblocktrans %}"`).

--- a/templates/events/sre_category_list.html
+++ b/templates/events/sre_category_list.html
@@ -48,13 +48,13 @@
             </td>
             <td>
                 <div role="group">
-                    <a href="{% url 'sre_categories:sre_category_edit' category_id=cat.pk %}">{% trans "Edit" %}</a>
+                    <a href="{% url 'sre_categories:sre_category_edit' category_id=cat.pk %}" aria-label="{% blocktrans with name=cat.name %}Edit {{ name }}{% endblocktrans %}">{% trans "Edit" %}</a>
                     <form method="post" action="{% url 'sre_categories:sre_category_toggle_active' category_id=cat.pk %}" style="display: inline;">
                         {% csrf_token %}
                         {% if cat.is_active %}
-                        <button type="submit" class="outline secondary" style="padding: 0.25rem 0.5rem; font-size: 0.85rem;">{% trans "Archive" %}</button>
+                        <button type="submit" class="outline secondary" style="padding: 0.25rem 0.5rem; font-size: 0.85rem;" aria-label="{% blocktrans with name=cat.name %}Archive {{ name }}{% endblocktrans %}">{% trans "Archive" %}</button>
                         {% else %}
-                        <button type="submit" class="outline" style="padding: 0.25rem 0.5rem; font-size: 0.85rem;">{% trans "Activate" %}</button>
+                        <button type="submit" class="outline" style="padding: 0.25rem 0.5rem; font-size: 0.85rem;" aria-label="{% blocktrans with name=cat.name %}Activate {{ name }}{% endblocktrans %}">{% trans "Activate" %}</button>
                         {% endif %}
                     </form>
                 </div>


### PR DESCRIPTION
💡 What: Added contextual `aria-label` attributes to the action buttons (Edit, Archive, Activate) in the SRE Categories list.
🎯 Why: Screen reader users tabbing through the list would previously only hear "Edit, button", "Archive, button", etc., without knowing which category the action applied to. The new labels dynamically include the category name.
♿ Accessibility: Improves WCAG compliance by ensuring interactive elements have sufficient contextual text for screen readers.

---
*PR created automatically by Jules for task [13638630843262400452](https://jules.google.com/task/13638630843262400452) started by @pboachie*