### PR TITLE
🛡️ Sentinel: [HIGH] Fix Login CSRF vulnerability in demo login endpoints

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,8 @@
 **Vulnerability:** XSS risk due to modifying the DOM using `.innerHTML` with potentially dynamic or unescaped translated values in `static/js/app.js`.
 **Learning:** `innerHTML` exposes a risk of executing unescaped input or malformed HTML translations. Instead of clearing nodes with `.innerHTML = ""` or creating nested HTML structures via strings, safer programmatic node manipulation should be utilized.
 **Prevention:** Use `.textContent` for assigning simple text to elements. Use programmatic DOM creation methods like `document.createElement` and `node.appendChild` instead of injecting raw HTML strings into `.innerHTML`. To clear an element, loop through and use `removeChild` on its children (e.g. `while (el.firstChild) el.removeChild(el.firstChild);`).
+
+## 2024-03-07 - [Login CSRF via `@csrf_exempt` on Demo Logins]
+**Vulnerability:** The `demo_login` and `demo_portal_login` endpoints in `apps/auth_app/views.py` were incorrectly marked with `@csrf_exempt`, leaving them vulnerable to Login CSRF attacks.
+**Learning:** Even demo-specific endpoints must maintain strict session security boundaries. Since these endpoints log the user in and set authentication cookies, an attacker could force a victim to log into a demo account, potentially harvesting activity performed under that session.
+**Prevention:** Never use `@csrf_exempt` on any authentication boundaries (login endpoints) unless mandated by an external provider (and even then, use state validation). Always ensure the corresponding frontend forms include `{% csrf_token %}` and rely on standard Django CSRF middleware.

--- a/apps/auth_app/views.py
+++ b/apps/auth_app/views.py
@@ -7,7 +7,6 @@ from django.contrib.auth.decorators import login_required
 from django.core.cache import cache
 from django.http import HttpResponse, HttpResponseNotAllowed
 from django.shortcuts import redirect, render
-from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 from django.utils import timezone
 from django.utils import translation
@@ -340,7 +339,6 @@ def azure_callback(request):
     return _set_language_cookie(response, lang_code)
 
 
-@csrf_exempt
 @require_POST
 @ratelimit(key="ip", rate="10/m", method=["POST"], block=True)
 def demo_login(request, role):
@@ -383,7 +381,6 @@ def demo_login(request, role):
     return _set_language_cookie(response, lang_code)
 
 
-@csrf_exempt
 @require_POST
 @ratelimit(key="ip", rate="10/m", method=["POST"], block=True)
 def demo_portal_login(request, record_id):


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Missing CSRF protection on demo login endpoints (`demo_login` and `demo_portal_login`).
🎯 Impact: Attackers could force a user to log in as a demo user (Login CSRF), potentially compromising any activity performed under that session.
🔧 Fix: Removed the unnecessary `@csrf_exempt` decorators from the endpoints, as the frontend already provides the `{% csrf_token %}`.
✅ Verification: Ran `python -m pytest tests/test_auth_views.py -v -k demo` and confirmed all tests pass without the decorator.

---
*PR created automatically by Jules for task [2459453810982972484](https://jules.google.com/task/2459453810982972484) started by @pboachie*