### PR TITLE
🎨 Palette: Add context to generic action buttons & fix button types

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -12,3 +12,7 @@
 ## 2025-03-10 - Add `data-select-on-click` to Copyable Text Inputs
 **Learning:** For read-only inputs containing shareable URLs (e.g. calendar feed, direct registration link), requiring users to manually highlight the text before copying can be frustrating and error-prone. The codebase already supports an accessible `data-select-on-click="true"` pattern used in invite links.
 **Action:** Consistently apply the `data-select-on-click="true"` attribute to all read-only `input` elements designated for copying, ensuring users can instantly select the full value with a single click.
+
+## 2024-06-03 - Contextual ARIA labels and explicit button types
+**Learning:** Generic action buttons in lists (like "Remove", "Archive", "Activate") need row-specific context in their `aria-label` (e.g., using `{% blocktrans with name=... %}`) to be accessible, and non-submit interactive elements (like HTMX triggers) must explicitly declare `type="button"` to prevent accidental form submissions and ensure correct screen reader semantics. Stateful toggles also require `aria-pressed`.
+**Action:** Always verify `type="button"` on non-submit buttons, provide context to generic labels in lists, and use `aria-pressed` for toggles.

--- a/templates/events/_meeting_card.html
+++ b/templates/events/_meeting_card.html
@@ -18,10 +18,12 @@
     {% if meeting.status == "scheduled" and not meeting.reminder_sent %}
     {% if features.messaging_sms or features.messaging_email %}
     <div id="send-reminder-{{ meeting.pk }}" style="margin-top: 0.25rem;">
-        <button class="outline" style="padding: 0.25rem 0.5rem; font-size: 0.875rem;"
+        <button type="button"
+                class="outline" style="padding: 0.25rem 0.5rem; font-size: 0.875rem;"
                 hx-get="{% url 'communications:send_reminder_preview' client_id=meeting.event.client_file_id event_id=meeting.event_id %}"
                 hx-target="#send-reminder-{{ meeting.pk }}"
-                hx-swap="innerHTML">
+                hx-swap="innerHTML"
+                aria-label="{% blocktrans with name=meeting.event.client_file.display_name %}Send reminder to {{ name }}{% endblocktrans %}">
             {% trans "Send Reminder" %}
         </button>
     </div>

--- a/templates/events/sre_category_list.html
+++ b/templates/events/sre_category_list.html
@@ -52,9 +52,9 @@
                     <form method="post" action="{% url 'sre_categories:sre_category_toggle_active' category_id=cat.pk %}" style="display: inline;">
                         {% csrf_token %}
                         {% if cat.is_active %}
-                        <button type="submit" class="outline secondary" style="padding: 0.25rem 0.5rem; font-size: 0.85rem;">{% trans "Archive" %}</button>
+                        <button type="submit" class="outline secondary" style="padding: 0.25rem 0.5rem; font-size: 0.85rem;" aria-label="{% blocktrans with name=cat.name %}Archive {{ name }}{% endblocktrans %}">{% trans "Archive" %}</button>
                         {% else %}
-                        <button type="submit" class="outline" style="padding: 0.25rem 0.5rem; font-size: 0.85rem;">{% trans "Activate" %}</button>
+                        <button type="submit" class="outline" style="padding: 0.25rem 0.5rem; font-size: 0.85rem;" aria-label="{% blocktrans with name=cat.name %}Activate {{ name }}{% endblocktrans %}">{% trans "Activate" %}</button>
                         {% endif %}
                     </form>
                 </div>

--- a/templates/plans/_metric_toggle.html
+++ b/templates/plans/_metric_toggle.html
@@ -1,8 +1,10 @@
 {% load i18n %}
-<button hx-post="{% url 'metrics:metric_toggle' metric_id=metric.pk %}"
+<button type="button"
+        hx-post="{% url 'metrics:metric_toggle' metric_id=metric.pk %}"
         hx-target="#metric-toggle-{{ metric.pk }}"
         hx-swap="innerHTML"
         class="outline small {% if metric.is_enabled %}contrast{% else %}secondary{% endif %}"
-        aria-label="{% if metric.is_enabled %}{% blocktrans with name=metric.name %}Disable {{ name }}{% endblocktrans %}{% else %}{% blocktrans with name=metric.name %}Enable {{ name }}{% endblocktrans %}{% endif %}">
+        aria-label="{% blocktrans with name=metric.name %}Toggle {{ name }}{% endblocktrans %}"
+        aria-pressed="{{ metric.is_enabled|yesno:'true,false' }}">
     {% if metric.is_enabled %}{% trans "Enabled" %}{% else %}{% trans "Disabled" %}{% endif %}
 </button>

--- a/templates/programs/_role_list.html
+++ b/templates/programs/_role_list.html
@@ -35,12 +35,14 @@
             {% if is_admin %}
             <td>
                 {% if role.status == "active" %}
-                <button hx-post="{% url 'programs:program_remove_role' program_id=program.pk role_id=role.pk %}"
+                <button type="button"
+                        hx-post="{% url 'programs:program_remove_role' program_id=program.pk role_id=role.pk %}"
                         hx-target="#role-list"
                         hx-swap="innerHTML"
                         hx-confirm="{% blocktrans with name=role.user.display_name %}Remove {{ name }} from this program?{% endblocktrans %}"
                         class="outline secondary"
-                        style="padding: 0.25rem 0.5rem; font-size: 0.8rem;">
+                        style="padding: 0.25rem 0.5rem; font-size: 0.8rem;"
+                        aria-label="{% blocktrans with name=role.user.display_name %}Remove {{ name }}{% endblocktrans %}">
                     {% trans "Remove" %}
                 </button>
                 {% endif %}


### PR DESCRIPTION
💡 **What**: Added specific, context-aware `aria-label` attributes to generic action buttons in iterators (like lists or tables) across multiple templates. Also added `type="button"` to elements that do not submit forms, and implemented `aria-pressed` on the toggle button component.

🎯 **Why**: Generic buttons like "Remove", "Archive", or "Activate" don't provide screen readers with enough information when read out of context. By leveraging `{% blocktrans %}` with context parameters, the labels become clear (e.g., "Remove Staff Name from this program"). Adding explicit `type="button"` declarations prevents browser default form submission behavior, mitigating bugs with standard JavaScript or HTMX triggers. Adding `aria-pressed` completes the semantic state for toggles.

📸 **Before/After**: N/A - Visual display is unchanged.

♿ **Accessibility**: Significant improvement to WCAG 4.1.2. Users utilizing assistive technologies will now hear explicitly what entity is targeted by iterative action buttons. Screen readers will also correctly announce the native 'pressed' state on toggle components.

---
*PR created automatically by Jules for task [12964192843122323947](https://jules.google.com/task/12964192843122323947) started by @pboachie*