### PR TITLE
🛡️ Sentinel: [HIGH] Fix Login CSRF vulnerability on demo endpoints

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,8 @@
 **Vulnerability:** XSS risk due to modifying the DOM using `.innerHTML` with potentially dynamic or unescaped translated values in `static/js/app.js`.
 **Learning:** `innerHTML` exposes a risk of executing unescaped input or malformed HTML translations. Instead of clearing nodes with `.innerHTML = ""` or creating nested HTML structures via strings, safer programmatic node manipulation should be utilized.
 **Prevention:** Use `.textContent` for assigning simple text to elements. Use programmatic DOM creation methods like `document.createElement` and `node.appendChild` instead of injecting raw HTML strings into `.innerHTML`. To clear an element, loop through and use `removeChild` on its children (e.g. `while (el.firstChild) el.removeChild(el.firstChild);`).
+
+## 2024-05-11 - Remove CSRF Exemption from Authentication Boundaries
+**Vulnerability:** The `demo_login` and `demo_portal_login` views used the `@csrf_exempt` decorator. While they were only accessible in demo mode, disabling CSRF protection on an authentication boundary introduces a Login CSRF vulnerability, allowing an attacker to log a victim into the attacker's account.
+**Learning:** Even endpoints designed for convenience or demo environments must maintain standard security controls if they act as authentication boundaries (i.e. if they log a user in or set a session cookie).
+**Prevention:** Avoid using `@csrf_exempt` on authentication boundaries (like login endpoints) unless absolutely required by an external system callback (e.g. SAML/OIDC), and ensure login forms consistently include `{% csrf_token %}` to maintain protection against CSRF.

--- a/apps/auth_app/views.py
+++ b/apps/auth_app/views.py
@@ -7,7 +7,6 @@ from django.contrib.auth.decorators import login_required
 from django.core.cache import cache
 from django.http import HttpResponse, HttpResponseNotAllowed
 from django.shortcuts import redirect, render
-from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 from django.utils import timezone
 from django.utils import translation
@@ -340,7 +339,6 @@ def azure_callback(request):
     return _set_language_cookie(response, lang_code)
 
 
-@csrf_exempt
 @require_POST
 @ratelimit(key="ip", rate="10/m", method=["POST"], block=True)
 def demo_login(request, role):
@@ -383,7 +381,6 @@ def demo_login(request, role):
     return _set_language_cookie(response, lang_code)
 
 
-@csrf_exempt
 @require_POST
 @ratelimit(key="ip", rate="10/m", method=["POST"], block=True)
 def demo_portal_login(request, record_id):


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `demo_login` and `demo_portal_login` endpoints in `apps/auth_app/views.py` were decorated with `@csrf_exempt`, disabling Django's cross-site request forgery protection on these routes.
🎯 Impact: This introduces a Login CSRF vulnerability on the demo endpoints. While restricted to demo mode, an attacker could potentially force a victim's browser to authenticate with the attacker's demo credentials.
🔧 Fix: Removed the `@csrf_exempt` decorators and the unused import from `apps/auth_app/views.py`. Confirmed that the `templates/auth/login.html` forms submitting to these endpoints already securely include `{% csrf_token %}`.
✅ Verification: Ran `python -m pytest tests/test_auth_views.py` successfully and verified all 53 authentication and demo login tests pass with CSRF protection enabled.

---
*PR created automatically by Jules for task [15767150770821400506](https://jules.google.com/task/15767150770821400506) started by @pboachie*