### PR TITLE
🎨 Palette: [UX improvement] Improve a11y for survey question removal button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -12,3 +12,7 @@
 ## 2025-03-10 - Add `data-select-on-click` to Copyable Text Inputs
 **Learning:** For read-only inputs containing shareable URLs (e.g. calendar feed, direct registration link), requiring users to manually highlight the text before copying can be frustrating and error-prone. The codebase already supports an accessible `data-select-on-click="true"` pattern used in invite links.
 **Action:** Consistently apply the `data-select-on-click="true"` attribute to all read-only `input` elements designated for copying, ensuring users can instantly select the full value with a single click.
+
+## 2025-03-10 - Add Contextual ARIA labels to Remove Action buttons with HTML entities
+**Learning:** Hardcoded text icons like '✕' inside generic icon-only action buttons miss important visual-to-speech cues and lack contextual information in loops.
+**Action:** Always wrap HTML entities like '&times;' in a '<span aria-hidden="true">' and ensure action buttons like "Remove" in loops include context using blocktrans.

--- a/templates/surveys/admin/survey_questions.html
+++ b/templates/surveys/admin/survey_questions.html
@@ -64,7 +64,7 @@
                     {% csrf_token %}
                     <input type="hidden" name="action" value="delete_question">
                     <input type="hidden" name="question_id" value="{{ q.pk }}">
-                    <button type="submit" class="outline secondary" aria-label="{% trans 'Remove question' %}">✕</button>
+                    <button type="submit" class="outline secondary" aria-label="{% blocktrans with text=q.question_text %}Remove question: {{ text }}{% endblocktrans %}"><span aria-hidden="true">&times;</span></button>
                 </form>
             </div>
         </li>


### PR DESCRIPTION
💡 What: Replaced the generic hardcoded '✕' character inside the survey question remove button with a semantic `&times;` entity wrapped in `<span aria-hidden="true">`. Added a dynamic `aria-label` using Django's `blocktrans` to include the actual text of the question being removed.

🎯 Why: Hardcoded text icons inside icon-only buttons create confusion for screen reader users (who might hear "times, button" or just "Remove question" multiple times without context). Including the question text in the label ensures users know exactly which item they are deleting.

📸 Before/After:
Before: `<button aria-label="Remove question">✕</button>`
After: `<button aria-label="Remove question: What is your age?"><span aria-hidden="true">&times;</span></button>`

♿ Accessibility:
- Fixes WCAG 4.1.2 (Name, Role, Value) by giving the button an accessible, context-aware name.
- Hides the decorative 'x' entity from screen readers to prevent confusing pronunciation.

---
*PR created automatically by Jules for task [13551394528249526133](https://jules.google.com/task/13551394528249526133) started by @pboachie*