### PR TITLE
🛡️ Sentinel: [HIGH] Fix CSRF vulnerability on demo login endpoints

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,8 @@
 **Vulnerability:** XSS risk due to modifying the DOM using `.innerHTML` with potentially dynamic or unescaped translated values in `static/js/app.js`.
 **Learning:** `innerHTML` exposes a risk of executing unescaped input or malformed HTML translations. Instead of clearing nodes with `.innerHTML = ""` or creating nested HTML structures via strings, safer programmatic node manipulation should be utilized.
 **Prevention:** Use `.textContent` for assigning simple text to elements. Use programmatic DOM creation methods like `document.createElement` and `node.appendChild` instead of injecting raw HTML strings into `.innerHTML`. To clear an element, loop through and use `removeChild` on its children (e.g. `while (el.firstChild) el.removeChild(el.firstChild);`).
+
+## 2025-01-20 - Enforce CSRF protection on Demo Login boundaries
+**Vulnerability:** Login CSRF vulnerability due to `@csrf_exempt` on demo login endpoints.
+**Learning:** Authentication endpoints, even demo ones, must maintain CSRF protection to prevent malicious forced logins.
+**Prevention:** Never use `@csrf_exempt` on authentication boundaries unless absolutely required by an external system callback.

--- a/apps/auth_app/views.py
+++ b/apps/auth_app/views.py
@@ -340,7 +340,6 @@ def azure_callback(request):
     return _set_language_cookie(response, lang_code)
 
 
-@csrf_exempt
 @require_POST
 @ratelimit(key="ip", rate="10/m", method=["POST"], block=True)
 def demo_login(request, role):
@@ -383,7 +382,6 @@ def demo_login(request, role):
     return _set_language_cookie(response, lang_code)
 
 
-@csrf_exempt
 @require_POST
 @ratelimit(key="ip", rate="10/m", method=["POST"], block=True)
 def demo_portal_login(request, record_id):


### PR DESCRIPTION
🚨 Severity: HIGH
💡 Vulnerability: Login CSRF vulnerability. The `demo_login` and `demo_portal_login` endpoints in `apps/auth_app/views.py` were decorated with `@csrf_exempt`.
🎯 Impact: Attackers could potentially force a victim's browser to log in to an attacker-controlled demo account, allowing the attacker to monitor the victim's activity or trick the victim into performing actions within the demo context.
🔧 Fix: Removed the `@csrf_exempt` decorators. Since these are standard web forms accessed via POST, Django's built-in CSRF protection is now enforced. The corresponding templates (`templates/auth/login.html` and `apps/portal/templates/portal/login.html`) already include `{% csrf_token %}` inside their forms.
✅ Verification: Ran `python3 -m pytest tests/test_auth_views.py apps/portal/tests/test_auth.py`. All 68 tests passed, confirming that the change does not break the login flow.

---
*PR created automatically by Jules for task [10446066389407830811](https://jules.google.com/task/10446066389407830811) started by @pboachie*