### PR TITLE
🛡️ Sentinel: [HIGH] Fix Login CSRF vulnerability in demo login endpoints

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,7 @@
 **Vulnerability:** XSS risk due to modifying the DOM using `.innerHTML` with potentially dynamic or unescaped translated values in `static/js/app.js`.
 **Learning:** `innerHTML` exposes a risk of executing unescaped input or malformed HTML translations. Instead of clearing nodes with `.innerHTML = ""` or creating nested HTML structures via strings, safer programmatic node manipulation should be utilized.
 **Prevention:** Use `.textContent` for assigning simple text to elements. Use programmatic DOM creation methods like `document.createElement` and `node.appendChild` instead of injecting raw HTML strings into `.innerHTML`. To clear an element, loop through and use `removeChild` on its children (e.g. `while (el.firstChild) el.removeChild(el.firstChild);`).
+## 2024-05-09 - [Login CSRF on Demo Endpoints]
+**Vulnerability:** The `demo_login` and `demo_portal_login` endpoints in `apps/auth_app/views.py` were decorated with `@csrf_exempt`, making them vulnerable to Login CSRF attacks where an attacker could force a victim to log into an attacker-controlled account.
+**Learning:** Even demo authentication boundaries need CSRF protection. Removing `@csrf_exempt` correctly enforces Django's built-in CSRF checks, provided the associated templates already include `{% csrf_token %}`.
+**Prevention:** Avoid using `@csrf_exempt` on state-changing authentication endpoints (like login forms) unless explicitly required for external API callbacks.

--- a/apps/auth_app/views.py
+++ b/apps/auth_app/views.py
@@ -340,7 +340,6 @@ def azure_callback(request):
     return _set_language_cookie(response, lang_code)
 
 
-@csrf_exempt
 @require_POST
 @ratelimit(key="ip", rate="10/m", method=["POST"], block=True)
 def demo_login(request, role):
@@ -383,7 +382,6 @@ def demo_login(request, role):
     return _set_language_cookie(response, lang_code)
 
 
-@csrf_exempt
 @require_POST
 @ratelimit(key="ip", rate="10/m", method=["POST"], block=True)
 def demo_portal_login(request, record_id):


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `demo_login` and `demo_portal_login` endpoints in `apps/auth_app/views.py` were decorated with `@csrf_exempt`, making them vulnerable to Login CSRF attacks. An attacker could potentially force a victim to authenticate into an attacker-controlled demo account.
🎯 Impact: While these are demo accounts, Login CSRF could still lead to confusion or be chained with other theoretical vulnerabilities within the authenticated session context.
🔧 Fix: Removed the `@csrf_exempt` decorators from both views. The `templates/auth/login.html` file already correctly included `{% csrf_token %}` for these forms.
✅ Verification: Ran the test suite (`tests/test_auth_views.py` and `tests/test_security.py`) which all pass, demonstrating the change does not break legitimate demo logins while correctly enforcing CSRF protection.

---
*PR created automatically by Jules for task [18207473609363777843](https://jules.google.com/task/18207473609363777843) started by @pboachie*