### PR TITLE
🎨 Palette: Improve skip-link accessibility in public survey templates

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -12,3 +12,6 @@
 ## 2025-03-10 - Add `data-select-on-click` to Copyable Text Inputs
 **Learning:** For read-only inputs containing shareable URLs (e.g. calendar feed, direct registration link), requiring users to manually highlight the text before copying can be frustrating and error-prone. The codebase already supports an accessible `data-select-on-click="true"` pattern used in invite links.
 **Action:** Consistently apply the `data-select-on-click="true"` attribute to all read-only `input` elements designated for copying, ensuring users can instantly select the full value with a single click.
+## 2024-05-18 - Skip Link Main Content Target Accessibility
+**Learning:** Skip links require the target container (typically `<main>`) to have a `tabindex="-1"` attribute in order to reliably programmatically receive focus, especially for keyboard and screen reader users across different browsers. Some templates had skip links but the targets were not focusable, or were missing skip links entirely.
+**Action:** Ensure that all `<main id="main-content">` tags paired with a 'Skip to main content' link have `tabindex="-1"`.

--- a/templates/surveys/public_consent.html
+++ b/templates/surveys/public_consent.html
@@ -15,7 +15,7 @@
 <body>
 <a href="#main-content" class="visually-hidden-focusable">{% trans "Skip to main content" %}</a>
 {% include "_lang_toggle.html" with max_width="720px" %}
-<main id="main-content" class="container" style="max-width:720px; padding-top:2rem" aria-label="{% trans 'Main content' %}">
+<main id="main-content" tabindex="-1" class="container" style="max-width:720px; padding-top:2rem" aria-label="{% trans 'Main content' %}">
 
 <h1>{{ survey.name|bilingual:survey.name_fr }}</h1>
 

--- a/templates/surveys/public_expired.html
+++ b/templates/surveys/public_expired.html
@@ -11,8 +11,9 @@
     {% include "_lang_toggle_styles.html" %}
 </head>
 <body>
+<a href="#main-content" class="visually-hidden-focusable">{% trans "Skip to main content" %}</a>
 {% include "_lang_toggle.html" with max_width="720px" %}
-<main class="container" style="max-width:720px; padding-top:2rem; text-align:center">
+<main id="main-content" tabindex="-1" class="container" style="max-width:720px; padding-top:2rem; text-align:center" aria-label="{% trans 'Main content' %}">
 
 <h1>{% trans "Survey Unavailable" %}</h1>
 <p>{% trans "This survey is no longer available." %}</p>

--- a/templates/surveys/public_form.html
+++ b/templates/surveys/public_form.html
@@ -19,7 +19,7 @@
 <body>
 <a href="#main-content" class="visually-hidden-focusable">{% trans "Skip to main content" %}</a>
 {% include "_lang_toggle.html" with max_width="720px" %}
-<main id="main-content" class="container" style="max-width:720px; padding-top:2rem" aria-label="{% trans 'Main content' %}">
+<main id="main-content" tabindex="-1" class="container" style="max-width:720px; padding-top:2rem" aria-label="{% trans 'Main content' %}">
 
 <h1>{{ survey.name|bilingual:survey.name_fr }}</h1>
 


### PR DESCRIPTION
🎨 Palette: Fix "Skip to main content" link accessibility in survey templates

💡 What:
- Added `tabindex="-1"` to the `<main id="main-content">` elements in `public_form.html` and `public_consent.html`.
- Added the missing "Skip to main content" link, `id="main-content"`, and `tabindex="-1"` to `public_expired.html`.

🎯 Why:
While most templates had a "Skip to main content" link, the target `<main>` tags were missing the `tabindex="-1"` attribute. Without this attribute, some browsers (and screen readers) fail to programmatically focus the main content area when the link is activated, breaking keyboard navigation. This ensures consistent, reliable skip-link behavior across all survey templates.

♿ Accessibility:
- Improves WCAG 2.4.1 (Bypass Blocks) compliance by ensuring skip links reliably move focus.
- Parity with other layouts (like `base.html` and `offline.html`).

---
*PR created automatically by Jules for task [1648791783774852276](https://jules.google.com/task/1648791783774852276) started by @pboachie*