### PR TITLE
🛡️ Sentinel: [HIGH] Fix Login CSRF on authentication boundaries

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,8 @@
 **Vulnerability:** XSS risk due to modifying the DOM using `.innerHTML` with potentially dynamic or unescaped translated values in `static/js/app.js`.
 **Learning:** `innerHTML` exposes a risk of executing unescaped input or malformed HTML translations. Instead of clearing nodes with `.innerHTML = ""` or creating nested HTML structures via strings, safer programmatic node manipulation should be utilized.
 **Prevention:** Use `.textContent` for assigning simple text to elements. Use programmatic DOM creation methods like `document.createElement` and `node.appendChild` instead of injecting raw HTML strings into `.innerHTML`. To clear an element, loop through and use `removeChild` on its children (e.g. `while (el.firstChild) el.removeChild(el.firstChild);`).
+
+## 2026-04-30 - Login CSRF at Authentication Boundaries
+**Vulnerability:** The `demo_login` and `demo_portal_login` views in `apps/auth_app/views.py` were decorated with `@csrf_exempt`, disabling Django's CSRF protection on these endpoints.
+**Learning:** Using `@csrf_exempt` on authentication boundaries (like demo login endpoints) introduces Login CSRF vulnerabilities, allowing attackers to log a victim into an attacker-controlled account, which could then be used to capture sensitive data the victim enters. The HTML form in `templates/auth/login.html` already included `{% csrf_token %}`, so the exemption was unnecessary and dangerous.
+**Prevention:** Avoid using `@csrf_exempt` on authentication boundaries unless absolutely required by an external system callback. Always ensure forms include `{% csrf_token %}` and rely on Django's built-in CSRF protection for all sensitive POST requests.

--- a/apps/auth_app/views.py
+++ b/apps/auth_app/views.py
@@ -340,7 +340,6 @@ def azure_callback(request):
     return _set_language_cookie(response, lang_code)
 
 
-@csrf_exempt
 @require_POST
 @ratelimit(key="ip", rate="10/m", method=["POST"], block=True)
 def demo_login(request, role):
@@ -383,7 +382,6 @@ def demo_login(request, role):
     return _set_language_cookie(response, lang_code)
 
 
-@csrf_exempt
 @require_POST
 @ratelimit(key="ip", rate="10/m", method=["POST"], block=True)
 def demo_portal_login(request, record_id):


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix Login CSRF on authentication boundaries

🚨 **Severity:** HIGH
💡 **Vulnerability:** The `demo_login` and `demo_portal_login` views in `apps/auth_app/views.py` were decorated with `@csrf_exempt`, disabling Django's CSRF protection on these authentication endpoints.
🎯 **Impact:** Using `@csrf_exempt` on authentication boundaries introduces Login CSRF vulnerabilities, allowing attackers to log a victim into an attacker-controlled account without their knowledge, which could then be used to capture sensitive data the victim subsequently enters.
🔧 **Fix:** Removed the `@csrf_exempt` decorators. The corresponding HTML form in `templates/auth/login.html` already included `{% csrf_token %}`, meaning standard Django CSRF protection is seamlessly enabled without breaking functionality.
✅ **Verification:** Ran `python -m pytest tests/test_auth_views.py` and confirmed all authentication flow tests pass successfully. Included critical learnings in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [14118471880066759473](https://jules.google.com/task/14118471880066759473) started by @pboachie*