### PR TITLE
🛡️ Sentinel: [HIGH] Fix Login CSRF on demo login endpoints

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,8 @@
 **Vulnerability:** XSS risk due to modifying the DOM using `.innerHTML` with potentially dynamic or unescaped translated values in `static/js/app.js`.
 **Learning:** `innerHTML` exposes a risk of executing unescaped input or malformed HTML translations. Instead of clearing nodes with `.innerHTML = ""` or creating nested HTML structures via strings, safer programmatic node manipulation should be utilized.
 **Prevention:** Use `.textContent` for assigning simple text to elements. Use programmatic DOM creation methods like `document.createElement` and `node.appendChild` instead of injecting raw HTML strings into `.innerHTML`. To clear an element, loop through and use `removeChild` on its children (e.g. `while (el.firstChild) el.removeChild(el.firstChild);`).
+
+## 2024-03-07 - [Missing CSRF Protection on Demo Login Endpoints]
+**Vulnerability:** The `demo_login` and `demo_portal_login` views had the `@csrf_exempt` decorator, removing CSRF protection.
+**Learning:** This exposes the application to Login CSRF, where an attacker can forge cross-site requests to authenticate a victim as a demo user or participant, bypassing standard protections. These endpoints act as authentication boundaries and must have CSRF protection.
+**Prevention:** Never use `@csrf_exempt` on authentication boundaries. Ensure frontend forms include the `{% csrf_token %}` tag and remove `@csrf_exempt` from views that process user logins.

--- a/apps/auth_app/views.py
+++ b/apps/auth_app/views.py
@@ -7,7 +7,6 @@ from django.contrib.auth.decorators import login_required
 from django.core.cache import cache
 from django.http import HttpResponse, HttpResponseNotAllowed
 from django.shortcuts import redirect, render
-from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 from django.utils import timezone
 from django.utils import translation
@@ -340,7 +339,6 @@ def azure_callback(request):
     return _set_language_cookie(response, lang_code)
 
 
-@csrf_exempt
 @require_POST
 @ratelimit(key="ip", rate="10/m", method=["POST"], block=True)
 def demo_login(request, role):
@@ -383,7 +381,6 @@ def demo_login(request, role):
     return _set_language_cookie(response, lang_code)
 
 
-@csrf_exempt
 @require_POST
 @ratelimit(key="ip", rate="10/m", method=["POST"], block=True)
 def demo_portal_login(request, record_id):


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Missing CSRF protection on authentication boundaries (`demo_login`, `demo_portal_login`).
🎯 Impact: Attackers can forge login requests (Login CSRF) by tricking an authenticated user into submitting a cross-site request, bypassing standard protections.
🔧 Fix: Removed `@csrf_exempt` decorators from demo login views to enforce CSRF validation. Verified frontend forms already send the token.
✅ Verification: Ran `pytest` on auth and portal tests to ensure everything still passes.

---
*PR created automatically by Jules for task [14343017618588630133](https://jules.google.com/task/14343017618588630133) started by @pboachie*