### PR TITLE
🎨 Palette: Add contextual ARIA label to Approve buttons in registration list

### DIFF
--- a/templates/registration/admin/submission_list.html
+++ b/templates/registration/admin/submission_list.html
@@ -78,7 +78,7 @@
                 {% if sub.status == "pending" %}
                 <form method="post" action="{% url 'registration:submission_approve' pk=sub.pk %}" style="display:inline" data-confirm="{% blocktrans with name=sub.first_name %}Approve registration for {{ name }}?{% endblocktrans %}">
                     {% csrf_token %}
-                    <button type="submit" class="outline" style="padding: 0.25rem 0.5rem; margin: 0;">
+                    <button type="submit" class="outline" style="padding: 0.25rem 0.5rem; margin: 0;" aria-label="{% blocktrans with name=sub.first_name %}Approve registration for {{ name }}{% endblocktrans %}">
                         {% trans "Approve" %}
                     </button>
                 </form>


### PR DESCRIPTION
💡 What: Added a dynamic `aria-label` to the "Approve" button within the list of registration submissions.
🎯 Why: Without contextual labels, screen reader users navigating the page hear only a list of buttons saying "Approve, button", "Approve, button" without knowing whose registration they are approving. This improves context.
📸 Before/After: Before, the button was `<button type="submit" class="outline"...> Approve </button>`. After, it uses `{% blocktrans %}` to say `Approve registration for [First Name]`.
♿ Accessibility: Ensures generic action buttons within a list loop meet WCAG guidelines by providing clear, unique contextual labels for assistive technologies.

---
*PR created automatically by Jules for task [5226037360269989864](https://jules.google.com/task/5226037360269989864) started by @pboachie*