### PR TITLE
🎨 Palette: Add contextual ARIA labels to list action buttons

### DIFF
--- a/templates/events/sre_category_list.html
+++ b/templates/events/sre_category_list.html
@@ -52,9 +52,9 @@
                     <form method="post" action="{% url 'sre_categories:sre_category_toggle_active' category_id=cat.pk %}" style="display: inline;">
                         {% csrf_token %}
                         {% if cat.is_active %}
-                        <button type="submit" class="outline secondary" style="padding: 0.25rem 0.5rem; font-size: 0.85rem;">{% trans "Archive" %}</button>
+                        <button type="submit" class="outline secondary" style="padding: 0.25rem 0.5rem; font-size: 0.85rem;" aria-label="{% blocktrans with name=cat.name %}Archive {{ name }}{% endblocktrans %}">{% trans "Archive" %}</button>
                         {% else %}
-                        <button type="submit" class="outline" style="padding: 0.25rem 0.5rem; font-size: 0.85rem;">{% trans "Activate" %}</button>
+                        <button type="submit" class="outline" style="padding: 0.25rem 0.5rem; font-size: 0.85rem;" aria-label="{% blocktrans with name=cat.name %}Activate {{ name }}{% endblocktrans %}">{% trans "Activate" %}</button>
                         {% endif %}
                     </form>
                 </div>

--- a/templates/programs/evaluation/framework_detail.html
+++ b/templates/programs/evaluation/framework_detail.html
@@ -73,7 +73,7 @@
                     <a href="{% url 'programs:component_edit' framework_id=framework.pk component_id=comp.pk %}">{% trans "Edit" %}</a>
                     <form method="post" action="{% url 'programs:component_deactivate' framework_id=framework.pk component_id=comp.pk %}" class="inline-form">
                         {% csrf_token %}
-                        <button type="submit" class="outline contrast compact-btn">{% trans "Remove" %}</button>
+                        <button type="submit" class="outline contrast compact-btn" aria-label="{% blocktrans with name=comp.name %}Remove {{ name }}{% endblocktrans %}">{% trans "Remove" %}</button>
                     </form>
                 </td>
             </tr>
@@ -112,7 +112,7 @@
                 <td>
                     <form method="post" action="{% url 'programs:evidence_delete' framework_id=framework.pk evidence_id=link.pk %}" class="inline-form">
                         {% csrf_token %}
-                        <button type="submit" class="outline contrast compact-btn">{% trans "Remove" %}</button>
+                        <button type="submit" class="outline contrast compact-btn" aria-label="{% blocktrans with name=link.title %}Remove {{ name }}{% endblocktrans %}">{% trans "Remove" %}</button>
                     </form>
                 </td>
             </tr>


### PR DESCRIPTION
### 💡 What
Added dynamic `aria-label` attributes to generic action buttons (e.g., "Archive", "Activate", "Remove") located inside list loops in SRE Category management (`templates/events/sre_category_list.html`) and Evaluation Framework Details (`templates/programs/evaluation/framework_detail.html`).

### 🎯 Why
Screen reader users navigating through a list of items need context when tabbing through action buttons. A generic "Remove" button offers no information about *what* is being removed. This change injects the specific item's name or title into the accessible name for that control (e.g., "Remove Housing Support Framework Component").

### 📸 Before/After
*N/A — No visual changes. Accessible name changes only.*

### ♿ Accessibility
Addresses a pattern documented in `.jules/palette.md` for contextual ARIA labels in dynamically generated lists. The visible text remains "Remove" or "Archive" but screen readers get full, dynamically populated sentence-level context using `{% blocktrans %}` context variables.

---
*PR created automatically by Jules for task [16817009608047154794](https://jules.google.com/task/16817009608047154794) started by @pboachie*