### PR TITLE
🎨 Palette: Add contextual ARIA label to Remove staff button

### DIFF
--- a/templates/programs/_role_list.html
+++ b/templates/programs/_role_list.html
@@ -40,7 +40,8 @@
                         hx-swap="innerHTML"
                         hx-confirm="{% blocktrans with name=role.user.display_name %}Remove {{ name }} from this program?{% endblocktrans %}"
                         class="outline secondary"
-                        style="padding: 0.25rem 0.5rem; font-size: 0.8rem;">
+                        style="padding: 0.25rem 0.5rem; font-size: 0.8rem;"
+                        aria-label="{% blocktrans with name=role.user.display_name %}Remove {{ name }}{% endblocktrans %}">
                     {% trans "Remove" %}
                 </button>
                 {% endif %}


### PR DESCRIPTION
💡 What: Added a contextual `aria-label` to the "Remove" button in the program role list (`templates/programs/_role_list.html`), replacing the generic button text with a specific identifier.

🎯 Why: Previously, screen readers traversing the list of staff in a program would only hear "Remove, button" repeatedly without context as to *which* user would be removed. This was confusing and unhelpful for visually impaired users. 

📸 Before/After: Visual presentation remains identical. For screen readers, the label changed from reading "Remove" to "Remove Jane Doe" (e.g. `aria-label="Remove Jane Doe"`).

♿ Accessibility: Directly satisfies WCAG guidelines on providing context to generic action buttons inside iterative loops, drastically improving usability for keyboard and screen reader users.

---
*PR created automatically by Jules for task [1134355266974704550](https://jules.google.com/task/1134355266974704550) started by @pboachie*