### PR TITLE
🛡️ Sentinel: [HIGH] Fix Login CSRF vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,8 @@
 **Vulnerability:** XSS risk due to modifying the DOM using `.innerHTML` with potentially dynamic or unescaped translated values in `static/js/app.js`.
 **Learning:** `innerHTML` exposes a risk of executing unescaped input or malformed HTML translations. Instead of clearing nodes with `.innerHTML = ""` or creating nested HTML structures via strings, safer programmatic node manipulation should be utilized.
 **Prevention:** Use `.textContent` for assigning simple text to elements. Use programmatic DOM creation methods like `document.createElement` and `node.appendChild` instead of injecting raw HTML strings into `.innerHTML`. To clear an element, loop through and use `removeChild` on its children (e.g. `while (el.firstChild) el.removeChild(el.firstChild);`).
+
+## 2024-10-24 - [Avoid `csrf_exempt` on Login Endpoints]
+**Vulnerability:** The `demo_login` and `demo_portal_login` views had the `@csrf_exempt` decorator, which bypasses Django's CSRF protection for these POST-only session-modifying endpoints.
+**Learning:** This exposes the application to "Login CSRF" attacks, where an attacker could force a victim's browser to authenticate into an attacker-controlled account or demo account. This could lead to a breach of privacy if the victim later performs actions thinking they are in their own session.
+**Prevention:** Avoid using `@csrf_exempt` on authentication boundaries (e.g., login, demo login, invite accept, password reset) unless absolutely required by an external system callback (such as `sendBeacon` in `emergency_logout`). Always ensure the forms submitting to these endpoints include the `{% csrf_token %}` tag.

--- a/apps/auth_app/views.py
+++ b/apps/auth_app/views.py
@@ -7,7 +7,6 @@ from django.contrib.auth.decorators import login_required
 from django.core.cache import cache
 from django.http import HttpResponse, HttpResponseNotAllowed
 from django.shortcuts import redirect, render
-from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 from django.utils import timezone
 from django.utils import translation
@@ -340,7 +339,6 @@ def azure_callback(request):
     return _set_language_cookie(response, lang_code)
 
 
-@csrf_exempt
 @require_POST
 @ratelimit(key="ip", rate="10/m", method=["POST"], block=True)
 def demo_login(request, role):
@@ -383,7 +381,6 @@ def demo_login(request, role):
     return _set_language_cookie(response, lang_code)
 
 
-@csrf_exempt
 @require_POST
 @ratelimit(key="ip", rate="10/m", method=["POST"], block=True)
 def demo_portal_login(request, record_id):


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `demo_login` and `demo_portal_login` views had the `@csrf_exempt` decorator, which bypasses Django's CSRF protection for these POST-only endpoints.
🎯 Impact: This exposes the application to "Login CSRF" attacks, where an attacker could force a victim's browser to authenticate into an attacker-controlled account or demo account. This could lead to a breach of privacy or unexpected actions performed by the victim.
🔧 Fix: Removed the `@csrf_exempt` decorator from both `demo_login` and `demo_portal_login` in `apps/auth_app/views.py`. Also removed the unused import `from django.views.decorators.csrf import csrf_exempt`. The frontend forms in `login.html` already properly send the `{% csrf_token %}`.
✅ Verification: Ran `python -m pytest tests/test_auth_views.py` and `python -m pytest tests/test_roles_invites.py` to ensure demo logins still work correctly via the test client which inherently handles CSRF properly.

---
*PR created automatically by Jules for task [4822759998500912694](https://jules.google.com/task/4822759998500912694) started by @pboachie*