### PR TITLE
🎨 Palette: Add skip navigation support to public survey pages

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -12,3 +12,7 @@
 ## 2025-03-10 - Add `data-select-on-click` to Copyable Text Inputs
 **Learning:** For read-only inputs containing shareable URLs (e.g. calendar feed, direct registration link), requiring users to manually highlight the text before copying can be frustrating and error-prone. The codebase already supports an accessible `data-select-on-click="true"` pattern used in invite links.
 **Action:** Consistently apply the `data-select-on-click="true"` attribute to all read-only `input` elements designated for copying, ensuring users can instantly select the full value with a single click.
+
+## 2025-03-10 - Add tabindex="-1" to <main id="main-content">
+**Learning:** To support "Skip to main content" accessibility links, the target container (e.g., `<main id="main-content">`) must include the `tabindex="-1"` attribute so it can programmatically receive focus, ensuring proper keyboard and screen reader support.
+**Action:** Always add `tabindex="-1"` to the primary `<main>` element when implementing skip navigation links.

--- a/templates/surveys/public_consent.html
+++ b/templates/surveys/public_consent.html
@@ -15,7 +15,7 @@
 <body>
 <a href="#main-content" class="visually-hidden-focusable">{% trans "Skip to main content" %}</a>
 {% include "_lang_toggle.html" with max_width="720px" %}
-<main id="main-content" class="container" style="max-width:720px; padding-top:2rem" aria-label="{% trans 'Main content' %}">
+<main id="main-content" tabindex="-1" class="container" style="max-width:720px; padding-top:2rem" aria-label="{% trans 'Main content' %}">
 
 <h1>{{ survey.name|bilingual:survey.name_fr }}</h1>
 

--- a/templates/surveys/public_expired.html
+++ b/templates/surveys/public_expired.html
@@ -11,8 +11,9 @@
     {% include "_lang_toggle_styles.html" %}
 </head>
 <body>
+<a href="#main-content" class="visually-hidden-focusable">{% trans "Skip to main content" %}</a>
 {% include "_lang_toggle.html" with max_width="720px" %}
-<main class="container" style="max-width:720px; padding-top:2rem; text-align:center">
+<main id="main-content" tabindex="-1" class="container" style="max-width:720px; padding-top:2rem; text-align:center" aria-label="{% trans 'Main content' %}">
 
 <h1>{% trans "Survey Unavailable" %}</h1>
 <p>{% trans "This survey is no longer available." %}</p>

--- a/templates/surveys/public_form.html
+++ b/templates/surveys/public_form.html
@@ -19,7 +19,7 @@
 <body>
 <a href="#main-content" class="visually-hidden-focusable">{% trans "Skip to main content" %}</a>
 {% include "_lang_toggle.html" with max_width="720px" %}
-<main id="main-content" class="container" style="max-width:720px; padding-top:2rem" aria-label="{% trans 'Main content' %}">
+<main id="main-content" tabindex="-1" class="container" style="max-width:720px; padding-top:2rem" aria-label="{% trans 'Main content' %}">
 
 <h1>{{ survey.name|bilingual:survey.name_fr }}</h1>
 


### PR DESCRIPTION
💡 What: Added `id="main-content"`, `tabindex="-1"`, and skip links to public survey templates.
🎯 Why: Improves keyboard accessibility by allowing users to bypass repetitive header/navigation content.
📸 Before/After: Visual structure maintained, functional skip links added.
♿ Accessibility: Fixes missing focusability on main content areas for screen readers and keyboard navigation.

---
*PR created automatically by Jules for task [1376697134236227461](https://jules.google.com/task/1376697134236227461) started by @pboachie*