### PR TITLE
🛡️ Sentinel: [HIGH] Fix Login CSRF in demo views

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -17,3 +17,8 @@
 **Vulnerability:** XSS risk due to modifying the DOM using `.innerHTML` with potentially dynamic or unescaped translated values in `static/js/app.js`.
 **Learning:** `innerHTML` exposes a risk of executing unescaped input or malformed HTML translations. Instead of clearing nodes with `.innerHTML = ""` or creating nested HTML structures via strings, safer programmatic node manipulation should be utilized.
 **Prevention:** Use `.textContent` for assigning simple text to elements. Use programmatic DOM creation methods like `document.createElement` and `node.appendChild` instead of injecting raw HTML strings into `.innerHTML`. To clear an element, loop through and use `removeChild` on its children (e.g. `while (el.firstChild) el.removeChild(el.firstChild);`).
+
+## 2024-11-20 - [Login CSRF in Demo Views]
+**Vulnerability:** The `demo_login` and `demo_portal_login` endpoints were marked with `@csrf_exempt`, which exposes them to Login CSRF attacks.
+**Learning:** Even endpoints meant for demo purposes need to have proper CSRF protections in place to ensure security. Forms in `templates/auth/login.html` already submit `{% csrf_token %}`.
+**Prevention:** Avoid using `@csrf_exempt` on authentication boundaries.

--- a/apps/auth_app/views.py
+++ b/apps/auth_app/views.py
@@ -340,7 +340,6 @@ def azure_callback(request):
     return _set_language_cookie(response, lang_code)
 
 
-@csrf_exempt
 @require_POST
 @ratelimit(key="ip", rate="10/m", method=["POST"], block=True)
 def demo_login(request, role):
@@ -383,7 +382,6 @@ def demo_login(request, role):
     return _set_language_cookie(response, lang_code)
 
 
-@csrf_exempt
 @require_POST
 @ratelimit(key="ip", rate="10/m", method=["POST"], block=True)
 def demo_portal_login(request, record_id):


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The `demo_login` and `demo_portal_login` endpoints in `apps/auth_app/views.py` were annotated with `@csrf_exempt`, which bypassed CSRF protection on these POST boundaries.
🎯 **Impact:** An attacker could exploit this Login CSRF vulnerability to force a victim's browser to log into a demo account without their consent, potentially leading to unauthorized actions or data exposure if the victim is unaware they are acting as the demo user. 
🔧 **Fix:** Removed the `@csrf_exempt` decorators from both functions. The frontend form in `templates/auth/login.html` already includes `{% csrf_token %}`.
✅ **Verification:** Ran tests `tests/test_auth_views.py` successfully. Checked for the presence of the CSRF token on the frontend forms. Recorded learning in `.jules/sentinel.md`.

---
*PR created automatically by Jules for task [1128570222419972067](https://jules.google.com/task/1128570222419972067) started by @pboachie*