### PR TITLE
🛡️ Sentinel: [CRITICAL] Remove @csrf_exempt from demo endpoints

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,8 @@
 **Vulnerability:** XSS risk due to modifying the DOM using `.innerHTML` with potentially dynamic or unescaped translated values in `static/js/app.js`.
 **Learning:** `innerHTML` exposes a risk of executing unescaped input or malformed HTML translations. Instead of clearing nodes with `.innerHTML = ""` or creating nested HTML structures via strings, safer programmatic node manipulation should be utilized.
 **Prevention:** Use `.textContent` for assigning simple text to elements. Use programmatic DOM creation methods like `document.createElement` and `node.appendChild` instead of injecting raw HTML strings into `.innerHTML`. To clear an element, loop through and use `removeChild` on its children (e.g. `while (el.firstChild) el.removeChild(el.firstChild);`).
+
+## 2026-06-04 - [Login CSRF in Demo Endpoints]
+**Vulnerability:** The `demo_login` and `demo_portal_login` endpoints bypassed CSRF validation via `@csrf_exempt`, exposing the app to Login CSRF attacks.
+**Learning:** Authentication boundaries, even demo endpoints, should never bypass CSRF validation unless strictly required by an external system callback. Frontend forms already include the token.
+**Prevention:** Do not use `@csrf_exempt` on authentication boundaries. Verify that frontend forms use `{% csrf_token %}`.

--- a/apps/auth_app/views.py
+++ b/apps/auth_app/views.py
@@ -340,7 +340,6 @@ def azure_callback(request):
     return _set_language_cookie(response, lang_code)
 
 
-@csrf_exempt
 @require_POST
 @ratelimit(key="ip", rate="10/m", method=["POST"], block=True)
 def demo_login(request, role):
@@ -383,7 +382,6 @@ def demo_login(request, role):
     return _set_language_cookie(response, lang_code)
 
 
-@csrf_exempt
 @require_POST
 @ratelimit(key="ip", rate="10/m", method=["POST"], block=True)
 def demo_portal_login(request, record_id):


### PR DESCRIPTION
🚨 **Severity**: CRITICAL
💡 **Vulnerability**: The `demo_login` and `demo_portal_login` views were marked with `@csrf_exempt`, bypassing CSRF validation and allowing Login CSRF attacks.
🎯 **Impact**: An attacker could potentially log a user into an attacker-controlled account or demo account, leading to confusion or potential information disclosure within the demo context, bypassing normal authentication flows.
🔧 **Fix**: Removed the `@csrf_exempt` decorator from `demo_login` and `demo_portal_login` in `apps/auth_app/views.py`.
✅ **Verification**: Ran `pytest tests/test_auth_views.py apps/portal/tests/test_auth.py` and all tests passed successfully. Verified that frontend templates correctly send the CSRF token.

---
*PR created automatically by Jules for task [11394196227502660970](https://jules.google.com/task/11394196227502660970) started by @pboachie*