### PR TITLE
🎨 Palette: [UX improvement] Add type="button" to tab buttons

### DIFF
--- a/templates/notes/suggestions/theme_detail.html
+++ b/templates/notes/suggestions/theme_detail.html
@@ -98,11 +98,11 @@
 
 {# ── Tabs: Linked / Link More ── #}
 <div class="theme-tabs" role="tablist" aria-label="{% trans 'Theme suggestions' %}">
-    <button role="tab" aria-selected="true" aria-controls="linked-tab" id="linked-tab-btn" class="tab-btn active">
+    <button type="button" role="tab" aria-selected="true" aria-controls="linked-tab" id="linked-tab-btn" class="tab-btn active">
         {% trans "Linked" %} ({{ linked_notes|length }})
     </button>
     {% if can_manage %}
-    <button role="tab" aria-selected="false" aria-controls="unlinked-tab" id="unlinked-tab-btn" class="tab-btn">
+    <button type="button" role="tab" aria-selected="false" aria-controls="unlinked-tab" id="unlinked-tab-btn" class="tab-btn">
         {% trans "Link More" %}
     </button>
     {% endif %}


### PR DESCRIPTION
💡 **What:** Added `type="button"` to the `#linked-tab-btn` and `#unlinked-tab-btn` elements in the `theme_detail.html` template.
🎯 **Why:** Generic `<button>` elements in HTML default to `type="submit"`. If these tabs are ever wrapped in a form, clicking a tab would unexpectedly trigger a form submission and a page reload. Specifying `type="button"` enforces the correct interactive behavior.
📸 **Before/After:** The buttons functionally act exactly the same, but they are now explicitly labeled as non-submit buttons in the DOM.
♿ **Accessibility:** This ensures proper native toggle semantics and keyboard accessibility without unintended form submission side effects.

---
*PR created automatically by Jules for task [5442343538649534360](https://jules.google.com/task/5442343538649534360) started by @pboachie*