### PR TITLE
🎨 Palette: Add contextual ARIA labels to framework action buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -12,3 +12,7 @@
 ## 2025-03-10 - Add `data-select-on-click` to Copyable Text Inputs
 **Learning:** For read-only inputs containing shareable URLs (e.g. calendar feed, direct registration link), requiring users to manually highlight the text before copying can be frustrating and error-prone. The codebase already supports an accessible `data-select-on-click="true"` pattern used in invite links.
 **Action:** Consistently apply the `data-select-on-click="true"` attribute to all read-only `input` elements designated for copying, ensuring users can instantly select the full value with a single click.
+
+## 2024-03-10 - Add Contextual ARIA Labels to Action Buttons in Evaluation Frameworks
+**Learning:** Action buttons like "Edit" and "Remove" in dynamically generated lists (like evaluation components and evidence links) lack context for screen readers when they don't explicitly reference the target item. A user tabbing through the page would hear "Edit, link", "Remove, button", etc., multiple times without knowing *what* is being edited or removed.
+**Action:** Always add descriptive `aria-label` attributes to generic action buttons inside iterative loops, using `{% blocktrans %}` to include the item's name dynamically (e.g., `aria-label="{% blocktrans with name=comp.name %}Edit {{ name }}{% endblocktrans %}"`).

--- a/templates/programs/evaluation/framework_detail.html
+++ b/templates/programs/evaluation/framework_detail.html
@@ -70,10 +70,10 @@
                 <td><code>{{ comp.cids_class }}</code></td>
                 <td>{{ comp.get_quality_state_display }}</td>
                 <td>
-                    <a href="{% url 'programs:component_edit' framework_id=framework.pk component_id=comp.pk %}">{% trans "Edit" %}</a>
+                    <a href="{% url 'programs:component_edit' framework_id=framework.pk component_id=comp.pk %}" aria-label="{% blocktrans with name=comp.name %}Edit {{ name }}{% endblocktrans %}">{% trans "Edit" %}</a>
                     <form method="post" action="{% url 'programs:component_deactivate' framework_id=framework.pk component_id=comp.pk %}" class="inline-form">
                         {% csrf_token %}
-                        <button type="submit" class="outline contrast compact-btn">{% trans "Remove" %}</button>
+                        <button type="submit" class="outline contrast compact-btn" aria-label="{% blocktrans with name=comp.name %}Remove {{ name }}{% endblocktrans %}">{% trans "Remove" %}</button>
                     </form>
                 </td>
             </tr>
@@ -112,7 +112,7 @@
                 <td>
                     <form method="post" action="{% url 'programs:evidence_delete' framework_id=framework.pk evidence_id=link.pk %}" class="inline-form">
                         {% csrf_token %}
-                        <button type="submit" class="outline contrast compact-btn">{% trans "Remove" %}</button>
+                        <button type="submit" class="outline contrast compact-btn" aria-label="{% blocktrans with name=link.title %}Remove {{ name }}{% endblocktrans %}">{% trans "Remove" %}</button>
                     </form>
                 </td>
             </tr>


### PR DESCRIPTION
💡 **What**: Added contextual `aria-label`s to the generic "Edit" and "Remove" action buttons in the dynamically generated Evaluation Frameworks list (components and evidence tables).
🎯 **Why**: When action buttons in lists don't explicitly reference the target item, they lack context for screen reader users (e.g., "Edit, link", "Remove, button" read repeatedly). This dynamically injects the item's name into the label, resolving the ambiguity.
📸 **Before/After**: Visually identical. Screen reader behavior is improved.
♿ **Accessibility**: Resolves an issue where interactive elements within data tables lacked necessary programmatic context (WCAG 4.1.2 Name, Role, Value).

---
*PR created automatically by Jules for task [11385387245289577162](https://jules.google.com/task/11385387245289577162) started by @pboachie*