### PR TITLE
🛡️ Sentinel: [HIGH] Fix Login CSRF vulnerability on demo endpoints

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,8 @@
 **Vulnerability:** XSS risk due to modifying the DOM using `.innerHTML` with potentially dynamic or unescaped translated values in `static/js/app.js`.
 **Learning:** `innerHTML` exposes a risk of executing unescaped input or malformed HTML translations. Instead of clearing nodes with `.innerHTML = ""` or creating nested HTML structures via strings, safer programmatic node manipulation should be utilized.
 **Prevention:** Use `.textContent` for assigning simple text to elements. Use programmatic DOM creation methods like `document.createElement` and `node.appendChild` instead of injecting raw HTML strings into `.innerHTML`. To clear an element, loop through and use `removeChild` on its children (e.g. `while (el.firstChild) el.removeChild(el.firstChild);`).
+
+## 2026-03-07 - Remove CSRF exempt from demo logins
+**Vulnerability:** Login CSRF vulnerability due to `@csrf_exempt` on authentication boundaries (`demo_login` and `demo_portal_login`).
+**Learning:** Authentication boundaries, even if only used for demo purposes, should not bypass CSRF protection to prevent attackers from forcing users to authenticate as a specific user.
+**Prevention:** Ensure all authentication endpoints (including demo logins and invite accept links) enforce CSRF protection unless strictly required by external system callbacks.

--- a/apps/auth_app/views.py
+++ b/apps/auth_app/views.py
@@ -340,7 +340,6 @@ def azure_callback(request):
     return _set_language_cookie(response, lang_code)
 
 
-@csrf_exempt
 @require_POST
 @ratelimit(key="ip", rate="10/m", method=["POST"], block=True)
 def demo_login(request, role):
@@ -383,7 +382,6 @@ def demo_login(request, role):
     return _set_language_cookie(response, lang_code)
 
 
-@csrf_exempt
 @require_POST
 @ratelimit(key="ip", rate="10/m", method=["POST"], block=True)
 def demo_portal_login(request, record_id):


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Login CSRF due to `@csrf_exempt` on `demo_login` and `demo_portal_login`.
🎯 Impact: Attackers could force a victim to log into the attacker's account or a demo account.
🔧 Fix: Removed `@csrf_exempt` from both endpoints.
✅ Verification: Ran `python -m pytest tests/test_auth_views.py` and verified tests pass.

---
*PR created automatically by Jules for task [13724824360597708537](https://jules.google.com/task/13724824360597708537) started by @pboachie*