### PR TITLE
🛡️ Sentinel: [HIGH] Remove @csrf_exempt from demo login boundaries

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,7 @@
 **Vulnerability:** XSS risk due to modifying the DOM using `.innerHTML` with potentially dynamic or unescaped translated values in `static/js/app.js`.
 **Learning:** `innerHTML` exposes a risk of executing unescaped input or malformed HTML translations. Instead of clearing nodes with `.innerHTML = ""` or creating nested HTML structures via strings, safer programmatic node manipulation should be utilized.
 **Prevention:** Use `.textContent` for assigning simple text to elements. Use programmatic DOM creation methods like `document.createElement` and `node.appendChild` instead of injecting raw HTML strings into `.innerHTML`. To clear an element, loop through and use `removeChild` on its children (e.g. `while (el.firstChild) el.removeChild(el.firstChild);`).
+## 2024-05-27 - Remove @csrf_exempt from authentication boundaries
+**Vulnerability:** Authentication boundary (demo login) was exempt from CSRF protection despite forms including CSRF tokens.
+**Learning:** Even demo login routes and fallback endpoints must maintain CSRF protection because they establish a user session. Login CSRF can be exploited to log victims into attacker-controlled accounts.
+**Prevention:** Never use `@csrf_exempt` on authentication boundaries (login, invite accept, demo logins) unless it's an external system callback that fundamentally cannot pass tokens.

--- a/apps/auth_app/views.py
+++ b/apps/auth_app/views.py
@@ -7,7 +7,7 @@ from django.contrib.auth.decorators import login_required
 from django.core.cache import cache
 from django.http import HttpResponse, HttpResponseNotAllowed
 from django.shortcuts import redirect, render
-from django.views.decorators.csrf import csrf_exempt
+
 from django.views.decorators.http import require_POST
 from django.utils import timezone
 from django.utils import translation
@@ -340,7 +340,7 @@ def azure_callback(request):
     return _set_language_cookie(response, lang_code)
 
 
-@csrf_exempt
+
 @require_POST
 @ratelimit(key="ip", rate="10/m", method=["POST"], block=True)
 def demo_login(request, role):
@@ -383,7 +383,7 @@ def demo_login(request, role):
     return _set_language_cookie(response, lang_code)
 
 
-@csrf_exempt
+
 @require_POST
 @ratelimit(key="ip", rate="10/m", method=["POST"], block=True)
 def demo_portal_login(request, record_id):


### PR DESCRIPTION
- 🚨 Severity: HIGH
- 💡 Vulnerability: Login endpoints were exempted from CSRF protection despite forms sending a token, exposing the site to Login CSRF attacks.
- 🎯 Impact: Attackers could potentially force victims to authenticate as an attacker-controlled demo account or other demo identities, potentially leading to disclosure of information entered while logged into that account.
- 🔧 Fix: Removed the `@csrf_exempt` decorator from `demo_login` and `demo_portal_login`.
- ✅ Verification: The forms in `templates/auth/login.html` have `{% csrf_token %}`. The auth tests were run successfully.

---
*PR created automatically by Jules for task [5877682722794283993](https://jules.google.com/task/5877682722794283993) started by @pboachie*