### PR TITLE
🛡️ Sentinel: [HIGH] Fix Login CSRF on demo authentication endpoints

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,8 @@
 **Vulnerability:** XSS risk due to modifying the DOM using `.innerHTML` with potentially dynamic or unescaped translated values in `static/js/app.js`.
 **Learning:** `innerHTML` exposes a risk of executing unescaped input or malformed HTML translations. Instead of clearing nodes with `.innerHTML = ""` or creating nested HTML structures via strings, safer programmatic node manipulation should be utilized.
 **Prevention:** Use `.textContent` for assigning simple text to elements. Use programmatic DOM creation methods like `document.createElement` and `node.appendChild` instead of injecting raw HTML strings into `.innerHTML`. To clear an element, loop through and use `removeChild` on its children (e.g. `while (el.firstChild) el.removeChild(el.firstChild);`).
+
+## 2026-03-07 - [Login CSRF on Demo Endpoints]
+**Vulnerability:** The `demo_login` and `demo_portal_login` endpoints in `apps/auth_app/views.py` were marked with `@csrf_exempt`, introducing a Login CSRF vulnerability.
+**Learning:** Even endpoints designed for demo purposes need CSRF protection. Removing `@csrf_exempt` from authentication boundaries is safe if the frontend forms already include `{% csrf_token %}`.
+**Prevention:** Avoid using `@csrf_exempt` on authentication boundaries unless absolutely required by an external system callback. Ensure forms include `{% csrf_token %}` to support CSRF protection.

--- a/apps/auth_app/views.py
+++ b/apps/auth_app/views.py
@@ -7,7 +7,6 @@ from django.contrib.auth.decorators import login_required
 from django.core.cache import cache
 from django.http import HttpResponse, HttpResponseNotAllowed
 from django.shortcuts import redirect, render
-from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 from django.utils import timezone
 from django.utils import translation
@@ -340,7 +339,6 @@ def azure_callback(request):
     return _set_language_cookie(response, lang_code)
 
 
-@csrf_exempt
 @require_POST
 @ratelimit(key="ip", rate="10/m", method=["POST"], block=True)
 def demo_login(request, role):
@@ -383,7 +381,6 @@ def demo_login(request, role):
     return _set_language_cookie(response, lang_code)
 
 
-@csrf_exempt
 @require_POST
 @ratelimit(key="ip", rate="10/m", method=["POST"], block=True)
 def demo_portal_login(request, record_id):


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `demo_login` and `demo_portal_login` endpoints in `apps/auth_app/views.py` were marked with `@csrf_exempt`, introducing a Login CSRF vulnerability.
🎯 Impact: Attackers could forcefully log victims into an attacker-controlled account, leading to potential information disclosure when users unknowingly enter sensitive data into that account.
🔧 Fix: Removed the unnecessary `@csrf_exempt` decorators since the frontend already correctly provides `{% csrf_token %}`.
✅ Verification: Run tests (`python -m pytest tests/test_auth_views.py tests/test_roles_invites.py`) to verify login works correctly with CSRF enabled.

---
*PR created automatically by Jules for task [18417713484183359799](https://jules.google.com/task/18417713484183359799) started by @pboachie*