### PR TITLE
🛡️ Sentinel: [HIGH] Fix Login CSRF vulnerability in demo login endpoints

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,8 @@
 **Vulnerability:** XSS risk due to modifying the DOM using `.innerHTML` with potentially dynamic or unescaped translated values in `static/js/app.js`.
 **Learning:** `innerHTML` exposes a risk of executing unescaped input or malformed HTML translations. Instead of clearing nodes with `.innerHTML = ""` or creating nested HTML structures via strings, safer programmatic node manipulation should be utilized.
 **Prevention:** Use `.textContent` for assigning simple text to elements. Use programmatic DOM creation methods like `document.createElement` and `node.appendChild` instead of injecting raw HTML strings into `.innerHTML`. To clear an element, loop through and use `removeChild` on its children (e.g. `while (el.firstChild) el.removeChild(el.firstChild);`).
+
+## 2024-03-05 - [Login CSRF in Demo Endpoints]
+**Vulnerability:** The `demo_login` and `demo_portal_login` endpoints in `apps/auth_app/views.py` were decorated with `@csrf_exempt`, making them vulnerable to Login CSRF attacks.
+**Learning:** Even demo authentication endpoints must enforce CSRF protection to prevent attackers from forcing victims to log in under an attacker-controlled account, which could lead to information disclosure or unauthorized actions.
+**Prevention:** Avoid using `@csrf_exempt` on any authentication boundary (e.g., login, demo login) unless absolutely required by an external system callback. Ensure frontend forms include `{% csrf_token %}` to support default CSRF protection.

--- a/apps/auth_app/views.py
+++ b/apps/auth_app/views.py
@@ -7,7 +7,6 @@ from django.contrib.auth.decorators import login_required
 from django.core.cache import cache
 from django.http import HttpResponse, HttpResponseNotAllowed
 from django.shortcuts import redirect, render
-from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 from django.utils import timezone
 from django.utils import translation
@@ -340,7 +339,6 @@ def azure_callback(request):
     return _set_language_cookie(response, lang_code)
 
 
-@csrf_exempt
 @require_POST
 @ratelimit(key="ip", rate="10/m", method=["POST"], block=True)
 def demo_login(request, role):
@@ -383,7 +381,6 @@ def demo_login(request, role):
     return _set_language_cookie(response, lang_code)
 
 
-@csrf_exempt
 @require_POST
 @ratelimit(key="ip", rate="10/m", method=["POST"], block=True)
 def demo_portal_login(request, record_id):


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `demo_login` and `demo_portal_login` endpoints in `apps/auth_app/views.py` were decorated with `@csrf_exempt`, bypassing Django's built-in CSRF protection. This made the application vulnerable to Login CSRF, where an attacker could force a victim's browser to authenticate as a demo user (an attacker-controlled context), potentially leading to information disclosure or tricking the victim into performing actions within the demo session that they believe are their own.
🎯 Impact: High potential for abuse as it involves authentication boundaries. Even though these are demo endpoints, they should adhere to standard security practices and not allow forced logins.
🔧 Fix: Removed the `@csrf_exempt` decorators from both `demo_login` and `demo_portal_login`. Removed the unused `csrf_exempt` import. Frontend templates (`templates/auth/login.html`) already properly sent `{% csrf_token %}`, so native Django CSRF middleware now correctly protects these routes.
✅ Verification: Ran `python3 -m pytest tests/test_auth_views.py -k "demo"` locally and all 10 tests passed successfully, proving that normal demo login functionality works and is not disrupted by the added security constraint.

---
*PR created automatically by Jules for task [4013158564747416275](https://jules.google.com/task/4013158564747416275) started by @pboachie*