### PR TITLE
🎨 Palette: [UX improvement] Add type="button" to generic buttons and aria-pressed to HTMX toggles

### DIFF
--- a/templates/clients/_client_layout.html
+++ b/templates/clients/_client_layout.html
@@ -25,7 +25,7 @@
         {% if not client.is_anonymised and not is_receptionist %}
         <div class="actions-dropdown">
             {# aria-haspopup="menu" is more precise than "true" and reduces AT interference with tablist arrow keys (QA-R8-A11Y8) #}
-            <button class="outline actions-dropdown-toggle" aria-expanded="false" aria-haspopup="menu" aria-label="{% trans 'Actions menu' %}">{% trans "Actions" %} ▾</button>
+            <button type="button" class="outline actions-dropdown-toggle" aria-expanded="false" aria-haspopup="menu" aria-label="{% trans 'Actions menu' %}">{% trans "Actions" %} ▾</button>
             <ul class="actions-dropdown-menu" role="menu" hidden>
                 {# QA-R8-UX6: Edit is first so it is immediately visible on mobile without scrolling #}
                 {% if can_edit_client %}

--- a/templates/consortia/dashboard.html
+++ b/templates/consortia/dashboard.html
@@ -46,10 +46,10 @@
 {% if is_consortium_lead %}
 <div class="view-toggle">
     <fieldset role="group">
-        <button id="btn-network" class="outline" aria-pressed="true" data-call-function="toggleView" data-call-args='["network"]'>
+        <button type="button" id="btn-network" class="outline" aria-pressed="true" data-call-function="toggleView" data-call-args='["network"]'>
             {% trans "Network View" %}
         </button>
-        <button id="btn-agency" class="outline secondary" aria-pressed="false" data-call-function="toggleView" data-call-args='["agency"]'>
+        <button type="button" id="btn-agency" class="outline secondary" aria-pressed="false" data-call-function="toggleView" data-call-args='["agency"]'>
             {% trans "Agency View" %}
         </button>
     </fieldset>

--- a/templates/notes/suggestions/theme_detail.html
+++ b/templates/notes/suggestions/theme_detail.html
@@ -98,11 +98,11 @@
 
 {# ── Tabs: Linked / Link More ── #}
 <div class="theme-tabs" role="tablist" aria-label="{% trans 'Theme suggestions' %}">
-    <button role="tab" aria-selected="true" aria-controls="linked-tab" id="linked-tab-btn" class="tab-btn active">
+    <button type="button" role="tab" aria-selected="true" aria-controls="linked-tab" id="linked-tab-btn" class="tab-btn active">
         {% trans "Linked" %} ({{ linked_notes|length }})
     </button>
     {% if can_manage %}
-    <button role="tab" aria-selected="false" aria-controls="unlinked-tab" id="unlinked-tab-btn" class="tab-btn">
+    <button type="button" role="tab" aria-selected="false" aria-controls="unlinked-tab" id="unlinked-tab-btn" class="tab-btn">
         {% trans "Link More" %}
     </button>
     {% endif %}

--- a/templates/plans/_metric_toggle.html
+++ b/templates/plans/_metric_toggle.html
@@ -3,6 +3,7 @@
         hx-target="#metric-toggle-{{ metric.pk }}"
         hx-swap="innerHTML"
         class="outline small {% if metric.is_enabled %}contrast{% else %}secondary{% endif %}"
+        aria-pressed="{{ metric.is_enabled|yesno:'true,false' }}"
         aria-label="{% if metric.is_enabled %}{% blocktrans with name=metric.name %}Disable {{ name }}{% endblocktrans %}{% else %}{% blocktrans with name=metric.name %}Enable {{ name }}{% endblocktrans %}{% endif %}">
     {% if metric.is_enabled %}{% trans "Enabled" %}{% else %}{% trans "Disabled" %}{% endif %}
 </button>

--- a/templates/plans/_target.html
+++ b/templates/plans/_target.html
@@ -30,7 +30,7 @@
         {% if can_edit %}
         <div class="goal-card-actions">
             <div class="actions-dropdown">
-                <button class="outline small actions-dropdown-toggle" aria-expanded="false" aria-haspopup="true" aria-label="{% blocktrans with name=target.name %}Actions for {{ name }}{% endblocktrans %}">{% trans "Actions" %} &#9662;</button>
+                <button type="button" class="outline small actions-dropdown-toggle" aria-expanded="false" aria-haspopup="true" aria-label="{% blocktrans with name=target.name %}Actions for {{ name }}{% endblocktrans %}">{% trans "Actions" %} &#9662;</button>
                 <ul class="actions-dropdown-menu" role="menu" hidden>
                     <li role="none"><a role="menuitem" href="{% url 'plans:target_edit' target_id=target.pk %}">{% trans "Edit" %}<small>{% blocktrans with target=term.target|default:"goal" %}Edit this {{ target }}{% endblocktrans %}</small></a></li>
                     <li role="none"><a role="menuitem" href="#"


### PR DESCRIPTION
💡 What: Added `type="button"` to generic interactive UI buttons across several templates and applied `aria-pressed` state logic to the metric HTMX toggle button. Also recorded this in the Palette journal.
🎯 Why: Prevents accidental form submissions (as `<button>` defaults to `type="submit"`) when these components are used within or near forms, and ensures screen readers correctly announce the active state of HTMX-powered toggle buttons.
📸 Before/After: Visuals remain unchanged, underlying semantics and accessibility behavior are improved.
♿ Accessibility: Improved keyboard/form semantics and added necessary dynamic `aria-pressed` state announcements for stateful toggles.

---
*PR created automatically by Jules for task [1693887723956852342](https://jules.google.com/task/1693887723956852342) started by @pboachie*