### PR TITLE
🎨 Palette: Add aria-label and type to remove role button

### DIFF
--- a/templates/programs/_role_list.html
+++ b/templates/programs/_role_list.html
@@ -35,12 +35,14 @@
             {% if is_admin %}
             <td>
                 {% if role.status == "active" %}
-                <button hx-post="{% url 'programs:program_remove_role' program_id=program.pk role_id=role.pk %}"
+                <button type="button"
+                        hx-post="{% url 'programs:program_remove_role' program_id=program.pk role_id=role.pk %}"
                         hx-target="#role-list"
                         hx-swap="innerHTML"
                         hx-confirm="{% blocktrans with name=role.user.display_name %}Remove {{ name }} from this program?{% endblocktrans %}"
                         class="outline secondary"
-                        style="padding: 0.25rem 0.5rem; font-size: 0.8rem;">
+                        style="padding: 0.25rem 0.5rem; font-size: 0.8rem;"
+                        aria-label="{% blocktrans with name=role.user.display_name %}Remove {{ name }} from program{% endblocktrans %}">
                     {% trans "Remove" %}
                 </button>
                 {% endif %}


### PR DESCRIPTION
💡 What: Added `aria-label` and `type="button"` to the remove role button in the assigned staff table.
🎯 Why: Improves accessibility for screen readers (gives context on who is being removed) and ensures standard button behavior to prevent accidental form submissions.
📸 Before/After: Not applicable (no visual change).
♿ Accessibility: Improved screen reader support for the remove role button.

---
*PR created automatically by Jules for task [3756367437091257929](https://jules.google.com/task/3756367437091257929) started by @pboachie*