### PR TITLE
🎨 Palette: Add contextual ARIA labels to Remove buttons in lists

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -12,3 +12,7 @@
 ## 2025-03-10 - Add `data-select-on-click` to Copyable Text Inputs
 **Learning:** For read-only inputs containing shareable URLs (e.g. calendar feed, direct registration link), requiring users to manually highlight the text before copying can be frustrating and error-prone. The codebase already supports an accessible `data-select-on-click="true"` pattern used in invite links.
 **Action:** Consistently apply the `data-select-on-click="true"` attribute to all read-only `input` elements designated for copying, ensuring users can instantly select the full value with a single click.
+
+## 2025-05-28 - Add Contextual ARIA Labels to Generic Buttons in Tables
+**Learning:** Action buttons like "Remove" in dynamically generated lists (such as program roles or evaluation components) lack context for screen readers when they don't explicitly reference the target item. A user tabbing through the page would hear "Remove, button" multiple times without knowing *what* is being removed.
+**Action:** Always add descriptive `aria-label` attributes to generic action buttons inside iterative loops, using `{% blocktrans %}` to include the item's name dynamically (e.g., `aria-label="{% blocktrans with name=role.user.display_name %}Remove {{ name }} from this program{% endblocktrans %}"`).

--- a/templates/auth_app/user_roles.html
+++ b/templates/auth_app/user_roles.html
@@ -31,6 +31,7 @@
                     {% csrf_token %}
                         <button type="submit" class="outline secondary"
                             style="padding: 0.25rem 0.5rem; margin: 0;"
+                            aria-label="{% blocktrans with name=edit_user.display_name prog=role.program.translated_name %}Remove {{ name }} from {{ prog }}{% endblocktrans %}"
                             data-confirm="{% blocktrans with prog=role.program.translated_name %}Remove role from {{ prog }}?{% endblocktrans %}">
                         {% trans "Remove" %}
                     </button>

--- a/templates/programs/_role_list.html
+++ b/templates/programs/_role_list.html
@@ -40,7 +40,8 @@
                         hx-swap="innerHTML"
                         hx-confirm="{% blocktrans with name=role.user.display_name %}Remove {{ name }} from this program?{% endblocktrans %}"
                         class="outline secondary"
-                        style="padding: 0.25rem 0.5rem; font-size: 0.8rem;">
+                        style="padding: 0.25rem 0.5rem; font-size: 0.8rem;"
+                        aria-label="{% blocktrans with name=role.user.display_name %}Remove {{ name }} from this program{% endblocktrans %}">
                     {% trans "Remove" %}
                 </button>
                 {% endif %}

--- a/templates/programs/evaluation/framework_detail.html
+++ b/templates/programs/evaluation/framework_detail.html
@@ -73,7 +73,7 @@
                     <a href="{% url 'programs:component_edit' framework_id=framework.pk component_id=comp.pk %}">{% trans "Edit" %}</a>
                     <form method="post" action="{% url 'programs:component_deactivate' framework_id=framework.pk component_id=comp.pk %}" class="inline-form">
                         {% csrf_token %}
-                        <button type="submit" class="outline contrast compact-btn">{% trans "Remove" %}</button>
+                        <button type="submit" class="outline contrast compact-btn" aria-label="{% blocktrans with comp_name=comp.get_component_type_display %}Remove {{ comp_name }}{% endblocktrans %}">{% trans "Remove" %}</button>
                     </form>
                 </td>
             </tr>
@@ -112,7 +112,7 @@
                 <td>
                     <form method="post" action="{% url 'programs:evidence_delete' framework_id=framework.pk evidence_id=link.pk %}" class="inline-form">
                         {% csrf_token %}
-                        <button type="submit" class="outline contrast compact-btn">{% trans "Remove" %}</button>
+                        <button type="submit" class="outline contrast compact-btn" aria-label="{% blocktrans with source_type=link.get_source_type_display %}Remove {{ source_type }}{% endblocktrans %}">{% trans "Remove" %}</button>
                     </form>
                 </td>
             </tr>


### PR DESCRIPTION
💡 What: Added context-specific `aria-label` attributes to generic "Remove" buttons inside dynamically generated tables/lists in `user_roles.html`, `_role_list.html`, and `framework_detail.html`.
🎯 Why: Previously, screen reader users navigating through these tables would hear repetitive "Remove, button" announcements without knowing which user, role, component, or evidence link was being targeted. Adding dynamic context to the aria-label makes it completely clear what will happen when the button is pressed.
📸 Before/After: Visuals are unchanged. The `aria-label` is invisible to sighted users but fully accessible to assistive tech.
♿ Accessibility: Improves WCAG 4.1.2 compliance (Name, Role, Value) by ensuring buttons have distinguishable names based on context, especially when iterated in tables.

---
*PR created automatically by Jules for task [9738655707592291486](https://jules.google.com/task/9738655707592291486) started by @pboachie*