### PR TITLE
🎨 Palette: Add ARIA labels to generic action buttons and progress bars

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -12,3 +12,11 @@
 ## 2025-03-10 - Add `data-select-on-click` to Copyable Text Inputs
 **Learning:** For read-only inputs containing shareable URLs (e.g. calendar feed, direct registration link), requiring users to manually highlight the text before copying can be frustrating and error-prone. The codebase already supports an accessible `data-select-on-click="true"` pattern used in invite links.
 **Action:** Consistently apply the `data-select-on-click="true"` attribute to all read-only `input` elements designated for copying, ensuring users can instantly select the full value with a single click.
+
+## 2025-03-10 - Using Django variables in `aria-label`s inside blocktrans
+**Learning:** When using `{% blocktrans %}` inside an `aria-label`, it is easy to assume context variables like `survey.name` or `cat.name` are available just by looking at other files. However, accessing non-existent variables can cause template rendering errors.
+**Action:** Always verify the actual context variables available in the specific template (e.g. by looking at how other elements in the template render values) before interpolating them into `aria-label` attributes.
+
+## 2025-03-10 - Environment dependency installation for testing
+**Learning:** Installing generic `pytest` or `django` dependencies manually in the sandbox via `pip install pytest django` can introduce incompatible versions (like Django 6.0 beta, causing `RemovedInDjango60Warning` failures with pytest-django).
+**Action:** Always install test dependencies precisely as specified in the project using `pip install -r requirements-test.txt` to guarantee compatibility and prevent spurious test failures.

--- a/apps/portal/templates/portal/surveys_list.html
+++ b/apps/portal/templates/portal/surveys_list.html
@@ -24,7 +24,7 @@
     {% if a.status == "in_progress" and a.total_questions %}
     <div style="margin-bottom: 0.75rem;">
         <small class="secondary">{{ a.answered_questions }} {% trans "of" %} {{ a.total_questions }} {% trans "questions answered" %}</small>
-        <progress value="{{ a.progress_pct }}" max="100" style="width: 100%; height: 0.5rem;">{{ a.progress_pct }}%</progress>
+        <progress value="{{ a.progress_pct }}" max="100" style="width: 100%; height: 0.5rem;" aria-label="{% trans 'Survey progress' %}">{{ a.progress_pct }}%</progress>
     </div>
     {% endif %}
     <a href="{% url 'portal:survey_fill' assignment_id=a.pk %}" class="secondary">

--- a/templates/events/sre_category_list.html
+++ b/templates/events/sre_category_list.html
@@ -52,9 +52,9 @@
                     <form method="post" action="{% url 'sre_categories:sre_category_toggle_active' category_id=cat.pk %}" style="display: inline;">
                         {% csrf_token %}
                         {% if cat.is_active %}
-                        <button type="submit" class="outline secondary" style="padding: 0.25rem 0.5rem; font-size: 0.85rem;">{% trans "Archive" %}</button>
+                        <button type="submit" class="outline secondary" style="padding: 0.25rem 0.5rem; font-size: 0.85rem;" aria-label="{% blocktrans with name=cat.name %}Archive {{ name }}{% endblocktrans %}">{% trans "Archive" %}</button>
                         {% else %}
-                        <button type="submit" class="outline" style="padding: 0.25rem 0.5rem; font-size: 0.85rem;">{% trans "Activate" %}</button>
+                        <button type="submit" class="outline" style="padding: 0.25rem 0.5rem; font-size: 0.85rem;" aria-label="{% blocktrans with name=cat.name %}Activate {{ name }}{% endblocktrans %}">{% trans "Activate" %}</button>
                         {% endif %}
                     </form>
                 </div>

--- a/templates/surveys/admin/rule_list.html
+++ b/templates/surveys/admin/rule_list.html
@@ -67,7 +67,7 @@
                 {% if rule.is_active %}
                 <form method="post" action="{% url 'survey_manage:survey_rule_deactivate' survey_id=survey.pk rule_id=rule.pk %}" style="display:inline">
                     {% csrf_token %}
-                    <button type="submit" class="outline secondary" style="margin-bottom:0">{% trans "Deactivate" %}</button>
+                    <button type="submit" class="outline secondary" style="margin-bottom:0" aria-label="{% trans 'Deactivate rule' %}">{% trans "Deactivate" %}</button>
                 </form>
                 {% endif %}
             </td>

--- a/templates/surveys/admin/survey_detail.html
+++ b/templates/surveys/admin/survey_detail.html
@@ -35,13 +35,13 @@
     <form method="post" action="{% url 'survey_manage:survey_status' survey_id=survey.pk %}" style="display:inline">
         {% csrf_token %}
         <input type="hidden" name="status" value="active">
-        <button type="submit" class="outline">{% trans "Activate" %}</button>
+        <button type="submit" class="outline" aria-label="{% blocktrans with name=survey.name %}Activate {{ name }}{% endblocktrans %}">{% trans "Activate" %}</button>
     </form>
     {% elif survey.status == "active" %}
     <form method="post" action="{% url 'survey_manage:survey_status' survey_id=survey.pk %}" style="display:inline">
         {% csrf_token %}
         <input type="hidden" name="status" value="closed">
-        <button type="submit" class="outline secondary">{% trans "Close" %}</button>
+        <button type="submit" class="outline secondary" aria-label="{% blocktrans with name=survey.name %}Close {{ name }}{% endblocktrans %}">{% trans "Close" %}</button>
     </form>
     {% endif %}
 </div>


### PR DESCRIPTION
💡 **What**:
- Added `aria-label` to "Archive" and "Activate" buttons in `templates/events/sre_category_list.html`
- Added `aria-label` to "Deactivate" button in `templates/surveys/admin/rule_list.html`
- Added `aria-label` to "Activate" and "Close" buttons in `templates/surveys/admin/survey_detail.html`
- Added `aria-label` to `<progress>` tag in `apps/portal/templates/portal/surveys_list.html`

🎯 **Why**:
Generic button text like "Activate" or "Archive" lacks context when read out of sequence by screen readers, particularly in tables or lists with multiple identical buttons. Adding the target item's name via `aria-label` ("Archive Medical Emergency") clarifies the button's purpose for assistive technologies. Adding labels to progress bars ensures the metric being tracked is audibly identified.

📸 **Before/After**:
Visually unchanged. The markup now includes ARIA attributes.

♿ **Accessibility**:
Improves WCAG 4.1.2 Name, Role, Value compliance by ensuring interactive elements and status indicators have descriptive, programmatically determinable names.

---
*PR created automatically by Jules for task [11404623023810956583](https://jules.google.com/task/11404623023810956583) started by @pboachie*