### PR TITLE
🛡️ Sentinel: [HIGH] Fix Login CSRF vulnerability on demo endpoints

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,8 @@
 **Vulnerability:** XSS risk due to modifying the DOM using `.innerHTML` with potentially dynamic or unescaped translated values in `static/js/app.js`.
 **Learning:** `innerHTML` exposes a risk of executing unescaped input or malformed HTML translations. Instead of clearing nodes with `.innerHTML = ""` or creating nested HTML structures via strings, safer programmatic node manipulation should be utilized.
 **Prevention:** Use `.textContent` for assigning simple text to elements. Use programmatic DOM creation methods like `document.createElement` and `node.appendChild` instead of injecting raw HTML strings into `.innerHTML`. To clear an element, loop through and use `removeChild` on its children (e.g. `while (el.firstChild) el.removeChild(el.firstChild);`).
+
+## 2026-06-08 - [Missing CSRF Protection on Demo Login Endpoints]
+**Vulnerability:** The `demo_login` and `demo_portal_login` views had `@csrf_exempt` decorators, which made them vulnerable to Login CSRF attacks.
+**Learning:** Even endpoints designed for demo purposes need CSRF protection. Authentication boundaries must be uniformly protected.
+**Prevention:** Avoid using `@csrf_exempt` on authentication boundaries (e.g., login, demo login, invite accept, password reset) unless absolutely required by an external system callback.

--- a/apps/auth_app/views.py
+++ b/apps/auth_app/views.py
@@ -340,7 +340,6 @@ def azure_callback(request):
     return _set_language_cookie(response, lang_code)
 
 
-@csrf_exempt
 @require_POST
 @ratelimit(key="ip", rate="10/m", method=["POST"], block=True)
 def demo_login(request, role):
@@ -383,7 +382,6 @@ def demo_login(request, role):
     return _set_language_cookie(response, lang_code)
 
 
-@csrf_exempt
 @require_POST
 @ratelimit(key="ip", rate="10/m", method=["POST"], block=True)
 def demo_portal_login(request, record_id):


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: The `demo_login` and `demo_portal_login` views had `@csrf_exempt` decorators, making them vulnerable to Login CSRF attacks. An attacker could force a victim to log in as a demo user.
🎯 Impact: While these are demo accounts, forcing a user into a different session context (Login CSRF) can be leveraged for further attacks or data confusion.
🔧 Fix: Removed the `@csrf_exempt` decorators from both views in `apps/auth_app/views.py`. The frontend forms already include `{% csrf_token %}` and these endpoints are correctly restricted with `@require_POST`, so Django's native CSRF middleware will now protect them.
✅ Verification: Verified the code using `py_compile`. Both endpoints are now correctly secured without `@csrf_exempt`.

---
*PR created automatically by Jules for task [11363437139581932544](https://jules.google.com/task/11363437139581932544) started by @pboachie*