### PR TITLE
🎨 Palette: Ensure "Skip to main content" target is focusable

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -12,3 +12,7 @@
 ## 2025-03-10 - Add `data-select-on-click` to Copyable Text Inputs
 **Learning:** For read-only inputs containing shareable URLs (e.g. calendar feed, direct registration link), requiring users to manually highlight the text before copying can be frustrating and error-prone. The codebase already supports an accessible `data-select-on-click="true"` pattern used in invite links.
 **Action:** Consistently apply the `data-select-on-click="true"` attribute to all read-only `input` elements designated for copying, ensuring users can instantly select the full value with a single click.
+
+## 2025-03-10 - Skip Links Require Target to be Focusable
+**Learning:** For a "Skip to main content" link to work correctly across all browsers and screen readers, the target container (e.g. `<main id="main-content">`) must have `tabindex="-1"`. Without this, some browsers will scroll the page visually but won't actually move the programmatic keyboard focus to the new area.
+**Action:** Always ensure any container targeted by an anchor/skip link includes `tabindex="-1"` so it can programmatically receive focus.

--- a/templates/surveys/public_consent.html
+++ b/templates/surveys/public_consent.html
@@ -15,7 +15,7 @@
 <body>
 <a href="#main-content" class="visually-hidden-focusable">{% trans "Skip to main content" %}</a>
 {% include "_lang_toggle.html" with max_width="720px" %}
-<main id="main-content" class="container" style="max-width:720px; padding-top:2rem" aria-label="{% trans 'Main content' %}">
+<main id="main-content" tabindex="-1" class="container" style="max-width:720px; padding-top:2rem" aria-label="{% trans 'Main content' %}">
 
 <h1>{{ survey.name|bilingual:survey.name_fr }}</h1>
 

--- a/templates/surveys/public_form.html
+++ b/templates/surveys/public_form.html
@@ -19,7 +19,7 @@
 <body>
 <a href="#main-content" class="visually-hidden-focusable">{% trans "Skip to main content" %}</a>
 {% include "_lang_toggle.html" with max_width="720px" %}
-<main id="main-content" class="container" style="max-width:720px; padding-top:2rem" aria-label="{% trans 'Main content' %}">
+<main id="main-content" tabindex="-1" class="container" style="max-width:720px; padding-top:2rem" aria-label="{% trans 'Main content' %}">
 
 <h1>{{ survey.name|bilingual:survey.name_fr }}</h1>
 


### PR DESCRIPTION
💡 **What:** Added `tabindex="-1"` to `<main id="main-content">` in public survey templates (`public_form.html` and `public_consent.html`).
🎯 **Why:** Without `tabindex="-1"`, clicking the "Skip to main content" link does not actually move keyboard focus to the main content container in many browsers, forcing keyboard users to tab through all the headers again anyway.
📸 **Before/After:** Focus outline was not applying to the main content area upon clicking the skip link. Now focus correctly moves to the main container.
♿ **Accessibility:** Fixes a WCAG 2.4.1 bypass block issue that was broken due to missing focusability on the target container.

---
*PR created automatically by Jules for task [5518904243913356928](https://jules.google.com/task/5518904243913356928) started by @pboachie*