### PR TITLE
🎨 Palette: Add ARIA labels to Remove buttons in framework detail

### DIFF
--- a/templates/programs/evaluation/framework_detail.html
+++ b/templates/programs/evaluation/framework_detail.html
@@ -73,7 +73,7 @@
                     <a href="{% url 'programs:component_edit' framework_id=framework.pk component_id=comp.pk %}">{% trans "Edit" %}</a>
                     <form method="post" action="{% url 'programs:component_deactivate' framework_id=framework.pk component_id=comp.pk %}" class="inline-form">
                         {% csrf_token %}
-                        <button type="submit" class="outline contrast compact-btn">{% trans "Remove" %}</button>
+                        <button type="submit" class="outline contrast compact-btn" aria-label="{% blocktrans with name=comp.name %}Remove {{ name }}{% endblocktrans %}">{% trans "Remove" %}</button>
                     </form>
                 </td>
             </tr>
@@ -112,7 +112,7 @@
                 <td>
                     <form method="post" action="{% url 'programs:evidence_delete' framework_id=framework.pk evidence_id=link.pk %}" class="inline-form">
                         {% csrf_token %}
-                        <button type="submit" class="outline contrast compact-btn">{% trans "Remove" %}</button>
+                        <button type="submit" class="outline contrast compact-btn" aria-label="{% blocktrans with name=link.title %}Remove {{ name }}{% endblocktrans %}">{% trans "Remove" %}</button>
                     </form>
                 </td>
             </tr>


### PR DESCRIPTION
💡 What: Added contextual `aria-label`s to the generic "Remove" action buttons for Components and Evidence in `templates/programs/evaluation/framework_detail.html`.
🎯 Why: In tables with repetitive actions (like "Remove" buttons on every row), screen readers read out "Remove button" without context, leaving users unsure of *which* item they are removing.
📸 Before/After: Visual UI unchanged. Screen reader text changes from "Remove button" to "Remove [Component/Evidence Name] button".
♿ Accessibility: Improves WCAG compliance by providing necessary context to assistive technology for generic action buttons.

---
*PR created automatically by Jules for task [2763401799645943240](https://jules.google.com/task/2763401799645943240) started by @pboachie*