### PR TITLE
🛡️ Sentinel: [HIGH] Fix Login CSRF on demo endpoints

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,8 @@
 **Vulnerability:** XSS risk due to modifying the DOM using `.innerHTML` with potentially dynamic or unescaped translated values in `static/js/app.js`.
 **Learning:** `innerHTML` exposes a risk of executing unescaped input or malformed HTML translations. Instead of clearing nodes with `.innerHTML = ""` or creating nested HTML structures via strings, safer programmatic node manipulation should be utilized.
 **Prevention:** Use `.textContent` for assigning simple text to elements. Use programmatic DOM creation methods like `document.createElement` and `node.appendChild` instead of injecting raw HTML strings into `.innerHTML`. To clear an element, loop through and use `removeChild` on its children (e.g. `while (el.firstChild) el.removeChild(el.firstChild);`).
+
+## 2024-03-08 - [Login CSRF on Demo Endpoints]
+**Vulnerability:** The `demo_login` and `demo_portal_login` endpoints in `apps/auth_app/views.py` were annotated with `@csrf_exempt`, bypassing Django's built-in CSRF protection for these POST endpoints. This opened up the possibility of Login CSRF, where an attacker could forge a login request to authenticate a victim as a demo user without their consent.
+**Learning:** Even though they are demo authentication endpoints, these routes are still authentication boundaries and must be protected against CSRF unless explicitly required by an external callback. Because the login forms in `templates/auth/login.html` already included `{% csrf_token %}`, the exemption was unnecessary and dangerous.
+**Prevention:** Avoid using `@csrf_exempt` on authentication boundaries (e.g., login, password reset). If `{% csrf_token %}` is present in the corresponding frontend form, the exemption is not needed and should not be added.

--- a/apps/auth_app/views.py
+++ b/apps/auth_app/views.py
@@ -7,7 +7,7 @@ from django.contrib.auth.decorators import login_required
 from django.core.cache import cache
 from django.http import HttpResponse, HttpResponseNotAllowed
 from django.shortcuts import redirect, render
-from django.views.decorators.csrf import csrf_exempt
+
 from django.views.decorators.http import require_POST
 from django.utils import timezone
 from django.utils import translation
@@ -340,7 +340,7 @@ def azure_callback(request):
     return _set_language_cookie(response, lang_code)
 
 
-@csrf_exempt
+
 @require_POST
 @ratelimit(key="ip", rate="10/m", method=["POST"], block=True)
 def demo_login(request, role):
@@ -383,7 +383,7 @@ def demo_login(request, role):
     return _set_language_cookie(response, lang_code)
 
 
-@csrf_exempt
+
 @require_POST
 @ratelimit(key="ip", rate="10/m", method=["POST"], block=True)
 def demo_portal_login(request, record_id):


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `demo_login` and `demo_portal_login` endpoints were decorated with `@csrf_exempt`, bypassing Django's built-in Cross-Site Request Forgery (CSRF) protection.
🎯 Impact: This allowed Login CSRF. An attacker could force an authenticated (or unauthenticated) victim's browser to submit a forged POST request to the demo endpoints, logging them in as a demo user (e.g. `admin`) without their consent. This can compromise data privacy or trick users into entering sensitive info into an account controlled by the attacker.
🔧 Fix: Removed `@csrf_exempt` from both endpoints since the corresponding forms in `templates/auth/login.html` already use `{% csrf_token %}`. Also removed unused imports.
✅ Verification: Ran `tests/test_auth_views.py` and `apps/portal/tests/test_auth.py` successfully. Verified `{% csrf_token %}` exists in the frontend template. Added an entry to Sentinel's journal.

---
*PR created automatically by Jules for task [8692838156458965599](https://jules.google.com/task/8692838156458965599) started by @pboachie*