### PR TITLE
🎨 Palette: Contextual ARIA labels for list actions

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -12,3 +12,7 @@
 ## 2025-03-10 - Add `data-select-on-click` to Copyable Text Inputs
 **Learning:** For read-only inputs containing shareable URLs (e.g. calendar feed, direct registration link), requiring users to manually highlight the text before copying can be frustrating and error-prone. The codebase already supports an accessible `data-select-on-click="true"` pattern used in invite links.
 **Action:** Consistently apply the `data-select-on-click="true"` attribute to all read-only `input` elements designated for copying, ensuring users can instantly select the full value with a single click.
+
+## 2025-03-10 - Add Contextual ARIA Labels to Action Buttons in Iterators
+**Learning:** Generic action buttons (like "Deactivate", "Archive", "Activate") within iterator lists (like survey links, categories, rules) lack context for screen readers if they don't explicitly reference the target item.
+**Action:** Always add descriptive `aria-label` attributes to generic action buttons inside iterative loops, using `{% blocktrans %}` to include the item's identifier dynamically.

--- a/templates/events/sre_category_list.html
+++ b/templates/events/sre_category_list.html
@@ -52,9 +52,9 @@
                     <form method="post" action="{% url 'sre_categories:sre_category_toggle_active' category_id=cat.pk %}" style="display: inline;">
                         {% csrf_token %}
                         {% if cat.is_active %}
-                        <button type="submit" class="outline secondary" style="padding: 0.25rem 0.5rem; font-size: 0.85rem;">{% trans "Archive" %}</button>
+                        <button type="submit" class="outline secondary" style="padding: 0.25rem 0.5rem; font-size: 0.85rem;" aria-label="{% blocktrans with name=cat.name %}Archive {{ name }}{% endblocktrans %}">{% trans "Archive" %}</button>
                         {% else %}
-                        <button type="submit" class="outline" style="padding: 0.25rem 0.5rem; font-size: 0.85rem;">{% trans "Activate" %}</button>
+                        <button type="submit" class="outline" style="padding: 0.25rem 0.5rem; font-size: 0.85rem;" aria-label="{% blocktrans with name=cat.name %}Activate {{ name }}{% endblocktrans %}">{% trans "Activate" %}</button>
                         {% endif %}
                     </form>
                 </div>

--- a/templates/surveys/admin/rule_list.html
+++ b/templates/surveys/admin/rule_list.html
@@ -67,7 +67,7 @@
                 {% if rule.is_active %}
                 <form method="post" action="{% url 'survey_manage:survey_rule_deactivate' survey_id=survey.pk rule_id=rule.pk %}" style="display:inline">
                     {% csrf_token %}
-                    <button type="submit" class="outline secondary" style="margin-bottom:0">{% trans "Deactivate" %}</button>
+                    <button type="submit" class="outline secondary" style="margin-bottom:0" aria-label="{% blocktrans with type=rule.get_trigger_type_display %}Deactivate rule for {{ type }}{% endblocktrans %}">{% trans "Deactivate" %}</button>
                 </form>
                 {% endif %}
             </td>

--- a/templates/surveys/admin/survey_links.html
+++ b/templates/surveys/admin/survey_links.html
@@ -77,7 +77,7 @@
                     {% csrf_token %}
                     <input type="hidden" name="action" value="deactivate">
                     <input type="hidden" name="link_id" value="{{ link.pk }}">
-                    <button type="submit" class="outline secondary" style="margin-bottom:0">{% trans "Deactivate" %}</button>
+                    <button type="submit" class="outline secondary" style="margin-bottom:0" aria-label="{% blocktrans with token=link.token|truncatechars:12 %}Deactivate link {{ token }}{% endblocktrans %}">{% trans "Deactivate" %}</button>
                 </form>
                 {% endif %}
             </td>


### PR DESCRIPTION
💡 **What:** Added descriptive `aria-label` attributes to generic "Deactivate", "Archive", and "Activate" action buttons rendered inside loops in `survey_links.html`, `sre_category_list.html`, and `rule_list.html`.
🎯 **Why:** Screen reader users tabbing through tables or lists would repeatedly hear "Deactivate, button" without knowing *which* specific survey link, category, or rule the button applied to.
📸 **Before/After:** No visual changes.
♿ **Accessibility:** Dynamically injects context using `{% blocktrans %}` (e.g., "Deactivate link 50280f9e31", "Archive Safety Alert") so assistive tech users understand exactly what action they are taking.

---
*PR created automatically by Jules for task [8608730254945867676](https://jules.google.com/task/8608730254945867676) started by @pboachie*