### PR TITLE
🛡️ Sentinel: [HIGH] Fix Login CSRF vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,8 @@
 **Vulnerability:** XSS risk due to modifying the DOM using `.innerHTML` with potentially dynamic or unescaped translated values in `static/js/app.js`.
 **Learning:** `innerHTML` exposes a risk of executing unescaped input or malformed HTML translations. Instead of clearing nodes with `.innerHTML = ""` or creating nested HTML structures via strings, safer programmatic node manipulation should be utilized.
 **Prevention:** Use `.textContent` for assigning simple text to elements. Use programmatic DOM creation methods like `document.createElement` and `node.appendChild` instead of injecting raw HTML strings into `.innerHTML`. To clear an element, loop through and use `removeChild` on its children (e.g. `while (el.firstChild) el.removeChild(el.firstChild);`).
+
+## 2024-11-20 - [Login CSRF in Demo Endpoints]
+**Vulnerability:** The `demo_login` and `demo_portal_login` views had the `@csrf_exempt` decorator, making them vulnerable to Login CSRF attacks where an attacker could force a victim to log into the attacker's account.
+**Learning:** Authentication boundaries, even demo logins, must be protected against CSRF unless strictly required by external callbacks. The frontend form already sends `{% csrf_token %}`.
+**Prevention:** Avoid using `@csrf_exempt` on authentication boundaries like login, demo login, and invite accept endpoints.

--- a/apps/auth_app/views.py
+++ b/apps/auth_app/views.py
@@ -7,7 +7,6 @@ from django.contrib.auth.decorators import login_required
 from django.core.cache import cache
 from django.http import HttpResponse, HttpResponseNotAllowed
 from django.shortcuts import redirect, render
-from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 from django.utils import timezone
 from django.utils import translation
@@ -340,7 +339,6 @@ def azure_callback(request):
     return _set_language_cookie(response, lang_code)
 
 
-@csrf_exempt
 @require_POST
 @ratelimit(key="ip", rate="10/m", method=["POST"], block=True)
 def demo_login(request, role):
@@ -383,7 +381,6 @@ def demo_login(request, role):
     return _set_language_cookie(response, lang_code)
 
 
-@csrf_exempt
 @require_POST
 @ratelimit(key="ip", rate="10/m", method=["POST"], block=True)
 def demo_portal_login(request, record_id):


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Login CSRF due to `@csrf_exempt` on demo login endpoints.
🎯 Impact: An attacker could force a victim to log into a demo account, potentially exposing the victim's activity or manipulating their session.
🔧 Fix: Removed `@csrf_exempt` decorators from `demo_login` and `demo_portal_login` views.
✅ Verification: Checked that the frontend form includes `{% csrf_token %}` and all relevant auth tests pass.

---
*PR created automatically by Jules for task [18167042213338487411](https://jules.google.com/task/18167042213338487411) started by @pboachie*