### PR TITLE
🛡️ Sentinel: [HIGH] Fix CSRF Vulnerability on Login Endpoints

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,7 @@
 **Vulnerability:** XSS risk due to modifying the DOM using `.innerHTML` with potentially dynamic or unescaped translated values in `static/js/app.js`.
 **Learning:** `innerHTML` exposes a risk of executing unescaped input or malformed HTML translations. Instead of clearing nodes with `.innerHTML = ""` or creating nested HTML structures via strings, safer programmatic node manipulation should be utilized.
 **Prevention:** Use `.textContent` for assigning simple text to elements. Use programmatic DOM creation methods like `document.createElement` and `node.appendChild` instead of injecting raw HTML strings into `.innerHTML`. To clear an element, loop through and use `removeChild` on its children (e.g. `while (el.firstChild) el.removeChild(el.firstChild);`).
+## 2025-04-28 - Removed CSRF Exemption from Authentication Endpoints
+**Vulnerability:** Login endpoints (`demo_login`, `demo_portal_login`) in `apps/auth_app/views.py` had the `@csrf_exempt` decorator, which disables Django's Cross-Site Request Forgery (CSRF) protection.
+**Learning:** Bypassing CSRF protection on login forms opens up the application to Login CSRF, where an attacker can forge a login request and force the victim to log into an attacker-controlled account, exposing their activity.
+**Prevention:** Avoid using `@csrf_exempt` on authentication boundaries (e.g., login, password reset, etc.) unless required by an external system callback. Ensure templates include `{% csrf_token %}` in forms.

--- a/apps/auth_app/views.py
+++ b/apps/auth_app/views.py
@@ -340,7 +340,6 @@ def azure_callback(request):
     return _set_language_cookie(response, lang_code)
 
 
-@csrf_exempt
 @require_POST
 @ratelimit(key="ip", rate="10/m", method=["POST"], block=True)
 def demo_login(request, role):
@@ -383,7 +382,6 @@ def demo_login(request, role):
     return _set_language_cookie(response, lang_code)
 
 
-@csrf_exempt
 @require_POST
 @ratelimit(key="ip", rate="10/m", method=["POST"], block=True)
 def demo_portal_login(request, record_id):


### PR DESCRIPTION
- 🚨 Severity: HIGH
- 💡 Vulnerability: Missing CSRF token validation on `demo_login` and `demo_portal_login` endpoints due to `@csrf_exempt` decorator.
- 🎯 Impact: Susceptible to Login CSRF, where an attacker could forge a login request to force a victim to log into an attacker-controlled account and expose their activity.
- 🔧 Fix: Removed `@csrf_exempt` from `demo_login` and `demo_portal_login`.
- ✅ Verification: The application correctly uses `{% csrf_token %}` in the template (`templates/auth/login.html`). Verified via `pytest` test suite executions.

---
*PR created automatically by Jules for task [5258686105384698198](https://jules.google.com/task/5258686105384698198) started by @pboachie*