### PR TITLE
🛡️ Sentinel: [HIGH] Fix Login CSRF vulnerability in demo endpoints

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,7 @@
 **Vulnerability:** XSS risk due to modifying the DOM using `.innerHTML` with potentially dynamic or unescaped translated values in `static/js/app.js`.
 **Learning:** `innerHTML` exposes a risk of executing unescaped input or malformed HTML translations. Instead of clearing nodes with `.innerHTML = ""` or creating nested HTML structures via strings, safer programmatic node manipulation should be utilized.
 **Prevention:** Use `.textContent` for assigning simple text to elements. Use programmatic DOM creation methods like `document.createElement` and `node.appendChild` instead of injecting raw HTML strings into `.innerHTML`. To clear an element, loop through and use `removeChild` on its children (e.g. `while (el.firstChild) el.removeChild(el.firstChild);`).
+## 2026-05-03 - [High Priority: Login CSRF]
+**Vulnerability:** The `demo_login` and `demo_portal_login` views were vulnerable to Login CSRF because they were marked with `@csrf_exempt`.
+**Learning:** Even though they are 'demo' features, authentication boundaries must always enforce CSRF validation. Bypassing it via `@csrf_exempt` can be exploited to force users into logging into attacker-controlled accounts.
+**Prevention:** Avoid using `@csrf_exempt` on authentication endpoints. Forms making POST requests to these endpoints must always use `{% csrf_token %}`.

--- a/apps/auth_app/views.py
+++ b/apps/auth_app/views.py
@@ -7,7 +7,6 @@ from django.contrib.auth.decorators import login_required
 from django.core.cache import cache
 from django.http import HttpResponse, HttpResponseNotAllowed
 from django.shortcuts import redirect, render
-from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 from django.utils import timezone
 from django.utils import translation
@@ -340,7 +339,7 @@ def azure_callback(request):
     return _set_language_cookie(response, lang_code)
 
 
-@csrf_exempt
+
 @require_POST
 @ratelimit(key="ip", rate="10/m", method=["POST"], block=True)
 def demo_login(request, role):
@@ -383,7 +382,7 @@ def demo_login(request, role):
     return _set_language_cookie(response, lang_code)
 
 
-@csrf_exempt
+
 @require_POST
 @ratelimit(key="ip", rate="10/m", method=["POST"], block=True)
 def demo_portal_login(request, record_id):


### PR DESCRIPTION
* 🚨 Severity: HIGH
* 💡 Vulnerability: Missing CSRF token validation on `demo_login` and `demo_portal_login` endpoints in `apps/auth_app/views.py` due to `@csrf_exempt` decorators.
* 🎯 Impact: Attackers could potentially force a user to log into an attacker-controlled account, which is known as Login CSRF. While these are demo accounts, authentication boundaries should always have CSRF protection.
* 🔧 Fix: Removed `@csrf_exempt` decorators from both endpoints. Forms in `login.html` already included `{% csrf_token %}`.
* ✅ Verification: Test suite for auth views ran successfully (`tests/test_auth_views.py`), verifying the endpoints function correctly with CSRF protection enabled.

---
*PR created automatically by Jules for task [1036244365637111124](https://jules.google.com/task/1036244365637111124) started by @pboachie*