### PR TITLE
🛡️ Sentinel: [HIGH] Fix CSRF vulnerability on demo login endpoints

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,8 @@
 **Vulnerability:** XSS risk due to modifying the DOM using `.innerHTML` with potentially dynamic or unescaped translated values in `static/js/app.js`.
 **Learning:** `innerHTML` exposes a risk of executing unescaped input or malformed HTML translations. Instead of clearing nodes with `.innerHTML = ""` or creating nested HTML structures via strings, safer programmatic node manipulation should be utilized.
 **Prevention:** Use `.textContent` for assigning simple text to elements. Use programmatic DOM creation methods like `document.createElement` and `node.appendChild` instead of injecting raw HTML strings into `.innerHTML`. To clear an element, loop through and use `removeChild` on its children (e.g. `while (el.firstChild) el.removeChild(el.firstChild);`).
+
+## 2026-06-02 - [Avoid `@csrf_exempt` on Authentication Boundaries]
+**Vulnerability:** Login endpoints (`demo_login`, `demo_portal_login`) were missing CSRF protection due to the `@csrf_exempt` decorator.
+**Learning:** Even demo or non-standard authentication endpoints are authentication boundaries. Leaving them unprotected introduces Login CSRF vulnerabilities, allowing attackers to force a victim's browser to log into an attacker-controlled account.
+**Prevention:** Never use `@csrf_exempt` on authentication boundaries unless explicitly required by an external system callback. Rely on Django's default CSRF middleware and ensure `{% csrf_token %}` is included in the corresponding frontend forms.

--- a/apps/auth_app/views.py
+++ b/apps/auth_app/views.py
@@ -340,7 +340,6 @@ def azure_callback(request):
     return _set_language_cookie(response, lang_code)
 
 
-@csrf_exempt
 @require_POST
 @ratelimit(key="ip", rate="10/m", method=["POST"], block=True)
 def demo_login(request, role):
@@ -383,7 +382,6 @@ def demo_login(request, role):
     return _set_language_cookie(response, lang_code)
 
 
-@csrf_exempt
 @require_POST
 @ratelimit(key="ip", rate="10/m", method=["POST"], block=True)
 def demo_portal_login(request, record_id):


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `demo_login` and `demo_portal_login` views in `apps/auth_app/views.py` were marked with `@csrf_exempt`, disabling CSRF protection for these authentication endpoints.
🎯 Impact: This exposes the application to Login CSRF attacks, where an attacker could forge a request to log a victim into the system as a demo user without their consent.
🔧 Fix: Removed the `@csrf_exempt` decorator from both functions. The corresponding frontend forms in `templates/auth/login.html` already include `{% csrf_token %}`, so functionality is unaffected.
✅ Verification: Verified that the `demo_login` and `demo_portal_login` tests in `tests/test_auth_views.py` continue to pass.

---
*PR created automatically by Jules for task [18310408134681996781](https://jules.google.com/task/18310408134681996781) started by @pboachie*