### PR TITLE
🎨 Palette: Add context and type to interactive HTMX buttons

### DIFF
--- a/templates/events/_meeting_card.html
+++ b/templates/events/_meeting_card.html
@@ -18,10 +18,11 @@
     {% if meeting.status == "scheduled" and not meeting.reminder_sent %}
     {% if features.messaging_sms or features.messaging_email %}
     <div id="send-reminder-{{ meeting.pk }}" style="margin-top: 0.25rem;">
-        <button class="outline" style="padding: 0.25rem 0.5rem; font-size: 0.875rem;"
+        <button type="button" class="outline" style="padding: 0.25rem 0.5rem; font-size: 0.875rem;"
                 hx-get="{% url 'communications:send_reminder_preview' client_id=meeting.event.client_file_id event_id=meeting.event_id %}"
                 hx-target="#send-reminder-{{ meeting.pk }}"
-                hx-swap="innerHTML">
+                hx-swap="innerHTML"
+                aria-label="{% blocktrans with date=meeting.event.start_timestamp|date %}Send reminder for meeting on {{ date }}{% endblocktrans %}">
             {% trans "Send Reminder" %}
         </button>
     </div>

--- a/templates/events/_tab_events.html
+++ b/templates/events/_tab_events.html
@@ -63,12 +63,12 @@
 <h2>{% trans "History" %}</h2>
 <div id="timeline-section">
     <div class="filter-bar" role="toolbar" aria-label="{% trans 'Filter history' %}">
-        <button class="filter-btn{% if active_filter == 'all' or not active_filter %} filter-active{% endif %}"
+        <button type="button" class="filter-btn{% if active_filter == 'all' or not active_filter %} filter-active{% endif %}"
                 aria-pressed="{% if active_filter == 'all' or not active_filter %}true{% else %}false{% endif %}"
                 hx-get="{% url 'events:event_list' client_id=client.pk %}?filter=all"
                 hx-target="#timeline-entries"
                 hx-swap="innerHTML">{% trans "All" %}</button>
-        <button class="filter-btn{% if active_filter == 'events' %} filter-active{% endif %}"
+        <button type="button" class="filter-btn{% if active_filter == 'events' %} filter-active{% endif %}"
                 aria-pressed="{% if active_filter == 'events' %}true{% else %}false{% endif %}"
                 hx-get="{% url 'events:event_list' client_id=client.pk %}?filter=events"
                 hx-target="#timeline-entries"

--- a/templates/events/_timeline_entries.html
+++ b/templates/events/_timeline_entries.html
@@ -76,7 +76,7 @@
     {% endfor %}
 {% if not is_append %}</div>{% endif %}
 {% if has_more %}
-<button class="outline secondary" style="width: 100%; margin-top: 0.5rem;"
+<button type="button" class="outline secondary" style="width: 100%; margin-top: 0.5rem;"
         hx-get="{% url 'events:event_list' client_id=client.pk %}?filter={{ active_filter|default:'all' }}&offset={{ next_offset }}"
         hx-target="this"
         hx-swap="outerHTML">


### PR DESCRIPTION
💡 What: Added type="button" to HTMX interaction buttons and a contextual ARIA label to the "Send Reminder" list button.
🎯 Why: Prevent accidental form submissions and give screen reader users context for list actions.
📸 Before/After: Visuals unchanged, but HTML markup includes proper type and accessibility attributes.
♿ Accessibility: Screen reader users will now hear the date of the meeting when focused on the "Send Reminder" button, avoiding repeated generic labels.

---
*PR created automatically by Jules for task [7943784727999054620](https://jules.google.com/task/7943784727999054620) started by @pboachie*