### PR TITLE
🛡️ Sentinel: [HIGH] Remove @csrf_exempt from demo login endpoints

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,8 @@
 **Vulnerability:** XSS risk due to modifying the DOM using `.innerHTML` with potentially dynamic or unescaped translated values in `static/js/app.js`.
 **Learning:** `innerHTML` exposes a risk of executing unescaped input or malformed HTML translations. Instead of clearing nodes with `.innerHTML = ""` or creating nested HTML structures via strings, safer programmatic node manipulation should be utilized.
 **Prevention:** Use `.textContent` for assigning simple text to elements. Use programmatic DOM creation methods like `document.createElement` and `node.appendChild` instead of injecting raw HTML strings into `.innerHTML`. To clear an element, loop through and use `removeChild` on its children (e.g. `while (el.firstChild) el.removeChild(el.firstChild);`).
+
+## 2024-05-18 - [Avoid `@csrf_exempt` on Demo Login Endpoints]
+**Vulnerability:** Demo login endpoints (`demo_login`, `demo_portal_login`) used the `@csrf_exempt` decorator, making them vulnerable to Login CSRF attacks despite the frontend having CSRF tokens.
+**Learning:** Authentication boundaries, including quick-login demo accounts, should never bypass CSRF validation. Doing so could allow an attacker to force a victim's browser to authenticate with an attacker-controlled demo account, potentially violating user privacy or logging their actions.
+**Prevention:** Remove `@csrf_exempt` from all authentication boundary endpoints. Verify that login forms properly include `{% csrf_token %}` to justify maintaining standard CSRF protection.

--- a/apps/auth_app/views.py
+++ b/apps/auth_app/views.py
@@ -7,7 +7,6 @@ from django.contrib.auth.decorators import login_required
 from django.core.cache import cache
 from django.http import HttpResponse, HttpResponseNotAllowed
 from django.shortcuts import redirect, render
-from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 from django.utils import timezone
 from django.utils import translation
@@ -340,7 +339,6 @@ def azure_callback(request):
     return _set_language_cookie(response, lang_code)
 
 
-@csrf_exempt
 @require_POST
 @ratelimit(key="ip", rate="10/m", method=["POST"], block=True)
 def demo_login(request, role):
@@ -383,7 +381,6 @@ def demo_login(request, role):
     return _set_language_cookie(response, lang_code)
 
 
-@csrf_exempt
 @require_POST
 @ratelimit(key="ip", rate="10/m", method=["POST"], block=True)
 def demo_portal_login(request, record_id):


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Demo login endpoints (`demo_login` and `demo_portal_login`) in `apps/auth_app/views.py` used the `@csrf_exempt` decorator. While they are demo endpoints, they are authentication boundaries. Exempting them from CSRF protection allows for Login CSRF attacks, where an attacker could force a victim to log in as an attacker-controlled demo user.
🎯 **Impact:** An attacker could potentially compromise a victim's session, violate their privacy, or log their actions by forcing them to authenticate with a demo account without their knowledge.
🔧 **Fix:** Removed the `@csrf_exempt` decorator from the `demo_login` and `demo_portal_login` functions. Verified that the corresponding frontend login forms already include `{% csrf_token %}`. Added an entry to `.jules/sentinel.md` documenting this finding.
✅ **Verification:** Ran `pytest tests/test_auth_views.py` to ensure the views still function and authentication tests pass.

---
*PR created automatically by Jules for task [2913182813273700799](https://jules.google.com/task/2913182813273700799) started by @pboachie*