### PR TITLE
🎨 Palette: Hide decorative characters from screen readers

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -12,3 +12,6 @@
 ## 2025-03-10 - Add `data-select-on-click` to Copyable Text Inputs
 **Learning:** For read-only inputs containing shareable URLs (e.g. calendar feed, direct registration link), requiring users to manually highlight the text before copying can be frustrating and error-prone. The codebase already supports an accessible `data-select-on-click="true"` pattern used in invite links.
 **Action:** Consistently apply the `data-select-on-click="true"` attribute to all read-only `input` elements designated for copying, ensuring users can instantly select the full value with a single click.
+## 2024-05-18 - Decorative Visual Characters and Translation Tags
+**Learning:** Decorative characters (like `✕` or `→`) used in templates for visual cues or dismiss buttons will be read aloud by screen readers if left alone. Placing them directly next to translation tags (e.g. `{% trans %}`) or inside strings can be problematic for a11y. They must be wrapped in `<span aria-hidden="true">`.
+**Action:** Always wrap decorative characters in `<span aria-hidden="true">` to prevent screen readers from reading them out, while ensuring this span resides *outside* of translation tags so it doesn't break localization strings. For JavaScript DOM manipulations, inject the span as part of the `innerHTML` construction.

--- a/templates/plans/goal_form.html
+++ b/templates/plans/goal_form.html
@@ -653,7 +653,7 @@
         if (e.target.closest('#btn-remove-custom-metric')) {
             e.preventDefault();
             var preview = e.target.closest('.custom-metric-preview');
-            if (preview) preview.innerHTML = '<small class="secondary">✕ ' + "{% trans 'Custom scale removed.' %}" + '</small>';
+            if (preview) preview.innerHTML = '<small class="secondary"><span aria-hidden="true">✕</span> ' + "{% trans 'Custom scale removed.' %}" + '</small>';
             // Add hidden field to skip custom metric on save
             var actions = document.querySelector('.suggestion-actions');
             if (actions) {

--- a/templates/surveys/admin/survey_questions.html
+++ b/templates/surveys/admin/survey_questions.html
@@ -64,7 +64,7 @@
                     {% csrf_token %}
                     <input type="hidden" name="action" value="delete_question">
                     <input type="hidden" name="question_id" value="{{ q.pk }}">
-                    <button type="submit" class="outline secondary" aria-label="{% trans 'Remove question' %}">✕</button>
+                    <button type="submit" class="outline secondary" aria-label="{% trans 'Remove question' %}"><span aria-hidden="true">✕</span></button>
                 </form>
             </div>
         </li>


### PR DESCRIPTION
💡 **What:** Wrapped decorative '✕' characters in `templates/surveys/admin/survey_questions.html` and `templates/plans/goal_form.html` inside `<span aria-hidden="true">`.

🎯 **Why:** Screen readers will unnecessarily read out decorative symbols like '✕' (often pronounced as "multiplication sign" or "cross"), adding noise and confusion for users relying on assistive technology. The actual action is already described by the `aria-label` or surrounding context.

📸 **Before/After:** No visual changes.

♿ **Accessibility:** Prevents screen readers from reciting meaningless decorative characters, making the UI much cleaner and easier to navigate for visually impaired users.

---
*PR created automatically by Jules for task [7086310000078046846](https://jules.google.com/task/7086310000078046846) started by @pboachie*