### PR TITLE
🎨 Palette: Add copy buttons for MFA secrets and shareable links

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -12,3 +12,7 @@
 ## 2025-03-10 - Add `data-select-on-click` to Copyable Text Inputs
 **Learning:** For read-only inputs containing shareable URLs (e.g. calendar feed, direct registration link), requiring users to manually highlight the text before copying can be frustrating and error-prone. The codebase already supports an accessible `data-select-on-click="true"` pattern used in invite links.
 **Action:** Consistently apply the `data-select-on-click="true"` attribute to all read-only `input` elements designated for copying, ensuring users can instantly select the full value with a single click.
+
+## 2024-03-11 - Pair plain-text codes and URLs with one-click copy buttons
+**Learning:** When users are presented with plain-text secret keys or URLs to copy (like MFA secrets or report share links), relying on manual highlighting is error-prone. Converting these to use `copy-btn` and `data-select-on-click` inputs greatly improves UX and accessibility.
+**Action:** Always provide explicit copy buttons for critical codes/URLs and use accessible read-only inputs for shareable links to eliminate manual text selection friction.

--- a/templates/auth/mfa_setup.html
+++ b/templates/auth/mfa_setup.html
@@ -17,7 +17,10 @@
     <details>
         <summary>{% trans "Can't scan the QR code?" %}</summary>
         <p>{% trans "Enter this secret key manually in your authenticator app:" %}</p>
-        <code style="word-break: break-all; font-size: 1.1rem;">{{ secret }}</code>
+        <div class="grid" style="align-items: center;">
+            <code id="mfa-secret" style="word-break: break-all; font-size: 1.1rem; margin-bottom: 0;">{{ secret }}</code>
+            <button type="button" class="outline secondary copy-btn" data-clipboard-target="#mfa-secret" aria-label="{% trans 'Copy secret key' %}" style="margin-bottom: 0;">{% trans "Copy" %}</button>
+        </div>
     </details>
 
     {% if error %}

--- a/templates/reports/funder_report_approved.html
+++ b/templates/reports/funder_report_approved.html
@@ -53,11 +53,25 @@
         {% endif %}
     </p>
     <a href="{{ download_path }}" role="button">{% trans "Download Report" %}</a>
-    <p style="margin-top: 1rem;">
-        <small>{% trans "This link will expire in 24 hours. You can also share this link:" %}</small>
-        <br>
-        <code style="word-break: break-all;">{{ download_url }}</code>
-    </p>
+    <div style="margin-top: 1rem;">
+        <p><small>{% trans "This link will expire in 24 hours. You can also share this link:" %}</small></p>
+        <div class="grid" style="align-items: center;">
+            <input type="text"
+                   id="download-url"
+                   value="{{ download_url }}"
+                   readonly
+                   data-select-on-click="true"
+                   aria-label="{% trans 'Shareable download URL' %}"
+                   style="margin-bottom: 0;">
+            <button type="button"
+                    class="outline secondary copy-btn"
+                    data-clipboard-target="#download-url"
+                    aria-label="{% trans 'Copy download link' %}"
+                    style="margin-bottom: 0;">
+                {% trans "Copy" %}
+            </button>
+        </div>
+    </div>
 </article>
 
 <a href="{% url 'reports:funder_report' %}">{% trans "Generate Another Report" %}</a>


### PR DESCRIPTION
💡 **What**: Replaced raw, plain-text `<code style="...">` blocks with a structured UI containing a one-click "Copy" button. For shareable download links, the `<code>` text was converted to a `<input readonly data-select-on-click="true">` for easier highlighting.
🎯 **Why**: When users need to save critical text like an MFA secret or distribute an export URL, forcing them to manually highlight and copy the text is frustrating and prone to error (e.g. accidentally missing the last character). Giving users a dedicated button eliminates friction.
📸 **Before/After**: The MFA configuration screen and Funder Report approved screen now display an explicitly actionable button aligned neatly next to the token/URL.
♿ **Accessibility**: The inputs use `data-select-on-click="true"` which makes it easy for all users (including those with motor impairments) to capture the full string. All new "Copy" buttons include clear, contextual `aria-label`s (e.g. `aria-label="Copy secret key"` or `aria-label="Copy download link"`) so screen readers aren't presented with ambiguous controls.

---
*PR created automatically by Jules for task [8102570398108428301](https://jules.google.com/task/8102570398108428301) started by @pboachie*