### PR TITLE
🎨 Palette: Add aria-pressed to metric toggle

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -12,3 +12,6 @@
 ## 2025-03-10 - Add `data-select-on-click` to Copyable Text Inputs
 **Learning:** For read-only inputs containing shareable URLs (e.g. calendar feed, direct registration link), requiring users to manually highlight the text before copying can be frustrating and error-prone. The codebase already supports an accessible `data-select-on-click="true"` pattern used in invite links.
 **Action:** Consistently apply the `data-select-on-click="true"` attribute to all read-only `input` elements designated for copying, ensuring users can instantly select the full value with a single click.
+## 2026-06-09 - Added aria-pressed to toggle
+**Learning:** Stateful toggle buttons require aria-pressed for native toggle semantics.
+**Action:** Always include aria-pressed on HTMX toggles.

--- a/templates/plans/_metric_toggle.html
+++ b/templates/plans/_metric_toggle.html
@@ -3,6 +3,7 @@
         hx-target="#metric-toggle-{{ metric.pk }}"
         hx-swap="innerHTML"
         class="outline small {% if metric.is_enabled %}contrast{% else %}secondary{% endif %}"
-        aria-label="{% if metric.is_enabled %}{% blocktrans with name=metric.name %}Disable {{ name }}{% endblocktrans %}{% else %}{% blocktrans with name=metric.name %}Enable {{ name }}{% endblocktrans %}{% endif %}">
+        aria-label="{% blocktrans with name=metric.name %}Toggle {{ name }}{% endblocktrans %}"
+        aria-pressed="{{ metric.is_enabled|yesno:'true,false' }}">
     {% if metric.is_enabled %}{% trans "Enabled" %}{% else %}{% trans "Disabled" %}{% endif %}
 </button>


### PR DESCRIPTION
💡 **What**: Added `aria-pressed="{{ metric.is_enabled|yesno:'true,false' }}"` to the HTMX metric toggle button and changed the `aria-label` to dynamically say "Toggle [name]".
🎯 **Why**: Previously, the button dynamically changed its `aria-label` based on state (e.g. "Enable X" vs "Disable X") without conveying native toggle semantics to screen readers.
📸 **Before/After**: The visual presentation is completely unchanged. The underlying DOM now correctly uses `aria-pressed` for screen readers.
♿ **Accessibility**: Aligns the button with standard W3C ARIA toggle patterns, avoiding redundant or contradictory screen reader announcements.

---
*PR created automatically by Jules for task [13802434702014176735](https://jules.google.com/task/13802434702014176735) started by @pboachie*