### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Login CSRF vulnerability on demo endpoints

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,8 @@
 **Vulnerability:** XSS risk due to modifying the DOM using `.innerHTML` with potentially dynamic or unescaped translated values in `static/js/app.js`.
 **Learning:** `innerHTML` exposes a risk of executing unescaped input or malformed HTML translations. Instead of clearing nodes with `.innerHTML = ""` or creating nested HTML structures via strings, safer programmatic node manipulation should be utilized.
 **Prevention:** Use `.textContent` for assigning simple text to elements. Use programmatic DOM creation methods like `document.createElement` and `node.appendChild` instead of injecting raw HTML strings into `.innerHTML`. To clear an element, loop through and use `removeChild` on its children (e.g. `while (el.firstChild) el.removeChild(el.firstChild);`).
+
+## 2024-05-28 - Removed @csrf_exempt from Demo Login Endpoints
+**Vulnerability:** The `demo_login` and `demo_portal_login` endpoints in `apps/auth_app/views.py` were decorated with `@csrf_exempt`, bypassing CSRF protections for demo logins.
+**Learning:** Bypassing CSRF protection on authentication endpoints, even demo endpoints, can introduce Login CSRF vulnerabilities where an attacker can force a victim's browser to log in to an attacker-controlled account, potentially tracking their actions.
+**Prevention:** Never use `@csrf_exempt` on authentication boundaries (login, invite accept, password reset) unless absolutely required by an external system callback. Ensure forms always include `{% csrf_token %}`.

--- a/apps/auth_app/views.py
+++ b/apps/auth_app/views.py
@@ -7,7 +7,6 @@ from django.contrib.auth.decorators import login_required
 from django.core.cache import cache
 from django.http import HttpResponse, HttpResponseNotAllowed
 from django.shortcuts import redirect, render
-from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 from django.utils import timezone
 from django.utils import translation
@@ -340,7 +339,7 @@ def azure_callback(request):
     return _set_language_cookie(response, lang_code)
 
 
-@csrf_exempt
+
 @require_POST
 @ratelimit(key="ip", rate="10/m", method=["POST"], block=True)
 def demo_login(request, role):
@@ -383,7 +382,7 @@ def demo_login(request, role):
     return _set_language_cookie(response, lang_code)
 
 
-@csrf_exempt
+
 @require_POST
 @ratelimit(key="ip", rate="10/m", method=["POST"], block=True)
 def demo_portal_login(request, record_id):


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `demo_login` and `demo_portal_login` endpoints in `apps/auth_app/views.py` were bypassing CSRF protections by using the `@csrf_exempt` decorator.
🎯 Impact: An attacker could perform a Login CSRF attack by forcing a victim's browser to authenticate with attacker-controlled demo credentials, potentially leading to tracking or session fixation if demo users were modified to have specific traits.
🔧 Fix: Removed the `@csrf_exempt` decorators from both functions. The existing demo login forms in `templates/auth/login.html` already included `{% csrf_token %}`, so this change correctly enforces the check without breaking functionality.
✅ Verification: Ran `python -m pytest tests/test_auth_views.py` to ensure all tests passed. Tested locally that the template uses the CSRF token.

---
*PR created automatically by Jules for task [2551292645997321945](https://jules.google.com/task/2551292645997321945) started by @pboachie*