### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix missing rate limit on access grant request

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,8 @@
 **Vulnerability:** XSS risk due to modifying the DOM using `.innerHTML` with potentially dynamic or unescaped translated values in `static/js/app.js`.
 **Learning:** `innerHTML` exposes a risk of executing unescaped input or malformed HTML translations. Instead of clearing nodes with `.innerHTML = ""` or creating nested HTML structures via strings, safer programmatic node manipulation should be utilized.
 **Prevention:** Use `.textContent` for assigning simple text to elements. Use programmatic DOM creation methods like `document.createElement` and `node.appendChild` instead of injecting raw HTML strings into `.innerHTML`. To clear an element, loop through and use `removeChild` on its children (e.g. `while (el.firstChild) el.removeChild(el.firstChild);`).
+
+## 2026-06-11 - [Missing Rate Limiting on Access Grant Request Endpoint]
+**Vulnerability:** The access_grant_request view was missing rate limiting, making it vulnerable to brute-force or DoS attacks.
+**Learning:** Endpoints that handle authorization boundaries and access escalation (like requesting Tier 3 GATED access) need to be protected. The django-ratelimit decorator with block=True should be applied uniformly to prevent abuse.
+**Prevention:** Always ensure the @ratelimit(key="ip", rate="...", method="POST", block=True) decorator is present on any view that processes access escalation or authorization requests. Also make sure the import is present: from django_ratelimit.decorators import ratelimit.

--- a/apps/auth_app/access_grant_views.py
+++ b/apps/auth_app/access_grant_views.py
@@ -5,6 +5,7 @@ from django.shortcuts import get_object_or_404, redirect, render
 from django.utils import timezone
 from django.utils.http import url_has_allowed_host_and_scheme
 from django.utils.translation import gettext as _
+from django_ratelimit.decorators import ratelimit
 
 from datetime import timedelta
 
@@ -17,6 +18,7 @@ from .models import AccessGrant
 
 
 @login_required
+@ratelimit(key="ip", rate="10/m", method=["POST"], block=True)
 def access_grant_request(request):
     """Show justification form (GET) or create an AccessGrant (POST).
 


### PR DESCRIPTION
🚨 Severity: MEDIUM
💡 Vulnerability: The `access_grant_request` view was missing rate limiting, allowing unrestricted POST requests.
🎯 Impact: Susceptible to brute-force and DoS attacks on an authorization boundary endpoint.
🔧 Fix: Added `@ratelimit(key="ip", rate="10/m", method=["POST"], block=True)` to the view.
✅ Verification: Tested endpoint locally to ensure it functions and tests still pass.

---
*PR created automatically by Jules for task [2275542210386759517](https://jules.google.com/task/2275542210386759517) started by @pboachie*