### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Login CSRF vulnerability

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,7 @@
 **Vulnerability:** XSS risk due to modifying the DOM using `.innerHTML` with potentially dynamic or unescaped translated values in `static/js/app.js`.
 **Learning:** `innerHTML` exposes a risk of executing unescaped input or malformed HTML translations. Instead of clearing nodes with `.innerHTML = ""` or creating nested HTML structures via strings, safer programmatic node manipulation should be utilized.
 **Prevention:** Use `.textContent` for assigning simple text to elements. Use programmatic DOM creation methods like `document.createElement` and `node.appendChild` instead of injecting raw HTML strings into `.innerHTML`. To clear an element, loop through and use `removeChild` on its children (e.g. `while (el.firstChild) el.removeChild(el.firstChild);`).
+## 2026-06-07 - Remove CSRF Exempt from Demo Login endpoints
+**Vulnerability:** Login endpoints in DEMO mode were decorated with @csrf_exempt, exposing the application to Login Cross-Site Request Forgery (CSRF).
+**Learning:** Avoid using @csrf_exempt on authentication boundaries (e.g., login, demo login, invite accept, password reset) unless absolutely required by an external system callback, as it introduces Login CSRF vulnerabilities.
+**Prevention:** Ensure frontend forms correctly include {% csrf_token %} and remove the @csrf_exempt decorators from views.

--- a/apps/auth_app/views.py
+++ b/apps/auth_app/views.py
@@ -340,7 +340,7 @@ def azure_callback(request):
     return _set_language_cookie(response, lang_code)
 
 
-@csrf_exempt
+
 @require_POST
 @ratelimit(key="ip", rate="10/m", method=["POST"], block=True)
 def demo_login(request, role):
@@ -383,7 +383,7 @@ def demo_login(request, role):
     return _set_language_cookie(response, lang_code)
 
 
-@csrf_exempt
+
 @require_POST
 @ratelimit(key="ip", rate="10/m", method=["POST"], block=True)
 def demo_portal_login(request, record_id):


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `demo_login` and `demo_portal_login` authentication boundaries lacked CSRF protection, enabling Login CSRF attacks.
🎯 Impact: An attacker could force an authenticated or unauthenticated user to log in to the attacker's controlled demo account, potentially harvesting sensitive information that the victim subsequently enters while believing they are in their own session.
🔧 Fix: Removed `@csrf_exempt` decorator from the demo login views. The frontend forms correctly sent `{% csrf_token %}` already, so functionality isn't broken.
✅ Verification: Run `python -m pytest tests/test_auth_views.py tests/test_roles_invites.py apps/portal/tests/test_auth.py` and observe tests pass.

---
*PR created automatically by Jules for task [10625352744721520637](https://jules.google.com/task/10625352744721520637) started by @pboachie*