### PR TITLE
🎨 Palette: Add static aria-label and aria-pressed to metric toggle

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -12,3 +12,7 @@
 ## 2025-03-10 - Add `data-select-on-click` to Copyable Text Inputs
 **Learning:** For read-only inputs containing shareable URLs (e.g. calendar feed, direct registration link), requiring users to manually highlight the text before copying can be frustrating and error-prone. The codebase already supports an accessible `data-select-on-click="true"` pattern used in invite links.
 **Action:** Consistently apply the `data-select-on-click="true"` attribute to all read-only `input` elements designated for copying, ensuring users can instantly select the full value with a single click.
+
+## 2025-03-10 - Use aria-pressed for Stateful Toggles
+**Learning:** HTMX-powered toggle buttons that dynamically change text (e.g., "Enable" -> "Disable") can create contradictory screen reader announcements if their `aria-label` also changes. Screen readers need a stable identity for the button.
+**Action:** When implementing stateful toggle buttons, use a static `aria-label` (like "Toggle [Name]") and rely on the `aria-pressed="true/false"` attribute to convey the current state to assistive technologies.

--- a/templates/plans/_metric_toggle.html
+++ b/templates/plans/_metric_toggle.html
@@ -3,6 +3,7 @@
         hx-target="#metric-toggle-{{ metric.pk }}"
         hx-swap="innerHTML"
         class="outline small {% if metric.is_enabled %}contrast{% else %}secondary{% endif %}"
-        aria-label="{% if metric.is_enabled %}{% blocktrans with name=metric.name %}Disable {{ name }}{% endblocktrans %}{% else %}{% blocktrans with name=metric.name %}Enable {{ name }}{% endblocktrans %}{% endif %}">
+        aria-pressed="{{ metric.is_enabled|yesno:'true,false' }}"
+        aria-label="{% blocktrans with name=metric.name %}Toggle {{ name }}{% endblocktrans %}">
     {% if metric.is_enabled %}{% trans "Enabled" %}{% else %}{% trans "Disabled" %}{% endif %}
 </button>


### PR DESCRIPTION
💡 What: Added the `aria-pressed` attribute to the stateful toggle button for metrics in `templates/plans/_metric_toggle.html`, and replaced its dynamically changing `aria-label` with a static one.
🎯 Why: HTMX-powered toggle buttons that dynamically change their text ("Enable" to "Disable") create contradictory and confusing announcements for screen reader users if their `aria-label` also changes. Screen readers need a stable identity for the button.
📸 Before/After: Visuals remain unchanged, but the accessibility tree correctly shows the button's pressed state.
♿ Accessibility: Improved screen reader support for stateful toggle buttons by ensuring a static accessible name and using `aria-pressed` to correctly convey state changes.

---
*PR created automatically by Jules for task [711699955412307413](https://jules.google.com/task/711699955412307413) started by @pboachie*