### PR TITLE
🎨 Palette: Add context and fix type for Send Reminder buttons

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -12,3 +12,6 @@
 ## 2025-03-10 - Add `data-select-on-click` to Copyable Text Inputs
 **Learning:** For read-only inputs containing shareable URLs (e.g. calendar feed, direct registration link), requiring users to manually highlight the text before copying can be frustrating and error-prone. The codebase already supports an accessible `data-select-on-click="true"` pattern used in invite links.
 **Action:** Consistently apply the `data-select-on-click="true"` attribute to all read-only `input` elements designated for copying, ensuring users can instantly select the full value with a single click.
+## 2025-05-30 - Added contextual ARIA labels and type to generic action buttons
+**Learning:** Generic action buttons in repeated components (like "Send Reminder" on meeting cards) lack specific context for screen reader users tabbing through the interface, and missing `type="button"` defaults them to `type="submit"` which can cause accidental form submissions.
+**Action:** Always add explicit `type="button"` to non-submit buttons, and use contextual `aria-label`s for repeated generic action buttons.

--- a/templates/events/_meeting_card.html
+++ b/templates/events/_meeting_card.html
@@ -18,7 +18,8 @@
     {% if meeting.status == "scheduled" and not meeting.reminder_sent %}
     {% if features.messaging_sms or features.messaging_email %}
     <div id="send-reminder-{{ meeting.pk }}" style="margin-top: 0.25rem;">
-        <button class="outline" style="padding: 0.25rem 0.5rem; font-size: 0.875rem;"
+        <button type="button" class="outline" style="padding: 0.25rem 0.5rem; font-size: 0.875rem;"
+                aria-label="{% blocktrans with name=meeting.event.client_file.display_name|default:'participant' %}Send reminder to {{ name }}{% endblocktrans %}"
                 hx-get="{% url 'communications:send_reminder_preview' client_id=meeting.event.client_file_id event_id=meeting.event_id %}"
                 hx-target="#send-reminder-{{ meeting.pk }}"
                 hx-swap="innerHTML">


### PR DESCRIPTION
💡 What: Added an explicit `type="button"` and a contextual `aria-label` using Django's `{% blocktrans %}` to the generic "Send Reminder" buttons on meeting cards. 
🎯 Why: Generic action buttons within lists or repeated components don't provide sufficient context to screen reader users (who would just hear "Send Reminder, button"). Also, buttons without `type="button"` default to `type="submit"`, which could trigger unexpected behavior if eventually wrapped in a form.
📸 Before/After: N/A visual change (Accessibility/semantic improvement only).
♿ Accessibility: Ensures correct element behavior, and improves the screen-reader experience by providing participant context directly on the action (e.g. "Send reminder to Participant Name").

---
*PR created automatically by Jules for task [16935944423565384284](https://jules.google.com/task/16935944423565384284) started by @pboachie*