### PR TITLE
🎨 Palette: Standardize portal empty states

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -12,3 +12,7 @@
 ## 2025-03-10 - Add `data-select-on-click` to Copyable Text Inputs
 **Learning:** For read-only inputs containing shareable URLs (e.g. calendar feed, direct registration link), requiring users to manually highlight the text before copying can be frustrating and error-prone. The codebase already supports an accessible `data-select-on-click="true"` pattern used in invite links.
 **Action:** Consistently apply the `data-select-on-click="true"` attribute to all read-only `input` elements designated for copying, ensuring users can instantly select the full value with a single click.
+
+## 2025-05-25 - Standardized Empty States in Portal
+**Learning:** Plain text empty states (like `<p>No items</p>`) lack visual hierarchy and are often missed by screen readers. The portal has dedicated `.portal-empty-state` and `.empty-state` classes which include visual formatting (dashed borders, center alignment, icons) and require a `role="status"` attribute. However, several list views were still using unstyled `<p>` tags.
+**Action:** Always use the dedicated empty state classes (`.portal-empty-state` for participant-facing portal views, `.empty-state` for staff-facing views) along with `role="status"` when rendering "no data" messages to ensure both visual consistency and screen reader accessibility.

--- a/apps/portal/templates/portal/staff_client_resources.html
+++ b/apps/portal/templates/portal/staff_client_resources.html
@@ -52,6 +52,8 @@
 </table>
 {% else %}
 <hr>
-<p>{% blocktrans with resource_term=term.resource_plural|lower %}No {{ resource_term }} added for this participant yet.{% endblocktrans %}</p>
+<div class="empty-state" role="status">
+    <p>{% blocktrans with resource_term=term.resource_plural|lower %}No {{ resource_term }} added for this participant yet.{% endblocktrans %}</p>
+</div>
 {% endif %}
 {% endblock %}

--- a/apps/portal/templates/portal/staff_program_resources.html
+++ b/apps/portal/templates/portal/staff_program_resources.html
@@ -59,6 +59,8 @@
 </table>
 {% else %}
 <hr>
-<p>{% blocktrans with resource_term=term.resource_plural|lower %}No {{ resource_term }} added yet.{% endblocktrans %}</p>
+<div class="empty-state" role="status">
+    <p>{% blocktrans with resource_term=term.resource_plural|lower %}No {{ resource_term }} added yet.{% endblocktrans %}</p>
+</div>
 {% endif %}
 {% endblock %}

--- a/apps/portal/templates/portal/surveys_list.html
+++ b/apps/portal/templates/portal/surveys_list.html
@@ -33,7 +33,9 @@
 </article>
 {% endfor %}
 {% else %}
-<p>{% trans "You have no surveys to complete right now." %}</p>
+<article class="portal-empty-state" role="status">
+    <p>{% trans "You have no surveys to complete right now." %}</p>
+</article>
 {% endif %}
 
 {% if responses %}


### PR DESCRIPTION
💡 What: Updated plain text "no data" messages in portal views to use standard empty state components (`.portal-empty-state` and `.empty-state`) with `role="status"`.

🎯 Why: To improve visual consistency and ensure screen readers announce these states dynamically.

📸 Before/After: Before, empty states were unstyled `<p>` tags that blended in with the rest of the text. Now, they have a dashed border, center alignment, and a clip board icon. 

♿ Accessibility: Added `role="status"` to ensure screen readers notify users of empty states.

---
*PR created automatically by Jules for task [14832875003305250751](https://jules.google.com/task/14832875003305250751) started by @pboachie*