### PR TITLE
🎨 Palette: Add contextual ARIA labels to Remove buttons in framework detail

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -12,3 +12,6 @@
 ## 2025-03-10 - Add `data-select-on-click` to Copyable Text Inputs
 **Learning:** For read-only inputs containing shareable URLs (e.g. calendar feed, direct registration link), requiring users to manually highlight the text before copying can be frustrating and error-prone. The codebase already supports an accessible `data-select-on-click="true"` pattern used in invite links.
 **Action:** Consistently apply the `data-select-on-click="true"` attribute to all read-only `input` elements designated for copying, ensuring users can instantly select the full value with a single click.
+## 2025-03-10 - Add Contextual ARIA Labels to Action Buttons in Lists
+**Learning:** Action buttons like "Remove" in dynamically generated lists lack context for screen readers when they don't explicitly reference the target item. A user tabbing through the page would hear "Remove, button", multiple times without knowing *what* is being removed.
+**Action:** Always add descriptive `aria-label` attributes to generic action buttons inside iterative loops, using `{% blocktrans %}` to include the item's name dynamically.

--- a/templates/programs/evaluation/framework_detail.html
+++ b/templates/programs/evaluation/framework_detail.html
@@ -73,7 +73,7 @@
                     <a href="{% url 'programs:component_edit' framework_id=framework.pk component_id=comp.pk %}">{% trans "Edit" %}</a>
                     <form method="post" action="{% url 'programs:component_deactivate' framework_id=framework.pk component_id=comp.pk %}" class="inline-form">
                         {% csrf_token %}
-                        <button type="submit" class="outline contrast compact-btn">{% trans "Remove" %}</button>
+                        <button type="submit" class="outline contrast compact-btn" aria-label="{% blocktrans with name=comp.name %}Remove {{ name }}{% endblocktrans %}">{% trans "Remove" %}</button>
                     </form>
                 </td>
             </tr>
@@ -112,7 +112,7 @@
                 <td>
                     <form method="post" action="{% url 'programs:evidence_delete' framework_id=framework.pk evidence_id=link.pk %}" class="inline-form">
                         {% csrf_token %}
-                        <button type="submit" class="outline contrast compact-btn">{% trans "Remove" %}</button>
+                        <button type="submit" class="outline contrast compact-btn" aria-label="{% blocktrans with title=link.title %}Remove {{ title }}{% endblocktrans %}">{% trans "Remove" %}</button>
                     </form>
                 </td>
             </tr>


### PR DESCRIPTION
💡 What: Added dynamic `aria-label` attributes to the "Remove" buttons in the Component and Evidence lists within the Evaluation Framework Detail view.
🎯 Why: Generic action buttons in iterated lists lack context for screen reader users. Hearing just "Remove" multiple times is confusing.
📸 Before/After: Before, buttons had no aria-labels. After, they provide context like `aria-label="Remove Program Logic Model"` or `aria-label="Remove Annual Report"`.
♿ Accessibility: Significant improvement for screen reader navigation by ensuring all "Remove" actions are properly distinguished by the name of the component or title of the evidence being removed.

---
*PR created automatically by Jules for task [15686749304805106897](https://jules.google.com/task/15686749304805106897) started by @pboachie*