### PR TITLE
🛡️ Sentinel: [HIGH] Fix CSRF vulnerability in demo login

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,9 @@
 **Vulnerability:** XSS risk due to modifying the DOM using `.innerHTML` with potentially dynamic or unescaped translated values in `static/js/app.js`.
 **Learning:** `innerHTML` exposes a risk of executing unescaped input or malformed HTML translations. Instead of clearing nodes with `.innerHTML = ""` or creating nested HTML structures via strings, safer programmatic node manipulation should be utilized.
 **Prevention:** Use `.textContent` for assigning simple text to elements. Use programmatic DOM creation methods like `document.createElement` and `node.appendChild` instead of injecting raw HTML strings into `.innerHTML`. To clear an element, loop through and use `removeChild` on its children (e.g. `while (el.firstChild) el.removeChild(el.firstChild);`).
+
+## 2024-05-23 - Login CSRF vulnerability on Demo Login
+
+**Vulnerability:** The `demo_login` and `demo_portal_login` POST endpoints in `apps/auth_app/views.py` were missing CSRF protection due to the use of `@csrf_exempt`.
+**Learning:** Even though these are demo endpoints and only enabled in `DEMO_MODE`, they are authentication boundaries (they log the user in and set a session). Bypassing CSRF on authentication boundaries creates a "Login CSRF" vulnerability where an attacker can force a victim to log into an attacker-controlled account.
+**Prevention:** Never use `@csrf_exempt` on any endpoint that sets an authentication session (like login, demo login, or one-time invite accept endpoints) unless there's a strict external system callback requirement that is otherwise mitigated. Ensure frontend forms use `{% csrf_token %}`.

--- a/apps/auth_app/views.py
+++ b/apps/auth_app/views.py
@@ -340,7 +340,6 @@ def azure_callback(request):
     return _set_language_cookie(response, lang_code)
 
 
-@csrf_exempt
 @require_POST
 @ratelimit(key="ip", rate="10/m", method=["POST"], block=True)
 def demo_login(request, role):
@@ -383,7 +382,6 @@ def demo_login(request, role):
     return _set_language_cookie(response, lang_code)
 
 
-@csrf_exempt
 @require_POST
 @ratelimit(key="ip", rate="10/m", method=["POST"], block=True)
 def demo_portal_login(request, record_id):


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `demo_login` and `demo_portal_login` POST endpoints in `apps/auth_app/views.py` were missing CSRF protection due to the use of the `@csrf_exempt` decorator.
🎯 Impact: An attacker could force a victim's browser to authenticate them into an attacker-controlled demo account or session via a "Login CSRF" attack.
🔧 Fix: Removed the `@csrf_exempt` decorators from both functions. The existing demo login forms in `templates/auth/login.html` already included `{% csrf_token %}`, so this change strictly enforces the token validation without breaking the forms.
✅ Verification: Ran `python -m pytest tests/test_auth_views.py` and all 53 authentication tests passed.

---
*PR created automatically by Jules for task [3508977041381488379](https://jules.google.com/task/3508977041381488379) started by @pboachie*